### PR TITLE
Add env templates and update .gitignore rules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://postgres:***@db.<project>.supabase.co:5432/postgres?sslmode=require

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 
 # Environment files
 /.env
+/.env.*
+!/.env.example
 
 # Angular CLI and build artefacts
 /.angular-cli.json


### PR DESCRIPTION
### Motivation
- Keep runtime secrets out of the repository while providing a safe example for configuring the database connection.
- Ensure environment files are ignored by default but keep an example template tracked for onboarding and CI.

### Description
- Added `/.env.local` containing the requested placeholder `DATABASE_URL` with `REPLACE_WITH_PASSWORD` left intact.
- Added `/.env.example` containing a sanitized template `DATABASE_URL` with `***` and `<project>` placeholders.
- Updated `/.gitignore` to ignore `/.env` and `/.env.*` while allowing `!/.env.example` to remain tracked.

### Testing
- No automated test suite was executed for this change.
- Verified file contents using `cat`/`nl` to confirm `/.env.local` and `/.env.example` contain the expected placeholders.
- Verified `/.gitignore` includes the new env ignore rules and the example whitelist entry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987949e2da083318f847826a08094d2)