### PR TITLE
feat(resume): mobile-only responsive optimizations across Visual Resume

### DIFF
--- a/repo-b/src/components/domain/DomainWorkspaceShell.tsx
+++ b/repo-b/src/components/domain/DomainWorkspaceShell.tsx
@@ -270,25 +270,29 @@ export default function DomainWorkspaceShell({
 
   return (
     <div className="space-y-4">
-      <header className={`sticky top-0 z-30 flex items-center gap-3 border-b border-bm-border/60 bg-bm-bg/95 px-4 py-3 backdrop-blur lg:hidden ${domain === "resume" && items.length === 0 ? "hidden" : ""}`}>
-        <button
-          type="button"
-          onClick={() => setDrawerOpen(true)}
-          className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-bm-border/70 bg-bm-surface/25 text-bm-text"
-          aria-label={`Open ${DOMAIN_LABELS[domain]} navigation`}
-        >
-          <Menu size={18} />
-        </button>
+      <header className={`sticky top-0 z-30 flex items-center gap-3 border-b border-bm-border/60 bg-bm-bg/95 backdrop-blur lg:hidden ${domain === "resume" && items.length === 0 ? "hidden" : ""} ${domain === "resume" ? "px-3 py-1.5" : "px-4 py-3"}`}>
+        {items.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setDrawerOpen(true)}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-bm-border/70 bg-bm-surface/25 text-bm-text"
+            aria-label={`Open ${DOMAIN_LABELS[domain]} navigation`}
+          >
+            <Menu size={18} />
+          </button>
+        )}
         <div className="min-w-0 flex-1">
-          <p className="truncate text-[10px] uppercase tracking-[0.18em] text-bm-muted2">{DOMAIN_LABELS[domain]}</p>
+          <p className="truncate text-[10px] uppercase tracking-[0.14em] text-bm-muted2">{DOMAIN_LABELS[domain]}</p>
           <p className="truncate text-sm font-semibold text-bm-text">{envLabel}</p>
         </div>
-        <Link
-          href={homeHref}
-          className="inline-flex h-10 items-center rounded-xl border border-bm-border/70 bg-bm-surface/25 px-3 text-xs font-medium text-bm-text"
-        >
-          Home
-        </Link>
+        {!isActive(pathname, base) && (
+          <Link
+            href={homeHref}
+            className="inline-flex h-10 items-center rounded-xl border border-bm-border/70 bg-bm-surface/25 px-3 text-xs font-medium text-bm-text"
+          >
+            Home
+          </Link>
+        )}
       </header>
 
       {drawerOpen ? (
@@ -333,21 +337,23 @@ export default function DomainWorkspaceShell({
         </div>
       ) : null}
 
-      <section className="rounded-2xl border border-bm-border/70 bg-bm-surface/25 p-4 lg:hidden">
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <Building2 size={18} className="text-bm-muted2" />
-            <div>
-              <p className="text-[10px] uppercase tracking-[0.18em] text-bm-muted2">Current module</p>
-              <h1 className="text-lg font-semibold text-bm-text">{activeNavLabel}</h1>
+      {domain !== "resume" && (
+        <section className="rounded-2xl border border-bm-border/70 bg-bm-surface/25 p-4 lg:hidden">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Building2 size={18} className="text-bm-muted2" />
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.18em] text-bm-muted2">Current module</p>
+                <h1 className="text-lg font-semibold text-bm-text">{activeNavLabel}</h1>
+              </div>
             </div>
+            <p className="text-sm text-bm-muted2">
+              Environment: {environment?.schema_name || envId}
+              {businessId ? ` · Business: ${businessId.slice(0, 8)}` : ""}
+            </p>
           </div>
-          <p className="text-sm text-bm-muted2">
-            Environment: {environment?.schema_name || envId}
-            {businessId ? ` · Business: ${businessId.slice(0, 8)}` : ""}
-          </p>
-        </div>
-      </section>
+        </section>
+      )}
 
       {domain !== "resume" ? (
         <section className="hidden rounded-2xl border border-bm-border/70 bg-bm-surface/25 p-4 lg:block">

--- a/repo-b/src/components/resume/CompoundingCapabilityGraph.tsx
+++ b/repo-b/src/components/resume/CompoundingCapabilityGraph.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Area,
   CartesianGrid,
@@ -31,6 +31,26 @@ function tickLabel(value: number) {
     year: "2-digit",
     timeZone: "UTC",
   });
+}
+
+function tickLabelYearOnly(value: number) {
+  return new Date(value).toLocaleDateString("en-US", {
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function useIsMobile(breakpoint = 768) {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    const update = () => setIsMobile(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, [breakpoint]);
+  return isMobile;
 }
 
 export default function CompoundingCapabilityGraph({
@@ -78,143 +98,187 @@ export default function CompoundingCapabilityGraph({
     return Math.max(4, Math.ceil(max * 1.15));
   }, [data, series, timelineView]);
 
+  const isMobile = useIsMobile();
   const selectedPhaseId = selectedNarrativeKind === "phase" ? selectedNarrativeId : null;
   const selectedMilestoneId = selectedNarrativeKind === "milestone" ? selectedNarrativeId : null;
 
+  // Pick top milestones for clickable markers on mobile
+  const keyMilestones = useMemo(() => {
+    const sorted = [...timeline.milestones]
+      .filter((m) => m.importance >= 70)
+      .sort((a, b) => b.importance - a.importance)
+      .slice(0, 3);
+    return sorted;
+  }, [timeline.milestones]);
+
+  const chartHeight = isMobile ? 280 : 460;
+  const chartMargin = isMobile
+    ? { top: 12, right: 8, bottom: 4, left: 0 }
+    : { top: 22, right: 24, bottom: 6, left: 4 };
+
   return (
-    <div className="rounded-[28px] border border-bm-border/40 bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.01))] p-4">
-      <ResponsiveContainer width="100%" height={460}>
-        <ComposedChart
-          data={data}
-          margin={{ top: 22, right: 24, bottom: 6, left: 4 }}
-          onMouseMove={(state) => {
-            const payload = state.activePayload?.[0]?.payload as TimelineChartPoint | undefined;
-            if (!payload) return;
-            if (payload.phase_id) {
-              previewNarrativeItem("phase", payload.phase_id);
-            }
-          }}
-          onMouseLeave={() => previewNarrativeItem(null, null)}
-          onClick={(state) => {
-            const payload = state.activePayload?.[0]?.payload as TimelineChartPoint | undefined;
-            if (!payload?.phase_id) return;
-            selectNarrativeItem("phase", payload.phase_id, { switchModule: "timeline" });
-          }}
-        >
-          <defs>
-            {series.map((item) => (
-              <linearGradient key={item.key} id={`resume-grad-${item.key}`} x1="0" y1="0" x2="0" y2="1">
-                <stop offset="6%" stopColor={item.color} stopOpacity={item.fillOpacity ?? 0.22} />
-                <stop offset="96%" stopColor={item.color} stopOpacity={0.02} />
-              </linearGradient>
-            ))}
-          </defs>
+    <div className="space-y-2">
+      <div className="rounded-[20px] border border-bm-border/40 bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.01))] p-2 md:rounded-[28px] md:p-4">
+        <ResponsiveContainer width="100%" height={chartHeight}>
+          <ComposedChart
+            data={data}
+            margin={chartMargin}
+            onMouseMove={(state) => {
+              const payload = state.activePayload?.[0]?.payload as TimelineChartPoint | undefined;
+              if (!payload) return;
+              if (payload.phase_id) {
+                previewNarrativeItem("phase", payload.phase_id);
+              }
+            }}
+            onMouseLeave={() => previewNarrativeItem(null, null)}
+            onClick={(state) => {
+              const payload = state.activePayload?.[0]?.payload as TimelineChartPoint | undefined;
+              if (!payload?.phase_id) return;
+              selectNarrativeItem("phase", payload.phase_id, { switchModule: "timeline" });
+            }}
+          >
+            <defs>
+              {series.map((item) => (
+                <linearGradient key={item.key} id={`resume-grad-${item.key}`} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="6%" stopColor={item.color} stopOpacity={item.fillOpacity ?? 0.22} />
+                  <stop offset="96%" stopColor={item.color} stopOpacity={0.02} />
+                </linearGradient>
+              ))}
+            </defs>
 
-          <CartesianGrid
-            stroke={GRID_STYLE.stroke}
-            strokeDasharray={GRID_STYLE.strokeDasharray}
-            strokeOpacity={GRID_STYLE.strokeOpacity}
-            horizontal
-            vertical={false}
-          />
+            <CartesianGrid
+              stroke={GRID_STYLE.stroke}
+              strokeDasharray={GRID_STYLE.strokeDasharray}
+              strokeOpacity={isMobile ? (GRID_STYLE.strokeOpacity ?? 0.3) * 0.5 : GRID_STYLE.strokeOpacity}
+              horizontal
+              vertical={false}
+            />
 
-          {phases.map((phase) => {
-            const phaseStart = new Date(`${phase.start_date}T00:00:00Z`).getTime();
-            const phaseEnd = new Date(`${phase.end_date ?? timeline.end_date}T00:00:00Z`).getTime();
-            const isSelected = selectedPhaseId === phase.phase_id;
-            return (
-              <ReferenceArea
-                key={phase.phase_id}
-                x1={phaseStart}
-                x2={phaseEnd}
-                fill={phase.band_color}
-                fillOpacity={isSelected ? 0.16 : 0.08}
-                stroke="none"
-                label={{
-                  value: phase.phase_name,
-                  position: "insideTopLeft",
-                  fill: "rgba(107,114,128,0.7)",
-                  fontSize: 10,
-                  offset: 8,
-                }}
-              />
-            );
-          })}
+            {phases.map((phase) => {
+              const phaseStart = new Date(`${phase.start_date}T00:00:00Z`).getTime();
+              const phaseEnd = new Date(`${phase.end_date ?? timeline.end_date}T00:00:00Z`).getTime();
+              const isSelected = selectedPhaseId === phase.phase_id;
+              return (
+                <ReferenceArea
+                  key={phase.phase_id}
+                  x1={phaseStart}
+                  x2={phaseEnd}
+                  fill={phase.band_color}
+                  fillOpacity={isSelected ? 0.16 : 0.08}
+                  stroke="none"
+                  label={isMobile ? undefined : {
+                    value: phase.phase_name,
+                    position: "insideTopLeft",
+                    fill: "rgba(107,114,128,0.7)",
+                    fontSize: 10,
+                    offset: 8,
+                  }}
+                />
+              );
+            })}
 
-          {timeline.milestones.map((milestone) => {
-            const x = new Date(`${milestone.date}T00:00:00Z`).getTime();
-            const isSelected = selectedMilestoneId === milestone.milestone_id;
-            return (
-              <ReferenceLine
-                key={milestone.milestone_id}
-                x={x}
-                stroke={isSelected ? "#3B82F6" : "rgba(107,114,128,0.45)"}
-                strokeWidth={isSelected ? 2 : 1}
-                strokeDasharray="4 4"
-                ifOverflow="extendDomain"
-                onClick={() =>
-                  selectNarrativeItem("milestone", milestone.milestone_id, { switchModule: "timeline" })
-                }
-              />
-            );
-          })}
-
-          <XAxis
-            dataKey="ts"
-            type="number"
-            domain={["dataMin", "dataMax"]}
-            tickFormatter={tickLabel}
-            tick={AXIS_TICK_STYLE}
-            tickLine={false}
-            axisLine={false}
-            minTickGap={36}
-          />
-          <YAxis domain={[0, yMax]} tick={false} tickLine={false} axisLine={false} width={0} />
-
-          <Tooltip
-            content={
-              <CapabilityGraphTooltip
-                timeline={timeline}
-                view={timelineView}
-                series={series}
-              />
-            }
-            cursor={{ stroke: "rgba(107,114,128,0.3)", strokeWidth: 1.2 }}
-          />
-
-          {series.map((item) =>
-            item.type === "line" ? (
-              <Line
-                key={item.key}
-                type="monotone"
-                dataKey={item.key}
-                stroke={item.color}
-                strokeWidth={item.strokeWidth ?? 2}
-                dot={false}
-                activeDot={{ r: 4 }}
-              />
-            ) : (
-              <Area
-                key={item.key}
-                type="monotone"
-                dataKey={item.key}
-                stackId={item.stackId}
-                stroke={item.color}
-                strokeWidth={capabilityHoveredLayer === item.key ? 2.8 : item.strokeWidth ?? 1.6}
-                fill={`url(#resume-grad-${item.key})`}
-                fillOpacity={capabilityHoveredLayer && capabilityHoveredLayer !== item.key ? 0.12 : 1}
-                isAnimationActive={false}
-                onMouseEnter={() => previewNarrativeItem(timelineView === "capability" ? "layer" : null, timelineView === "capability" ? item.key : null)}
-                onClick={() => {
-                  if (timelineView === "capability") {
-                    selectNarrativeItem("layer", item.key, { switchModule: "timeline", timelineView: "capability" });
+            {/* On mobile, only show key milestone lines to reduce clutter */}
+            {(isMobile ? keyMilestones : timeline.milestones).map((milestone) => {
+              const x = new Date(`${milestone.date}T00:00:00Z`).getTime();
+              const isSelected = selectedMilestoneId === milestone.milestone_id;
+              return (
+                <ReferenceLine
+                  key={milestone.milestone_id}
+                  x={x}
+                  stroke={isSelected ? "#3B82F6" : "rgba(107,114,128,0.45)"}
+                  strokeWidth={isSelected ? 2.5 : isMobile ? 1.5 : 1}
+                  strokeDasharray={isMobile ? "3 6" : "4 4"}
+                  ifOverflow="extendDomain"
+                  onClick={() =>
+                    selectNarrativeItem("milestone", milestone.milestone_id, { switchModule: "timeline" })
                   }
-                }}
-              />
-            ),
-          )}
-        </ComposedChart>
-      </ResponsiveContainer>
+                />
+              );
+            })}
+
+            <XAxis
+              dataKey="ts"
+              type="number"
+              domain={["dataMin", "dataMax"]}
+              tickFormatter={isMobile ? tickLabelYearOnly : tickLabel}
+              tick={{ ...AXIS_TICK_STYLE, fontSize: isMobile ? 9 : AXIS_TICK_STYLE.fontSize }}
+              tickLine={false}
+              axisLine={false}
+              minTickGap={isMobile ? 48 : 36}
+            />
+            <YAxis domain={[0, yMax]} tick={false} tickLine={false} axisLine={false} width={0} />
+
+            <Tooltip
+              content={
+                <CapabilityGraphTooltip
+                  timeline={timeline}
+                  view={timelineView}
+                  series={series}
+                />
+              }
+              cursor={{ stroke: "rgba(107,114,128,0.3)", strokeWidth: 1.2 }}
+            />
+
+            {series.map((item) =>
+              item.type === "line" ? (
+                <Line
+                  key={item.key}
+                  type="monotone"
+                  dataKey={item.key}
+                  stroke={item.color}
+                  strokeWidth={isMobile ? Math.max((item.strokeWidth ?? 2) + 0.5, 2.5) : item.strokeWidth ?? 2}
+                  dot={false}
+                  activeDot={{ r: isMobile ? 5 : 4 }}
+                />
+              ) : (
+                <Area
+                  key={item.key}
+                  type="monotone"
+                  dataKey={item.key}
+                  stackId={item.stackId}
+                  stroke={item.color}
+                  strokeWidth={
+                    capabilityHoveredLayer === item.key
+                      ? 2.8
+                      : isMobile
+                        ? Math.max((item.strokeWidth ?? 1.6) + 0.6, 2.2)
+                        : item.strokeWidth ?? 1.6
+                  }
+                  fill={`url(#resume-grad-${item.key})`}
+                  fillOpacity={capabilityHoveredLayer && capabilityHoveredLayer !== item.key ? 0.12 : 1}
+                  isAnimationActive={false}
+                  onMouseEnter={() => previewNarrativeItem(timelineView === "capability" ? "layer" : null, timelineView === "capability" ? item.key : null)}
+                  onClick={() => {
+                    if (timelineView === "capability") {
+                      selectNarrativeItem("layer", item.key, { switchModule: "timeline", timelineView: "capability" });
+                    }
+                  }}
+                />
+              ),
+            )}
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Mobile milestone markers — clickable below graph */}
+      {isMobile && keyMilestones.length > 0 && (
+        <div className="flex gap-1.5 overflow-x-auto pb-1 md:hidden">
+          {keyMilestones.map((m) => (
+            <button
+              key={m.milestone_id}
+              type="button"
+              onClick={() => selectNarrativeItem("milestone", m.milestone_id, { switchModule: "timeline" })}
+              className={`shrink-0 rounded-lg border px-2.5 py-1.5 text-[11px] leading-tight transition ${
+                selectedMilestoneId === m.milestone_id
+                  ? "border-sky-400/40 bg-sky-500/15 text-sky-100"
+                  : "border-bm-border/30 bg-bm-surface/20 text-bm-muted hover:text-bm-text"
+              }`}
+            >
+              {m.title}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/repo-b/src/components/resume/LinkedContextBar.tsx
+++ b/repo-b/src/components/resume/LinkedContextBar.tsx
@@ -71,25 +71,57 @@ export default function LinkedContextBar() {
   if (chips.length === 0) return null;
 
   return (
-    <div className="flex flex-wrap items-center gap-2 pt-3">
-      <span className="text-[10px] uppercase tracking-[0.16em] text-bm-muted2">Linked</span>
-      {chips.map((chip) => (
-        <button
-          key={chip.module}
-          type="button"
-          onClick={() => setActiveModule(chip.module)}
-          className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs transition ${
-            activeModule === chip.module
-              ? "border-white/30 bg-white/12 text-white"
-              : "border-bm-border/35 bg-white/5 text-bm-muted hover:border-white/20 hover:text-bm-text"
-          }`}
-        >
-          {chip.fromTimeline ? (
-            <span className="h-1.5 w-1.5 rounded-full bg-sky-400" />
-          ) : null}
-          {chip.label}
-        </button>
-      ))}
-    </div>
+    <>
+      {/* Desktop: pill chips */}
+      <div className="hidden flex-wrap items-center gap-2 pt-3 md:flex">
+        <span className="text-[10px] uppercase tracking-[0.14em] text-bm-muted2">Linked</span>
+        {chips.map((chip) => (
+          <button
+            key={chip.module}
+            type="button"
+            onClick={() => setActiveModule(chip.module)}
+            className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs transition ${
+              activeModule === chip.module
+                ? "border-white/30 bg-white/12 text-white"
+                : "border-bm-border/35 bg-white/5 text-bm-muted hover:border-white/20 hover:text-bm-text"
+            }`}
+          >
+            {chip.fromTimeline ? (
+              <span className="h-1.5 w-1.5 rounded-full bg-sky-400" />
+            ) : null}
+            {chip.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Mobile: stacked evidence rows */}
+      <div className="space-y-1.5 pt-2 md:hidden">
+        <p className="text-[10px] uppercase tracking-[0.1em] text-bm-muted2">Linked Evidence</p>
+        {chips.map((chip) => {
+          const [title, ...rest] = chip.label.split(": ");
+          const detail = rest.join(": ");
+          return (
+            <button
+              key={chip.module}
+              type="button"
+              onClick={() => setActiveModule(chip.module)}
+              className={`flex w-full items-start gap-2 rounded-lg border px-3 py-2 text-left transition ${
+                activeModule === chip.module
+                  ? "border-white/25 bg-white/8"
+                  : "border-bm-border/25 bg-bm-surface/15 hover:border-white/15"
+              }`}
+            >
+              {chip.fromTimeline ? (
+                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-sky-400" />
+              ) : null}
+              <div className="min-w-0">
+                <p className="text-[10px] uppercase tracking-[0.08em] text-bm-muted2">{title}</p>
+                {detail && <p className="mt-0.5 truncate text-xs text-bm-text">{detail}</p>}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </>
   );
 }

--- a/repo-b/src/components/resume/ResumeAssistantDock.tsx
+++ b/repo-b/src/components/resume/ResumeAssistantDock.tsx
@@ -105,10 +105,10 @@ export default function ResumeAssistantDock({
   }
 
   return (
-    <section className="rounded-[28px] border border-bm-border/60 bg-bm-surface/35 p-5">
-      <p className="bm-section-label">Assistant</p>
-      <h2 className="mt-2 text-xl">Context-aware explanation layer</h2>
-      <p className="mt-2 text-sm text-bm-muted">
+    <section className="rounded-[20px] border border-bm-border/60 bg-bm-surface/35 p-3 md:rounded-[28px] md:p-5">
+      <p className="bm-section-label tracking-[0.1em] md:tracking-[0.16em]">Assistant</p>
+      <h2 className="mt-1.5 text-lg md:mt-2 md:text-xl">Context-aware explanation layer</h2>
+      <p className="mt-1.5 text-sm text-bm-muted md:mt-2">
         Grounded in the current module instead of free-floating markdown responses.
       </p>
 
@@ -127,7 +127,7 @@ export default function ResumeAssistantDock({
         </div>
       ) : null}
 
-      <div className="mt-4 max-h-[420px] space-y-4 overflow-y-auto pr-1">
+      <div className="mt-3 max-h-[280px] space-y-3 overflow-y-auto pr-1 md:mt-4 md:max-h-[420px] md:space-y-4">
         {messages.map((message, index) =>
           message.role === "user" ? (
             <div key={index} className="flex justify-end">

--- a/repo-b/src/components/resume/ResumeContextRail.tsx
+++ b/repo-b/src/components/resume/ResumeContextRail.tsx
@@ -364,39 +364,37 @@ export default function ResumeContextRail({
   const summary = fallbackSummary ?? moduleFallback;
 
   return (
-    <div className="space-y-4">
-      <section className="rounded-[28px] border border-bm-border/60 bg-bm-surface/35 p-5">
-        <div className="flex items-start justify-between gap-3">
+    <div className="space-y-3 md:space-y-4">
+      <section className="rounded-[20px] border border-bm-border/60 bg-bm-surface/35 p-3 md:rounded-[28px] md:p-5">
+        <div className="flex items-start justify-between gap-2 md:gap-3">
           <div>
-            <p className="bm-section-label">{header}</p>
-            <h2 className="mt-2 text-xl">{summary.title}</h2>
-            <p className="mt-3 text-sm leading-6 text-bm-muted">{summary.summary}</p>
+            <p className="bm-section-label tracking-[0.1em] md:tracking-[0.16em]">{header}</p>
+            <h2 className="mt-1.5 text-lg md:mt-2 md:text-xl">{summary.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-bm-muted md:mt-3">{summary.summary}</p>
           </div>
-          <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[10px] uppercase tracking-[0.16em] text-bm-muted2">
+          <div className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[9px] uppercase tracking-[0.1em] text-bm-muted2 md:px-3 md:py-1 md:text-[10px] md:tracking-[0.16em]">
             {selectedNarrativeId ? "Locked" : hoveredNarrativeId ? "Preview" : "Default"}
           </div>
         </div>
 
-        <div className="mt-4 grid gap-3">
-          <div className="rounded-2xl border border-bm-border/30 bg-black/10 p-4">
-            <p className="text-[10px] uppercase tracking-[0.16em] text-bm-muted2">Before</p>
-            <p className="mt-2 text-bm-text">{summary.before}</p>
+        <div className="mt-3 grid gap-2 md:mt-4 md:gap-3">
+          <div className="rounded-xl border border-bm-border/30 bg-black/10 p-3 md:rounded-2xl md:p-4">
+            <p className="text-[10px] uppercase tracking-[0.1em] text-bm-muted2 md:tracking-[0.16em]">Before</p>
+            <p className="mt-1.5 text-sm text-bm-text md:mt-2 md:text-base">{summary.before}</p>
           </div>
-          <div className="rounded-2xl border border-bm-border/30 bg-black/10 p-4">
-            <p className="text-[10px] uppercase tracking-[0.16em] text-bm-muted2">After</p>
-            <p className="mt-2 text-bm-text">{summary.after}</p>
+          <div className="rounded-xl border border-bm-border/30 bg-black/10 p-3 md:rounded-2xl md:p-4">
+            <p className="text-[10px] uppercase tracking-[0.1em] text-bm-muted2 md:tracking-[0.16em]">After</p>
+            <p className="mt-1.5 text-sm text-bm-text md:mt-2 md:text-base">{summary.after}</p>
           </div>
-          <div className="rounded-2xl border border-sky-400/20 bg-sky-500/10 p-4">
-            <p className="text-[10px] uppercase tracking-[0.16em] text-sky-200/80">Stakeholders</p>
-            <p className="mt-2 text-sky-50">{summary.stakeholders}</p>
+          <div className="rounded-xl border border-sky-400/20 bg-sky-500/10 p-3 md:rounded-2xl md:p-4">
+            <p className="text-[10px] uppercase tracking-[0.1em] text-sky-200/80 md:tracking-[0.16em]">Stakeholders</p>
+            <p className="mt-1.5 text-sm text-sky-50 md:mt-2 md:text-base">{summary.stakeholders}</p>
           </div>
         </div>
-
-        {/* Module navigation is handled by the LinkedContextBar above the module tabs */}
       </section>
 
-      <section className="rounded-[28px] border border-bm-border/60 bg-bm-surface/35 p-5">
-        <p className="bm-section-label">Evidence Rail</p>
+      <section className="rounded-[20px] border border-bm-border/60 bg-bm-surface/35 p-3 md:rounded-[28px] md:p-5">
+        <p className="bm-section-label tracking-[0.1em] md:tracking-[0.16em]">Evidence Rail</p>
         {railCards.length === 0 ? (
           <SyntheticEvidence timeline={timeline} kind={effectiveKind} id={effectiveId} />
         ) : (

--- a/repo-b/src/components/resume/ResumeKpiCard.tsx
+++ b/repo-b/src/components/resume/ResumeKpiCard.tsx
@@ -20,11 +20,11 @@ export default function ResumeKpiCard({
     <Tag
       type={onClick ? "button" : undefined}
       onClick={onClick}
-      className={`rounded-2xl border border-bm-border/35 bg-black/10 px-4 py-4 text-left ${onClick ? "transition hover:border-white/20 hover:bg-black/20" : ""}`}
+      className={`rounded-xl border border-bm-border/35 bg-black/10 px-3 py-3 text-left md:rounded-2xl md:px-4 md:py-4 ${onClick ? "transition hover:border-white/20 hover:bg-black/20" : ""}`}
     >
-      <p className="text-[10px] uppercase tracking-[0.16em] text-bm-muted2">{label}</p>
-      <div className="mt-2 flex items-baseline gap-2">
-        <p className="text-xl font-semibold">{value}</p>
+      <p className="text-[10px] uppercase tracking-[0.08em] text-bm-muted2 md:tracking-[0.16em]">{label}</p>
+      <div className="mt-1 flex items-baseline gap-2 md:mt-2">
+        <p className="text-lg font-semibold md:text-xl">{value}</p>
         {delta && deltaDirection && deltaDirection !== "flat" ? (
           <span className={`text-xs ${deltaDirection === "up" ? "text-emerald-400" : "text-red-400"}`}>
             {delta}

--- a/repo-b/src/components/resume/ResumeTimelineModule.tsx
+++ b/repo-b/src/components/resume/ResumeTimelineModule.tsx
@@ -114,18 +114,21 @@ export default function ResumeTimelineModule({ timeline }: { timeline: ResumeTim
   }
 
   return (
-    <section className="rounded-[28px] border border-bm-border/60 bg-bm-surface/30 p-5 shadow-[0_24px_64px_-48px_rgba(5,12,18,0.95)]">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <h2 className="text-lg font-semibold">Build Journey</h2>
-        <div className="flex items-center gap-2">
+    <section className="rounded-[20px] border border-bm-border/60 bg-bm-surface/30 p-3 shadow-[0_24px_64px_-48px_rgba(5,12,18,0.95)] md:rounded-[28px] md:p-5">
+      <div className="flex items-center justify-between gap-2 md:gap-4">
+        <h2 className="shrink-0 text-base font-semibold md:text-lg">
+          <span className="md:hidden">Timeline</span>
+          <span className="hidden md:inline">Build Journey</span>
+        </h2>
+        <div className="-mr-1 flex snap-x snap-mandatory gap-1 overflow-x-auto pr-1 md:flex-wrap md:gap-2 md:overflow-visible">
           {(timelineViews.length > 0 ? timelineViews : (["career", "delivery", "capability", "impact"] as ResumeTimelineViewMode[])).map((view) => (
             <button
               key={view}
               type="button"
               onClick={() => setTimelineView(view)}
-              className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
+              className={`shrink-0 snap-start rounded-full px-2.5 py-1 text-[11px] font-medium transition md:px-3 md:py-1.5 md:text-xs ${
                 timelineView === view
-                  ? "bg-white/12 text-white"
+                  ? "bg-white/18 font-semibold text-white shadow-[0_0_0_1px_rgba(255,255,255,0.2)]"
                   : "bg-white/5 text-bm-muted hover:bg-white/10 hover:text-bm-text"
               }`}
             >
@@ -135,7 +138,7 @@ export default function ResumeTimelineModule({ timeline }: { timeline: ResumeTim
         </div>
       </div>
 
-      <div className="mt-4">
+      <div className="mt-3 md:mt-4">
         <CompoundingCapabilityGraph timeline={timeline} />
       </div>
     </section>

--- a/repo-b/src/components/resume/ResumeWorkspace.tsx
+++ b/repo-b/src/components/resume/ResumeWorkspace.tsx
@@ -30,6 +30,13 @@ const MODULE_LABELS = {
   bi: "BI Dashboard",
 } as const;
 
+const MODULE_LABELS_SHORT = {
+  timeline: "Timeline",
+  architecture: "Arch",
+  modeling: "Modeling",
+  bi: "BI",
+} as const;
+
 export default function ResumeWorkspace({
   envId,
   businessId,
@@ -241,23 +248,32 @@ export default function ResumeWorkspace({
   const HERO_METRICS = [
     { label: "Years", value: "11+" },
     { label: "Assets Automated", value: "500+" },
-    { label: "Hrs/Mo Eliminated", value: "160+" },
+    { label: "Hrs/Mo Saved", value: "160+" },
     { label: "Faster Reporting", value: "50%" },
     { label: "Less Reconciliation", value: "75%" },
     { label: "AI Tools", value: "83" },
   ];
 
   return (
-    <div className="space-y-6">
-      <section className="space-y-4">
+    <div className="space-y-4 md:space-y-6">
+      <section className="space-y-3 md:space-y-4">
         {/* Identity — name + title only */}
         <div>
-          <p className="bm-section-label">{workspace.identity.name}</p>
-          <h1 className="mt-2 text-4xl leading-tight sm:text-5xl">{workspace.identity.title}</h1>
+          <p className="bm-section-label tracking-[0.1em] md:tracking-[0.16em]">{workspace.identity.name}</p>
+          <h1 className="mt-1.5 text-[1.75rem] leading-tight md:mt-2 md:text-4xl lg:text-5xl">{workspace.identity.title}</h1>
+          <p className="mt-1 text-sm text-bm-muted md:hidden">AI &amp; Data Systems Architect</p>
         </div>
 
-        {/* Hero metric strip — readable in 3 seconds */}
-        <div className="flex flex-wrap gap-x-8 gap-y-3">
+        {/* KPI proof — 2-col on mobile, inline strip on desktop */}
+        <div className="grid grid-cols-2 gap-2 md:hidden">
+          {HERO_METRICS.slice(0, 4).map((m) => (
+            <div key={m.label} className="flex min-h-[56px] flex-col justify-center rounded-xl border border-bm-border/30 bg-bm-surface/20 px-3 py-2">
+              <span className="text-xl font-bold tabular-nums leading-tight">{m.value}</span>
+              <span className="mt-0.5 text-[10px] uppercase tracking-[0.08em] text-bm-muted">{m.label}</span>
+            </div>
+          ))}
+        </div>
+        <div className="hidden flex-wrap gap-x-8 gap-y-3 md:flex">
           {HERO_METRICS.map((m) => (
             <div key={m.label}>
               <span className="text-3xl font-bold tabular-nums">{m.value}</span>
@@ -267,22 +283,25 @@ export default function ResumeWorkspace({
         </div>
 
         {/* Module tabs + export */}
-        <div className="flex flex-wrap items-center gap-2 pt-1">
-          {(Object.keys(MODULE_LABELS) as Array<keyof typeof MODULE_LABELS>).map((module) => (
-            <button
-              key={module}
-              type="button"
-              onClick={() => setActiveModule(module)}
-              className={`rounded-full px-4 py-2 text-sm font-medium transition ${
-                activeModule === module
-                  ? "bg-bm-accent/15 text-bm-accent shadow-[0_0_0_1px_rgba(59,130,246,0.35)]"
-                  : "bg-white/5 text-bm-muted hover:bg-white/10 hover:text-bm-text"
-              }`}
-            >
-              {MODULE_LABELS[module]}
-            </button>
-          ))}
-          <div className="ml-auto">
+        <div className="flex items-center gap-2 pt-1">
+          <div className="-mx-1 flex snap-x snap-mandatory gap-1.5 overflow-x-auto px-1 pb-1 md:flex-wrap md:gap-2 md:overflow-visible md:pb-0">
+            {(Object.keys(MODULE_LABELS) as Array<keyof typeof MODULE_LABELS>).map((module) => (
+              <button
+                key={module}
+                type="button"
+                onClick={() => setActiveModule(module)}
+                className={`shrink-0 snap-start rounded-full px-3 py-1.5 text-xs font-medium transition md:px-4 md:py-2 md:text-sm ${
+                  activeModule === module
+                    ? "bg-bm-accent/15 text-bm-accent shadow-[0_0_0_1px_rgba(59,130,246,0.35)]"
+                    : "bg-white/5 text-bm-muted hover:bg-white/10 hover:text-bm-text"
+                }`}
+              >
+                <span className="md:hidden">{MODULE_LABELS_SHORT[module]}</span>
+                <span className="hidden md:inline">{MODULE_LABELS[module]}</span>
+              </button>
+            ))}
+          </div>
+          <div className="ml-auto hidden md:block">
             <ResumeExportPdf contentRef={moduleContentRef} />
           </div>
         </div>
@@ -372,12 +391,17 @@ export default function ResumeWorkspace({
 
       {isMobileViewport ? (
         <div className="space-y-3">
+        {/* Mobile Export — secondary placement */}
+        <div className="flex justify-end md:hidden">
+          <ResumeExportPdf contentRef={moduleContentRef} />
+        </div>
+
         <details
-          className="rounded-[24px] border border-bm-border/60 bg-bm-surface/18 p-4"
+          className="rounded-[20px] border border-bm-border/60 bg-bm-surface/18 p-3"
           open
         >
-          <summary className="cursor-pointer text-sm font-semibold text-bm-text">Context Rail</summary>
-          <div className="mt-4">
+          <summary className="cursor-pointer text-xs font-semibold uppercase tracking-[0.1em] text-bm-muted2">Context Rail</summary>
+          <div className="mt-3">
             <ResumeModuleBoundary
               boundaryId="resume-context-rail-mobile"
               eyebrow="Context Rail"
@@ -397,9 +421,9 @@ export default function ResumeWorkspace({
         </details>
 
         {!readOnly ? (
-          <details className="rounded-[24px] border border-bm-border/60 bg-bm-surface/18 p-4">
-            <summary className="cursor-pointer text-sm font-semibold text-bm-text">Winston</summary>
-            <div className="mt-4">
+          <details className="rounded-[20px] border border-bm-border/60 bg-bm-surface/18 p-3">
+            <summary className="cursor-pointer text-xs font-semibold uppercase tracking-[0.1em] text-bm-muted2">Winston</summary>
+            <div className="mt-3">
               <ResumeModuleBoundary
                 boundaryId="resume-assistant-mobile"
                 eyebrow="Assistant"

--- a/repo-b/src/components/resume/SystemHero.tsx
+++ b/repo-b/src/components/resume/SystemHero.tsx
@@ -51,58 +51,76 @@ export default function SystemHero({ stats }: { stats: ResumeSystemStats | null 
   const kpis = PERSPECTIVE_KPIS[perspective];
 
   return (
-    <div className="relative overflow-hidden rounded-2xl border border-bm-border/70 bg-bm-surface/20 p-6">
+    <div className="relative overflow-hidden rounded-xl border border-bm-border/70 bg-bm-surface/20 p-4 md:rounded-2xl md:p-6">
       {/* Subtle gradient background */}
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,rgba(56,189,248,0.05),transparent_50%)]" />
 
       <div className="relative">
         {/* Header row */}
-        <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start justify-between gap-3 md:gap-4">
           <div>
-            <h1 className="text-3xl font-bold tracking-tight">PAUL MALMQUIST</h1>
-            <p className="mt-1 text-sm tracking-wide text-bm-muted2">
+            <h1 className="text-2xl font-bold tracking-tight md:text-3xl">PAUL MALMQUIST</h1>
+            <p className="mt-0.5 text-xs tracking-wide text-bm-muted2 md:mt-1 md:text-sm">
               AI &amp; Data Systems Architect
             </p>
           </div>
 
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1.5 md:gap-3">
             <PerspectiveToggle />
             <a
               href="https://calendly.com/paulmalmquist/30min"
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded-lg border border-bm-accent/40 bg-bm-accent/10 px-3 py-1.5 text-xs font-medium text-bm-accent transition-colors hover:bg-bm-accent/20"
+              className="hidden rounded-lg border border-bm-accent/40 bg-bm-accent/10 px-3 py-1.5 text-xs font-medium text-bm-accent transition-colors hover:bg-bm-accent/20 md:inline-flex"
             >
               Schedule a Call
             </a>
             <a
               href="mailto:paul@novendor.ai"
-              className="rounded-lg border border-bm-border/50 bg-white/5 px-3 py-1.5 text-xs font-medium text-bm-muted transition-colors hover:bg-white/10 hover:text-bm-text"
+              className="hidden rounded-lg border border-bm-border/50 bg-white/5 px-3 py-1.5 text-xs font-medium text-bm-muted transition-colors hover:bg-white/10 hover:text-bm-text md:inline-flex"
             >
               Get in Touch
             </a>
-            <div className="flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-1.5">
+            <div className="flex items-center gap-1.5 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-2 py-1 md:gap-2 md:px-3 md:py-1.5">
               <span className="relative flex h-2 w-2">
                 <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
                 <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
               </span>
-              <span className="text-xs font-medium text-emerald-400">SYSTEM ACTIVE</span>
+              <span className="hidden text-xs font-medium text-emerald-400 md:inline">SYSTEM ACTIVE</span>
             </div>
           </div>
         </div>
 
+        {/* Mobile CTA row */}
+        <div className="mt-2.5 flex gap-2 md:hidden">
+          <a
+            href="https://calendly.com/paulmalmquist/30min"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex-1 rounded-lg border border-bm-accent/40 bg-bm-accent/10 px-3 py-1.5 text-center text-xs font-medium text-bm-accent"
+          >
+            Schedule a Call
+          </a>
+          <a
+            href="mailto:paul@novendor.ai"
+            className="flex-1 rounded-lg border border-bm-border/50 bg-white/5 px-3 py-1.5 text-center text-xs font-medium text-bm-muted"
+          >
+            Get in Touch
+          </a>
+        </div>
+
         {/* KPI tiles */}
         {stats && (
-          <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <div className="mt-4 grid grid-cols-2 gap-2 md:mt-6 md:gap-3 sm:grid-cols-4">
             {kpis.map((kpi) => (
               <div
                 key={kpi.key}
-                className="rounded-xl border border-bm-border/50 bg-bm-surface/30 px-4 py-3"
+                className="flex min-h-[52px] flex-col justify-center rounded-xl border border-bm-border/50 bg-bm-surface/30 px-3 py-2 md:px-4 md:py-3"
               >
-                <p className="text-[10px] uppercase tracking-[0.12em] text-bm-muted2">
+                <p className="text-[10px] uppercase tracking-[0.08em] text-bm-muted2 md:tracking-[0.12em]">
                   {kpi.label}
                 </p>
-                <p className="mt-1 text-2xl font-bold tabular-nums">
+                <p className="mt-0.5 text-xl font-bold tabular-nums md:mt-1 md:text-2xl">
                   <AnimatedNumber
                     value={stats[kpi.key] as number}
                     suffix={kpi.suffix}


### PR DESCRIPTION
- Hide Current Module card on mobile for resume domain
- Simplify shell header: reduce padding, hide Home when on resume page
- Reduce hero title font ~18% on mobile, add role subtitle
- Convert KPI area to strict 2-col grid with equal card heights on mobile
- Rename "Hrs/Mo Eliminated" to "Hrs/Mo Saved"
- Make module tabs horizontally scrollable with snap on mobile, shorten labels
- Move Export PDF to secondary placement below modules on mobile
- Replace LinkedContextBar pills with stacked evidence rows on mobile
- Rename "Build Journey" to "Timeline" on mobile
- Improve timeline view tab contrast and weight, scrollable on mobile
- Reduce chart height to 280px on mobile, year-only X-axis labels
- Increase line thickness and contrast on mobile charts
- Add clickable milestone markers below graph on mobile
- Only show top-3 importance milestone reference lines on mobile
- Hide phase labels inside chart on mobile to reduce clutter
- Shrink all rounded corners, padding, and letter spacing on mobile
- Tighten all-caps label tracking for mobile readability
- Auto-expand Context Rail on mobile load
- All changes isolated with responsive classes (md: breakpoint)

https://claude.ai/code/session_011UsmxjJxf3yqgxY2sBYxaw