### PR TITLE
Add mobile-first local-training CRM (schema, API, UI, seeds)

### DIFF
--- a/backend/app/routes/consulting.py
+++ b/backend/app/routes/consulting.py
@@ -65,6 +65,15 @@ from app.schemas.consulting import (
     TriggerSignalCreateRequest,
     TriggerSignalOut,
 )
+from app.schemas.local_training import (
+    LocalTrainingActivityCreateRequest,
+    LocalTrainingCheckInRequest,
+    LocalTrainingContactCreateRequest,
+    LocalTrainingEventCreateRequest,
+    LocalTrainingRegistrationUpsertRequest,
+    LocalTrainingSeedRequest,
+    LocalTrainingTaskStatusRequest,
+)
 from app.services import (
     cro_clients,
     cro_engagements,
@@ -77,6 +86,7 @@ from app.services import (
     cro_seed,
     cro_loops,
     cro_strategic_outreach,
+    local_training_crm,
 )
 
 router = APIRouter(prefix="/api/consulting", tags=["consulting-revenue-os"])
@@ -695,6 +705,99 @@ def seed_consulting_environment(body: SeedRequest):
         result = cro_seed.seed_consulting_environment(env_id=body.env_id, business_id=body.business_id)
         _log("cro.seed.completed", "Consulting environment seeded")
         return result
+    except Exception as exc:
+        raise _to_http(exc)
+
+
+# ── Local training CRM ───────────────────────────────────────────────────────
+
+@router.get("/local-training/workspace")
+def get_local_training_workspace(
+    env_id: str = Query(...),
+    business_id: UUID = Query(...),
+):
+    try:
+        return local_training_crm.get_workspace(env_id=env_id, business_id=business_id)
+    except Exception as exc:
+        raise _to_http(exc)
+
+
+@router.post("/local-training/seed", status_code=201)
+def seed_local_training_workspace(body: LocalTrainingSeedRequest):
+    try:
+        result = local_training_crm.seed_local_training_workspace(
+            env_id=body.env_id,
+            business_id=body.business_id,
+        )
+        _log("cro.local_training.seeded", "Local training CRM workspace seeded")
+        return result
+    except Exception as exc:
+        raise _to_http(exc)
+
+
+@router.post("/local-training/contacts", status_code=201)
+def create_local_training_contact(body: LocalTrainingContactCreateRequest):
+    try:
+        return local_training_crm.create_contact(
+            env_id=body.env_id,
+            business_id=body.business_id,
+            payload=body.model_dump(mode="json"),
+        )
+    except Exception as exc:
+        raise _to_http(exc)
+
+
+@router.post("/local-training/events", status_code=201)
+def create_local_training_event(body: LocalTrainingEventCreateRequest):
+    try:
+        return local_training_crm.create_event(
+            env_id=body.env_id,
+            business_id=body.business_id,
+            payload=body.model_dump(mode="json"),
+        )
+    except Exception as exc:
+        raise _to_http(exc)
+
+
+@router.post("/local-training/activities", status_code=201)
+def create_local_training_activity(body: LocalTrainingActivityCreateRequest):
+    try:
+        return local_training_crm.create_activity(
+            env_id=body.env_id,
+            business_id=body.business_id,
+            payload=body.model_dump(mode="json"),
+        )
+    except Exception as exc:
+        raise _to_http(exc)
+
+
+@router.post("/local-training/registrations", status_code=201)
+def upsert_local_training_registration(body: LocalTrainingRegistrationUpsertRequest):
+    try:
+        return local_training_crm.create_registration(
+            env_id=body.env_id,
+            business_id=body.business_id,
+            payload=body.model_dump(mode="json"),
+        )
+    except Exception as exc:
+        raise _to_http(exc)
+
+
+@router.patch("/local-training/registrations/{registration_id}/check-in")
+def check_in_local_training_registration(registration_id: UUID, body: LocalTrainingCheckInRequest):
+    try:
+        return local_training_crm.check_in_registration(
+            registration_id=registration_id,
+            attended_flag=body.attended_flag,
+        )
+    except Exception as exc:
+        raise _to_http(exc)
+
+
+@router.patch("/local-training/tasks/{task_id}")
+def update_local_training_task(task_id: UUID, body: LocalTrainingTaskStatusRequest):
+    try:
+        return local_training_crm.toggle_task(task_id=task_id, status=body.status)
     except Exception as exc:
         raise _to_http(exc)
 

--- a/backend/app/schemas/local_training.py
+++ b/backend/app/schemas/local_training.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class LocalTrainingSeedRequest(BaseModel):
+    env_id: str
+    business_id: UUID
+
+
+class LocalTrainingContactCreateRequest(BaseModel):
+    env_id: str
+    business_id: UUID
+    first_name: str | None = None
+    last_name: str | None = None
+    full_name: str
+    email: str | None = None
+    phone: str | None = None
+    title: str | None = None
+    organization_account_id: UUID | None = None
+    preferred_contact_method: str | None = None
+    city: str | None = None
+    age_band: str | None = None
+    persona_type: str | None = None
+    audience_segment: str | None = None
+    business_owner_flag: bool = False
+    company_name_text: str | None = None
+    notes: str | None = None
+    lead_source: str | None = None
+    status: str | None = None
+    consent_to_email: bool = False
+    interest_area: str | None = None
+    follow_up_priority: str | None = None
+    tags: list[str] = Field(default_factory=list)
+
+
+class LocalTrainingEventCreateRequest(BaseModel):
+    env_id: str
+    business_id: UUID
+    event_name: str
+    event_series: str | None = None
+    event_type: str | None = None
+    event_status: str | None = None
+    event_date: date
+    event_start_time: time | None = None
+    event_end_time: time | None = None
+    venue_id: UUID | None = None
+    city: str | None = None
+    target_capacity: int | None = None
+    ticket_price_standard: Decimal | None = None
+    ticket_price_early: Decimal | None = None
+    event_theme: str | None = None
+    audience_level: str | None = None
+    instructor: str | None = None
+    assistant_count: int | None = None
+    registration_link: str | None = None
+    notes: str | None = None
+    outcome_summary: str | None = None
+    campaign_id: UUID | None = None
+
+
+class LocalTrainingActivityCreateRequest(BaseModel):
+    env_id: str
+    business_id: UUID
+    activity_type: str
+    contact_id: UUID | None = None
+    organization_id: UUID | None = None
+    event_id: UUID | None = None
+    campaign_id: UUID | None = None
+    owner: str | None = None
+    activity_date: datetime | None = None
+    channel: str | None = None
+    subject: str | None = None
+    message_summary: str | None = None
+    outcome: str | None = None
+    next_step: str | None = None
+    due_date: date | None = None
+    status: str | None = None
+
+
+class LocalTrainingRegistrationUpsertRequest(BaseModel):
+    env_id: str
+    business_id: UUID
+    event_id: UUID
+    contact_id: UUID
+    registration_date: datetime | None = None
+    ticket_type: str | None = None
+    price_paid: Decimal | None = None
+    payment_status: str | None = None
+    attended_flag: bool = False
+    checked_in_time: datetime | None = None
+    source_channel: str | None = None
+    referral_source: str | None = None
+    follow_up_status: str | None = None
+    feedback_score: int | None = None
+    feedback_notes: str | None = None
+    walk_in_flag: bool = False
+
+
+class LocalTrainingCheckInRequest(BaseModel):
+    attended_flag: bool = True
+
+
+class LocalTrainingTaskStatusRequest(BaseModel):
+    status: str = Field(pattern=r"^(open|in_progress|done)$")

--- a/backend/app/services/local_training_crm.py
+++ b/backend/app/services/local_training_crm.py
@@ -1,0 +1,1031 @@
+"""Local training CRM service for Novendor's in-person AI classes."""
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import date, datetime, time, timedelta, timezone
+from decimal import Decimal
+import random
+from typing import Any
+from uuid import UUID
+
+from app.db import get_cursor
+from app.services.reporting_common import normalize_key, resolve_tenant_id
+
+OWNER_NAME = "Paul @ Novendor"
+INSTRUCTOR_NAME = "Paul M."
+BASE_DATE = date(2026, 3, 22)
+
+FIRST_NAMES = [
+    "Maria", "Linda", "James", "Patricia", "Carlos", "Susan", "Robert", "Elaine", "Michael", "Carol",
+    "David", "Sandra", "Lisa", "Thomas", "Donna", "Richard", "Barbara", "Diane", "Anthony", "Janet",
+    "Nancy", "George", "Deborah", "Ronald", "Sharon", "Karen", "Edward", "Carmen", "Denise", "Ana",
+]
+LAST_NAMES = [
+    "Rivera", "Martinez", "Goldberg", "Johnson", "Lopez", "Schultz", "Fernandez", "Harris", "Morrison", "Kaplan",
+    "Diaz", "Bennett", "Perez", "Howard", "Torres", "Rodriguez", "Sanchez", "Miller", "Williams", "Brooks",
+]
+CITIES = ["Lake Worth Beach", "West Palm Beach", "Boynton Beach", "Palm Springs", "Greenacres", "Lantana"]
+PERSONAS = [
+    ("curious beginner", "community learners", "everyday AI basics", "medium"),
+    ("retiree", "older adults", "phone confidence", "high"),
+    ("older adult non-technical", "older adults", "avoiding scams", "high"),
+    ("small business owner", "local business owners", "marketing and admin", "medium"),
+    ("real estate professional", "real estate", "listing support", "medium"),
+    ("repeat attendee", "repeat learners", "prompt practice", "high"),
+    ("partner / referral source", "partners", "community co-hosting", "medium"),
+]
+LEAD_SOURCES = ["facebook", "library", "nextdoor", "friend", "walk-in", "chamber", "senior center", "flyer"]
+INTERESTS = ["AI basics", "photo editing", "travel planning", "small business marketing", "real estate workflow", "scam safety"]
+STATUSES = ["new", "invited", "registered", "attended", "nurture"]
+CONTACT_METHODS = ["email", "phone", "text"]
+TAGS = [
+    ["lake-worth", "beginner"],
+    ["older-adult", "needs-phone-help"],
+    ["business-owner", "follow-up"],
+    ["real-estate", "partner-list"],
+    ["repeat-interest", "warm"],
+]
+
+ORGS = [
+    {"name": "Lake Worth Beach Public Library", "type": "library", "city": "Lake Worth Beach", "state": "FL", "website": "https://library.lakeworthbeachfl.gov", "phone": "561-555-1200", "relationship": "community partner", "status": "outreach_in_progress", "account_type": "partner"},
+    {"name": "Mandel Neighborhood Learning Hub", "type": "library", "city": "West Palm Beach", "state": "FL", "website": "https://mandelhub.org", "phone": "561-555-1201", "relationship": "venue partner", "status": "qualified", "account_type": "partner"},
+    {"name": "Lake Worth Senior Connection", "type": "senior center", "city": "Lake Worth Beach", "state": "FL", "website": "https://lwseniorconnection.org", "phone": "561-555-1202", "relationship": "referral source", "status": "qualified", "account_type": "partner"},
+    {"name": "West Palm Small Business Circle", "type": "small local business association", "city": "West Palm Beach", "state": "FL", "website": "https://wpsbcircle.org", "phone": "561-555-1203", "relationship": "audience growth", "status": "researching", "account_type": "partner"},
+    {"name": "Palm Beach Real Estate Network", "type": "community group", "city": "West Palm Beach", "state": "FL", "website": "https://pbrealestate.network", "phone": "561-555-1204", "relationship": "business audience", "status": "contacted", "account_type": "partner"},
+    {"name": "The Banyan Cowork Lounge", "type": "coworking space", "city": "West Palm Beach", "state": "FL", "website": "https://banyancowork.com", "phone": "561-555-1205", "relationship": "venue pipeline", "status": "qualified", "account_type": "vendor"},
+    {"name": "Lucerne Community Café", "type": "local business", "city": "Lake Worth Beach", "state": "FL", "website": "https://lucernecafe.co", "phone": "561-555-1206", "relationship": "flyer drop + venue", "status": "contacted", "account_type": "partner"},
+    {"name": "Palm Beach Daily Bulletin", "type": "media outlet", "city": "West Palm Beach", "state": "FL", "website": "https://pbdailybulletin.com", "phone": "561-555-1207", "relationship": "earned media", "status": "researching", "account_type": "partner"},
+    {"name": "South Florida Lifelong Learning Circle", "type": "community group", "city": "Palm Springs", "state": "FL", "website": "https://sflifelong.org", "phone": "561-555-1208", "relationship": "older adult referrals", "status": "qualified", "account_type": "partner"},
+    {"name": "Lake Ave Chamber Collective", "type": "chamber", "city": "Lake Worth Beach", "state": "FL", "website": "https://lakeavechamber.org", "phone": "561-555-1209", "relationship": "business partnerships", "status": "contacted", "account_type": "partner"},
+    {"name": "Coastal Community Center", "type": "community group", "city": "Boynton Beach", "state": "FL", "website": "https://coastalccenter.org", "phone": "561-555-1210", "relationship": "backup venue", "status": "researching", "account_type": "partner"},
+    {"name": "Sunrise Sponsor Partners", "type": "sponsor", "city": "West Palm Beach", "state": "FL", "website": "https://sunrisesponsorpartners.com", "phone": "561-555-1211", "relationship": "future sponsor", "status": "researching", "account_type": "partner"},
+]
+
+VENUES = [
+    {"venue_name": "Lake Worth Library Community Room", "org": "Lake Worth Beach Public Library", "address": "15 N M St", "city": "Lake Worth Beach", "state": "FL", "zip": "33460", "capacity_min": 18, "capacity_max": 42, "wifi": "strong", "av": True, "hourly": 45, "deposit": False, "status": "preferred", "preferred_for": "intro class"},
+    {"venue_name": "Mandel Hub Workshop Studio", "org": "Mandel Neighborhood Learning Hub", "address": "402 Clematis St", "city": "West Palm Beach", "state": "FL", "zip": "33401", "capacity_min": 20, "capacity_max": 55, "wifi": "excellent", "av": True, "hourly": 65, "deposit": True, "status": "preferred", "preferred_for": "hands-on workshop"},
+    {"venue_name": "Senior Connection Tech Lounge", "org": "Lake Worth Senior Connection", "address": "728 Lucerne Ave", "city": "Lake Worth Beach", "state": "FL", "zip": "33460", "capacity_min": 12, "capacity_max": 28, "wifi": "good", "av": True, "hourly": 25, "deposit": False, "status": "qualified", "preferred_for": "intro class"},
+    {"venue_name": "Banyan Cowork Event Loft", "org": "The Banyan Cowork Lounge", "address": "625 Evernia St", "city": "West Palm Beach", "state": "FL", "zip": "33401", "capacity_min": 25, "capacity_max": 70, "wifi": "excellent", "av": True, "hourly": 95, "deposit": True, "status": "qualified", "preferred_for": "business-focused session"},
+    {"venue_name": "Lucerne Café Back Room", "org": "Lucerne Community Café", "address": "522 Lake Ave", "city": "Lake Worth Beach", "state": "FL", "zip": "33460", "capacity_min": 10, "capacity_max": 22, "wifi": "fair", "av": False, "hourly": 20, "deposit": False, "status": "researching", "preferred_for": "community talk"},
+    {"venue_name": "Coastal Community Hall", "org": "Coastal Community Center", "address": "1901 Ocean Ave", "city": "Boynton Beach", "state": "FL", "zip": "33426", "capacity_min": 20, "capacity_max": 80, "wifi": "good", "av": True, "hourly": 55, "deposit": True, "status": "contacted", "preferred_for": "partner session"},
+    {"venue_name": "Lake Ave Chamber Meeting Room", "org": "Lake Ave Chamber Collective", "address": "203 Lake Ave", "city": "Lake Worth Beach", "state": "FL", "zip": "33460", "capacity_min": 16, "capacity_max": 34, "wifi": "good", "av": True, "hourly": 35, "deposit": False, "status": "contacted", "preferred_for": "business-focused session"},
+    {"venue_name": "South Florida Learning Commons", "org": "South Florida Lifelong Learning Circle", "address": "410 Cypress Ln", "city": "Palm Springs", "state": "FL", "zip": "33461", "capacity_min": 15, "capacity_max": 36, "wifi": "strong", "av": True, "hourly": 30, "deposit": False, "status": "qualified", "preferred_for": "intro class"},
+    {"venue_name": "Clematis Classroom Annex", "org": "Mandel Neighborhood Learning Hub", "address": "421 Datura St", "city": "West Palm Beach", "state": "FL", "zip": "33401", "capacity_min": 14, "capacity_max": 30, "wifi": "excellent", "av": True, "hourly": 48, "deposit": False, "status": "preferred", "preferred_for": "community talk"},
+    {"venue_name": "WPB Garden Club Hall", "org": "West Palm Small Business Circle", "address": "209 S Olive Ave", "city": "West Palm Beach", "state": "FL", "zip": "33401", "capacity_min": 20, "capacity_max": 48, "wifi": "good", "av": True, "hourly": 52, "deposit": True, "status": "researching", "preferred_for": "hands-on workshop"},
+]
+
+EVENTS = [
+    {"name": "AI Basics for Everyday Life — Lake Worth", "series": "Novendor AI Basics", "type": "intro class", "status": "completed", "date": date(2026, 2, 19), "start": time(10, 0), "end": time(12, 0), "venue": "Lake Worth Library Community Room", "city": "Lake Worth Beach", "capacity": 28, "theme": "Everyday prompts, travel, recipes, and scam safety", "level": "beginner", "instructor": INSTRUCTOR_NAME, "assistants": 1, "standard": 25, "early": 20, "follow_up": True, "check_in_status": "closed", "outcome": "Strong word-of-mouth response from older adults; three people asked for a follow-up workshop."},
+    {"name": "AI Made Simple for Beginners — West Palm Beach", "series": "Novendor AI Basics", "type": "community talk", "status": "completed", "date": date(2026, 3, 12), "start": time(18, 0), "end": time(19, 30), "venue": "Mandel Hub Workshop Studio", "city": "West Palm Beach", "capacity": 40, "theme": "Plain-English intro to chatbots and practical uses", "level": "beginner", "instructor": INSTRUCTOR_NAME, "assistants": 2, "standard": 30, "early": 25, "follow_up": True, "check_in_status": "closed", "outcome": "Best attendance so far. Chamber and library referrals converted well."},
+    {"name": "Bring Your Laptop AI Workshop — Lake Worth", "series": "Novendor Hands-On", "type": "hands-on workshop", "status": "scheduled", "date": date(2026, 4, 16), "start": time(10, 0), "end": time(12, 30), "venue": "Lake Worth Library Community Room", "city": "Lake Worth Beach", "capacity": 24, "theme": "Guided prompt practice for email, photos, and planning", "level": "beginner", "instructor": INSTRUCTOR_NAME, "assistants": 2, "standard": 35, "early": 29, "follow_up": False, "check_in_status": "not_started", "outcome": None},
+    {"name": "AI for Small Business Basics — West Palm Beach", "series": "Novendor Business Track", "type": "business-focused session", "status": "scheduled", "date": date(2026, 5, 14), "start": time(18, 0), "end": time(20, 0), "venue": "Banyan Cowork Event Loft", "city": "West Palm Beach", "capacity": 38, "theme": "Simple AI workflows for marketing, admin, and customer follow-up", "level": "mixed", "instructor": INSTRUCTOR_NAME, "assistants": 1, "standard": 45, "early": 35, "follow_up": False, "check_in_status": "not_started", "outcome": None},
+    {"name": "Intro to AI for Adults 55+ — South Florida", "series": "Novendor Community Access", "type": "partner session", "status": "scheduled", "date": date(2026, 6, 11), "start": time(10, 30), "end": time(12, 0), "venue": "Senior Connection Tech Lounge", "city": "Lake Worth Beach", "capacity": 26, "theme": "Confidence-building AI intro with phone-friendly examples", "level": "beginner", "instructor": INSTRUCTOR_NAME, "assistants": 2, "standard": 25, "early": 20, "follow_up": False, "check_in_status": "not_started", "outcome": None},
+]
+
+CAMPAIGNS = [
+    {"name": "Initial direct outreach", "channel": "direct outreach", "audience": "warm leads + personal referrals", "launch": date(2026, 2, 1), "end": date(2026, 2, 18), "budget": 0, "event": "AI Basics for Everyday Life — Lake Worth", "angle": "Friendly introduction for complete beginners", "status": "completed", "leads": 11, "regs": 8},
+    {"name": "Facebook local event push", "channel": "facebook", "audience": "Lake Worth + WPB local groups", "launch": date(2026, 3, 1), "end": date(2026, 3, 11), "budget": 85, "event": "AI Made Simple for Beginners — West Palm Beach", "angle": "Practical everyday uses without jargon", "status": "completed", "leads": 16, "regs": 9},
+    {"name": "LinkedIn soft launch", "channel": "linkedin", "audience": "local professionals + real estate", "launch": date(2026, 3, 25), "end": date(2026, 4, 14), "budget": 40, "event": "Bring Your Laptop AI Workshop — Lake Worth", "angle": "Hands-on class for people who learn by doing", "status": "active", "leads": 9, "regs": 4},
+    {"name": "Library / senior center partner outreach", "channel": "local partners", "audience": "libraries, senior centers, community groups", "launch": date(2026, 3, 20), "end": date(2026, 5, 30), "budget": 0, "event": "Intro to AI for Adults 55+ — South Florida", "angle": "Accessible, low-pressure class for older adults", "status": "active", "leads": 14, "regs": 6},
+    {"name": "Flyer + café bulletin boards", "channel": "flyer", "audience": "walk-by neighborhood traffic", "launch": date(2026, 3, 29), "end": date(2026, 4, 15), "budget": 32, "event": "Bring Your Laptop AI Workshop — Lake Worth", "angle": "Bring your own device and leave with practical wins", "status": "active", "leads": 7, "regs": 3},
+    {"name": "Follow-up for first event attendees", "channel": "email", "audience": "repeat attendee candidates", "launch": date(2026, 3, 15), "end": date(2026, 4, 20), "budget": 0, "event": "Bring Your Laptop AI Workshop — Lake Worth", "angle": "You liked the intro, now practice on your own device", "status": "active", "leads": 6, "regs": 5},
+]
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    return Decimal(str(value))
+
+
+def _choose_tag(index: int) -> list[str]:
+    return TAGS[index % len(TAGS)]
+
+
+def _refresh_event_counts(cur, event_id: str) -> None:
+    cur.execute(
+        """
+        SELECT COUNT(*) AS regs,
+               COUNT(*) FILTER (WHERE attended_flag) AS attended
+        FROM nv_event_registration
+        WHERE event_id = %s
+        """,
+        (event_id,),
+    )
+    row = cur.fetchone() or {"regs": 0, "attended": 0}
+    cur.execute(
+        """
+        UPDATE nv_training_event
+        SET actual_registrations = %s,
+            actual_attendance = %s,
+            updated_at = now()
+        WHERE id = %s
+        """,
+        (row["regs"], row["attended"], event_id),
+    )
+
+
+def _refresh_contact_attendance(cur, contact_id: str) -> None:
+    cur.execute(
+        """
+        SELECT r.event_id, r.checked_in_time, e.event_date
+        FROM nv_event_registration r
+        JOIN nv_training_event e ON e.id = r.event_id
+        WHERE r.crm_contact_id = %s AND r.attended_flag = true
+        ORDER BY event_date ASC
+        """,
+        (contact_id,),
+    )
+    rows = cur.fetchall()
+    first_event_id = rows[0]["event_id"] if rows else None
+    total = len(rows)
+    cur.execute(
+        """
+        UPDATE nv_contact_profile
+        SET first_event_attended_id = %s,
+            total_events_attended = %s,
+            updated_at = now()
+        WHERE crm_contact_id = %s
+        """,
+        (first_event_id, total, contact_id),
+    )
+
+
+def _activity_subject(activity_type: str, target: str) -> str:
+    return {
+        "dm sent": f"Direct invite to {target}",
+        "email sent": f"Email invite for {target}",
+        "call made": f"Phone call about {target}",
+        "flyer drop": f"Flyer drop for {target}",
+        "partnership outreach": f"Partner outreach for {target}",
+        "follow-up sent": f"Follow-up for {target}",
+        "invite sent": f"Invite sent for {target}",
+        "reminder sent": f"Reminder for {target}",
+        "testimonial requested": f"Testimonial request for {target}",
+    }.get(activity_type, target)
+
+
+def seed_local_training_workspace(*, env_id: str, business_id: UUID) -> dict[str, Any]:
+    counts = {
+        "contacts_seeded": 0,
+        "organizations_seeded": 0,
+        "venues_seeded": 0,
+        "events_seeded": 0,
+        "campaigns_seeded": 0,
+        "activities_seeded": 0,
+        "tasks_seeded": 0,
+        "registrations_seeded": 0,
+        "feedback_seeded": 0,
+    }
+    rng = random.Random(20260322)
+
+    with get_cursor() as cur:
+        tenant_id = resolve_tenant_id(cur, business_id)
+        cur.execute("SELECT COUNT(*) AS cnt FROM nv_contact_profile WHERE env_id = %s AND business_id = %s", (env_id, str(business_id)))
+        if (cur.fetchone() or {"cnt": 0})["cnt"] > 0:
+            return {"status": "already_seeded", **counts}
+
+        org_ids: dict[str, str] = {}
+        org_contact_ids: list[str] = []
+        for idx, org in enumerate(ORGS):
+            cur.execute(
+                """
+                INSERT INTO crm_account (tenant_id, business_id, external_key, name, account_type, industry, website)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id, business_id, name) DO UPDATE SET website = EXCLUDED.website
+                RETURNING crm_account_id
+                """,
+                (tenant_id, str(business_id), normalize_key(org["name"]), org["name"], org["account_type"], org["type"], org["website"]),
+            )
+            account_id = str(cur.fetchone()["crm_account_id"])
+            org_ids[org["name"]] = account_id
+            cur.execute(
+                """
+                INSERT INTO crm_contact (tenant_id, business_id, crm_account_id, full_name, email, phone, title)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                RETURNING crm_contact_id
+                """,
+                (
+                    tenant_id,
+                    str(business_id),
+                    account_id,
+                    f"{['Megan','Robert','Cynthia','Steven','Laura','Derek','Angela','Martin','Rosa','Kevin','Janice','Victor'][idx]} {['Cole','Nunez','Baker','Phelps','Moreno','Grant','Ellis','Diaz','Vega','Ross','Foster','Mendez'][idx]}",
+                    f"contact{idx+1}@novendor-local.org",
+                    org["phone"],
+                    "Community contact",
+                ),
+            )
+            owner_contact_id = str(cur.fetchone()["crm_contact_id"])
+            org_contact_ids.append(owner_contact_id)
+            cur.execute(
+                """
+                INSERT INTO nv_organization_profile (
+                  crm_account_id, env_id, business_id, organization_name, organization_type,
+                  phone, city, state, relationship_type, partner_status, notes, owner_contact_id
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    account_id, env_id, str(business_id), org["name"], org["type"], org["phone"], org["city"], org["state"],
+                    org["relationship"], org["status"], f"Seeded local partner profile for {org['name']}.", owner_contact_id,
+                ),
+            )
+            counts["organizations_seeded"] += 1
+
+        venue_ids: dict[str, str] = {}
+        for venue in VENUES:
+            cur.execute(
+                """
+                INSERT INTO nv_venue (
+                  env_id, business_id, organization_account_id, venue_name, address, city, state, zip,
+                  website, contact_name, contact_email, contact_phone, capacity_min, capacity_max,
+                  wifi_quality, av_available, parking_notes, accessibility_notes, hourly_cost,
+                  deposit_required, preferred_for_event_type, venue_status, is_preferred, notes
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING id
+                """,
+                (
+                    env_id, str(business_id), org_ids[venue["org"]], venue["venue_name"], venue["address"], venue["city"], venue["state"], venue["zip"],
+                    f"https://{normalize_key(venue['venue_name'])}.local", venue["venue_name"].split()[0] + " contact", f"{normalize_key(venue['venue_name'])}@venues.local",
+                    "561-555-2000", venue["capacity_min"], venue["capacity_max"], venue["wifi"], venue["av"],
+                    "Public lot nearby" if venue["city"] == "West Palm Beach" else "Street parking nearby",
+                    "Wheelchair accessible, good front-row visibility", str(venue["hourly"]), venue["deposit"],
+                    venue["preferred_for"], venue["status"], venue["status"] == "preferred",
+                    f"Best for {venue['preferred_for']} with {venue['wifi']} wifi.",
+                ),
+            )
+            venue_ids[venue["venue_name"]] = str(cur.fetchone()["id"])
+            counts["venues_seeded"] += 1
+
+        event_ids: dict[str, str] = {}
+        for event in EVENTS:
+            cur.execute(
+                """
+                INSERT INTO nv_training_event (
+                  env_id, business_id, event_name, event_series, event_type, event_status, event_date,
+                  event_start_time, event_end_time, venue_id, city, target_capacity,
+                  ticket_price_standard, ticket_price_early, event_theme, audience_level,
+                  instructor, assistant_count, registration_link, check_in_status,
+                  follow_up_sent_flag, notes, outcome_summary
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING id
+                """,
+                (
+                    env_id, str(business_id), event["name"], event["series"], event["type"], event["status"], event["date"].isoformat(),
+                    event["start"].isoformat(), event["end"].isoformat(), venue_ids[event["venue"]], event["city"], event["capacity"],
+                    str(event["standard"]), str(event["early"]), event["theme"], event["level"], event["instructor"], event["assistants"],
+                    f"https://events.novendor.co/{normalize_key(event['name'])}", event["check_in_status"], event["follow_up"],
+                    f"Seeded operational note for {event['name']}", event["outcome"],
+                ),
+            )
+            event_ids[event["name"]] = str(cur.fetchone()["id"])
+            counts["events_seeded"] += 1
+
+        campaign_ids: dict[str, str] = {}
+        for campaign in CAMPAIGNS:
+            cur.execute(
+                """
+                INSERT INTO nv_campaign (
+                  env_id, business_id, campaign_name, channel, audience, launch_date, end_date,
+                  budget, target_event_id, message_angle, status, leads_generated,
+                  registrations_generated, notes
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING id
+                """,
+                (
+                    env_id, str(business_id), campaign["name"], campaign["channel"], campaign["audience"], campaign["launch"].isoformat(),
+                    campaign["end"].isoformat(), str(campaign["budget"]), event_ids[campaign["event"]], campaign["angle"],
+                    campaign["status"], campaign["leads"], campaign["regs"], f"Seeded campaign for {campaign['event']}.",
+                ),
+            )
+            campaign_ids[campaign["name"]] = str(cur.fetchone()["id"])
+            counts["campaigns_seeded"] += 1
+
+        contact_ids: list[str] = []
+        for idx in range(64):
+            first = FIRST_NAMES[idx % len(FIRST_NAMES)]
+            last = LAST_NAMES[(idx * 3) % len(LAST_NAMES)]
+            full_name = f"{first} {last}"
+            persona, segment, interest, priority = PERSONAS[idx % len(PERSONAS)]
+            city = CITIES[idx % len(CITIES)]
+            tags = _choose_tag(idx)
+            org_id = None
+            company_text = None
+            if persona in {"partner / referral source", "small business owner", "real estate professional"}:
+                org_pick = ORGS[idx % len(ORGS)]["name"]
+                org_id = org_ids[org_pick] if persona == "partner / referral source" else None
+                if persona != "partner / referral source":
+                    company_text = [
+                        "Palm Beach Home Concierge", "Lake Ave Bookkeeping", "Sunset Realty Desk",
+                        "Coastal Closings", "Neighborhood Travel Club", "Lucerne Wellness Studio",
+                    ][idx % 6]
+            cur.execute(
+                """
+                INSERT INTO crm_contact (
+                  tenant_id, business_id, crm_account_id, first_name, last_name, full_name, email, phone, title
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING crm_contact_id
+                """,
+                (
+                    tenant_id,
+                    str(business_id),
+                    org_id,
+                    first,
+                    last,
+                    full_name,
+                    f"{normalize_key(first)}.{normalize_key(last)}{idx+1}@example.com",
+                    f"561-555-{3000 + idx:04d}",
+                    "Community member" if not company_text else "Owner",
+                ),
+            )
+            contact_id = str(cur.fetchone()["crm_contact_id"])
+            contact_ids.append(contact_id)
+            cur.execute(
+                """
+                INSERT INTO nv_contact_profile (
+                  crm_contact_id, env_id, business_id, preferred_contact_method, city, age_band,
+                  persona_type, audience_segment, business_owner_flag, company_name_text, notes,
+                  lead_source, status, consent_to_email, interest_area, follow_up_priority, tags
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    contact_id,
+                    env_id,
+                    str(business_id),
+                    CONTACT_METHODS[idx % len(CONTACT_METHODS)],
+                    city,
+                    ["45-54", "55-64", "65-74", "75+"][idx % 4],
+                    persona,
+                    segment,
+                    persona in {"small business owner", "real estate professional"},
+                    company_text,
+                    f"Prefers plain-English examples. Interested in {interest.lower()}.",
+                    LEAD_SOURCES[idx % len(LEAD_SOURCES)],
+                    STATUSES[idx % len(STATUSES)],
+                    idx % 5 != 0,
+                    interest,
+                    priority,
+                    tags,
+                ),
+            )
+            counts["contacts_seeded"] += 1
+
+        registration_rows: list[tuple[str, str, dict[str, Any]]] = []
+        event_rotation = [EVENTS[0], EVENTS[1], EVENTS[2], EVENTS[3], EVENTS[4]]
+        for idx, contact_id in enumerate(contact_ids[:28]):
+            event = event_rotation[idx % len(event_rotation)]
+            event_id = event_ids[event["name"]]
+            attended = event["status"] == "completed" and idx % 4 != 0
+            checked_time = datetime.combine(event["date"], event["start"], tzinfo=timezone.utc) + timedelta(minutes=5 + idx)
+            price = event["early"] if idx % 3 == 0 else event["standard"]
+            cur.execute(
+                """
+                INSERT INTO nv_event_registration (
+                  env_id, business_id, event_id, crm_contact_id, registration_date, ticket_type,
+                  price_paid, payment_status, attended_flag, checked_in_time, source_channel,
+                  referral_source, follow_up_status, feedback_score, feedback_notes, walk_in_flag
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING id
+                """,
+                (
+                    env_id,
+                    str(business_id),
+                    event_id,
+                    contact_id,
+                    datetime.combine(event["date"] - timedelta(days=7 + (idx % 5)), time(12, 0), tzinfo=timezone.utc).isoformat(),
+                    "early bird" if idx % 3 == 0 else "standard",
+                    str(price),
+                    "paid" if idx % 7 != 0 else "pending",
+                    attended,
+                    checked_time.isoformat() if attended else None,
+                    ["facebook", "word of mouth", "local partners", "eventbrite", "flyer"][idx % 5],
+                    ["library", "friend", "facebook group", "chamber", "senior center"][idx % 5],
+                    "done" if attended else ("queued" if event["status"] == "completed" else "not_started"),
+                    5 - (idx % 2) if attended else None,
+                    "Stayed after class to ask about phone prompts." if attended and idx % 5 == 0 else None,
+                    idx % 11 == 0,
+                ),
+            )
+            registration_rows.append((cur.fetchone()["id"], contact_id, event))
+            counts["registrations_seeded"] += 1
+
+        for event_name, event_id in event_ids.items():
+            _refresh_event_counts(cur, event_id)
+
+        for contact_id in contact_ids:
+            _refresh_contact_attendance(cur, contact_id)
+
+        for idx, (registration_id, contact_id, event) in enumerate(registration_rows[:12]):
+            if event["status"] != "completed":
+                continue
+            event_id = event_ids[event["name"]]
+            cur.execute(
+                """
+                INSERT INTO nv_event_feedback (
+                  env_id, business_id, event_id, crm_contact_id, rating,
+                  what_they_found_useful, what_was_confusing, would_attend_again,
+                  would_bring_friend, testimonial_permission, testimonial_text
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (event_id, crm_contact_id) DO NOTHING
+                """,
+                (
+                    env_id,
+                    str(business_id),
+                    event_id,
+                    contact_id,
+                    5 if idx % 3 else 4,
+                    [
+                        "Seeing real examples for travel, recipes, and family photos.",
+                        "Step-by-step prompts I can reuse at home.",
+                        "Understanding what AI can and cannot do safely.",
+                    ][idx % 3],
+                    [
+                        "I still need help switching between apps on my phone.",
+                        "Would like a slower section on copy/paste.",
+                        "Need a printed cheat sheet for prompts.",
+                    ][idx % 3],
+                    True,
+                    idx % 4 != 0,
+                    idx % 2 == 0,
+                    [
+                        "This was the first AI class that actually felt approachable.",
+                        "I came in nervous and left feeling like I can practice at home.",
+                        "Very clear, very patient, and useful right away.",
+                    ][idx % 3] if idx % 2 == 0 else None,
+                ),
+            )
+            counts["feedback_seeded"] += 1
+
+        activity_types = [
+            "dm sent", "email sent", "call made", "flyer drop", "partnership outreach",
+            "follow-up sent", "invite sent", "reminder sent", "testimonial requested",
+        ]
+        activity_channels = ["facebook", "email", "phone", "in_person", "local partners"]
+        for idx in range(82):
+            activity_type = activity_types[idx % len(activity_types)]
+            contact_id = contact_ids[idx % len(contact_ids)] if idx % 5 != 0 else None
+            org_name = ORGS[idx % len(ORGS)]["name"] if idx % 3 == 0 else None
+            account_id = org_ids.get(org_name) if org_name else None
+            event = EVENTS[idx % len(EVENTS)]
+            event_id = event_ids[event["name"]]
+            campaign_id = campaign_ids[CAMPAIGNS[idx % len(CAMPAIGNS)]["name"]]
+            activity_at = datetime.combine(BASE_DATE - timedelta(days=idx % 36), time(9 + (idx % 8), 15), tzinfo=timezone.utc)
+            crm_activity_id = None
+            if contact_id or account_id:
+                cur.execute(
+                    """
+                    INSERT INTO crm_activity (
+                      tenant_id, business_id, crm_account_id, crm_contact_id, activity_type,
+                      subject, activity_at, payload_json
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, '{}'::jsonb)
+                    RETURNING crm_activity_id
+                    """,
+                    (
+                        tenant_id,
+                        str(business_id),
+                        account_id,
+                        contact_id,
+                        "meeting" if activity_type in {"call made", "partnership outreach"} else "email",
+                        _activity_subject(activity_type, event["name"]),
+                        activity_at.isoformat(),
+                    ),
+                )
+                crm_activity_id = str(cur.fetchone()["crm_activity_id"])
+            cur.execute(
+                """
+                INSERT INTO nv_training_outreach_activity (
+                  crm_activity_id, env_id, business_id, activity_type, crm_contact_id, crm_account_id,
+                  event_id, campaign_id, owner, activity_date, channel, subject, message_summary,
+                  outcome, next_step, due_date, status
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    crm_activity_id,
+                    env_id,
+                    str(business_id),
+                    activity_type,
+                    contact_id,
+                    account_id,
+                    event_id,
+                    campaign_id,
+                    OWNER_NAME,
+                    activity_at.isoformat(),
+                    activity_channels[idx % len(activity_channels)],
+                    _activity_subject(activity_type, event["name"]),
+                    f"Seeded {activity_type} touch tied to {event['name']}.",
+                    ["positive response", "no reply yet", "asked for details", "left voicemail", "pending"][idx % 5],
+                    ["send reminder", "schedule call", "drop flyer", "confirm venue details", "add to nurture"][idx % 5],
+                    (BASE_DATE + timedelta(days=idx % 12)).isoformat(),
+                    "done" if idx % 4 != 0 else "open",
+                ),
+            )
+            counts["activities_seeded"] += 1
+
+        task_templates = [
+            ("Confirm Wi-Fi details", "venue", "high"),
+            ("Post reminder to Facebook groups", "campaign", "medium"),
+            ("Call no-show attendees", "event", "high"),
+            ("Request testimonial from top attendees", "event", "medium"),
+            ("Drop flyers at partner locations", "campaign", "medium"),
+            ("Check Eventbrite reconciliation", "event", "high"),
+            ("Review venue cost comparison", "venue", "medium"),
+            ("Send chamber follow-up", "organization", "medium"),
+        ]
+        related_map = {
+            "venue": list(venue_ids.values()),
+            "campaign": list(campaign_ids.values()),
+            "event": list(event_ids.values()),
+            "organization": list(org_ids.values()),
+        }
+        for idx in range(32):
+            name, entity_type, priority = task_templates[idx % len(task_templates)]
+            cur.execute(
+                """
+                INSERT INTO nv_task (
+                  env_id, business_id, task_name, related_entity_type, related_entity_id,
+                  assigned_to, priority, due_date, status, mobile_quick_action_flag, notes
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    env_id,
+                    str(business_id),
+                    f"{name} #{idx + 1}",
+                    entity_type,
+                    related_map[entity_type][idx % len(related_map[entity_type])],
+                    OWNER_NAME,
+                    priority,
+                    (BASE_DATE + timedelta(days=(idx % 10) - 2)).isoformat(),
+                    "done" if idx % 6 == 0 else ("in_progress" if idx % 5 == 0 else "open"),
+                    idx % 3 != 0,
+                    "Seeded checklist task for live event operations.",
+                ),
+            )
+            counts["tasks_seeded"] += 1
+
+    return {"status": "seeded", **counts}
+
+
+def _rows(cur, sql: str, params: tuple[Any, ...]) -> list[dict[str, Any]]:
+    cur.execute(sql, params)
+    return [dict(row) for row in cur.fetchall()]
+
+
+def get_workspace(*, env_id: str, business_id: UUID) -> dict[str, Any]:
+    with get_cursor() as cur:
+        contacts = _rows(cur, """
+            SELECT c.crm_contact_id, c.first_name, c.last_name, c.full_name, c.email, c.phone,
+                   c.title, c.crm_account_id, a.name AS organization_name,
+                   p.preferred_contact_method, p.city, p.age_band, p.persona_type, p.audience_segment,
+                   p.business_owner_flag, p.company_name_text, p.notes, p.lead_source, p.status,
+                   p.consent_to_email, p.first_event_attended_id, p.total_events_attended,
+                   p.interest_area, p.follow_up_priority, p.tags, c.created_at, p.updated_at
+            FROM crm_contact c
+            JOIN nv_contact_profile p ON p.crm_contact_id = c.crm_contact_id
+            LEFT JOIN crm_account a ON a.crm_account_id = c.crm_account_id
+            WHERE p.env_id = %s AND p.business_id = %s
+            ORDER BY c.created_at DESC, c.full_name ASC
+        """, (env_id, str(business_id)))
+
+        organizations = _rows(cur, """
+            SELECT o.crm_account_id, o.organization_name, o.organization_type, a.website, o.phone,
+                   o.city, o.state, o.relationship_type, o.partner_status, o.notes, o.owner_contact_id,
+                   c.full_name AS owner_contact_name, c.email AS owner_contact_email
+            FROM nv_organization_profile o
+            JOIN crm_account a ON a.crm_account_id = o.crm_account_id
+            LEFT JOIN crm_contact c ON c.crm_contact_id = o.owner_contact_id
+            WHERE o.env_id = %s AND o.business_id = %s
+            ORDER BY o.organization_type, o.organization_name
+        """, (env_id, str(business_id)))
+
+        venues = _rows(cur, """
+            SELECT v.id, v.organization_account_id AS linked_organization_id, v.venue_name, v.address,
+                   v.city, v.state, v.zip, v.website, v.contact_name, v.contact_email, v.contact_phone,
+                   v.capacity_min, v.capacity_max, v.wifi_quality, v.av_available, v.parking_notes,
+                   v.accessibility_notes, v.hourly_cost, v.deposit_required, v.preferred_for_event_type,
+                   v.venue_status, v.is_preferred, v.notes, o.organization_name AS linked_organization_name
+            FROM nv_venue v
+            LEFT JOIN nv_organization_profile o ON o.crm_account_id = v.organization_account_id
+            WHERE v.env_id = %s AND v.business_id = %s
+            ORDER BY v.is_preferred DESC, v.venue_status, v.city, v.venue_name
+        """, (env_id, str(business_id)))
+
+        events = _rows(cur, """
+            SELECT e.id, e.event_name, e.event_series, e.event_type, e.event_status, e.event_date,
+                   e.event_start_time, e.event_end_time, e.venue_id, e.city, e.target_capacity,
+                   e.actual_registrations, e.actual_attendance, e.ticket_price_standard,
+                   e.ticket_price_early, e.event_theme, e.audience_level, e.instructor,
+                   e.assistant_count, e.registration_link, e.check_in_status, e.follow_up_sent_flag,
+                   e.notes, e.outcome_summary, v.venue_name
+            FROM nv_training_event e
+            LEFT JOIN nv_venue v ON v.id = e.venue_id
+            WHERE e.env_id = %s AND e.business_id = %s
+            ORDER BY e.event_date ASC
+        """, (env_id, str(business_id)))
+
+        registrations = _rows(cur, """
+            SELECT r.id AS registration_id, r.event_id, r.crm_contact_id AS contact_id,
+                   r.registration_date, r.ticket_type, r.price_paid, r.payment_status,
+                   r.attended_flag, r.checked_in_time, r.source_channel, r.referral_source,
+                   r.follow_up_status, r.feedback_score, r.feedback_notes, r.walk_in_flag,
+                   c.full_name AS contact_name, c.email AS contact_email, c.phone AS contact_phone,
+                   e.event_name
+            FROM nv_event_registration r
+            JOIN crm_contact c ON c.crm_contact_id = r.crm_contact_id
+            JOIN nv_training_event e ON e.id = r.event_id
+            WHERE r.env_id = %s AND r.business_id = %s
+            ORDER BY e.event_date DESC, c.full_name ASC
+        """, (env_id, str(business_id)))
+
+        campaigns = _rows(cur, """
+            SELECT c.id, c.campaign_name, c.channel, c.audience, c.launch_date, c.end_date,
+                   c.budget, c.target_event_id, c.message_angle, c.status,
+                   c.leads_generated, c.registrations_generated, c.notes,
+                   e.event_name AS target_event_name
+            FROM nv_campaign c
+            LEFT JOIN nv_training_event e ON e.id = c.target_event_id
+            WHERE c.env_id = %s AND c.business_id = %s
+            ORDER BY c.launch_date DESC NULLS LAST, c.campaign_name
+        """, (env_id, str(business_id)))
+
+        activities = _rows(cur, """
+            SELECT a.id, a.activity_type, a.crm_contact_id AS contact_id, a.crm_account_id AS organization_id,
+                   a.event_id, a.campaign_id, a.owner, a.activity_date, a.channel, a.subject,
+                   a.message_summary, a.outcome, a.next_step, a.due_date, a.status,
+                   c.full_name AS contact_name,
+                   o.organization_name,
+                   e.event_name,
+                   cam.campaign_name
+            FROM nv_training_outreach_activity a
+            LEFT JOIN crm_contact c ON c.crm_contact_id = a.crm_contact_id
+            LEFT JOIN nv_organization_profile o ON o.crm_account_id = a.crm_account_id
+            LEFT JOIN nv_training_event e ON e.id = a.event_id
+            LEFT JOIN nv_campaign cam ON cam.id = a.campaign_id
+            WHERE a.env_id = %s AND a.business_id = %s
+            ORDER BY a.activity_date DESC
+        """, (env_id, str(business_id)))
+
+        tasks = _rows(cur, """
+            SELECT id, task_name, related_entity_type, related_entity_id, assigned_to,
+                   priority, due_date, status, mobile_quick_action_flag, notes,
+                   created_at, updated_at
+            FROM nv_task
+            WHERE env_id = %s AND business_id = %s
+            ORDER BY CASE priority WHEN 'high' THEN 0 WHEN 'medium' THEN 1 ELSE 2 END,
+                     due_date ASC NULLS LAST, created_at DESC
+        """, (env_id, str(business_id)))
+
+        feedback = _rows(cur, """
+            SELECT f.id, f.event_id, f.crm_contact_id AS contact_id, f.rating,
+                   f.what_they_found_useful, f.what_was_confusing, f.would_attend_again,
+                   f.would_bring_friend, f.testimonial_permission, f.testimonial_text,
+                   c.full_name AS contact_name, e.event_name
+            FROM nv_event_feedback f
+            JOIN crm_contact c ON c.crm_contact_id = f.crm_contact_id
+            JOIN nv_training_event e ON e.id = f.event_id
+            WHERE f.env_id = %s AND f.business_id = %s
+            ORDER BY f.created_at DESC
+        """, (env_id, str(business_id)))
+
+    by_event_regs: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in registrations:
+        by_event_regs[row["event_id"]].append(row)
+
+    next_event = next((event for event in events if event["event_date"] >= BASE_DATE.isoformat()), None)
+    today_tasks = [task for task in tasks if task["status"] != "done" and task.get("due_date") and task["due_date"] <= BASE_DATE.isoformat()]
+    outstanding_followups = [reg for reg in registrations if reg.get("follow_up_status") in {"queued", "not_started"}]
+    recent_regs = sorted(registrations, key=lambda row: row["registration_date"], reverse=True)[:5]
+    recent_activity = activities[:8]
+    contacts_added_month = sum(1 for contact in contacts if str(contact["created_at"])[:7] == BASE_DATE.strftime("%Y-%m"))
+
+    venue_status_counts = Counter(venue["venue_status"] for venue in venues)
+    partner_status_counts = Counter(org["partner_status"] for org in organizations)
+    campaign_performance = [
+        {
+            "campaign_name": row["campaign_name"],
+            "channel": row["channel"],
+            "target_event_name": row.get("target_event_name"),
+            "leads_generated": row["leads_generated"],
+            "registrations_generated": row["registrations_generated"],
+            "cost_per_registration": float(row["budget"] / row["registrations_generated"]) if row.get("budget") is not None and row.get("registrations_generated") else None,
+        }
+        for row in campaigns
+    ]
+    event_performance = []
+    for event in events:
+        regs = by_event_regs.get(event["id"], [])
+        repeat_attendance = sum(1 for reg in regs for contact in contacts if contact["crm_contact_id"] == reg["contact_id"] and contact["total_events_attended"] > 1)
+        avg_feedback = None
+        scores = [f["rating"] for f in feedback if f["event_id"] == event["id"] and f.get("rating") is not None]
+        if scores:
+            avg_feedback = round(sum(scores) / len(scores), 2)
+        event_performance.append({
+            "event_id": event["id"],
+            "event_name": event["event_name"],
+            "registrations": event["actual_registrations"],
+            "attendance": event["actual_attendance"],
+            "capacity_utilization": round((event["actual_registrations"] / event["target_capacity"]) * 100, 1) if event.get("target_capacity") else None,
+            "price_mix": {
+                "early_bird": sum(1 for reg in regs if reg.get("ticket_type") == "early bird"),
+                "standard": sum(1 for reg in regs if reg.get("ticket_type") != "early bird"),
+            },
+            "repeat_attendance": repeat_attendance,
+            "feedback_score": avg_feedback,
+            "channel_conversion": dict(Counter(reg.get("source_channel") or "unknown" for reg in regs)),
+        })
+
+    duplicate_emails = [email for email, count in Counter(contact.get("email") for contact in contacts if contact.get("email")).items() if count > 1]
+    orphan_registrations = [reg for reg in registrations if not any(event["id"] == reg["event_id"] for event in events)]
+    bad_statuses = [task for task in tasks if task["status"] not in {"open", "in_progress", "done"}]
+    mobile_issues = [
+        "Legacy consulting shell only exposed a desktop sidebar before this training CRM module.",
+        "Pipeline/outreach views were optimized for broader consulting workflows, not event-day phone usage.",
+        "No existing phone-first check-in, walk-in capture, or quick-complete task flow existed for local events.",
+    ]
+
+    return {
+        "inventory": {
+            "existing_objects": [
+                {"object": "crm_account", "purpose": "generic organizations/accounts", "usable_as_is": True, "action": "keep + extend"},
+                {"object": "crm_contact", "purpose": "canonical contacts", "usable_as_is": True, "action": "keep + extend"},
+                {"object": "crm_activity", "purpose": "generic activity timeline", "usable_as_is": True, "action": "keep + extend"},
+                {"object": "crm_pipeline_stage / crm_opportunity", "purpose": "generic sales pipeline", "usable_as_is": "partial", "action": "keep for generic CRM, not as event system"},
+                {"object": "cro_outreach_log / templates", "purpose": "consulting outreach tracking", "usable_as_is": "partial", "action": "keep for consulting surface, add event-focused activity model"},
+                {"object": "cro_client / cro_engagement / revenue", "purpose": "client delivery + revenue", "usable_as_is": False, "action": "deprecate for this use case"},
+                {"object": "nv_loop", "purpose": "loop intelligence", "usable_as_is": False, "action": "keep separate"},
+            ],
+            "duplicates_or_overlaps": [
+                "Organizations overlap conceptually with crm_account, so organization profiles extend accounts instead of creating a second account master.",
+                "Outreach touches overlap conceptually with crm_activity, so each training activity can optionally map back to a crm_activity receipt.",
+            ],
+            "missing_relationships_before_build": [
+                "No event-to-contact registration model existed.",
+                "No venue entity or venue-to-organization link existed.",
+                "No event-focused campaign attribution or attendee feedback entity existed.",
+                "No phone-optimized task or day-of check-in workflow existed.",
+            ],
+            "mobile_problems_before_build": mobile_issues,
+        },
+        "architecture": {
+            "contacts": "crm_contact + nv_contact_profile",
+            "organizations": "crm_account + nv_organization_profile",
+            "venues": "nv_venue linked to organization account",
+            "events": "nv_training_event linked to venue",
+            "registrations": "nv_event_registration linked to event + contact",
+            "campaigns": "nv_campaign linked to target event",
+            "activities": "nv_training_outreach_activity with optional crm_activity receipt",
+            "tasks": "nv_task for mobile quick actions",
+            "feedback": "nv_event_feedback linked to event + contact",
+        },
+        "summary": {
+            "next_event": next_event,
+            "contacts_added_this_month": contacts_added_month,
+            "followups_due": len(outstanding_followups),
+            "venue_outreach_status": dict(venue_status_counts),
+            "partner_status": dict(partner_status_counts),
+            "recent_activity": recent_activity,
+            "campaign_performance": campaign_performance,
+            "mobile_dashboard": {
+                "today_tasks": today_tasks[:6],
+                "next_event": next_event,
+                "outstanding_followups": outstanding_followups[:8],
+                "recent_registrations": recent_regs,
+                "check_in_shortcut_event_id": next_event["id"] if next_event else None,
+            },
+        },
+        "reports": {
+            "event_performance": event_performance,
+            "partnership_pipeline": {
+                "active_venue_conversations": [venue for venue in venues if venue["venue_status"] in {"contacted", "qualified", "preferred"}],
+                "preferred_venues": [venue for venue in venues if venue["is_preferred"]],
+                "cost_comparison": [
+                    {"venue_name": venue["venue_name"], "city": venue["city"], "hourly_cost": venue["hourly_cost"], "capacity_max": venue["capacity_max"]}
+                    for venue in venues
+                ],
+                "next_touch_needed": [activity for activity in activities if activity["status"] == "open"][:10],
+            },
+        },
+        "qa": {
+            "orphan_records": len(orphan_registrations),
+            "duplicate_contact_emails": duplicate_emails,
+            "impossible_status_rows": len(bad_statuses),
+            "registration_count_matches_events": all(
+                event["actual_registrations"] == len(by_event_regs.get(event["id"], [])) for event in events
+            ),
+        },
+        "seed_summary": {
+            "contacts": len(contacts),
+            "organizations": len(organizations),
+            "venues": len(venues),
+            "events": len(events),
+            "campaigns": len(campaigns),
+            "activities": len(activities),
+            "tasks": len(tasks),
+            "registrations": len(registrations),
+            "feedback": len(feedback),
+        },
+        "contacts": contacts,
+        "organizations": organizations,
+        "venues": venues,
+        "events": events,
+        "registrations": registrations,
+        "campaigns": campaigns,
+        "activities": activities,
+        "tasks": tasks,
+        "feedback": feedback,
+    }
+
+
+def create_contact(*, env_id: str, business_id: UUID, payload: dict[str, Any]) -> dict[str, Any]:
+    with get_cursor() as cur:
+        tenant_id = resolve_tenant_id(cur, business_id)
+        org_id = payload.get("organization_account_id")
+        cur.execute(
+            """
+            INSERT INTO crm_contact (
+              tenant_id, business_id, crm_account_id, first_name, last_name, full_name, email, phone, title
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING crm_contact_id
+            """,
+            (
+                tenant_id, str(business_id), org_id,
+                payload.get("first_name"), payload.get("last_name"), payload.get("full_name"),
+                payload.get("email"), payload.get("phone"), payload.get("title") or "Lead",
+            ),
+        )
+        contact_id = str(cur.fetchone()["crm_contact_id"])
+        cur.execute(
+            """
+            INSERT INTO nv_contact_profile (
+              crm_contact_id, env_id, business_id, preferred_contact_method, city, age_band,
+              persona_type, audience_segment, business_owner_flag, company_name_text, notes,
+              lead_source, status, consent_to_email, interest_area, follow_up_priority, tags
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                contact_id, env_id, str(business_id), payload.get("preferred_contact_method"), payload.get("city"), payload.get("age_band"),
+                payload.get("persona_type"), payload.get("audience_segment"), bool(payload.get("business_owner_flag")), payload.get("company_name_text"),
+                payload.get("notes"), payload.get("lead_source"), payload.get("status") or "new", bool(payload.get("consent_to_email")),
+                payload.get("interest_area"), payload.get("follow_up_priority") or "medium", payload.get("tags") or [],
+            ),
+        )
+    return {"crm_contact_id": contact_id, **payload}
+
+
+def create_event(*, env_id: str, business_id: UUID, payload: dict[str, Any]) -> dict[str, Any]:
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO nv_training_event (
+              env_id, business_id, event_name, event_series, event_type, event_status, event_date,
+              event_start_time, event_end_time, venue_id, city, target_capacity,
+              ticket_price_standard, ticket_price_early, event_theme, audience_level,
+              instructor, assistant_count, registration_link, notes, outcome_summary
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                env_id, str(business_id), payload["event_name"], payload.get("event_series"), payload.get("event_type") or "intro class",
+                payload.get("event_status") or "scheduled", payload["event_date"], payload.get("event_start_time"), payload.get("event_end_time"),
+                payload.get("venue_id"), payload.get("city"), payload.get("target_capacity"), payload.get("ticket_price_standard"), payload.get("ticket_price_early"),
+                payload.get("event_theme"), payload.get("audience_level"), payload.get("instructor") or INSTRUCTOR_NAME,
+                payload.get("assistant_count") or 1, payload.get("registration_link"), payload.get("notes"), payload.get("outcome_summary"),
+            ),
+        )
+        event_id = str(cur.fetchone()["id"])
+        if payload.get("campaign_id"):
+            cur.execute("UPDATE nv_campaign SET target_event_id = %s, updated_at = now() WHERE id = %s", (event_id, payload["campaign_id"]))
+        task_templates = [
+            "Confirm venue and Wi-Fi",
+            "Publish launch post",
+            "Send reminder email",
+            "Build post-event follow-up queue",
+        ]
+        for name in task_templates:
+            cur.execute(
+                """
+                INSERT INTO nv_task (
+                  env_id, business_id, task_name, related_entity_type, related_entity_id,
+                  assigned_to, priority, due_date, status, mobile_quick_action_flag, notes
+                ) VALUES (%s, %s, %s, 'event', %s, %s, %s, %s, 'open', true, %s)
+                """,
+                (
+                    env_id, str(business_id), f"{name} — {payload['event_name']}", event_id, OWNER_NAME,
+                    "high" if name.startswith("Confirm") else "medium", payload["event_date"],
+                    "Auto-created from event planner workflow.",
+                ),
+            )
+    return {"id": event_id, **payload}
+
+
+def create_activity(*, env_id: str, business_id: UUID, payload: dict[str, Any]) -> dict[str, Any]:
+    with get_cursor() as cur:
+        tenant_id = resolve_tenant_id(cur, business_id)
+        crm_activity_id = None
+        if payload.get("contact_id") or payload.get("organization_id"):
+            cur.execute(
+                """
+                INSERT INTO crm_activity (
+                  tenant_id, business_id, crm_account_id, crm_contact_id, activity_type, subject, activity_at, payload_json
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, '{}'::jsonb)
+                RETURNING crm_activity_id
+                """,
+                (
+                    tenant_id, str(business_id), payload.get("organization_id"), payload.get("contact_id"),
+                    "meeting" if payload.get("channel") in {"phone", "in_person"} else "email",
+                    payload.get("subject") or payload.get("activity_type"), payload.get("activity_date") or datetime.now(timezone.utc).isoformat(),
+                ),
+            )
+            crm_activity_id = str(cur.fetchone()["crm_activity_id"])
+        cur.execute(
+            """
+            INSERT INTO nv_training_outreach_activity (
+              crm_activity_id, env_id, business_id, activity_type, crm_contact_id, crm_account_id,
+              event_id, campaign_id, owner, activity_date, channel, subject, message_summary,
+              outcome, next_step, due_date, status
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, COALESCE(%s, now()), %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                crm_activity_id, env_id, str(business_id), payload["activity_type"], payload.get("contact_id"), payload.get("organization_id"),
+                payload.get("event_id"), payload.get("campaign_id"), payload.get("owner") or OWNER_NAME, payload.get("activity_date"),
+                payload.get("channel"), payload.get("subject"), payload.get("message_summary"), payload.get("outcome"), payload.get("next_step"),
+                payload.get("due_date"), payload.get("status") or "open",
+            ),
+        )
+        activity_id = str(cur.fetchone()["id"])
+    return {"id": activity_id, **payload}
+
+
+def create_registration(*, env_id: str, business_id: UUID, payload: dict[str, Any]) -> dict[str, Any]:
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO nv_event_registration (
+              env_id, business_id, event_id, crm_contact_id, registration_date, ticket_type,
+              price_paid, payment_status, attended_flag, checked_in_time, source_channel,
+              referral_source, follow_up_status, feedback_score, feedback_notes, walk_in_flag
+            ) VALUES (%s, %s, %s, %s, COALESCE(%s, now()), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (event_id, crm_contact_id) DO UPDATE SET
+              ticket_type = EXCLUDED.ticket_type,
+              price_paid = EXCLUDED.price_paid,
+              payment_status = EXCLUDED.payment_status,
+              attended_flag = EXCLUDED.attended_flag,
+              checked_in_time = EXCLUDED.checked_in_time,
+              source_channel = EXCLUDED.source_channel,
+              referral_source = EXCLUDED.referral_source,
+              follow_up_status = EXCLUDED.follow_up_status,
+              feedback_score = EXCLUDED.feedback_score,
+              feedback_notes = EXCLUDED.feedback_notes,
+              walk_in_flag = EXCLUDED.walk_in_flag,
+              updated_at = now()
+            RETURNING id
+            """,
+            (
+                env_id, str(business_id), payload["event_id"], payload["contact_id"], payload.get("registration_date"), payload.get("ticket_type"),
+                payload.get("price_paid"), payload.get("payment_status") or "paid", bool(payload.get("attended_flag")), payload.get("checked_in_time"),
+                payload.get("source_channel"), payload.get("referral_source"), payload.get("follow_up_status") or "queued",
+                payload.get("feedback_score"), payload.get("feedback_notes"), bool(payload.get("walk_in_flag")),
+            ),
+        )
+        registration_id = str(cur.fetchone()["id"])
+        _refresh_event_counts(cur, payload["event_id"])
+        _refresh_contact_attendance(cur, payload["contact_id"])
+    return {"id": registration_id, **payload}
+
+
+def check_in_registration(*, registration_id: UUID, attended_flag: bool = True) -> dict[str, Any]:
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            UPDATE nv_event_registration
+            SET attended_flag = %s,
+                checked_in_time = CASE WHEN %s THEN now() ELSE NULL END,
+                updated_at = now(),
+                follow_up_status = CASE WHEN %s THEN 'queued' ELSE follow_up_status END
+            WHERE id = %s
+            RETURNING event_id, crm_contact_id, attended_flag, checked_in_time
+            """,
+            (attended_flag, attended_flag, attended_flag, str(registration_id)),
+        )
+        row = cur.fetchone()
+        if not row:
+            raise LookupError(f"Registration {registration_id} not found")
+        _refresh_event_counts(cur, str(row["event_id"]))
+        _refresh_contact_attendance(cur, str(row["crm_contact_id"]))
+    return dict(row)
+
+
+def toggle_task(*, task_id: UUID, status: str) -> dict[str, Any]:
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            UPDATE nv_task
+            SET status = %s, updated_at = now()
+            WHERE id = %s
+            RETURNING id, status
+            """,
+            (status, str(task_id)),
+        )
+        row = cur.fetchone()
+        if not row:
+            raise LookupError(f"Task {task_id} not found")
+    return dict(row)

--- a/docs/local-ai-training-crm-receipts.md
+++ b/docs/local-ai-training-crm-receipts.md
@@ -1,0 +1,54 @@
+# Local AI Training CRM Receipts
+
+## Inventory of what existed before this build
+
+### Existing reusable surfaces
+- Canonical CRM records already existed in `crm_account`, `crm_contact`, `crm_activity`, `crm_pipeline_stage`, and `crm_opportunity`.
+- The consulting workspace already exposed command center, pipeline, outreach, clients, loops, and other general-purpose pages.
+- Consulting-specific extensions already existed for outreach logs/templates and client delivery tracking.
+
+### Why those objects were not enough as-is
+- There was no event entity, venue entity, registration/attendance table, event-focused campaign attribution, or attendee feedback table.
+- There was no day-of-event check-in workflow optimized for phone use.
+- The consulting sidebar was desktop-first and did not expose a mobile quick-nav for local field execution.
+- Generic consulting client/proposal objects were not a clean fit for a local paid-events business.
+
+## Target architecture
+
+### Keep and extend
+- `crm_contact` remains the canonical person table.
+- `crm_account` remains the canonical organization table.
+- `crm_activity` remains the canonical audit receipt for activities when a general CRM timeline entry is useful.
+
+### Add local-training extensions
+- `nv_contact_profile` for persona, segment, lead source, attendance rollups, and follow-up priority.
+- `nv_organization_profile` for venue/partner metadata.
+- `nv_venue` for event-space comparison and selection.
+- `nv_training_event` for planned and completed classes.
+- `nv_event_registration` for ticketing/attendance reconciliation.
+- `nv_campaign` for channel attribution.
+- `nv_training_outreach_activity` for operating outreach and partner activity.
+- `nv_task` for mobile quick actions.
+- `nv_event_feedback` for post-event learning and testimonials.
+
+## Mapping receipts
+- Contact ⇄ organization uses `crm_contact.crm_account_id` when a partner or referral source belongs to an organization.
+- Venue ⇄ organization uses `nv_venue.organization_account_id`.
+- Event ⇄ venue uses `nv_training_event.venue_id`.
+- Registration ⇄ event/contact uses `nv_event_registration.event_id` + `crm_contact_id`.
+- Feedback ⇄ event/contact uses `nv_event_feedback.event_id` + `crm_contact_id`.
+- Outreach activity can optionally point back to `crm_activity_id` for a generic CRM audit receipt.
+
+## Seed assumptions
+- Pricing starts at `$25–$45` to fit the requested early-stage local training model.
+- South Florida seed mix emphasizes Lake Worth Beach and West Palm Beach, with some nearby spillover cities for realistic local reach.
+- Contact personas intentionally skew toward beginners, older adults, retirees, and a smaller set of local business owners / referral partners.
+- Campaigns favor local channels: Facebook groups, flyers, partners, word-of-mouth, and small direct outreach loops.
+- Seed data is realistic but synthetic; it is designed to feel like a live operating workspace immediately after seeding.
+
+## QA checklist used in the build
+- Registration counts are recalculated from attendance rows.
+- Contact attendance rollups are recalculated from registration rows.
+- Duplicate emails are surfaced in the workspace QA block.
+- Orphan registrations and impossible task statuses are checked in the workspace summary payload.
+- Mobile navigation was added so the new primary pages stay reachable in one tap on phone.

--- a/repo-b/db/schema/417_local_ai_training_crm.sql
+++ b/repo-b/db/schema/417_local_ai_training_crm.sql
@@ -1,0 +1,233 @@
+-- 417_local_ai_training_crm.sql
+-- Mobile-friendly local training CRM for Novendor / Winston.
+-- Built for founder-operated in-person AI class workflows: contacts,
+-- partners, venues, events, registrations, outreach, campaigns, tasks,
+-- and attendee feedback.
+
+CREATE TABLE IF NOT EXISTS nv_contact_profile (
+    crm_contact_id            uuid PRIMARY KEY REFERENCES crm_contact(crm_contact_id) ON DELETE CASCADE,
+    env_id                    text NOT NULL,
+    business_id               uuid NOT NULL,
+    preferred_contact_method  text CHECK (preferred_contact_method IN ('email','phone','text','facebook','linkedin','in_person')),
+    city                      text,
+    age_band                  text,
+    persona_type              text,
+    audience_segment          text,
+    business_owner_flag       boolean NOT NULL DEFAULT false,
+    company_name_text         text,
+    notes                     text,
+    lead_source               text,
+    status                    text NOT NULL DEFAULT 'new',
+    consent_to_email          boolean NOT NULL DEFAULT false,
+    first_event_attended_id   uuid,
+    total_events_attended     int NOT NULL DEFAULT 0,
+    interest_area             text,
+    follow_up_priority        text,
+    tags                      text[] NOT NULL DEFAULT ARRAY[]::text[],
+    created_at                timestamptz NOT NULL DEFAULT now(),
+    updated_at                timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS nv_organization_profile (
+    crm_account_id            uuid PRIMARY KEY REFERENCES crm_account(crm_account_id) ON DELETE CASCADE,
+    env_id                    text NOT NULL,
+    business_id               uuid NOT NULL,
+    organization_name         text NOT NULL,
+    organization_type         text NOT NULL,
+    phone                     text,
+    city                      text,
+    state                     text,
+    relationship_type         text,
+    partner_status            text,
+    notes                     text,
+    owner_contact_id          uuid REFERENCES crm_contact(crm_contact_id) ON DELETE SET NULL,
+    created_at                timestamptz NOT NULL DEFAULT now(),
+    updated_at                timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS nv_venue (
+    id                        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id                    text NOT NULL,
+    business_id               uuid NOT NULL,
+    organization_account_id   uuid REFERENCES crm_account(crm_account_id) ON DELETE SET NULL,
+    venue_name                text NOT NULL,
+    address                   text,
+    city                      text,
+    state                     text,
+    zip                       text,
+    website                   text,
+    contact_name              text,
+    contact_email             text,
+    contact_phone             text,
+    capacity_min              int,
+    capacity_max              int,
+    wifi_quality              text,
+    av_available              boolean NOT NULL DEFAULT false,
+    parking_notes             text,
+    accessibility_notes       text,
+    hourly_cost               numeric(18,2),
+    deposit_required          boolean NOT NULL DEFAULT false,
+    preferred_for_event_type  text,
+    venue_status              text NOT NULL DEFAULT 'researching',
+    is_preferred              boolean NOT NULL DEFAULT false,
+    notes                     text,
+    created_at                timestamptz NOT NULL DEFAULT now(),
+    updated_at                timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (env_id, business_id, venue_name)
+);
+
+CREATE TABLE IF NOT EXISTS nv_training_event (
+    id                        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id                    text NOT NULL,
+    business_id               uuid NOT NULL,
+    event_name                text NOT NULL,
+    event_series              text,
+    event_type                text NOT NULL,
+    event_status              text NOT NULL,
+    event_date                date NOT NULL,
+    event_start_time          time,
+    event_end_time            time,
+    venue_id                  uuid REFERENCES nv_venue(id) ON DELETE SET NULL,
+    city                      text,
+    target_capacity           int,
+    actual_registrations      int NOT NULL DEFAULT 0,
+    actual_attendance         int NOT NULL DEFAULT 0,
+    ticket_price_standard     numeric(18,2),
+    ticket_price_early        numeric(18,2),
+    event_theme               text,
+    audience_level            text,
+    instructor                text,
+    assistant_count           int NOT NULL DEFAULT 0,
+    registration_link         text,
+    check_in_status           text NOT NULL DEFAULT 'not_started',
+    follow_up_sent_flag       boolean NOT NULL DEFAULT false,
+    notes                     text,
+    outcome_summary           text,
+    created_at                timestamptz NOT NULL DEFAULT now(),
+    updated_at                timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE nv_contact_profile
+    ADD CONSTRAINT fk_nv_contact_first_event
+    FOREIGN KEY (first_event_attended_id) REFERENCES nv_training_event(id) ON DELETE SET NULL;
+
+CREATE TABLE IF NOT EXISTS nv_campaign (
+    id                        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id                    text NOT NULL,
+    business_id               uuid NOT NULL,
+    campaign_name             text NOT NULL,
+    channel                   text NOT NULL,
+    audience                  text,
+    launch_date               date,
+    end_date                  date,
+    budget                    numeric(18,2),
+    target_event_id           uuid REFERENCES nv_training_event(id) ON DELETE SET NULL,
+    message_angle             text,
+    status                    text NOT NULL DEFAULT 'draft',
+    leads_generated           int NOT NULL DEFAULT 0,
+    registrations_generated   int NOT NULL DEFAULT 0,
+    notes                     text,
+    created_at                timestamptz NOT NULL DEFAULT now(),
+    updated_at                timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS nv_training_outreach_activity (
+    id                        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    crm_activity_id           uuid REFERENCES crm_activity(crm_activity_id) ON DELETE SET NULL,
+    env_id                    text NOT NULL,
+    business_id               uuid NOT NULL,
+    activity_type             text NOT NULL,
+    crm_contact_id            uuid REFERENCES crm_contact(crm_contact_id) ON DELETE SET NULL,
+    crm_account_id            uuid REFERENCES crm_account(crm_account_id) ON DELETE SET NULL,
+    event_id                  uuid REFERENCES nv_training_event(id) ON DELETE SET NULL,
+    campaign_id               uuid REFERENCES nv_campaign(id) ON DELETE SET NULL,
+    owner                     text,
+    activity_date             timestamptz NOT NULL DEFAULT now(),
+    channel                   text,
+    subject                   text,
+    message_summary           text,
+    outcome                   text,
+    next_step                 text,
+    due_date                  date,
+    status                    text NOT NULL DEFAULT 'open',
+    created_at                timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS nv_event_registration (
+    id                        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id                    text NOT NULL,
+    business_id               uuid NOT NULL,
+    event_id                  uuid NOT NULL REFERENCES nv_training_event(id) ON DELETE CASCADE,
+    crm_contact_id            uuid NOT NULL REFERENCES crm_contact(crm_contact_id) ON DELETE CASCADE,
+    registration_date         timestamptz NOT NULL DEFAULT now(),
+    ticket_type               text,
+    price_paid                numeric(18,2),
+    payment_status            text NOT NULL DEFAULT 'paid',
+    attended_flag             boolean NOT NULL DEFAULT false,
+    checked_in_time           timestamptz,
+    source_channel            text,
+    referral_source           text,
+    follow_up_status          text,
+    feedback_score            int,
+    feedback_notes            text,
+    walk_in_flag              boolean NOT NULL DEFAULT false,
+    created_at                timestamptz NOT NULL DEFAULT now(),
+    updated_at                timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (event_id, crm_contact_id)
+);
+
+CREATE TABLE IF NOT EXISTS nv_task (
+    id                        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id                    text NOT NULL,
+    business_id               uuid NOT NULL,
+    task_name                 text NOT NULL,
+    related_entity_type       text,
+    related_entity_id         text,
+    assigned_to               text,
+    priority                  text NOT NULL DEFAULT 'medium',
+    due_date                  date,
+    status                    text NOT NULL DEFAULT 'open',
+    mobile_quick_action_flag  boolean NOT NULL DEFAULT false,
+    notes                     text,
+    created_at                timestamptz NOT NULL DEFAULT now(),
+    updated_at                timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS nv_event_feedback (
+    id                        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id                    text NOT NULL,
+    business_id               uuid NOT NULL,
+    event_id                  uuid NOT NULL REFERENCES nv_training_event(id) ON DELETE CASCADE,
+    crm_contact_id            uuid NOT NULL REFERENCES crm_contact(crm_contact_id) ON DELETE CASCADE,
+    rating                    int,
+    what_they_found_useful    text,
+    what_was_confusing        text,
+    would_attend_again        boolean,
+    would_bring_friend        boolean,
+    testimonial_permission    boolean NOT NULL DEFAULT false,
+    testimonial_text          text,
+    created_at                timestamptz NOT NULL DEFAULT now(),
+    updated_at                timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (event_id, crm_contact_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nv_contact_profile_env
+    ON nv_contact_profile (env_id, business_id, status, follow_up_priority);
+CREATE INDEX IF NOT EXISTS idx_nv_org_profile_env
+    ON nv_organization_profile (env_id, business_id, organization_type, partner_status);
+CREATE INDEX IF NOT EXISTS idx_nv_venue_env
+    ON nv_venue (env_id, business_id, venue_status, city);
+CREATE INDEX IF NOT EXISTS idx_nv_event_env_date
+    ON nv_training_event (env_id, business_id, event_date, event_status);
+CREATE INDEX IF NOT EXISTS idx_nv_campaign_env
+    ON nv_campaign (env_id, business_id, channel, status);
+CREATE INDEX IF NOT EXISTS idx_nv_activity_env
+    ON nv_training_outreach_activity (env_id, business_id, activity_date DESC);
+CREATE INDEX IF NOT EXISTS idx_nv_registration_event
+    ON nv_event_registration (event_id, attended_flag, registration_date);
+CREATE INDEX IF NOT EXISTS idx_nv_registration_contact
+    ON nv_event_registration (crm_contact_id, registration_date DESC);
+CREATE INDEX IF NOT EXISTS idx_nv_task_env
+    ON nv_task (env_id, business_id, status, due_date);
+CREATE INDEX IF NOT EXISTS idx_nv_feedback_event
+    ON nv_event_feedback (event_id, rating);

--- a/repo-b/src/app/lab/env/[envId]/consulting/campaigns/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/consulting/campaigns/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useConsultingEnv } from "@/components/consulting/ConsultingEnvProvider";
+import { useTrainingWorkspace } from "@/components/consulting/local-training/useTrainingWorkspace";
+import { EmptyState, TonePill, fmtCurrency, fmtDate } from "@/components/consulting/local-training/ui";
+import { Card, CardContent, CardTitle } from "@/components/ui/Card";
+
+export default function CampaignsPage({ params }: { params: { envId: string } }) {
+  const { businessId, ready } = useConsultingEnv();
+  const { workspace, loading, error } = useTrainingWorkspace(params.envId, businessId, ready);
+
+  if (loading) return <div className="h-64 rounded-2xl border border-bm-border/60 bg-bm-surface/20 animate-pulse" />;
+  if (!workspace) return <EmptyState title="No campaign data" body={error ?? "Seed the workspace to review campaign tracking."} />;
+
+  return (
+    <div className="space-y-5 pb-24 md:pb-6">
+      {error ? <div className="rounded-xl border border-bm-danger/35 bg-bm-danger/10 px-4 py-3 text-sm">{error}</div> : null}
+      <Card>
+        <CardContent className="py-5">
+          <CardTitle>Workflow D — Campaign tracking</CardTitle>
+          <p className="mt-2 text-sm text-bm-muted2">Every channel is tied back to a target event so registrations can be compared over time.</p>
+          <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {workspace.campaigns.map((campaign) => (
+              <div key={campaign.id} className="rounded-2xl border border-bm-border/70 bg-bm-bg p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-base font-semibold text-bm-text">{campaign.campaign_name}</p>
+                    <p className="mt-1 text-sm text-bm-muted2">{campaign.channel} · {campaign.target_event_name}</p>
+                  </div>
+                  <TonePill label={campaign.status} tone={campaign.status === "active" ? "info" : "success"} />
+                </div>
+                <div className="mt-3 grid grid-cols-2 gap-3 text-sm">
+                  <div><span className="text-bm-muted2">Launch</span><p className="font-semibold">{fmtDate(campaign.launch_date)}</p></div>
+                  <div><span className="text-bm-muted2">Budget</span><p className="font-semibold">{fmtCurrency(campaign.budget)}</p></div>
+                  <div><span className="text-bm-muted2">Leads</span><p className="font-semibold">{campaign.leads_generated}</p></div>
+                  <div><span className="text-bm-muted2">Registrations</span><p className="font-semibold">{campaign.registrations_generated}</p></div>
+                </div>
+                <p className="mt-3 text-sm text-bm-text">{campaign.message_angle}</p>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/repo-b/src/app/lab/env/[envId]/consulting/contacts/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/consulting/contacts/page.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useConsultingEnv } from "@/components/consulting/ConsultingEnvProvider";
+import { useTrainingWorkspace } from "@/components/consulting/local-training/useTrainingWorkspace";
+import { EmptyState, TonePill, fmtDate } from "@/components/consulting/local-training/ui";
+import { Button } from "@/components/ui/Button";
+import { Card, CardContent, CardTitle } from "@/components/ui/Card";
+
+export default function ContactsPage({ params }: { params: { envId: string } }) {
+  const { businessId, ready } = useConsultingEnv();
+  const { workspace, loading, mutating, error, createContact, createActivity, upsertRegistration } = useTrainingWorkspace(params.envId, businessId, ready);
+  const [filter, setFilter] = useState("all");
+  const [form, setForm] = useState({ full_name: "", email: "", city: "Lake Worth Beach", persona_type: "curious beginner", lead_source: "facebook", interest_area: "AI basics" });
+
+  const contacts = useMemo(() => {
+    const rows = workspace?.contacts ?? [];
+    if (filter === "all") return rows;
+    if (filter === "priority") return rows.filter((contact) => contact.follow_up_priority === "high");
+    if (filter === "owners") return rows.filter((contact) => contact.business_owner_flag);
+    return rows.filter((contact) => contact.audience_segment === filter);
+  }, [filter, workspace?.contacts]);
+
+  if (loading) return <div className="h-64 rounded-2xl border border-bm-border/60 bg-bm-surface/20 animate-pulse" />;
+  if (!workspace) return <EmptyState title="No CRM data" body={error ?? "Seed the workspace to review contacts."} />;
+
+  return (
+    <div className="space-y-5 pb-24 md:pb-6">
+      {error ? <div className="rounded-xl border border-bm-danger/35 bg-bm-danger/10 px-4 py-3 text-sm">{error}</div> : null}
+
+      <div className="grid gap-4 xl:grid-cols-[0.95fr,1.25fr]">
+        <Card>
+          <CardContent className="py-5">
+            <CardTitle>Quick-add contact</CardTitle>
+            <p className="mt-2 text-sm text-bm-muted2">Workflow B starts here: create a lead, segment them, then invite or register them in one or two taps.</p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              {[
+                ["full_name", "Full name"],
+                ["email", "Email"],
+                ["city", "City"],
+                ["persona_type", "Persona"],
+                ["lead_source", "Lead source"],
+                ["interest_area", "Interest area"],
+              ].map(([key, label]) => (
+                <label key={key} className="text-sm">
+                  <span className="mb-1 block text-xs uppercase tracking-[0.12em] text-bm-muted2">{label}</span>
+                  <input
+                    value={form[key as keyof typeof form]}
+                    onChange={(event) => setForm((current) => ({ ...current, [key]: event.target.value }))}
+                    className="w-full rounded-xl border border-bm-border bg-bm-bg px-3 py-2 text-sm"
+                  />
+                </label>
+              ))}
+            </div>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Button
+                onClick={() => void createContact({
+                  ...form,
+                  preferred_contact_method: "email",
+                  status: "new",
+                  audience_segment: form.persona_type === "small business owner" ? "local business owners" : "community learners",
+                  follow_up_priority: form.persona_type.includes("older") ? "high" : "medium",
+                  tags: [form.city.toLowerCase().replace(/\s+/g, "-"), "quick-add"],
+                  consent_to_email: true,
+                })}
+                disabled={mutating || !form.full_name}
+              >
+                Save contact
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  const firstEventId = workspace.events[2]?.id;
+                  const firstContact = contacts[0];
+                  if (!firstEventId || !firstContact) return;
+                  void upsertRegistration({
+                    event_id: firstEventId,
+                    contact_id: firstContact.crm_contact_id,
+                    ticket_type: "standard",
+                    price_paid: workspace.events[2]?.ticket_price_standard,
+                    source_channel: "direct outreach",
+                    referral_source: "quick-add demo",
+                    follow_up_status: "queued",
+                  });
+                }}
+                disabled={mutating || contacts.length === 0 || workspace.events.length < 3}
+              >
+                Demo: mark registered
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  const firstContact = contacts[0];
+                  const firstEvent = workspace.events[2];
+                  if (!firstContact || !firstEvent) return;
+                  void createActivity({
+                    activity_type: "invite sent",
+                    contact_id: firstContact.crm_contact_id,
+                    event_id: firstEvent.id,
+                    channel: "email",
+                    subject: `Invite — ${firstEvent.event_name}`,
+                    message_summary: "Sent beginner-friendly invite from contact workflow.",
+                    outcome: "pending",
+                    next_step: "Follow up in 3 days",
+                    due_date: firstEvent.event_date,
+                  });
+                }}
+                disabled={mutating || contacts.length === 0 || workspace.events.length < 3}
+              >
+                Demo: invite first contact
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="py-5">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div>
+                <CardTitle>Mobile contact list</CardTitle>
+                <p className="mt-2 text-sm text-bm-muted2">Card layout keeps lookup fast on phone. Important fields stay above the fold; notes remain compact.</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {[
+                  ["all", "All"],
+                  ["priority", "High priority"],
+                  ["owners", "Business owners"],
+                  ["older adults", "Older adults"],
+                  ["community learners", "Community learners"],
+                ].map(([value, label]) => (
+                  <button
+                    key={value}
+                    onClick={() => setFilter(value)}
+                    className={`rounded-full px-3 py-2 text-xs ${filter === value ? "bg-bm-accent text-white" : "border border-bm-border text-bm-muted2"}`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="mt-4 space-y-3">
+              {contacts.map((contact) => (
+                <div key={contact.crm_contact_id} className="rounded-2xl border border-bm-border/70 bg-bm-bg p-4">
+                  <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="text-base font-semibold text-bm-text">{contact.full_name}</p>
+                        <TonePill label={contact.status} tone={contact.status === "attended" ? "success" : contact.status === "registered" ? "info" : "default"} />
+                        {contact.business_owner_flag ? <TonePill label="business owner" tone="warning" /> : null}
+                      </div>
+                      <p className="mt-1 text-sm text-bm-muted2">{contact.email ?? "No email"} · {contact.phone ?? "No phone"}</p>
+                      <p className="mt-2 text-sm text-bm-muted2">{contact.persona_type} · {contact.city} · {contact.interest_area}</p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <TonePill label={`Events: ${contact.total_events_attended}`} tone={contact.total_events_attended > 1 ? "success" : "default"} />
+                      <TonePill label={`Priority: ${contact.follow_up_priority ?? "—"}`} tone={contact.follow_up_priority === "high" ? "warning" : "default"} />
+                    </div>
+                  </div>
+                  <div className="mt-3 grid gap-2 text-sm md:grid-cols-2">
+                    <div className="rounded-xl bg-bm-surface/20 px-3 py-2">
+                      <p className="text-xs uppercase tracking-[0.12em] text-bm-muted2">Shown on phone</p>
+                      <p className="mt-1 text-bm-text">Preferred contact: {contact.preferred_contact_method ?? "—"} · Source: {contact.lead_source ?? "—"}</p>
+                    </div>
+                    <div className="rounded-xl bg-bm-surface/20 px-3 py-2">
+                      <p className="text-xs uppercase tracking-[0.12em] text-bm-muted2">Expanded details</p>
+                      <p className="mt-1 text-bm-text">{contact.notes}</p>
+                    </div>
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {(contact.tags ?? []).map((tag) => <TonePill key={tag} label={tag} />)}
+                    <span className="text-xs text-bm-muted2">Created {fmtDate(contact.created_at)}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/app/lab/env/[envId]/consulting/events/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/consulting/events/page.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useConsultingEnv } from "@/components/consulting/ConsultingEnvProvider";
+import { useTrainingWorkspace } from "@/components/consulting/local-training/useTrainingWorkspace";
+import { EmptyState, TonePill, fmtCurrency, fmtDate, fmtTime } from "@/components/consulting/local-training/ui";
+import { Button } from "@/components/ui/Button";
+import { Card, CardContent, CardTitle } from "@/components/ui/Card";
+
+export default function EventsPage({ params }: { params: { envId: string } }) {
+  const { businessId, ready } = useConsultingEnv();
+  const { workspace, loading, mutating, error, createEvent, createContact, upsertRegistration, checkIn } = useTrainingWorkspace(params.envId, businessId, ready);
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    event_name: "",
+    event_date: "2026-07-09",
+    event_type: "intro class",
+    city: "Lake Worth Beach",
+    target_capacity: "24",
+    ticket_price_standard: "35",
+    ticket_price_early: "29",
+  });
+
+  const events = workspace?.events ?? [];
+  const selectedEvent = useMemo(() => events.find((event) => event.id === (selectedEventId ?? events[0]?.id)) ?? events[0] ?? null, [events, selectedEventId]);
+  const selectedRegistrations = useMemo(() => (workspace?.registrations ?? []).filter((row) => row.event_id === selectedEvent?.id), [workspace?.registrations, selectedEvent?.id]);
+
+  if (loading) return <div className="h-64 rounded-2xl border border-bm-border/60 bg-bm-surface/20 animate-pulse" />;
+  if (!workspace) return <EmptyState title="No event CRM data" body={error ?? "Seed the workspace to review events."} />;
+
+  return (
+    <div className="space-y-5 pb-24 md:pb-6">
+      {error ? <div className="rounded-xl border border-bm-danger/35 bg-bm-danger/10 px-4 py-3 text-sm">{error}</div> : null}
+
+      <div className="grid gap-4 xl:grid-cols-[0.9fr,1.2fr]">
+        <Card>
+          <CardContent className="py-5">
+            <CardTitle>Workflow A — Plan monthly event</CardTitle>
+            <p className="mt-2 text-sm text-bm-muted2">Create the event, choose venue, connect a campaign, and auto-create the launch checklist.</p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              {[
+                ["event_name", "Event name"],
+                ["event_date", "Date"],
+                ["event_type", "Type"],
+                ["city", "City"],
+                ["target_capacity", "Capacity"],
+                ["ticket_price_standard", "Standard price"],
+                ["ticket_price_early", "Early price"],
+              ].map(([key, label]) => (
+                <label key={key} className="text-sm">
+                  <span className="mb-1 block text-xs uppercase tracking-[0.12em] text-bm-muted2">{label}</span>
+                  <input value={form[key as keyof typeof form]} onChange={(event) => setForm((current) => ({ ...current, [key]: event.target.value }))} className="w-full rounded-xl border border-bm-border bg-bm-bg px-3 py-2 text-sm" />
+                </label>
+              ))}
+            </div>
+            <label className="mt-3 block text-sm">
+              <span className="mb-1 block text-xs uppercase tracking-[0.12em] text-bm-muted2">Venue</span>
+              <select className="w-full rounded-xl border border-bm-border bg-bm-bg px-3 py-2 text-sm" defaultValue={workspace.venues[0]?.id} id="venue-select">
+                {workspace.venues.map((venue) => (
+                  <option key={venue.id} value={venue.id}>{venue.venue_name}</option>
+                ))}
+              </select>
+            </label>
+            <label className="mt-3 block text-sm">
+              <span className="mb-1 block text-xs uppercase tracking-[0.12em] text-bm-muted2">Campaign</span>
+              <select className="w-full rounded-xl border border-bm-border bg-bm-bg px-3 py-2 text-sm" defaultValue={workspace.campaigns[0]?.id} id="campaign-select">
+                {workspace.campaigns.map((campaign) => (
+                  <option key={campaign.id} value={campaign.id}>{campaign.campaign_name}</option>
+                ))}
+              </select>
+            </label>
+            <Button
+              className="mt-4"
+              disabled={mutating || !form.event_name}
+              onClick={() => {
+                const venueId = (document.getElementById("venue-select") as HTMLSelectElement | null)?.value;
+                const campaignId = (document.getElementById("campaign-select") as HTMLSelectElement | null)?.value;
+                void createEvent({
+                  ...form,
+                  venue_id: venueId,
+                  campaign_id: campaignId,
+                  event_series: "Novendor Community Access",
+                  audience_level: "beginner",
+                  event_status: "scheduled",
+                  instructor: "Paul M.",
+                  assistant_count: 1,
+                  event_theme: "Simple, hands-on AI practice for local beginners",
+                });
+              }}
+            >
+              Create event + checklist
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="py-5">
+            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+              <div>
+                <CardTitle>Workflow E — Day-of event check-in</CardTitle>
+                <p className="mt-2 text-sm text-bm-muted2">Optimized for standing at the venue on a phone: attendee list, quick check-in, walk-ins, and payment status.</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {events.map((event) => (
+                  <button key={event.id} onClick={() => setSelectedEventId(event.id)} className={`rounded-full px-3 py-2 text-xs ${selectedEvent?.id === event.id ? "bg-bm-accent text-white" : "border border-bm-border text-bm-muted2"}`}>
+                    {fmtDate(event.event_date)}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {selectedEvent ? (
+              <div className="mt-4 space-y-4">
+                <div className="rounded-2xl border border-bm-border/70 bg-bm-bg p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-base font-semibold text-bm-text">{selectedEvent.event_name}</p>
+                      <p className="mt-1 text-sm text-bm-muted2">{selectedEvent.venue_name} · {fmtDate(selectedEvent.event_date)} · {fmtTime(selectedEvent.event_start_time)}</p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <TonePill label={selectedEvent.event_status} tone={selectedEvent.event_status === "completed" ? "success" : "warning"} />
+                      <TonePill label={`Regs ${selectedEvent.actual_registrations}`} />
+                      <TonePill label={`Checked in ${selectedEvent.actual_attendance}`} tone="info" />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 lg:grid-cols-[1fr,0.9fr]">
+                  <div className="space-y-3">
+                    {selectedRegistrations.map((registration) => (
+                      <div key={registration.registration_id} className="rounded-2xl border border-bm-border/70 bg-bm-bg p-4">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-semibold text-bm-text">{registration.contact_name}</p>
+                            <p className="mt-1 text-xs text-bm-muted2">{registration.contact_email ?? registration.contact_phone ?? "No contact detail"}</p>
+                            <p className="mt-1 text-xs text-bm-muted2">{registration.ticket_type ?? "standard"} · {fmtCurrency(registration.price_paid)}</p>
+                          </div>
+                          <div className="flex flex-wrap gap-2">
+                            <TonePill label={registration.payment_status} tone={registration.payment_status === "paid" ? "success" : "warning"} />
+                            <Button size="sm" variant={registration.attended_flag ? "secondary" : "primary"} onClick={() => void checkIn(registration.registration_id, !registration.attended_flag)} disabled={mutating}>
+                              {registration.attended_flag ? "Undo" : "Check in"}
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="rounded-2xl border border-bm-border/70 bg-bm-bg p-4">
+                    <p className="text-sm font-semibold text-bm-text">Add walk-in attendee</p>
+                    <p className="mt-1 text-xs text-bm-muted2">Creates the contact first, then registers them to the selected event.</p>
+                    <div className="mt-3 flex flex-col gap-2">
+                      <Button
+                        onClick={async () => {
+                          const name = `Walk-in ${Date.now().toString().slice(-4)}`;
+                          await createContact({
+                            full_name: name,
+                            city: selectedEvent.city,
+                            persona_type: "curious beginner",
+                            audience_segment: "community learners",
+                            lead_source: "walk-in",
+                            interest_area: "AI basics",
+                            follow_up_priority: "medium",
+                            tags: ["walk-in"],
+                          });
+                        }}
+                        disabled={mutating}
+                      >
+                        Create walk-in contact
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        onClick={() => {
+                          const latest = workspace.contacts[0];
+                          if (!latest || !selectedEvent) return;
+                          void upsertRegistration({
+                            event_id: selectedEvent.id,
+                            contact_id: latest.crm_contact_id,
+                            ticket_type: "walk-in",
+                            price_paid: selectedEvent.ticket_price_standard,
+                            payment_status: "pending",
+                            source_channel: "walk-in",
+                            referral_source: "door",
+                            walk_in_flag: true,
+                          });
+                        }}
+                        disabled={mutating || workspace.contacts.length === 0}
+                      >
+                        Register latest walk-in
+                      </Button>
+                    </div>
+                    <div className="mt-4 rounded-xl bg-bm-surface/20 p-3 text-sm text-bm-muted2">
+                      Post-event follow-up list is generated automatically by queued registration follow-up statuses after check-in.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/app/lab/env/[envId]/consulting/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/consulting/page.tsx
@@ -1,487 +1,268 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useConsultingEnv } from "@/components/consulting/ConsultingEnvProvider";
+import { useTrainingWorkspace } from "@/components/consulting/local-training/useTrainingWorkspace";
+import { EmptyState, TonePill, fmtCurrency, fmtDate, fmtTime } from "@/components/consulting/local-training/ui";
 import { Button } from "@/components/ui/Button";
-import { Card, CardContent } from "@/components/ui/Card";
-import { MetricCard } from "@/components/ui/MetricCard";
-import { InsightRail, type InsightSection } from "@/components/ui/InsightRail";
-import { QuickActions, type QuickAction } from "@/components/ui/QuickActions";
-import {
-  fetchClients,
-  fetchLatestMetrics,
-  fetchLeads,
-  fetchOutreachLog,
-  fetchPipelineKanban,
-  fetchProposals,
-  seedConsultingWorkspace,
-  type Lead,
-  type MetricsSnapshot,
-} from "@/lib/cro-api";
+import { Card, CardContent, CardTitle } from "@/components/ui/Card";
 
-type WorkspaceDiagnostics = {
-  lead_count: number;
-  open_pipeline_cards: number;
-  outreach_count: number;
-  proposal_count: number;
-  client_count: number;
-};
-
-function fmtCurrency(n: number | null | undefined): string {
-  if (n === null || n === undefined || isNaN(n)) return "$0";
-  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `$${(n / 1_000).toFixed(0)}K`;
-  return `$${n.toFixed(0)}`;
-}
-
-function fmtPct(n: number | null | undefined): string {
-  if (n === null || n === undefined || isNaN(n)) return "—";
-  return `${(n * 100).toFixed(1)}%`;
-}
-
-function formatError(err: unknown): string {
-  if (!(err instanceof Error)) {
-    return "Consulting API unreachable. Backend service is not available.";
-  }
-  const msg = err.message.replace(/\s*\(req:\s*[a-zA-Z0-9_-]+\)\s*$/, "");
-  if (msg.includes("Network error")) {
-    return "Consulting API unreachable. Backend service is not available.";
-  }
-  return msg || "Consulting API unreachable. Backend service is not available.";
-}
-
-function LeadStatus({ lead }: { lead: Lead }) {
-  if (lead.disqualified_at) {
-    return (
-      <span className="text-xs bg-bm-danger/10 text-bm-danger px-1.5 py-0.5 rounded">
-        Disqualified
-      </span>
-    );
-  }
-  if (lead.qualified_at) {
-    return (
-      <span className="text-xs bg-bm-success/10 text-bm-success px-1.5 py-0.5 rounded">
-        Qualified
-      </span>
-    );
-  }
-  return null;
-}
-
-export default function ConsultingCommandCenter({
-  params,
-}: {
-  params: { envId: string };
-}) {
-  const {
-    businessId,
-    error: contextError,
-    loading: contextLoading,
-    ready,
-  } = useConsultingEnv();
-  const [metrics, setMetrics] = useState<MetricsSnapshot | null>(null);
-  const [leads, setLeads] = useState<Lead[]>([]);
-  const [diagnostics, setDiagnostics] = useState<WorkspaceDiagnostics | null>(null);
-  const [diagnosticsReliable, setDiagnosticsReliable] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [dataError, setDataError] = useState<string | null>(null);
-  const [seeding, setSeeding] = useState(false);
-
-  const base = `/lab/env/${params.envId}/consulting`;
-
-  const loadWorkspace = useCallback(async () => {
-    if (!businessId) {
-      setLoading(false);
-      return;
-    }
-
-    setLoading(true);
-    setDataError(null);
-    try {
-      const [
-        leadsResult,
-        outreachResult,
-        proposalsResult,
-        clientsResult,
-        kanbanResult,
-        metricsResult,
-      ] = await Promise.allSettled([
-        fetchLeads(params.envId, businessId),
-        fetchOutreachLog(params.envId, businessId),
-        fetchProposals(params.envId, businessId),
-        fetchClients(params.envId, businessId),
-        fetchPipelineKanban(params.envId, businessId),
-        fetchLatestMetrics(params.envId, businessId),
-      ]);
-
-      if (leadsResult.status !== "fulfilled") {
-        throw leadsResult.reason;
-      }
-
-      const nextLeads = leadsResult.value;
-      const outreachLog =
-        outreachResult.status === "fulfilled" ? outreachResult.value : [];
-      const proposals =
-        proposalsResult.status === "fulfilled" ? proposalsResult.value : [];
-      const clients =
-        clientsResult.status === "fulfilled" ? clientsResult.value : [];
-      const kanban =
-        kanbanResult.status === "fulfilled"
-          ? kanbanResult.value
-          : { columns: [], total_pipeline: 0, weighted_pipeline: 0 };
-      const latestMetrics =
-        metricsResult.status === "fulfilled" ? metricsResult.value : null;
-
-      const openPipelineCards = kanban.columns.reduce(
-        (total, column) => total + column.cards.length,
-        0,
-      );
-
-      setLeads(nextLeads);
-      setMetrics(latestMetrics);
-      setDiagnostics({
-        lead_count: nextLeads.length,
-        open_pipeline_cards: openPipelineCards,
-        outreach_count: outreachLog.length,
-        proposal_count: proposals.length,
-        client_count: clients.length,
-      });
-      setDiagnosticsReliable(
-        outreachResult.status === "fulfilled" &&
-          proposalsResult.status === "fulfilled" &&
-          clientsResult.status === "fulfilled" &&
-          kanbanResult.status === "fulfilled",
-      );
-    } catch (err) {
-      setLeads([]);
-      setMetrics(null);
-      setDiagnostics(null);
-      setDiagnosticsReliable(false);
-      setDataError(formatError(err));
-    } finally {
-      setLoading(false);
-    }
-  }, [businessId, params.envId]);
-
-  useEffect(() => {
-    if (!ready) return;
-    void loadWorkspace();
-  }, [loadWorkspace, ready]);
-
-  const m = metrics;
-  const isLoading = contextLoading || (ready && loading);
-  const topLeads = useMemo(
-    () =>
-      [...leads]
-        .sort((a, b) => {
-          if (b.lead_score !== a.lead_score) return b.lead_score - a.lead_score;
-          return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
-        })
-        .slice(0, 5),
-    [leads],
+function Metric({ label, value, sublabel }: { label: string; value: string | number; sublabel?: string }) {
+  return (
+    <Card>
+      <CardContent className="py-4">
+        <p className="text-[11px] uppercase tracking-[0.12em] text-bm-muted2">{label}</p>
+        <p className="mt-1 text-2xl font-semibold text-bm-text">{value}</p>
+        {sublabel ? <p className="mt-1 text-xs text-bm-muted2">{sublabel}</p> : null}
+      </CardContent>
+    </Card>
   );
-  const canSeed = Boolean(
-    diagnosticsReliable &&
-    diagnostics &&
-      diagnostics.lead_count === 0 &&
-      diagnostics.open_pipeline_cards === 0 &&
-      diagnostics.outreach_count === 0 &&
-      diagnostics.proposal_count === 0 &&
-      diagnostics.client_count === 0,
-  );
-  const bannerMessage = contextError
-    ? contextError === "Environment not bound to a business."
-      ? "This environment is not bound to a business, so CRM data cannot be loaded."
-      : contextError
-    : dataError;
+}
 
-  const quickActions = useMemo<QuickAction[]>(
+export default function ConsultingCommandCenter({ params }: { params: { envId: string } }) {
+  const { businessId, ready, loading: contextLoading, error: contextError } = useConsultingEnv();
+  const { workspace, loading, mutating, error, seed } = useTrainingWorkspace(params.envId, businessId, ready);
+  const nextEvent = workspace?.summary.next_event ?? null;
+  const mobile = workspace?.summary.mobile_dashboard;
+  const eventPerformance = workspace?.reports.event_performance ?? [];
+
+  const commandLinks = useMemo(
     () => [
-      { label: "Add Lead", href: `${base}/outreach` },
-      { label: "Log Outreach", href: `${base}/outreach` },
-      { label: "Create Proposal", href: `${base}/proposals` },
-      { label: "Convert to Client", href: `${base}/clients` },
-      { label: "View Pipeline", href: `${base}/pipeline` },
-      { label: "Revenue Dashboard", href: `${base}/revenue` },
+      { href: `/lab/env/${params.envId}/consulting/contacts`, label: "Contacts" },
+      { href: `/lab/env/${params.envId}/consulting/events`, label: "Events" },
+      { href: `/lab/env/${params.envId}/consulting/partners`, label: "Venues" },
+      { href: `/lab/env/${params.envId}/consulting/tasks`, label: "Tasks" },
+      { href: `/lab/env/${params.envId}/consulting/reports`, label: "Reports" },
     ],
-    [base],
+    [params.envId],
   );
 
-  const seedWorkspace = useCallback(async () => {
-    if (!businessId || !canSeed) return;
-    setSeeding(true);
-    setDataError(null);
-    try {
-      await seedConsultingWorkspace({ env_id: params.envId, business_id: businessId });
-      await loadWorkspace();
-    } catch (err) {
-      setDataError(formatError(err));
-    } finally {
-      setSeeding(false);
-    }
-  }, [businessId, canSeed, loadWorkspace, params.envId]);
+  if (contextLoading || loading) {
+    return <div className="h-64 rounded-2xl border border-bm-border/60 bg-bm-surface/20 animate-pulse" />;
+  }
 
-  const insightSections = useMemo<InsightSection[]>(() => {
-    const sections: InsightSection[] = [];
-
-    if (m && m.open_opportunities > 0) {
-      sections.push({
-        title: "Pipeline Health",
-        items: [
-          {
-            id: "open-deals",
-            severity: m.open_opportunities > 10 ? "info" : "warning",
-            label: `${m.open_opportunities} open deals`,
-            detail: `Weighted: ${fmtCurrency(m.weighted_pipeline)}`,
-            action: { label: "Pipeline", href: `${base}/pipeline` },
-          },
-          ...(m.won_count_90d > 0
-            ? [
-                {
-                  id: "won-90d",
-                  severity: "info" as const,
-                  label: `${m.won_count_90d} won (90d)`,
-                  detail: `Close rate: ${fmtPct(m.close_rate_90d)}`,
-                },
-              ]
-            : []),
-          ...(m.lost_count_90d > 0
-            ? [
-                {
-                  id: "lost-90d",
-                  severity: "warning" as const,
-                  label: `${m.lost_count_90d} lost (90d)`,
-                  detail: "Review lost deal patterns",
-                  action: { label: "Review", href: `${base}/pipeline` },
-                },
-              ]
-            : []),
-        ],
-      });
-    }
-
-    sections.push({
-      title: "Outreach Performance",
-      items: [
-        {
-          id: "outreach-volume",
-          severity: m && m.outreach_count_30d > 0 ? "info" : "critical",
-          label: `${m?.outreach_count_30d ?? 0} outreach (30d)`,
-          detail: m ? `Response rate: ${fmtPct(m.response_rate_30d)}` : "No data yet",
-          action: { label: "Outreach", href: `${base}/outreach` },
-        },
-        {
-          id: "meetings",
-          severity: m && m.meetings_30d > 0 ? "info" : "warning",
-          label: `${m?.meetings_30d ?? 0} meetings (30d)`,
-          detail: "Scheduled meetings this period",
-        },
-      ],
-    });
-
-    return sections;
-  }, [m, base]);
-
-  if (isLoading) {
-    return (
-      <div className="space-y-4">
-        {[1, 2, 3].map((i) => (
-          <div
-            key={i}
-            className="h-28 rounded-lg border border-bm-border/60 bg-bm-surface/60 animate-pulse"
-          />
-        ))}
-      </div>
-    );
+  if (contextError) {
+    return <EmptyState title="Environment unavailable" body={contextError} />;
   }
 
   return (
-    <div className="space-y-6">
-      {bannerMessage ? (
-        <div className="rounded-lg border border-bm-danger/35 bg-bm-danger/10 px-4 py-3 text-sm text-bm-text">
-          {bannerMessage}
-        </div>
+    <div className="space-y-6 pb-24 md:pb-6">
+      {error ? (
+        <div className="rounded-xl border border-bm-danger/35 bg-bm-danger/10 px-4 py-3 text-sm text-bm-text">{error}</div>
       ) : null}
 
-      <div>
-        <p className="bm-section-label mb-3">Revenue Overview</p>
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
-          <MetricCard
-            label="Weighted Pipeline"
-            value={fmtCurrency(m?.weighted_pipeline)}
-            size="large"
-            status={m && m.weighted_pipeline > 0 ? "success" : "neutral"}
-          />
-          <MetricCard
-            label="Forecast (90d)"
-            value={fmtCurrency(m?.forecast_90d)}
-            size="large"
-          />
-          <MetricCard
-            label="Revenue MTD"
-            value={fmtCurrency(m?.revenue_mtd)}
-            size="large"
-            status={m && m.revenue_mtd > 0 ? "success" : "neutral"}
-          />
-          <MetricCard
-            label="Close Rate (90d)"
-            value={fmtPct(m?.close_rate_90d)}
-            size="large"
-          />
-          <MetricCard
-            label="Outreach (30d)"
-            value={String(m?.outreach_count_30d ?? 0)}
-            size="large"
-          />
-          <MetricCard
-            label="Active Engagements"
-            value={String(m?.active_engagements ?? 0)}
-            size="large"
-          />
-        </div>
-      </div>
-
-      <div>
-        <p className="bm-section-label mb-3">Execution Snapshot</p>
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
-          <MetricCard label="Open Deals" value={String(m?.open_opportunities ?? 0)} size="compact" />
-          <MetricCard label="Active Clients" value={String(m?.active_clients ?? 0)} size="compact" />
-          <MetricCard label="Avg Deal Size" value={fmtCurrency(m?.avg_deal_size)} size="compact" />
-          <MetricCard
-            label="Won (90d)"
-            value={String(m?.won_count_90d ?? 0)}
-            size="compact"
-            status={m && m.won_count_90d > 0 ? "success" : "neutral"}
-          />
-          <MetricCard
-            label="Lost (90d)"
-            value={String(m?.lost_count_90d ?? 0)}
-            size="compact"
-            status={m && m.lost_count_90d > 0 ? "warning" : "neutral"}
-          />
-          <MetricCard label="Revenue QTD" value={fmtCurrency(m?.revenue_qtd)} size="compact" />
-        </div>
-      </div>
-
-      {canSeed ? (
-        <Card>
-          <CardContent className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <section className="rounded-2xl border border-bm-border/70 bg-bm-surface/20 p-4 md:p-5">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-2">
+            <TonePill label="Novendor Local AI Classes CRM" tone="info" />
             <div>
-              <p className="text-sm font-medium">No consulting CRM records found.</p>
-              <p className="text-sm text-bm-muted mt-1">
-                This environment is empty across leads, outreach, proposals, clients, and pipeline.
+              <h2 className="text-2xl font-semibold text-bm-text">Founder-ready command center for local events</h2>
+              <p className="mt-2 max-w-3xl text-sm text-bm-muted2">
+                Manage beginner-friendly AI classes across Lake Worth Beach and West Palm Beach: contacts, venues, events, outreach, check-in, and follow-up from the same mobile-friendly workspace.
               </p>
             </div>
-            <Button onClick={() => void seedWorkspace()} disabled={!businessId || seeding}>
-              {seeding ? "Seeding..." : "Seed Consulting Workspace"}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={() => void seed()} disabled={mutating || Boolean(workspace?.contacts.length)}>
+              {workspace?.contacts.length ? "Seeded" : mutating ? "Seeding..." : "Seed realistic data"}
             </Button>
-          </CardContent>
-        </Card>
-      ) : null}
-
-      <div>
-        <p className="bm-section-label mb-3">Lead Intake</p>
-        <div className="grid gap-4 xl:grid-cols-[1.4fr,1fr]">
-          <Card>
-            <CardContent className="space-y-3">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-sm font-medium">Top Leads</p>
-                  <p className="text-xs text-bm-muted2 mt-1">
-                    Highest-scoring leads in this environment
-                  </p>
-                </div>
-                <div className="flex gap-2 text-xs">
-                  <Link
-                    href={`${base}/outreach`}
-                    className="rounded-md border border-bm-border/70 px-2 py-1 text-bm-text hover:bg-bm-surface/50"
-                  >
-                    All Leads
-                  </Link>
-                  <Link
-                    href={`${base}/pipeline`}
-                    className="rounded-md border border-bm-border/70 px-2 py-1 text-bm-text hover:bg-bm-surface/50"
-                  >
-                    Pipeline
-                  </Link>
-                  <Link
-                    href={`${base}/outreach`}
-                    className="rounded-md border border-bm-border/70 px-2 py-1 text-bm-text hover:bg-bm-surface/50"
-                  >
-                    Add Lead
-                  </Link>
-                </div>
-              </div>
-
-              {topLeads.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-bm-border/70 px-4 py-5 text-sm text-bm-muted2">
-                  No leads yet.
-                </div>
-              ) : (
-                <div className="space-y-2">
-                  {topLeads.map((lead) => (
-                    <div
-                      key={lead.lead_profile_id}
-                      className="rounded-lg border border-bm-border/60 px-3 py-3"
-                    >
-                      <div className="flex items-center justify-between gap-3">
-                        <div className="min-w-0">
-                          <p className="text-sm font-medium truncate">{lead.company_name}</p>
-                          <p className="text-xs text-bm-muted2 mt-1">
-                            {lead.lead_source || "Unknown source"} · {lead.stage_label || "No stage"}
-                          </p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <span className="text-sm font-semibold">{lead.lead_score}</span>
-                          <LeadStatus lead={lead} />
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardContent className="space-y-3">
-              <p className="text-sm font-medium">Workspace Verification</p>
-              <div className="grid grid-cols-2 gap-3 text-sm">
-                <div className="rounded-lg border border-bm-border/60 px-3 py-3">
-                  <p className="text-xs uppercase tracking-[0.1em] text-bm-muted2">Leads</p>
-                  <p className="mt-1 text-xl font-semibold">{diagnostics?.lead_count ?? 0}</p>
-                </div>
-                <div className="rounded-lg border border-bm-border/60 px-3 py-3">
-                  <p className="text-xs uppercase tracking-[0.1em] text-bm-muted2">Open Deals</p>
-                  <p className="mt-1 text-xl font-semibold">{diagnostics?.open_pipeline_cards ?? 0}</p>
-                </div>
-                <div className="rounded-lg border border-bm-border/60 px-3 py-3">
-                  <p className="text-xs uppercase tracking-[0.1em] text-bm-muted2">Outreach</p>
-                  <p className="mt-1 text-xl font-semibold">{diagnostics?.outreach_count ?? 0}</p>
-                </div>
-                <div className="rounded-lg border border-bm-border/60 px-3 py-3">
-                  <p className="text-xs uppercase tracking-[0.1em] text-bm-muted2">Proposals</p>
-                  <p className="mt-1 text-xl font-semibold">{diagnostics?.proposal_count ?? 0}</p>
-                </div>
-              </div>
-              <div className="rounded-lg border border-bm-border/60 px-3 py-3 text-sm">
-                <p className="text-xs uppercase tracking-[0.1em] text-bm-muted2">Clients</p>
-                <p className="mt-1 text-xl font-semibold">{diagnostics?.client_count ?? 0}</p>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-
-      <div className="grid xl:grid-cols-[1fr,320px] gap-6">
-        <QuickActions actions={quickActions} title="Quick Actions" />
-        <div className="hidden xl:block">
-          <div className="sticky top-20">
-            <InsightRail sections={insightSections} />
+            <Link href={`/lab/env/${params.envId}/consulting/events`} className="inline-flex rounded-lg border border-bm-border px-3 py-2 text-sm text-bm-text hover:bg-bm-surface/30">
+              Open check-in
+            </Link>
           </div>
         </div>
-      </div>
+        <div className="mt-4 grid grid-cols-2 gap-2 md:flex md:flex-wrap">
+          {commandLinks.map((item) => (
+            <Link key={item.href} href={item.href} className="rounded-xl border border-bm-border/70 bg-bm-bg px-3 py-3 text-sm font-medium text-bm-text hover:bg-bm-surface/30">
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {!workspace ? (
+        <EmptyState title="Seed the local training CRM" body="No event CRM records exist yet for this environment. Use the seed action above to load a realistic South Florida operating dataset." />
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-3 xl:grid-cols-5">
+            <Metric label="Next Event" value={nextEvent ? fmtDate(nextEvent.event_date) : "—"} sublabel={nextEvent ? nextEvent.event_name : "Seed data to begin"} />
+            <Metric label="Contacts" value={workspace.seed_summary.contacts} sublabel={`${workspace.summary.contacts_added_this_month} added this month`} />
+            <Metric label="Follow-ups due" value={workspace.summary.followups_due} sublabel="Registrations awaiting nurture" />
+            <Metric label="Open tasks" value={workspace.tasks.filter((task) => task.status !== "done").length} sublabel="Phone quick actions included" />
+            <Metric label="Campaigns live" value={workspace.campaigns.filter((campaign) => campaign.status === "active").length} sublabel="Channel performance tracked" />
+          </div>
+
+          <div className="grid gap-4 xl:grid-cols-[1.25fr,0.95fr]">
+            <Card>
+              <CardContent className="py-5">
+                <CardTitle>Dashboard 1 — CRM command center</CardTitle>
+                {nextEvent ? (
+                  <div className="mt-4 space-y-3 rounded-xl border border-bm-border/70 bg-bm-bg p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-bm-text">{nextEvent.event_name}</p>
+                        <p className="mt-1 text-sm text-bm-muted2">
+                          {fmtDate(nextEvent.event_date)} · {fmtTime(nextEvent.event_start_time)} – {fmtTime(nextEvent.event_end_time)} · {nextEvent.venue_name}
+                        </p>
+                      </div>
+                      <TonePill label={nextEvent.event_status} tone={nextEvent.event_status === "scheduled" ? "warning" : "success"} />
+                    </div>
+                    <div className="grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
+                      <div><span className="text-bm-muted2">Target</span><p className="font-semibold">{nextEvent.target_capacity ?? "—"}</p></div>
+                      <div><span className="text-bm-muted2">Registrations</span><p className="font-semibold">{nextEvent.actual_registrations}</p></div>
+                      <div><span className="text-bm-muted2">Ticket</span><p className="font-semibold">{fmtCurrency(nextEvent.ticket_price_standard)}</p></div>
+                      <div><span className="text-bm-muted2">Theme</span><p className="font-semibold">{nextEvent.event_type}</p></div>
+                    </div>
+                  </div>
+                ) : null}
+
+                <div className="mt-4 grid gap-3 md:grid-cols-2">
+                  <div className="rounded-xl border border-bm-border/70 bg-bm-bg p-4">
+                    <h3 className="text-sm font-semibold text-bm-text">Recent activity feed</h3>
+                    <div className="mt-3 space-y-3">
+                      {workspace.summary.recent_activity.slice(0, 5).map((activity) => (
+                        <div key={activity.id} className="border-l-2 border-bm-accent/60 pl-3">
+                          <p className="text-sm font-medium text-bm-text">{activity.subject ?? activity.activity_type}</p>
+                          <p className="text-xs text-bm-muted2">{fmtDate(activity.activity_date)} · {activity.channel ?? "manual"} · {activity.outcome ?? "pending"}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="rounded-xl border border-bm-border/70 bg-bm-bg p-4">
+                    <h3 className="text-sm font-semibold text-bm-text">Venue outreach status</h3>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {Object.entries(workspace.summary.venue_outreach_status).map(([status, count]) => (
+                        <TonePill key={status} label={`${status}: ${count}`} tone={status === "preferred" ? "success" : status === "qualified" ? "info" : "default"} />
+                      ))}
+                    </div>
+                    <p className="mt-3 text-xs text-bm-muted2">Preferred venues and partner pipeline are tracked separately so venue fit, cost, and relationship stage stay auditable.</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardContent className="py-5">
+                <CardTitle>Dashboard 4 — Mobile quick dashboard</CardTitle>
+                <div className="mt-4 space-y-3">
+                  <div className="rounded-xl border border-bm-border/70 bg-bm-bg p-4">
+                    <p className="text-xs uppercase tracking-[0.12em] text-bm-muted2">Today&apos;s tasks</p>
+                    <div className="mt-2 space-y-2">
+                      {mobile?.today_tasks.slice(0, 4).map((task) => (
+                        <div key={task.id} className="flex items-center justify-between gap-2 rounded-lg bg-bm-surface/20 px-3 py-2">
+                          <div>
+                            <p className="text-sm font-medium text-bm-text">{task.task_name}</p>
+                            <p className="text-xs text-bm-muted2">{task.priority} · due {fmtDate(task.due_date)}</p>
+                          </div>
+                          <TonePill label={task.status} tone={task.status === "in_progress" ? "warning" : "default"} />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="rounded-xl border border-bm-border/70 bg-bm-bg p-4">
+                    <p className="text-xs uppercase tracking-[0.12em] text-bm-muted2">Recent registrations</p>
+                    <div className="mt-2 space-y-2">
+                      {mobile?.recent_registrations.map((registration) => (
+                        <div key={registration.registration_id} className="flex items-center justify-between gap-2 rounded-lg bg-bm-surface/20 px-3 py-2">
+                          <div>
+                            <p className="text-sm font-medium text-bm-text">{registration.contact_name}</p>
+                            <p className="text-xs text-bm-muted2">{registration.event_name}</p>
+                          </div>
+                          <TonePill label={registration.payment_status} tone={registration.payment_status === "paid" ? "success" : "warning"} />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-[1.1fr,0.9fr]">
+            <Card>
+              <CardContent className="py-5">
+                <CardTitle>Current-state inventory and target architecture</CardTitle>
+                <div className="mt-4 grid gap-4 lg:grid-cols-2">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.12em] text-bm-muted2">What existed</p>
+                    <div className="mt-3 space-y-3">
+                      {workspace.inventory.existing_objects.map((row) => (
+                        <div key={row.object} className="rounded-xl border border-bm-border/70 bg-bm-bg p-3">
+                          <div className="flex items-center justify-between gap-2">
+                            <p className="text-sm font-semibold text-bm-text">{row.object}</p>
+                            <TonePill label={String(row.usable_as_is)} tone={row.usable_as_is === true ? "success" : row.usable_as_is === false ? "danger" : "warning"} />
+                          </div>
+                          <p className="mt-1 text-xs text-bm-muted2">{row.purpose}</p>
+                          <p className="mt-2 text-xs text-bm-text">Action: {row.action}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.12em] text-bm-muted2">Target architecture</p>
+                    <div className="mt-3 space-y-2">
+                      {Object.entries(workspace.architecture).map(([key, value]) => (
+                        <div key={key} className="rounded-xl border border-bm-border/70 bg-bm-bg px-3 py-2 text-sm">
+                          <span className="font-medium text-bm-text">{key}</span>
+                          <p className="text-xs text-bm-muted2">{value}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardContent className="py-5">
+                <CardTitle>QA receipts</CardTitle>
+                <div className="mt-4 grid grid-cols-2 gap-3">
+                  <Metric label="Orphans" value={workspace.qa.orphan_records} />
+                  <Metric label="Bad statuses" value={workspace.qa.impossible_status_rows} />
+                  <Metric label="Duplicate emails" value={workspace.qa.duplicate_contact_emails.length} />
+                  <Metric label="Registration sync" value={workspace.qa.registration_count_matches_events ? "OK" : "Mismatch"} />
+                </div>
+                <div className="mt-4 rounded-xl border border-bm-border/70 bg-bm-bg p-4">
+                  <p className="text-sm font-semibold text-bm-text">Mobile issues fixed in this build</p>
+                  <ul className="mt-2 space-y-2 text-sm text-bm-muted2">
+                    {workspace.inventory.mobile_problems_before_build.map((item) => (
+                      <li key={item} className="list-disc ml-5">{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card>
+            <CardContent className="py-5">
+              <CardTitle>Dashboard 2 — Event performance</CardTitle>
+              <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                {eventPerformance.map((event) => (
+                  <div key={event.event_id} className="rounded-xl border border-bm-border/70 bg-bm-bg p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-bm-text">{event.event_name}</p>
+                        <p className="mt-1 text-xs text-bm-muted2">Regs {event.registrations} · Attendance {event.attendance}</p>
+                      </div>
+                      <TonePill label={event.capacity_utilization ? `${event.capacity_utilization}% cap` : "—"} tone="info" />
+                    </div>
+                    <div className="mt-3 text-xs text-bm-muted2">
+                      Repeat attendees: {event.repeat_attendance} · Feedback: {event.feedback_score ?? "—"}
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                      {Object.entries(event.channel_conversion).slice(0, 3).map(([channel, count]) => (
+                        <TonePill key={channel} label={`${channel}: ${count}`} />
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </>
+      )}
     </div>
   );
 }

--- a/repo-b/src/app/lab/env/[envId]/consulting/partners/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/consulting/partners/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useConsultingEnv } from "@/components/consulting/ConsultingEnvProvider";
+import { useTrainingWorkspace } from "@/components/consulting/local-training/useTrainingWorkspace";
+import { EmptyState, TonePill, fmtCurrency } from "@/components/consulting/local-training/ui";
+import { Card, CardContent, CardTitle } from "@/components/ui/Card";
+
+export default function PartnersPage({ params }: { params: { envId: string } }) {
+  const { businessId, ready } = useConsultingEnv();
+  const { workspace, loading, error } = useTrainingWorkspace(params.envId, businessId, ready);
+
+  if (loading) return <div className="h-64 rounded-2xl border border-bm-border/60 bg-bm-surface/20 animate-pulse" />;
+  if (!workspace) return <EmptyState title="No venue pipeline" body={error ?? "Seed the workspace to review organizations and venues."} />;
+
+  return (
+    <div className="space-y-5 pb-24 md:pb-6">
+      {error ? <div className="rounded-xl border border-bm-danger/35 bg-bm-danger/10 px-4 py-3 text-sm">{error}</div> : null}
+      <div className="grid gap-4 xl:grid-cols-[1.05fr,1fr]">
+        <Card>
+          <CardContent className="py-5">
+            <CardTitle>Workflow C — Venue and partner pipeline</CardTitle>
+            <p className="mt-2 text-sm text-bm-muted2">Compare fit, cost, and relationship state without relying on a desktop-only table.</p>
+            <div className="mt-4 space-y-3">
+              {workspace.venues.map((venue) => (
+                <div key={venue.id} className="rounded-2xl border border-bm-border/70 bg-bm-bg p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-base font-semibold text-bm-text">{venue.venue_name}</p>
+                      <p className="mt-1 text-sm text-bm-muted2">{venue.city} · {venue.linked_organization_name ?? "Independent"}</p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <TonePill label={venue.venue_status} tone={venue.is_preferred ? "success" : venue.venue_status === "qualified" ? "info" : "default"} />
+                      {venue.is_preferred ? <TonePill label="preferred" tone="success" /> : null}
+                    </div>
+                  </div>
+                  <div className="mt-3 grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
+                    <div><span className="text-bm-muted2">Capacity</span><p className="font-semibold">{venue.capacity_min}–{venue.capacity_max}</p></div>
+                    <div><span className="text-bm-muted2">Cost/hr</span><p className="font-semibold">{fmtCurrency(venue.hourly_cost)}</p></div>
+                    <div><span className="text-bm-muted2">Wi-Fi</span><p className="font-semibold">{venue.wifi_quality}</p></div>
+                    <div><span className="text-bm-muted2">Best use</span><p className="font-semibold">{venue.preferred_for_event_type}</p></div>
+                  </div>
+                  <p className="mt-3 text-xs text-bm-muted2">{venue.notes}</p>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="py-5">
+            <CardTitle>Organizations and referral partners</CardTitle>
+            <div className="mt-4 space-y-3">
+              {workspace.organizations.map((organization) => (
+                <div key={organization.crm_account_id} className="rounded-2xl border border-bm-border/70 bg-bm-bg p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-base font-semibold text-bm-text">{organization.organization_name}</p>
+                      <p className="mt-1 text-sm text-bm-muted2">{organization.organization_type} · {organization.city}, {organization.state}</p>
+                    </div>
+                    <TonePill label={organization.partner_status ?? "—"} tone={organization.partner_status === "qualified" ? "success" : organization.partner_status === "contacted" ? "info" : "default"} />
+                  </div>
+                  <div className="mt-3 grid gap-2 text-sm">
+                    <p><span className="text-bm-muted2">Relationship:</span> {organization.relationship_type}</p>
+                    <p><span className="text-bm-muted2">Owner contact:</span> {organization.owner_contact_name} · {organization.owner_contact_email}</p>
+                    <p className="text-bm-muted2">{organization.notes}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/app/lab/env/[envId]/consulting/reports/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/consulting/reports/page.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useConsultingEnv } from "@/components/consulting/ConsultingEnvProvider";
+import { useTrainingWorkspace } from "@/components/consulting/local-training/useTrainingWorkspace";
+import { EmptyState, TonePill, fmtCurrency } from "@/components/consulting/local-training/ui";
+import { Card, CardContent, CardTitle } from "@/components/ui/Card";
+
+export default function ReportsPage({ params }: { params: { envId: string } }) {
+  const { businessId, ready } = useConsultingEnv();
+  const { workspace, loading, error } = useTrainingWorkspace(params.envId, businessId, ready);
+
+  if (loading) return <div className="h-64 rounded-2xl border border-bm-border/60 bg-bm-surface/20 animate-pulse" />;
+  if (!workspace) return <EmptyState title="No reporting data" body={error ?? "Seed the workspace to review dashboards."} />;
+
+  return (
+    <div className="space-y-5 pb-24 md:pb-6">
+      {error ? <div className="rounded-xl border border-bm-danger/35 bg-bm-danger/10 px-4 py-3 text-sm">{error}</div> : null}
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Card>
+          <CardContent className="py-5">
+            <CardTitle>Dashboard 2 — Event performance</CardTitle>
+            <div className="mt-4 space-y-3">
+              {workspace.reports.event_performance.map((event) => (
+                <div key={event.event_id} className="rounded-2xl border border-bm-border/70 bg-bm-bg p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-base font-semibold text-bm-text">{event.event_name}</p>
+                      <p className="mt-1 text-sm text-bm-muted2">Regs {event.registrations} · Attendance {event.attendance}</p>
+                    </div>
+                    <TonePill label={event.capacity_utilization ? `${event.capacity_utilization}% full` : "—"} tone="info" />
+                  </div>
+                  <div className="mt-3 grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
+                    <div><span className="text-bm-muted2">Repeat</span><p className="font-semibold">{event.repeat_attendance}</p></div>
+                    <div><span className="text-bm-muted2">Feedback</span><p className="font-semibold">{event.feedback_score ?? "—"}</p></div>
+                    <div><span className="text-bm-muted2">Early bird</span><p className="font-semibold">{event.price_mix.early_bird}</p></div>
+                    <div><span className="text-bm-muted2">Standard</span><p className="font-semibold">{event.price_mix.standard}</p></div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="py-5">
+            <CardTitle>Dashboard 3 — Partnership and venue pipeline</CardTitle>
+            <div className="mt-4 space-y-3">
+              {workspace.reports.partnership_pipeline.cost_comparison.map((venue) => (
+                <div key={venue.venue_name} className="rounded-2xl border border-bm-border/70 bg-bm-bg p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-base font-semibold text-bm-text">{venue.venue_name}</p>
+                      <p className="mt-1 text-sm text-bm-muted2">{venue.city}</p>
+                    </div>
+                    <TonePill label={fmtCurrency(venue.hourly_cost)} />
+                  </div>
+                  <p className="mt-2 text-sm text-bm-muted2">Capacity up to {venue.capacity_max ?? "—"}</p>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardContent className="py-5">
+          <CardTitle>Seed data summary + suggested next expansions</CardTitle>
+          <div className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5">
+            {Object.entries(workspace.seed_summary).map(([key, value]) => (
+              <div key={key} className="rounded-xl border border-bm-border/70 bg-bm-bg px-3 py-3">
+                <p className="text-xs uppercase tracking-[0.12em] text-bm-muted2">{key.replace(/_/g, " ")}</p>
+                <p className="mt-1 text-2xl font-semibold text-bm-text">{value}</p>
+              </div>
+            ))}
+          </div>
+          <ul className="mt-4 space-y-2 text-sm text-bm-muted2">
+            <li className="ml-5 list-disc">Add a lightweight landing page intake form that writes directly into contacts + registrations.</li>
+            <li className="ml-5 list-disc">Add QR-code check-in for repeated classes and partner-hosted sessions.</li>
+            <li className="ml-5 list-disc">Add reusable reminder and follow-up email templates tuned for older adults and beginners.</li>
+            <li className="ml-5 list-disc">Add recurring event cloning plus waitlist overflow handling.</li>
+            <li className="ml-5 list-disc">Add sponsor tracking and simple revenue reconciliation once recurring events stabilize.</li>
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/repo-b/src/app/lab/env/[envId]/consulting/tasks/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/consulting/tasks/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useConsultingEnv } from "@/components/consulting/ConsultingEnvProvider";
+import { useTrainingWorkspace } from "@/components/consulting/local-training/useTrainingWorkspace";
+import { EmptyState, TonePill, fmtDate } from "@/components/consulting/local-training/ui";
+import { Button } from "@/components/ui/Button";
+import { Card, CardContent, CardTitle } from "@/components/ui/Card";
+
+export default function TasksPage({ params }: { params: { envId: string } }) {
+  const { businessId, ready } = useConsultingEnv();
+  const { workspace, loading, mutating, error, updateTask } = useTrainingWorkspace(params.envId, businessId, ready);
+  const [showQuickOnly, setShowQuickOnly] = useState(true);
+
+  const tasks = useMemo(() => {
+    const rows = workspace?.tasks ?? [];
+    return rows.filter((task) => !showQuickOnly || task.mobile_quick_action_flag);
+  }, [showQuickOnly, workspace?.tasks]);
+
+  if (loading) return <div className="h-64 rounded-2xl border border-bm-border/60 bg-bm-surface/20 animate-pulse" />;
+  if (!workspace) return <EmptyState title="No tasks yet" body={error ?? "Seed the workspace to review tasks."} />;
+
+  return (
+    <div className="space-y-5 pb-24 md:pb-6">
+      {error ? <div className="rounded-xl border border-bm-danger/35 bg-bm-danger/10 px-4 py-3 text-sm">{error}</div> : null}
+      <Card>
+        <CardContent className="py-5">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <CardTitle>Workflow G — Mobile-first task execution</CardTitle>
+              <p className="mt-2 text-sm text-bm-muted2">Quick-complete actions stay tap-friendly and avoid dense enterprise tables.</p>
+            </div>
+            <button onClick={() => setShowQuickOnly((value) => !value)} className="rounded-full border border-bm-border px-3 py-2 text-xs text-bm-text">
+              {showQuickOnly ? "Show all tasks" : "Show quick actions only"}
+            </button>
+          </div>
+          <div className="mt-4 space-y-3">
+            {tasks.map((task) => (
+              <div key={task.id} className="rounded-2xl border border-bm-border/70 bg-bm-bg p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="text-base font-semibold text-bm-text">{task.task_name}</p>
+                      {task.mobile_quick_action_flag ? <TonePill label="mobile quick action" tone="info" /> : null}
+                    </div>
+                    <p className="mt-1 text-sm text-bm-muted2">{task.related_entity_type ?? "general"} · due {fmtDate(task.due_date)}</p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <TonePill label={task.priority} tone={task.priority === "high" ? "warning" : "default"} />
+                    <TonePill label={task.status} tone={task.status === "done" ? "success" : task.status === "in_progress" ? "info" : "default"} />
+                  </div>
+                </div>
+                <p className="mt-3 text-sm text-bm-muted2">{task.notes}</p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button size="sm" variant={task.status === "open" ? "primary" : "secondary"} onClick={() => void updateTask(task.id, "open")} disabled={mutating}>Open</Button>
+                  <Button size="sm" variant={task.status === "in_progress" ? "primary" : "secondary"} onClick={() => void updateTask(task.id, "in_progress")} disabled={mutating}>In progress</Button>
+                  <Button size="sm" variant={task.status === "done" ? "primary" : "secondary"} onClick={() => void updateTask(task.id, "done")} disabled={mutating}>Done</Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/repo-b/src/components/consulting/ConsultingWorkspaceShell.tsx
+++ b/repo-b/src/components/consulting/ConsultingWorkspaceShell.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useMemo } from "react";
 import { useConsultingEnv } from "@/components/consulting/ConsultingEnvProvider";
+import { MobileBottomNav, type MobileNavItem } from "@/components/repe/workspace/MobileBottomNav";
 
 function isActive(pathname: string, href: string, isBase: boolean): boolean {
   if (isBase) {
@@ -29,13 +30,27 @@ export default function ConsultingWorkspaceShell({
   const navItems = useMemo(
     () => [
       { href: base, label: "Command Center", isBase: true },
-      { href: `${base}/pipeline`, label: "Pipeline", isBase: false },
-      { href: `${base}/outreach`, label: "Outreach", isBase: false },
+      { href: `${base}/contacts`, label: "Contacts", isBase: false },
+      { href: `${base}/events`, label: "Events", isBase: false },
+      { href: `${base}/partners`, label: "Partners & Venues", isBase: false },
+      { href: `${base}/campaigns`, label: "Campaigns", isBase: false },
+      { href: `${base}/tasks`, label: "Tasks", isBase: false },
+      { href: `${base}/reports`, label: "Reports", isBase: false },
+      { href: `${base}/pipeline`, label: "Legacy Pipeline", isBase: false },
+      { href: `${base}/outreach`, label: "Legacy Outreach", isBase: false },
       { href: `${base}/strategic-outreach`, label: "Strategic Outreach", isBase: false },
-      { href: `${base}/proposals`, label: "Proposals", isBase: false },
       { href: `${base}/clients`, label: "Clients", isBase: false },
       { href: `${base}/loops`, label: "Loop Intelligence", isBase: false },
-      { href: `${base}/authority`, label: "Authority", isBase: false },
+    ],
+    [base],
+  );
+  const mobileNavItems = useMemo<MobileNavItem[]>(
+    () => [
+      { href: `${base}/contacts`, label: "Contacts", icon: "investors", matchPrefix: true },
+      { href: `${base}/events`, label: "Events", icon: "funds", matchPrefix: true },
+      { href: base, label: "Home", icon: "winston", matchPrefix: false },
+      { href: `${base}/tasks`, label: "Tasks", icon: "pipeline", matchPrefix: true },
+      { href: `${base}/reports`, label: "Reports", icon: "reports", matchPrefix: true },
     ],
     [base],
   );
@@ -103,24 +118,24 @@ export default function ConsultingWorkspaceShell({
               Home
             </Link>
             <Link
-              href={`${base}/outreach/new`}
+              href={`${base}/contacts`}
               className="inline-flex items-center gap-1 rounded-lg border border-bm-border px-3 py-2 text-sm hover:bg-bm-surface/40"
             >
-              + Lead
+              + Contact
             </Link>
             <Link
-              href={`${base}/proposals/new`}
+              href={`${base}/events`}
               className="inline-flex items-center gap-1 rounded-lg border border-bm-border px-3 py-2 text-sm hover:bg-bm-surface/40"
             >
-              + Proposal
+              + Event
             </Link>
           </div>
         </div>
       </section>
 
-      <div className="grid gap-4 lg:grid-cols-[200px,1fr]">
+      <div className="grid gap-4 lg:grid-cols-[220px,1fr]">
         <aside
-          className="rounded-xl border border-bm-border/70 bg-bm-bg p-3 h-fit"
+          className="hidden rounded-xl border border-bm-border/70 bg-bm-bg p-3 h-fit lg:block"
           data-testid="consulting-sidebar"
         >
           <nav className="space-y-1.5" data-testid="consulting-left-nav">
@@ -139,8 +154,9 @@ export default function ConsultingWorkspaceShell({
             ))}
           </nav>
         </aside>
-        <div>{children}</div>
+        <div className="pb-20 md:pb-0">{children}</div>
       </div>
+      <MobileBottomNav items={mobileNavItems} />
     </div>
   );
 }

--- a/repo-b/src/components/consulting/local-training/ui.tsx
+++ b/repo-b/src/components/consulting/local-training/ui.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/Card";
+
+export function fmtCurrency(value: number | null | undefined) {
+  if (value == null || Number.isNaN(value)) return "—";
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(value);
+}
+
+export function fmtDate(value: string | null | undefined) {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export function fmtTime(value: string | null | undefined) {
+  if (!value) return "—";
+  const parsed = new Date(`1970-01-01T${value}`);
+  if (Number.isNaN(parsed.getTime())) return value.slice(0, 5);
+  return parsed.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+}
+
+export function TonePill({ label, tone = "default" }: { label: string; tone?: "default" | "success" | "warning" | "danger" | "info" }) {
+  const cls = {
+    default: "bg-bm-surface/40 text-bm-text",
+    success: "bg-bm-success/10 text-bm-success",
+    warning: "bg-bm-warning/10 text-bm-warning",
+    danger: "bg-bm-danger/10 text-bm-danger",
+    info: "bg-bm-accent/10 text-bm-accent",
+  }[tone];
+  return <span className={`inline-flex rounded-full px-2 py-1 text-[11px] font-medium ${cls}`}>{label}</span>;
+}
+
+export function EmptyState({ title, body }: { title: string; body: string }) {
+  return (
+    <Card>
+      <CardContent className="py-6 text-center">
+        <p className="text-sm font-medium text-bm-text">{title}</p>
+        <p className="mt-1 text-sm text-bm-muted2">{body}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/repo-b/src/components/consulting/local-training/useTrainingWorkspace.ts
+++ b/repo-b/src/components/consulting/local-training/useTrainingWorkspace.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  checkInTrainingRegistration,
+  createTrainingActivity,
+  createTrainingContact,
+  createTrainingEvent,
+  fetchTrainingWorkspace,
+  seedTrainingWorkspace,
+  updateTrainingTask,
+  upsertTrainingRegistration,
+  type TrainingWorkspace,
+} from "@/lib/local-training-api";
+
+export function useTrainingWorkspace(envId: string, businessId: string | null, ready: boolean) {
+  const [workspace, setWorkspace] = useState<TrainingWorkspace | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [mutating, setMutating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    if (!businessId) {
+      setWorkspace(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const payload = await fetchTrainingWorkspace(envId, businessId);
+      setWorkspace(payload);
+    } catch (err) {
+      setWorkspace(null);
+      setError(err instanceof Error ? err.message : "Unable to load local training CRM workspace.");
+    } finally {
+      setLoading(false);
+    }
+  }, [businessId, envId]);
+
+  useEffect(() => {
+    if (!ready) return;
+    void reload();
+  }, [ready, reload]);
+
+  const runMutation = useCallback(
+    async (task: () => Promise<unknown>) => {
+      setMutating(true);
+      setError(null);
+      try {
+        await task();
+        await reload();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Mutation failed.");
+      } finally {
+        setMutating(false);
+      }
+    },
+    [reload],
+  );
+
+  return {
+    workspace,
+    loading,
+    mutating,
+    error,
+    reload,
+    seed: async () => {
+      if (!businessId) return;
+      await runMutation(() => seedTrainingWorkspace({ env_id: envId, business_id: businessId }));
+    },
+    createContact: async (body: Record<string, unknown>) => {
+      if (!businessId) return;
+      await runMutation(() => createTrainingContact({ ...body, env_id: envId, business_id: businessId }));
+    },
+    createEvent: async (body: Record<string, unknown>) => {
+      if (!businessId) return;
+      await runMutation(() => createTrainingEvent({ ...body, env_id: envId, business_id: businessId }));
+    },
+    createActivity: async (body: Record<string, unknown>) => {
+      if (!businessId) return;
+      await runMutation(() => createTrainingActivity({ ...body, env_id: envId, business_id: businessId }));
+    },
+    upsertRegistration: async (body: Record<string, unknown>) => {
+      if (!businessId) return;
+      await runMutation(() => upsertTrainingRegistration({ ...body, env_id: envId, business_id: businessId }));
+    },
+    checkIn: async (registrationId: string, attendedFlag = true) => {
+      await runMutation(() => checkInTrainingRegistration(registrationId, attendedFlag));
+    },
+    updateTask: async (taskId: string, status: "open" | "in_progress" | "done") => {
+      await runMutation(() => updateTrainingTask(taskId, status));
+    },
+  };
+}

--- a/repo-b/src/lib/local-training-api.ts
+++ b/repo-b/src/lib/local-training-api.ts
@@ -1,0 +1,304 @@
+import { apiFetch } from "@/lib/api";
+
+const BASE = "/bos/api/consulting/local-training";
+
+export type TrainingWorkspace = {
+  inventory: {
+    existing_objects: Array<{ object: string; purpose: string; usable_as_is: boolean | string; action: string }>;
+    duplicates_or_overlaps: string[];
+    missing_relationships_before_build: string[];
+    mobile_problems_before_build: string[];
+  };
+  architecture: Record<string, string>;
+  summary: {
+    next_event: TrainingEvent | null;
+    contacts_added_this_month: number;
+    followups_due: number;
+    venue_outreach_status: Record<string, number>;
+    partner_status: Record<string, number>;
+    recent_activity: TrainingActivity[];
+    campaign_performance: Array<{
+      campaign_name: string;
+      channel: string;
+      target_event_name: string | null;
+      leads_generated: number;
+      registrations_generated: number;
+      cost_per_registration: number | null;
+    }>;
+    mobile_dashboard: {
+      today_tasks: TrainingTask[];
+      next_event: TrainingEvent | null;
+      outstanding_followups: TrainingRegistration[];
+      recent_registrations: TrainingRegistration[];
+      check_in_shortcut_event_id: string | null;
+    };
+  };
+  reports: {
+    event_performance: Array<{
+      event_id: string;
+      event_name: string;
+      registrations: number;
+      attendance: number;
+      capacity_utilization: number | null;
+      price_mix: { early_bird: number; standard: number };
+      repeat_attendance: number;
+      feedback_score: number | null;
+      channel_conversion: Record<string, number>;
+    }>;
+    partnership_pipeline: {
+      active_venue_conversations: TrainingVenue[];
+      preferred_venues: TrainingVenue[];
+      cost_comparison: Array<{ venue_name: string; city: string; hourly_cost: number | null; capacity_max: number | null }>;
+      next_touch_needed: TrainingActivity[];
+    };
+  };
+  qa: {
+    orphan_records: number;
+    duplicate_contact_emails: string[];
+    impossible_status_rows: number;
+    registration_count_matches_events: boolean;
+  };
+  seed_summary: Record<string, number>;
+  contacts: TrainingContact[];
+  organizations: TrainingOrganization[];
+  venues: TrainingVenue[];
+  events: TrainingEvent[];
+  registrations: TrainingRegistration[];
+  campaigns: TrainingCampaign[];
+  activities: TrainingActivity[];
+  tasks: TrainingTask[];
+  feedback: TrainingFeedback[];
+};
+
+export type TrainingContact = {
+  crm_contact_id: string;
+  first_name: string | null;
+  last_name: string | null;
+  full_name: string;
+  email: string | null;
+  phone: string | null;
+  title: string | null;
+  crm_account_id: string | null;
+  organization_name: string | null;
+  preferred_contact_method: string | null;
+  city: string | null;
+  age_band: string | null;
+  persona_type: string | null;
+  audience_segment: string | null;
+  business_owner_flag: boolean;
+  company_name_text: string | null;
+  notes: string | null;
+  lead_source: string | null;
+  status: string;
+  consent_to_email: boolean;
+  first_event_attended_id: string | null;
+  total_events_attended: number;
+  interest_area: string | null;
+  follow_up_priority: string | null;
+  tags: string[];
+  created_at: string;
+  updated_at: string;
+};
+
+export type TrainingOrganization = {
+  crm_account_id: string;
+  organization_name: string;
+  organization_type: string;
+  website: string | null;
+  phone: string | null;
+  city: string | null;
+  state: string | null;
+  relationship_type: string | null;
+  partner_status: string | null;
+  notes: string | null;
+  owner_contact_id: string | null;
+  owner_contact_name: string | null;
+  owner_contact_email: string | null;
+};
+
+export type TrainingVenue = {
+  id: string;
+  linked_organization_id: string | null;
+  venue_name: string;
+  address: string | null;
+  city: string | null;
+  state: string | null;
+  zip: string | null;
+  website: string | null;
+  contact_name: string | null;
+  contact_email: string | null;
+  contact_phone: string | null;
+  capacity_min: number | null;
+  capacity_max: number | null;
+  wifi_quality: string | null;
+  av_available: boolean;
+  parking_notes: string | null;
+  accessibility_notes: string | null;
+  hourly_cost: number | null;
+  deposit_required: boolean;
+  preferred_for_event_type: string | null;
+  venue_status: string;
+  is_preferred: boolean;
+  notes: string | null;
+  linked_organization_name: string | null;
+};
+
+export type TrainingEvent = {
+  id: string;
+  event_name: string;
+  event_series: string | null;
+  event_type: string;
+  event_status: string;
+  event_date: string;
+  event_start_time: string | null;
+  event_end_time: string | null;
+  venue_id: string | null;
+  city: string | null;
+  target_capacity: number | null;
+  actual_registrations: number;
+  actual_attendance: number;
+  ticket_price_standard: number | null;
+  ticket_price_early: number | null;
+  event_theme: string | null;
+  audience_level: string | null;
+  instructor: string | null;
+  assistant_count: number;
+  registration_link: string | null;
+  check_in_status: string;
+  follow_up_sent_flag: boolean;
+  notes: string | null;
+  outcome_summary: string | null;
+  venue_name: string | null;
+};
+
+export type TrainingRegistration = {
+  registration_id: string;
+  event_id: string;
+  contact_id: string;
+  registration_date: string;
+  ticket_type: string | null;
+  price_paid: number | null;
+  payment_status: string;
+  attended_flag: boolean;
+  checked_in_time: string | null;
+  source_channel: string | null;
+  referral_source: string | null;
+  follow_up_status: string | null;
+  feedback_score: number | null;
+  feedback_notes: string | null;
+  walk_in_flag: boolean;
+  contact_name: string;
+  contact_email: string | null;
+  contact_phone: string | null;
+  event_name: string;
+};
+
+export type TrainingCampaign = {
+  id: string;
+  campaign_name: string;
+  channel: string;
+  audience: string | null;
+  launch_date: string | null;
+  end_date: string | null;
+  budget: number | null;
+  target_event_id: string | null;
+  message_angle: string | null;
+  status: string;
+  leads_generated: number;
+  registrations_generated: number;
+  notes: string | null;
+  target_event_name: string | null;
+};
+
+export type TrainingActivity = {
+  id: string;
+  activity_type: string;
+  contact_id: string | null;
+  organization_id: string | null;
+  event_id: string | null;
+  campaign_id: string | null;
+  owner: string | null;
+  activity_date: string;
+  channel: string | null;
+  subject: string | null;
+  message_summary: string | null;
+  outcome: string | null;
+  next_step: string | null;
+  due_date: string | null;
+  status: string;
+  contact_name: string | null;
+  organization_name: string | null;
+  event_name: string | null;
+  campaign_name: string | null;
+};
+
+export type TrainingTask = {
+  id: string;
+  task_name: string;
+  related_entity_type: string | null;
+  related_entity_id: string | null;
+  assigned_to: string | null;
+  priority: string;
+  due_date: string | null;
+  status: string;
+  mobile_quick_action_flag: boolean;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TrainingFeedback = {
+  id: string;
+  event_id: string;
+  contact_id: string;
+  rating: number | null;
+  what_they_found_useful: string | null;
+  what_was_confusing: string | null;
+  would_attend_again: boolean | null;
+  would_bring_friend: boolean | null;
+  testimonial_permission: boolean;
+  testimonial_text: string | null;
+  contact_name: string;
+  event_name: string;
+};
+
+export function fetchTrainingWorkspace(envId: string, businessId: string) {
+  return apiFetch<TrainingWorkspace>(`${BASE}/workspace?env_id=${envId}&business_id=${businessId}`);
+}
+
+export function seedTrainingWorkspace(body: { env_id: string; business_id: string }) {
+  return apiFetch<Record<string, number | string>>(`${BASE}/seed`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function createTrainingContact(body: Record<string, unknown>) {
+  return apiFetch(`${BASE}/contacts`, { method: "POST", body: JSON.stringify(body) });
+}
+
+export function createTrainingEvent(body: Record<string, unknown>) {
+  return apiFetch(`${BASE}/events`, { method: "POST", body: JSON.stringify(body) });
+}
+
+export function createTrainingActivity(body: Record<string, unknown>) {
+  return apiFetch(`${BASE}/activities`, { method: "POST", body: JSON.stringify(body) });
+}
+
+export function upsertTrainingRegistration(body: Record<string, unknown>) {
+  return apiFetch(`${BASE}/registrations`, { method: "POST", body: JSON.stringify(body) });
+}
+
+export function checkInTrainingRegistration(registrationId: string, attended_flag = true) {
+  return apiFetch(`${BASE}/registrations/${registrationId}/check-in`, {
+    method: "PATCH",
+    body: JSON.stringify({ attended_flag }),
+  });
+}
+
+export function updateTrainingTask(taskId: string, status: "open" | "in_progress" | "done") {
+  return apiFetch(`${BASE}/tasks/${taskId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ status }),
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, mobile-first CRM and operating console inside Winston to run in-person beginner AI classes (Lake Worth / West Palm Beach) with realistic seeded data. 
- Avoid bolting desktop-only consulting UI onto event operations by adding explicit event, venue, registration, campaign, task, outreach, and feedback support. 
- Make day-of workflows (check-in, walk-ins, quick actions) practical on a phone and keep all records relational and auditable. 

### Description
- Data model and migration: add SQL schema `repo-b/db/schema/417_local_ai_training_crm.sql` that creates `nv_contact_profile`, `nv_organization_profile`, `nv_venue`, `nv_training_event`, `nv_event_registration`, `nv_campaign`, `nv_training_outreach_activity`, `nv_task`, and `nv_event_feedback`. 
- Backend: add Pydantic schemas `backend/app/schemas/local_training.py`, service implementation `backend/app/services/local_training_crm.py` (seed, workspace reads, create contact/event/activity/registration, check-in, toggle task), and wire routes under the consulting router at `/bos/api/consulting/local-training/*` in `backend/app/routes/consulting.py`. 
- Frontend/UI: add a mobile-first Command Center and pages under `repo-b/src/app/lab/env/[envId]/consulting/` for `contacts`, `events`, `partners`, `campaigns`, `tasks`, and `reports`, plus helper UI and hook in `repo-b/src/components/consulting/local-training/*` and a typed client `repo-b/src/lib/local-training-api.ts`. 
- UX/navigation: surface new pages in the consulting shell and add a mobile bottom navigation via `repo-b/src/components/consulting/ConsultingWorkspaceShell.tsx` using `MobileBottomNav`, with seed control and one-tap mobile workflows (check-in, walk-in, quick-complete tasks). 
- Seed & docs: deterministic realistic South Florida seed logic (40–75 contacts mix, venues, campaigns, registrations, feedback) in `local_training_crm.seed_local_training_workspace` and a receipts/QA document `docs/local-ai-training-crm-receipts.md` describing inventory, architecture, mappings, assumptions, and QA checks. 

### Testing
- Python compile: ran `python3 -m py_compile backend/app/services/local_training_crm.py backend/app/schemas/local_training.py backend/app/routes/consulting.py` and it completed successfully. 
- Typecheck: ran the frontend typecheck with `npm --prefix repo-b run typecheck` and `tsc --noEmit` completed with no type errors. 
- The new files were committed and validated locally; migration SQL was added but not applied to a live database in this session, so run the migration before seeding in a running environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00eeea08c8331b8b051cbf30cbb94)