### PR TITLE
fix(chat): Lane B routing + New Chat cleanup + catalog guard

### DIFF
--- a/backend/app/services/ai_gateway.py
+++ b/backend/app/services/ai_gateway.py
@@ -1343,12 +1343,25 @@ async def _run_repe_fast_path(
                 from app.sql_agent.combined_agent import generate_sql
                 from app.sql_agent.catalog import catalog_text_dynamic
                 catalog = catalog_text_dynamic(business_id=scenario.business_id)
-                generated = await generate_sql(
-                    message=intent.original_message,
-                    catalog=catalog,
-                    business_id=scenario.business_id,
-                )
-                sql = generated.get("sql", "")
+                if not catalog or len(catalog.strip()) < 50:
+                    emit_log(
+                        level="error",
+                        service="backend",
+                        action="ai.gateway.generate_sql.empty_catalog",
+                        message="catalog_text_dynamic returned empty or too-short catalog",
+                        context={"business_id": str(scenario.business_id), "catalog_len": len(catalog or "")},
+                    )
+                    err_text = "I couldn't generate a query — the data catalog for this environment is not available."
+                    yield _sse("token", {"text": err_text})
+                    collected_text_parts.append(err_text)
+                    sql = ""
+                else:
+                    generated = await generate_sql(
+                        message=intent.original_message,
+                        catalog=catalog,
+                        business_id=scenario.business_id,
+                    )
+                    sql = generated.get("sql", "")
             except RuntimeError as e:
                 # Config/key error (e.g. OPENAI_API_KEY not set) — surface to user
                 emit_log(
@@ -3694,6 +3707,16 @@ async def run_gateway_stream(
     )
     timings["tools_sent"] = len(openai_tools)
     timings["total_ms"] = elapsed_ms
+
+    if elapsed_ms > 10_000 and route.lane == "B":
+        emit_log(
+            level="warning",
+            service="backend",
+            action="ai.gateway.lane_b_slow",
+            message=f"Lane B response exceeding 10s target ({elapsed_ms}ms)",
+            context={"elapsed_ms": elapsed_ms, "tokens": total_completion_tokens,
+                      "tool_calls": tool_call_count, "history_msgs": len(messages)},
+        )
 
     # Track RAG as data source
     if rag_chunks:

--- a/backend/app/services/request_router.py
+++ b/backend/app/services/request_router.py
@@ -311,7 +311,8 @@ def classify_request(
             needs_structured_retrieval=has_financial_metrics,
         )
 
-    # Simple list with visible data already present → Lane A
+    # Simple list with visible data → Lane B (tool-backed) so Winston pulls
+    # enriched live data instead of restating what's already on screen.
     if _SIMPLE_LIST_RE.search(message) and visible_data:
         for entity_word, records in [
             ("fund", visible_data.funds),
@@ -323,16 +324,16 @@ def classify_request(
         ]:
             if records and entity_word in message.lower():
                 return RouteDecision(
-                    lane="A",
+                    lane="B",
                     skip_rag=True,
-                    skip_tools=True,
-                    max_tool_rounds=0,
-                    max_tokens=512,
-                    temperature=0.1,
+                    skip_tools=False,
+                    max_tool_rounds=2,
+                    max_tokens=1024,
+                    temperature=0.2,
                     model=OPENAI_CHAT_MODEL_FAST,
                     rag_top_k=0,
                     rag_max_tokens=0,
-                    history_max_tokens=800,
+                    history_max_tokens=1500,
                 )
 
     # Simple lookup → Lane B (2 tool rounds, no RAG)

--- a/repo-b/src/components/winston/WinstonChatWorkspace.tsx
+++ b/repo-b/src/components/winston/WinstonChatWorkspace.tsx
@@ -147,9 +147,17 @@ export default function WinstonChatWorkspace() {
     setBusy(false);
     setThinkingStatus(undefined);
     setContextPanel({ tools: [], citations: [] });
+    // Clear stale context so the next message fetches fresh data
+    setContextSnapshot(null);
     if (abortRef.current) {
       abortRef.current.abort();
       abortRef.current = null;
+    }
+    // Flush token buffer to prevent stale tokens from previous conversation
+    tokenBufferRef.current = "";
+    if (tokenFlushTimerRef.current) {
+      clearTimeout(tokenFlushTimerRef.current);
+      tokenFlushTimerRef.current = null;
     }
   }, [contextKey]);
 


### PR DESCRIPTION
## Summary
- **Lane A → Lane B routing**: Simple list queries ("What funds do we have?") now route to Lane B with tools enabled, so Winston calls `repe.get_environment_snapshot` for enriched data instead of narrating on Lane A with no tool access
- **New Chat state cleanup**: `startNewConversation()` now clears `contextSnapshot`, `tokenBufferRef`, and `tokenFlushTimerRef` — prevents stale context and buffered tokens from leaking into new conversations
- **Empty catalog guard**: SQL generation fails fast with a user-facing message when `catalog_text_dynamic()` returns empty, instead of burning 12-14s on a doomed LLM call
- **Lane B latency warning**: Logs a warning when Lane B responses exceed 10s for observability

## Test plan
- [ ] Send "What funds do we have?" — verify it routes to Lane B, calls tools, returns real data
- [ ] Click "New Chat" then send a message — verify `conversation_id` is null on request, no history from previous thread
- [ ] Send "Show me top 5 assets by NOI" in an environment with no catalog — verify fast error message
- [ ] Check Railway logs for `ai.gateway.lane_b_slow` entries on slow responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)