### PR TITLE
feat(markets): refactor decision engine mobile UI into decision-first layout

### DIFF
--- a/repo-b/src/app/lab/env/[envId]/markets/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/markets/page.tsx
@@ -36,6 +36,7 @@ import { DivergenceTable } from "@/components/market/DivergenceTable";
 import { AgentForecastPanel } from "@/components/market/AgentForecastPanel";
 import { DebugPanel } from "@/components/market/DebugPanel";
 import { CalibrationFooter } from "@/components/market/CalibrationFooter";
+import { MobileDecisionEngine } from "@/components/market/MobileDecisionEngine";
 import type { DecisionTab, AssetScope } from "@/lib/trading-lab/decision-engine-types";
 import type {
   TradingHypothesis,
@@ -214,6 +215,16 @@ export default function TradingLabPage() {
   const [closingPosition, setClosingPosition] = useState<TradingPosition | null>(null);
   const [editingPosition, setEditingPosition] = useState<TradingPosition | null>(null);
 
+  // Mobile detection
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 768px)");
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
   // Decision Engine data (replaces hardcoded mock data)
   const de = useDecisionEngine(envId, assetScope);
   const [showDebug, setShowDebug] = useState(() =>
@@ -356,6 +367,31 @@ export default function TradingLabPage() {
             ))}
           </div>
         </div>
+      </div>
+    );
+  }
+
+  // Mobile layout — decision-first, no sidebar
+  if (isMobile) {
+    return (
+      <div className={`flex-1 flex flex-col ${t.pageBg} ${t.pageText} font-sans min-h-full transition-colors duration-200`}>
+        {/* Compact mobile header */}
+        <div className={`border-b ${t.headerBorder} px-4 py-2 ${t.headerBg} flex items-center justify-between`}>
+          <h1 className={`text-sm font-bold ${t.accentBold} font-mono`}>
+            DECISION ENGINE
+          </h1>
+          {de.raw?.provenance && (
+            <DataProvenanceBadge
+              seedPct={de.raw.provenance.seedDataPct}
+              lastUpdated={de.raw.provenance.dataFreshness}
+            />
+          )}
+        </div>
+        <MobileDecisionEngine
+          assetScope={assetScope}
+          onScopeChange={setAssetScope}
+          decisionEngine={de}
+        />
       </div>
     );
   }

--- a/repo-b/src/components/market/CommandCenterLayout.tsx
+++ b/repo-b/src/components/market/CommandCenterLayout.tsx
@@ -76,6 +76,7 @@ export function CommandCenterLayout({
             analogOverlay={data.analogOverlay}
             radarDims={data.radarDims}
             topMatch={topMatch ?? null}
+            episodes={decisionEngine?.raw?.analogs.episodeLibrary}
           />
           <WhatChangedPanel
             realitySignals={data.realitySignals}

--- a/repo-b/src/components/market/MobileDecisionEngine.tsx
+++ b/repo-b/src/components/market/MobileDecisionEngine.tsx
@@ -1,0 +1,747 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import type { AssetScope } from "@/lib/trading-lab/decision-engine-types";
+import type { DecisionEngineResult } from "@/components/market/hooks/useDecisionEngine";
+import type { ApiPrediction } from "@/components/market/hooks/useDecisionEngine";
+import { useAssetScopedData } from "@/components/market/hooks/useAssetScopedData";
+import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import {
+  safeNum, safePct, safeScore, isValid, hasData, safeStr, scenariosValid,
+} from "@/lib/trading-lab/safe-display";
+
+/* ── Scope selector (replaces sidebar on mobile) ─────────── */
+
+const SCOPES: { scope: AssetScope; label: string }[] = [
+  { scope: "global", label: "Global" },
+  { scope: "equities", label: "Equities" },
+  { scope: "crypto", label: "Crypto" },
+  { scope: "real-estate", label: "Real Estate" },
+];
+
+function ScopeSegmentedControl({
+  active,
+  onChange,
+}: {
+  active: AssetScope;
+  onChange: (s: AssetScope) => void;
+}) {
+  return (
+    <div className="flex rounded-lg border border-bm-border/50 bg-bm-bg/80 overflow-hidden">
+      {SCOPES.map(({ scope, label }) => (
+        <button
+          key={scope}
+          onClick={() => onChange(scope)}
+          className={`flex-1 px-3 py-2 text-xs font-medium transition-colors ${
+            active === scope
+              ? "bg-bm-accent/15 text-bm-accent border-b-2 border-bm-accent"
+              : "text-bm-muted hover:text-bm-text"
+          }`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ── Data integrity logging ──────────────────────────────── */
+
+interface IntegrityReport {
+  missingPipelines: string[];
+  hasDecisionData: boolean;
+  hasAnalogData: boolean;
+  hasTrapData: boolean;
+  hasAgentData: boolean;
+  hasForecastData: boolean;
+}
+
+function validateIntegrity(
+  de: DecisionEngineResult | null,
+  fallback: ReturnType<typeof useAssetScopedData>,
+): IntegrityReport {
+  const missing: string[] = [];
+  const data = de && !de.loading ? de : null;
+  const agents = data?.agentData ?? fallback.agentData;
+  const traps = data?.trapChecks ?? fallback.trapChecks;
+  const forecast = data?.raw?.forecasts.current ?? null;
+  const analog = data?.raw?.analogs.topMatch ?? null;
+
+  if (!hasData(agents)) missing.push("agent-calibration");
+  if (!hasData(data?.realitySignals ?? fallback.realitySignals)) missing.push("reality-signals");
+  if (!hasData(data?.dataSignals ?? fallback.dataSignals)) missing.push("data-signals");
+  if (!analog) missing.push("analog-engine");
+  if (!hasData(traps)) missing.push("trap-detector");
+  if (!forecast) missing.push("forecast-pipeline");
+
+  if (missing.length > 0 && process.env.NODE_ENV === "development") {
+    console.warn("[DecisionEngine] Missing pipelines:", missing.join(", "));
+  }
+
+  return {
+    missingPipelines: missing,
+    hasDecisionData: hasData(agents),
+    hasAnalogData: !!analog && hasData(analog.matches),
+    hasTrapData: hasData(traps),
+    hasAgentData: hasData(agents),
+    hasForecastData: !!forecast,
+  };
+}
+
+/* ── Section A: Decision Block (sticky) ──────────────────── */
+
+function DecisionBlock({
+  de,
+  fallback,
+  assetScope,
+  integrity,
+}: {
+  de: DecisionEngineResult;
+  fallback: ReturnType<typeof useAssetScopedData>;
+  assetScope: AssetScope;
+  integrity: IntegrityReport;
+}) {
+  const data = de && !de.loading ? de : null;
+  const agents = data?.agentData ?? fallback.agentData;
+  const narrativeState = data?.narrativeState ?? fallback.narrativeState;
+  const mismatchData = data?.mismatchData ?? fallback.mismatchData;
+  const trapChecks = data?.trapChecks ?? fallback.trapChecks;
+
+  // Compute ensemble direction + confidence
+  const totalWeight = agents.reduce((s, a) => s + a.wt, 0);
+  const weightedConf = totalWeight > 0
+    ? agents.reduce((s, a) => s + a.conf * a.wt, 0) / totalWeight
+    : NaN;
+
+  const bearishCount = agents.filter((a) => a.dir === "Bearish").length;
+  const confidenceValid = isValid(weightedConf);
+
+  // Recommended action
+  const action = !confidenceValid
+    ? "Insufficient data"
+    : weightedConf < 40
+      ? "No edge. Do nothing."
+      : bearishCount >= 3
+        ? "Reduce Risk"
+        : "Hold Current Position";
+
+  const actionColor = !confidenceValid
+    ? "text-bm-muted"
+    : weightedConf < 40
+      ? "text-bm-muted"
+      : bearishCount >= 3
+        ? "text-bm-danger"
+        : "text-bm-accent";
+
+  // Regime
+  const exhaustedNarratives = narrativeState.filter(
+    (n) => n.lifecycle === "exhaustion"
+  ).length;
+
+  // Key risk
+  const topTrap = trapChecks?.find(
+    (t) => t.variant === "warning" || t.variant === "danger",
+  );
+  const keyRisk = topTrap
+    ? `${topTrap.check}: ${safeStr(topTrap.value)}`
+    : mismatchData.filter((m) => m.mismatch > 0.6).length > 0
+      ? "Narrative-reality divergence elevated"
+      : "No elevated risks detected";
+
+  const scopeLabels: Record<AssetScope, string> = {
+    global: "Markets",
+    equities: "Equities",
+    crypto: "Crypto",
+    "real-estate": "Real Estate",
+  };
+
+  return (
+    <Card className="p-4 border-l-4 border-l-bm-accent">
+      {/* Regime classification */}
+      <p className="text-[10px] font-mono uppercase tracking-wider text-bm-muted2 mb-1">
+        {scopeLabels[assetScope]} Decision Brief
+      </p>
+      <p className="text-sm text-bm-text leading-relaxed mb-3">
+        {scopeLabels[assetScope]} are in a{" "}
+        <span className="font-semibold text-bm-warning">late-cycle tightening</span>{" "}
+        environment.
+        {exhaustedNarratives > 0 && (
+          <> {exhaustedNarratives} dominant narratives approaching exhaustion.</>
+        )}
+      </p>
+
+      {/* Action + Confidence + Risk */}
+      <div className="space-y-2">
+        <div className="flex items-baseline justify-between">
+          <div>
+            <p className="text-[9px] text-bm-muted2 uppercase">Recommended Action</p>
+            <p className={`text-lg font-mono font-bold ${actionColor}`}>{action}</p>
+          </div>
+          <div className="text-right">
+            <p className="text-[9px] text-bm-muted2 uppercase">Confidence</p>
+            <p className="text-lg font-mono font-bold text-bm-text">
+              {confidenceValid ? safePct(weightedConf) : "Not available"}
+            </p>
+          </div>
+        </div>
+        <div>
+          <p className="text-[9px] text-bm-muted2 uppercase">Key Risk</p>
+          <p className="text-xs text-bm-muted">{keyRisk}</p>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+/* ── Section B: What Changed Today ───────────────────────── */
+
+function WhatChangedMobile({
+  de,
+  fallback,
+}: {
+  de: DecisionEngineResult;
+  fallback: ReturnType<typeof useAssetScopedData>;
+}) {
+  const data = de && !de.loading ? de : null;
+  const realitySignals = data?.realitySignals ?? fallback.realitySignals;
+  const dataSignals = data?.dataSignals ?? fallback.dataSignals;
+
+  // Only material changes: reality signals with high acceleration + data surprises
+  const materialChanges: { signal: string; detail: string; direction: "bullish" | "bearish" | "neutral" }[] = [];
+
+  for (const s of realitySignals) {
+    if (Math.abs(s.accel) > 2) {
+      materialChanges.push({
+        signal: s.signal,
+        detail: `${s.accel > 0 ? "+" : ""}${safeNum(s.accel, (n) => n.toFixed(1))} acceleration, now ${safeNum(s.value)}%`,
+        direction: s.accel > 0 && s.value > 0 ? "bullish" : s.accel < 0 && s.value < 0 ? "bearish" : "neutral",
+      });
+    }
+  }
+
+  for (const d of dataSignals) {
+    if (d.surprise !== 0 && Math.abs(d.surprise) > 0.05) {
+      materialChanges.push({
+        signal: d.metric,
+        detail: `Reported ${safeNum(d.reported)} vs ${safeNum(d.expected)} expected (${d.surprise > 0 ? "+" : ""}${safeNum(d.surprise)})`,
+        direction: d.surprise > 0 ? "bearish" : "bullish",
+      });
+    }
+  }
+
+  if (materialChanges.length === 0) {
+    return (
+      <Card className="p-4">
+        <p className="text-[10px] font-bold uppercase tracking-wider text-bm-muted2 mb-2">
+          What Changed Today
+        </p>
+        <p className="text-xs text-bm-muted2">No material changes.</p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-[10px] font-bold uppercase tracking-wider text-bm-muted2">
+          What Changed Today
+        </p>
+        <Badge>{materialChanges.length} DELTAS</Badge>
+      </div>
+      <div className="space-y-1.5">
+        {materialChanges.map((c) => {
+          const color = c.direction === "bullish" ? "text-emerald-400" : c.direction === "bearish" ? "text-red-400" : "text-bm-muted";
+          return (
+            <div key={c.signal} className="flex items-start gap-2 py-1.5 border-b border-bm-border/20 last:border-0">
+              <span className={`text-sm font-mono font-bold mt-0.5 ${color}`}>
+                {c.direction === "bullish" ? "+" : c.direction === "bearish" ? "-" : "~"}
+              </span>
+              <div className="min-w-0">
+                <p className="text-xs font-semibold text-bm-text">{c.signal}</p>
+                <p className="text-[10px] text-bm-muted2">{c.detail}</p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
+/* ── Section C: History Rhymes (primary module) ──────────── */
+
+function HistoryRhymesMobile({
+  de,
+  fallback,
+}: {
+  de: DecisionEngineResult;
+  fallback: ReturnType<typeof useAssetScopedData>;
+}) {
+  const data = de && !de.loading ? de : null;
+  const topMatch = data?.raw?.analogs.topMatch;
+  const topAnalog = topMatch?.matches?.[0];
+
+  if (!topAnalog) return null; // Don't render without real data
+
+  const analogName = safeStr(topAnalog.episode_name);
+  const rhymeScore = topAnalog.rhyme_score;
+  const keySim = safeStr(topAnalog.key_similarity);
+  const keyDiv = safeStr(topAnalog.key_divergence);
+  const isSeed = topMatch?.source === "seed";
+
+  // Forward outcome summary from episode library
+  const episodes = data?.raw?.analogs.episodeLibrary ?? [];
+  const matchedEpisode = episodes.find(
+    (e) => e.name === topAnalog.episode_name || e.id === topAnalog.episode_id,
+  );
+
+  const forwardOutcome = matchedEpisode
+    ? `Historically led to ${Math.abs(matchedEpisode.peak_to_trough_pct).toFixed(0)}% drawdown over ${matchedEpisode.duration_days} days${
+        matchedEpisode.recovery_duration_days
+          ? `, recovery took ${matchedEpisode.recovery_duration_days} days`
+          : ""
+      }`
+    : null;
+
+  return (
+    <Card className="p-4 border-l-4 border-l-bm-warning">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-[10px] font-bold uppercase tracking-wider text-bm-muted2">
+          Top Analog
+        </p>
+        <Badge variant={isSeed ? "accent" : "success"}>{isSeed ? "SEED" : "LIVE"}</Badge>
+      </div>
+
+      {/* Analog headline */}
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex-1 min-w-0">
+          <p className="text-base font-semibold text-bm-text">{analogName}</p>
+          {isValid(rhymeScore) && (
+            <p className="text-[10px] text-bm-muted2 mt-0.5">
+              Rhyme Score: <span className="font-mono font-bold text-bm-accent text-sm">{safeScore(rhymeScore)}</span>
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Key similarities & divergences as first-class insights */}
+      <div className="grid grid-cols-2 gap-3 mb-3">
+        <div className="rounded-lg bg-emerald-500/5 border border-emerald-500/20 p-3">
+          <p className="text-[9px] text-emerald-400 uppercase font-bold mb-1">Key Similarities</p>
+          <p className="text-xs text-bm-text leading-relaxed">{keySim}</p>
+        </div>
+        <div className="rounded-lg bg-amber-500/5 border border-amber-500/20 p-3">
+          <p className="text-[9px] text-amber-400 uppercase font-bold mb-1">Key Divergences</p>
+          <p className="text-xs text-bm-text leading-relaxed">{keyDiv}</p>
+        </div>
+      </div>
+
+      {/* What happened next — forward outcome */}
+      {forwardOutcome && (
+        <div className="rounded-lg bg-bm-surface/30 border border-bm-border/30 p-3 mb-3">
+          <p className="text-[9px] text-bm-muted2 uppercase font-bold mb-1">What Happened Next</p>
+          <p className="text-xs text-bm-text leading-relaxed">{forwardOutcome}</p>
+        </div>
+      )}
+
+      {/* Modern analog thesis from episode if available */}
+      {matchedEpisode?.modern_analog_thesis && (
+        <p className="text-[10px] text-bm-muted leading-relaxed italic">
+          {matchedEpisode.modern_analog_thesis}
+        </p>
+      )}
+    </Card>
+  );
+}
+
+/* ── Section D: Scenario Probabilities ───────────────────── */
+
+function ScenariosMobile({
+  de,
+}: {
+  de: DecisionEngineResult;
+}) {
+  const forecast = de.raw?.forecasts.current ?? null;
+  if (!forecast) return null;
+
+  const bull = Math.round((forecast.scenario_bull_prob ?? 0) * 100);
+  const base = Math.round((forecast.scenario_base_prob ?? 0) * 100);
+  const bear = Math.round((forecast.scenario_bear_prob ?? 0) * 100);
+
+  if (!scenariosValid(bull, base, bear)) return null;
+
+  const scenarios = [
+    { label: "BULL", prob: bull, variant: "success" as const },
+    { label: "BASE", prob: base, variant: "accent" as const },
+    { label: "BEAR", prob: bear, variant: "danger" as const },
+  ];
+
+  return (
+    <Card className="p-4">
+      <p className="text-[10px] font-bold uppercase tracking-wider text-bm-muted2 mb-3">
+        Scenario Probabilities
+      </p>
+      <div className="grid grid-cols-3 gap-2">
+        {scenarios.map((s) => (
+          <div key={s.label} className="text-center rounded-lg border border-bm-border/40 bg-bm-surface/15 p-3">
+            <Badge variant={s.variant} className="mb-1">{s.label}</Badge>
+            <p className="text-xl font-bold font-mono text-bm-text">{s.prob}%</p>
+          </div>
+        ))}
+      </div>
+      {forecast.synthesis_narrative && (
+        <p className="text-[10px] text-bm-muted mt-3 leading-relaxed">
+          {forecast.synthesis_narrative}
+        </p>
+      )}
+    </Card>
+  );
+}
+
+/* ── Section E: Trap Detector ────────────────────────────── */
+
+function TrapDetectorMobile({
+  de,
+  fallback,
+}: {
+  de: DecisionEngineResult;
+  fallback: ReturnType<typeof useAssetScopedData>;
+}) {
+  const data = de && !de.loading ? de : null;
+  const trapChecks = data?.trapChecks ?? fallback.trapChecks;
+  const positioningData = data?.positioningData ?? fallback.positioningData;
+
+  const activeTraps = trapChecks.filter(
+    (t) => t.variant === "warning" || t.variant === "danger",
+  );
+
+  // If no active traps at all, hide the section entirely
+  if (activeTraps.length === 0) return null;
+
+  const honeypots = data?.raw?.traps.honeypotPatterns ?? [];
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-[10px] font-bold uppercase tracking-wider text-bm-muted2">
+          Trap Detector
+        </p>
+        <Badge variant={activeTraps.length > 2 ? "danger" : "warning"}>
+          {activeTraps.length} ACTIVE
+        </Badge>
+      </div>
+
+      <div className="space-y-2">
+        {activeTraps.map((t) => {
+          // Narrative-style reasoning instead of numeric junk
+          const reasoning = buildTrapNarrative(t.check, t.value, positioningData, honeypots);
+          return (
+            <div key={t.check} className="rounded-lg bg-bm-surface/15 border border-bm-border/30 p-3">
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-xs font-semibold text-bm-text">{t.check}</span>
+                <Badge variant={t.variant}>{t.status}</Badge>
+              </div>
+              <p className="text-[11px] text-bm-muted leading-relaxed">{reasoning}</p>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
+function buildTrapNarrative(
+  check: string,
+  value: string,
+  positioning: { asset: string; crowding: number; extreme: boolean }[],
+  honeypots: { name: string; apparent_signal: string; actual_outcome: string; flow_narrative_mismatch: boolean }[],
+): string {
+  switch (check) {
+    case "Flow / Narrative":
+      return `Flow vs narrative mismatch: ${safeStr(value, "bearish talk but buying flows detected")}. Actions contradict stated convictions.`;
+    case "Crowding Score": {
+      const extremes = positioning.filter((p) => p.extreme);
+      const crowdedAssets = extremes.map((p) => p.asset).join(", ");
+      return `Crowding elevated${crowdedAssets ? ` in ${crowdedAssets}` : ""}. ${safeStr(value)}. Vulnerable to position unwind.`;
+    }
+    case "Info Provenance":
+      return `Low-provenance sources amplified: ${safeStr(value)}. Discount these narratives when making decisions.`;
+    case "Consensus Divergence":
+      return `Agent disagreement detected: ${safeStr(value)}. Low consensus increases uncertainty.`;
+    case "Honeypot Match": {
+      const topHoneypot = honeypots[0];
+      if (topHoneypot) {
+        return `Pattern matches "${topHoneypot.name}": appears to signal ${topHoneypot.apparent_signal}, but historically resulted in ${topHoneypot.actual_outcome}.`;
+      }
+      return `Nearest historical trap pattern: ${safeStr(value)}.`;
+    }
+    default:
+      return safeStr(value);
+  }
+}
+
+/* ── Section F: Model Transparency (collapsible) ─────────── */
+
+function ModelTransparencyMobile({
+  de,
+  fallback,
+}: {
+  de: DecisionEngineResult;
+  fallback: ReturnType<typeof useAssetScopedData>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const data = de && !de.loading ? de : null;
+  const agents = data?.agentData ?? fallback.agentData;
+  const brierHist = data?.brierHist ?? fallback.brierHist;
+  const ensemble = data?.raw?.agents.ensemble;
+
+  if (!hasData(agents)) return null;
+
+  const totalWeight = agents.reduce((s, a) => s + a.wt, 0);
+  const weightedConf = totalWeight > 0
+    ? agents.reduce((s, a) => s + a.conf * a.wt, 0) / totalWeight
+    : NaN;
+
+  const ensembleDir = ensemble?.direction ?? (
+    agents.filter((a) => a.dir === "Bearish").length >= 3 ? "Bearish Lean" : "Mixed"
+  );
+
+  return (
+    <Card className="p-4">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center justify-between"
+      >
+        <p className="text-[10px] font-bold uppercase tracking-wider text-bm-muted2">
+          Model Transparency
+        </p>
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] text-bm-muted">{agents.length} agents</span>
+          <span className="text-bm-muted2 text-xs">{expanded ? "▲" : "▼"}</span>
+        </div>
+      </button>
+
+      {/* Summary strip always visible */}
+      <div className="flex items-center gap-4 mt-3">
+        <div>
+          <p className="text-[9px] text-bm-muted2 uppercase">Ensemble</p>
+          <p className="text-sm font-mono font-bold text-bm-warning">{ensembleDir}</p>
+        </div>
+        <div>
+          <p className="text-[9px] text-bm-muted2 uppercase">Confidence</p>
+          <p className="text-sm font-mono font-bold text-bm-text">
+            {isValid(weightedConf) ? safePct(weightedConf) : "Not available"}
+          </p>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="mt-3 space-y-0.5 border-t border-bm-border/30 pt-3">
+          {agents.map((a) => {
+            const dirColor =
+              a.dir === "Bullish" ? "text-emerald-400"
+                : a.dir === "Bearish" ? "text-red-400"
+                  : a.dir === "TRAP" ? "text-amber-400"
+                    : "text-bm-muted";
+            return (
+              <div
+                key={a.agent}
+                className="flex items-center justify-between py-1.5 border-b border-bm-border/20 last:border-0"
+              >
+                <span className="text-xs font-semibold text-bm-text w-16">{a.agent}</span>
+                <span className={`text-[10px] font-bold ${dirColor} w-14`}>{a.dir}</span>
+                <div className="flex-1 mx-2">
+                  <div className="h-1.5 rounded-full bg-bm-bg overflow-hidden">
+                    <div
+                      className={`h-full rounded-full ${
+                        a.dir === "Bullish" ? "bg-emerald-400/70"
+                          : a.dir === "Bearish" ? "bg-red-400/70"
+                            : "bg-amber-400/70"
+                      }`}
+                      style={{ width: `${a.conf}%` }}
+                    />
+                  </div>
+                </div>
+                <span className="font-mono text-[10px] text-bm-muted w-8 text-right">
+                  {isValid(a.conf) ? `${a.conf}%` : "—"}
+                </span>
+              </div>
+            );
+          })}
+
+          {/* Brier calibration check */}
+          {hasData(brierHist) && (
+            <div className="mt-2 pt-2 border-t border-bm-border/30">
+              <p className="text-[9px] text-bm-muted2 uppercase">Calibration (Brier)</p>
+              <p className="text-xs text-bm-muted">
+                Latest: {safeScore(brierHist[brierHist.length - 1]?.agg)}{" "}
+                <span className="text-bm-muted2">(target: &lt;0.20, coin flip: 0.25)</span>
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+/* ── Section G: Signal Layers (deep dive, collapsed) ─────── */
+
+function SignalLayersMobile({
+  de,
+  fallback,
+}: {
+  de: DecisionEngineResult;
+  fallback: ReturnType<typeof useAssetScopedData>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const data = de && !de.loading ? de : null;
+  const realitySignals = data?.realitySignals ?? fallback.realitySignals;
+  const dataSignals = data?.dataSignals ?? fallback.dataSignals;
+  const narrativeState = data?.narrativeState ?? fallback.narrativeState;
+
+  const totalSignals = realitySignals.length + dataSignals.length + narrativeState.length;
+  if (totalSignals === 0) return null;
+
+  return (
+    <Card className="p-4">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center justify-between"
+      >
+        <p className="text-[10px] font-bold uppercase tracking-wider text-bm-muted2">
+          Signal Layers
+        </p>
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] text-bm-muted">{totalSignals} signals</span>
+          <span className="text-bm-muted2 text-xs">{expanded ? "▲" : "▼"}</span>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="mt-3 space-y-3">
+          {/* Reality signals */}
+          {hasData(realitySignals) && (
+            <div>
+              <p className="text-[9px] font-bold uppercase text-emerald-500 mb-1">Reality</p>
+              <p className="text-[10px] text-bm-muted leading-relaxed">
+                {realitySignals
+                  .sort((a, b) => Math.abs(b.accel) - Math.abs(a.accel))
+                  .slice(0, 5)
+                  .map((s) => `${s.signal} (${s.accel > 0 ? "+" : ""}${safeNum(s.accel, (n) => n.toFixed(1))})`)
+                  .join(" · ")}
+              </p>
+            </div>
+          )}
+
+          {/* Data signals */}
+          {hasData(dataSignals) && (
+            <div>
+              <p className="text-[9px] font-bold uppercase text-sky-400 mb-1">Data</p>
+              <p className="text-[10px] text-bm-muted leading-relaxed">
+                {dataSignals
+                  .filter((d) => d.surprise !== 0)
+                  .map((d) => `${d.metric}: ${safeNum(d.reported)} (${d.surprise > 0 ? "+" : ""}${safeNum(d.surprise)} surprise)`)
+                  .join(" · ")}
+              </p>
+            </div>
+          )}
+
+          {/* Narrative state */}
+          {hasData(narrativeState) && (
+            <div>
+              <p className="text-[9px] font-bold uppercase text-amber-400 mb-1">Narrative</p>
+              <p className="text-[10px] text-bm-muted leading-relaxed">
+                {narrativeState
+                  .sort((a, b) => b.intensity - a.intensity)
+                  .slice(0, 4)
+                  .map((n) => `${n.label} (${n.lifecycle}, ${n.intensity}% intensity)`)
+                  .join(" · ")}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+/* ── Main component ──────────────────────────────────────── */
+
+interface MobileDecisionEngineProps {
+  assetScope: AssetScope;
+  onScopeChange: (scope: AssetScope) => void;
+  decisionEngine: DecisionEngineResult;
+}
+
+export function MobileDecisionEngine({
+  assetScope,
+  onScopeChange,
+  decisionEngine: de,
+}: MobileDecisionEngineProps) {
+  const fallback = useAssetScopedData(assetScope);
+
+  const integrity = useMemo(
+    () => validateIntegrity(de, fallback),
+    [de, fallback],
+  );
+
+  if (de.loading) {
+    return (
+      <div className="p-4 space-y-3">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="h-24 bg-bm-surface/30 rounded-lg animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (de.error) {
+    return (
+      <div className="p-4">
+        <Card className="p-4">
+          <p className="text-xs text-bm-danger font-mono">
+            Decision engine unavailable: {de.error}
+          </p>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col min-h-full">
+      {/* Sticky top: scope selector + decision block */}
+      <div className="sticky top-0 z-20 bg-bm-bg/95 backdrop-blur-sm pb-2 px-4 pt-3 space-y-3 border-b border-bm-border/30">
+        <ScopeSegmentedControl active={assetScope} onChange={onScopeChange} />
+        <DecisionBlock
+          de={de}
+          fallback={fallback}
+          assetScope={assetScope}
+          integrity={integrity}
+        />
+      </div>
+
+      {/* Scrollable content — decision-first ordering */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {/* B. What Changed Today */}
+        <WhatChangedMobile de={de} fallback={fallback} />
+
+        {/* C. History Rhymes (primary module) */}
+        <HistoryRhymesMobile de={de} fallback={fallback} />
+
+        {/* D. Scenario Probabilities */}
+        <ScenariosMobile de={de} />
+
+        {/* E. Trap Detector */}
+        <TrapDetectorMobile de={de} fallback={fallback} />
+
+        {/* F. Model Transparency (collapsible) */}
+        <ModelTransparencyMobile de={de} fallback={fallback} />
+
+        {/* G. Signal Layers (collapsed by default) */}
+        <SignalLayersMobile de={de} fallback={fallback} />
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/market/panels/DecisionNarrativeCard.tsx
+++ b/repo-b/src/components/market/panels/DecisionNarrativeCard.tsx
@@ -13,6 +13,7 @@ import type {
   AssetScope,
 } from "@/lib/trading-lab/decision-engine-types";
 import type { ApiPrediction } from "@/components/market/hooks/useDecisionEngine";
+import { isValid, safeStr, scenariosValid } from "@/lib/trading-lab/safe-display";
 
 interface DecisionNarrativeCardProps {
   agentData: AgentDataItem[];
@@ -43,9 +44,11 @@ export function DecisionNarrativeCard({
   trapChecks,
 }: DecisionNarrativeCardProps) {
   const bearishCount = agentData.filter((a) => a.dir === "Bearish").length;
-  const totalConf =
-    agentData.reduce((s, a) => s + a.conf * a.wt, 0) /
-    agentData.reduce((s, a) => s + a.wt, 0);
+  const totalWeight = agentData.reduce((s, a) => s + a.wt, 0);
+  const totalConf = totalWeight > 0
+    ? agentData.reduce((s, a) => s + a.conf * a.wt, 0) / totalWeight
+    : NaN;
+  const confidenceValid = isValid(totalConf);
 
   const mismatchCount = mismatchData.filter((m) => m.mismatch > 0.6).length;
   const accelCount = realitySignals.filter((s) => Math.abs(s.accel) > 3).length;
@@ -56,62 +59,67 @@ export function DecisionNarrativeCard({
 
   const scopeLabel = SCOPE_LABELS[assetScope];
 
-  // Determine recommended action
-  const isNoEdge = totalConf < 40;
+  // Determine recommended action — guard against NaN
+  const isNoEdge = !confidenceValid || totalConf < 40;
   const isBearish = bearishCount >= 3;
-  const action = isNoEdge
-    ? "No edge. Do nothing."
-    : isBearish
-      ? "Reduce Risk"
-      : "Hold Current Position";
-  const actionColor = isNoEdge
+  const action = !confidenceValid
+    ? "Insufficient data"
+    : isNoEdge
+      ? "No edge. Do nothing."
+      : isBearish
+        ? "Reduce Risk"
+        : "Hold Current Position";
+  const actionColor = !confidenceValid
     ? "text-bm-muted"
-    : isBearish
-      ? "text-bm-danger"
-      : "text-bm-accent";
+    : isNoEdge
+      ? "text-bm-muted"
+      : isBearish
+        ? "text-bm-danger"
+        : "text-bm-accent";
 
   // Key risk — dynamic from trap checks
   const topTrap = trapChecks?.find(
     (t) => t.variant === "warning" || t.variant === "danger",
   );
   const keyRisk = topTrap
-    ? `${topTrap.check}: ${topTrap.value}`
-    : "Bear trap due to crowded positioning";
+    ? `${topTrap.check}: ${safeStr(topTrap.value)}`
+    : mismatchCount > 0
+      ? "Narrative-reality divergence elevated"
+      : "No elevated risks detected";
 
-  // Scenarios — dynamic from forecast if available
+  // Scenarios — only render if data is valid and sums to ~100%
   const bullProb = forecast
-    ? Math.round((forecast.scenario_bull_prob ?? 0.20) * 100)
-    : 20;
+    ? Math.round((forecast.scenario_bull_prob ?? 0) * 100)
+    : NaN;
   const baseProb = forecast
-    ? Math.round((forecast.scenario_base_prob ?? 0.52) * 100)
-    : 52;
+    ? Math.round((forecast.scenario_base_prob ?? 0) * 100)
+    : NaN;
   const bearProb = forecast
-    ? Math.round((forecast.scenario_bear_prob ?? 0.28) * 100)
-    : 28;
+    ? Math.round((forecast.scenario_bear_prob ?? 0) * 100)
+    : NaN;
 
-  const scenarios = [
+  const showScenarios = scenariosValid(bullProb, baseProb, bearProb);
+
+  const scenarios = showScenarios ? [
     {
       label: "BULL",
       prob: bullProb,
-      ret: "+12%",
       variant: "success" as const,
-      note: "Requires dovish pivot + stabilization",
+      note: forecast?.synthesis_narrative ? "" : "Requires dovish pivot + stabilization",
     },
     {
       label: "BASE",
       prob: baseProb,
-      ret: "-3%",
       variant: "accent" as const,
-      note: "Grinding chop, data-dependent, slow deterioration",
+      note: forecast?.synthesis_narrative ? "" : "Grinding chop, data-dependent, slow deterioration",
     },
     {
       label: "BEAR",
       prob: bearProb,
-      ret: "-18%",
       variant: "danger" as const,
-      note: "Credit contagion, tightening, positioning unwind",
+      note: forecast?.synthesis_narrative ? "" : "Credit contagion, tightening, positioning unwind",
     },
-  ];
+  ] : [];
 
   return (
     <section data-testid="decision-narrative">
@@ -166,7 +174,7 @@ export function DecisionNarrativeCard({
               Confidence
             </p>
             <p className="text-xl font-mono font-bold text-bm-text">
-              {isNoEdge ? "Low" : `${totalConf.toFixed(0)}%`}
+              {confidenceValid ? (isNoEdge ? "Low" : `${totalConf.toFixed(0)}%`) : "Not available"}
             </p>
           </div>
           <div>
@@ -179,31 +187,39 @@ export function DecisionNarrativeCard({
           </div>
         </div>
 
-        {/* Scenario probabilities */}
-        <div>
-          <p className="text-[10px] font-mono uppercase tracking-wider text-bm-muted2 mb-3">
-            SCENARIO PROBABILITIES
-          </p>
-          <div className="grid grid-cols-3 gap-3">
-            {scenarios.map((s) => (
-              <div
-                key={s.label}
-                className="rounded-lg border border-bm-border/50 bg-bm-surface/20 p-3 text-center"
-              >
-                <Badge variant={s.variant} className="mb-1.5">
-                  {s.label}
-                </Badge>
-                <p className="text-2xl font-bold font-mono text-bm-text">
-                  {s.prob}%
-                </p>
-                <p className="text-xs text-bm-text mt-0.5">{s.ret}</p>
-                <p className="text-[10px] text-bm-muted2 mt-1.5 leading-relaxed">
-                  {s.note}
-                </p>
-              </div>
-            ))}
+        {/* Scenario probabilities — only shown if data validates */}
+        {showScenarios && (
+          <div>
+            <p className="text-[10px] font-mono uppercase tracking-wider text-bm-muted2 mb-3">
+              SCENARIO PROBABILITIES
+            </p>
+            <div className="grid grid-cols-3 gap-3">
+              {scenarios.map((s) => (
+                <div
+                  key={s.label}
+                  className="rounded-lg border border-bm-border/50 bg-bm-surface/20 p-3 text-center"
+                >
+                  <Badge variant={s.variant} className="mb-1.5">
+                    {s.label}
+                  </Badge>
+                  <p className="text-2xl font-bold font-mono text-bm-text">
+                    {s.prob}%
+                  </p>
+                  {s.note && (
+                    <p className="text-[10px] text-bm-muted2 mt-1.5 leading-relaxed">
+                      {s.note}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+            {forecast?.synthesis_narrative && (
+              <p className="text-[10px] text-bm-muted mt-3 leading-relaxed">
+                {forecast.synthesis_narrative}
+              </p>
+            )}
           </div>
-        </div>
+        )}
       </Card>
     </section>
   );

--- a/repo-b/src/components/market/panels/ModelTransparencyPanel.tsx
+++ b/repo-b/src/components/market/panels/ModelTransparencyPanel.tsx
@@ -34,14 +34,23 @@ interface ModelTransparencyPanelProps {
 }
 
 export function ModelTransparencyPanel({ agentData, brierHist, agentReasoning }: ModelTransparencyPanelProps) {
+  // Don't render if no agent data
+  if (agentData.length === 0) return null;
+
   const AGENT_REASONING = agentReasoning ?? FALLBACK_REASONING;
   const [expandedAgent, setExpandedAgent] = useState<string | null>(null);
 
-  const totalConf =
-    agentData.reduce((s, a) => s + a.conf * a.wt, 0) /
-    agentData.reduce((s, a) => s + a.wt, 0);
+  const totalWeight = agentData.reduce((s, a) => s + a.wt, 0);
+  const totalConf = totalWeight > 0
+    ? agentData.reduce((s, a) => s + a.conf * a.wt, 0) / totalWeight
+    : NaN;
+  const confidenceValid = Number.isFinite(totalConf);
 
-  const latestBrier = brierHist[brierHist.length - 1]?.agg ?? 0;
+  const latestBrier = brierHist.length > 0 ? brierHist[brierHist.length - 1]?.agg : NaN;
+  const brierValid = Number.isFinite(latestBrier);
+
+  const bearishCount = agentData.filter((a) => a.dir === "Bearish").length;
+  const ensembleDir = bearishCount >= 3 ? "Bearish Lean" : bearishCount === 0 ? "Bullish Lean" : "Mixed";
 
   return (
     <Card className="p-4">
@@ -49,7 +58,7 @@ export function ModelTransparencyPanel({ agentData, brierHist, agentReasoning }:
         <p className="text-[10px] font-bold uppercase tracking-wider text-bm-muted2">
           Model Transparency
         </p>
-        <Badge>5 AGENTS</Badge>
+        <Badge>{agentData.length} AGENTS</Badge>
       </div>
 
       {/* Aggregate output */}
@@ -57,25 +66,27 @@ export function ModelTransparencyPanel({ agentData, brierHist, agentReasoning }:
         <div>
           <p className="text-[9px] text-bm-muted2 uppercase">Ensemble</p>
           <p className="text-lg font-mono font-bold text-bm-warning">
-            Bearish Lean
+            {ensembleDir}
           </p>
         </div>
         <div>
           <p className="text-[9px] text-bm-muted2 uppercase">Confidence</p>
           <p className="text-lg font-mono font-bold text-bm-text">
-            {totalConf.toFixed(0)}%
+            {confidenceValid ? `${totalConf.toFixed(0)}%` : "Not available"}
           </p>
         </div>
-        <div>
-          <p className="text-[9px] text-bm-muted2 uppercase">90d Brier</p>
-          <p
-            className={`text-lg font-mono font-bold ${
-              latestBrier < 0.2 ? "text-emerald-400" : "text-amber-400"
-            }`}
-          >
-            {latestBrier.toFixed(2)}
-          </p>
-        </div>
+        {brierValid && (
+          <div>
+            <p className="text-[9px] text-bm-muted2 uppercase">90d Brier</p>
+            <p
+              className={`text-lg font-mono font-bold ${
+                latestBrier < 0.2 ? "text-emerald-400" : "text-amber-400"
+              }`}
+            >
+              {latestBrier.toFixed(2)}
+            </p>
+          </div>
+        )}
       </div>
 
       {/* Agent rows */}
@@ -154,49 +165,51 @@ export function ModelTransparencyPanel({ agentData, brierHist, agentReasoning }:
         <span className="text-center">Wt</span>
       </div>
 
-      {/* Brier sparkline */}
-      <div>
-        <p className="text-[9px] text-bm-muted2 uppercase tracking-wider mb-1">
-          Calibration History (24w)
-        </p>
-        <ResponsiveContainer width="100%" height={80}>
-          <AreaChart
-            data={brierHist}
-            margin={{ top: 2, right: 4, left: 0, bottom: 2 }}
-          >
-            <CartesianGrid {...GRID_STYLE} />
-            <XAxis dataKey="w" tick={false} axisLine={false} />
-            <YAxis
-              tick={false}
-              axisLine={false}
-              domain={[0.05, 0.35]}
-              width={0}
-            />
-            <Tooltip contentStyle={TOOLTIP_STYLE} />
-            <Area
-              type="monotone"
-              dataKey="base"
-              stroke={CH.red}
-              fill={CH.red}
-              fillOpacity={0.04}
-              strokeDasharray="4 4"
-              name="Coin Flip"
-            />
-            <Area
-              type="monotone"
-              dataKey="agg"
-              stroke={CH.cyan}
-              fill={CH.cyan}
-              fillOpacity={0.08}
-              strokeWidth={1.5}
-              name="Aggregate"
-            />
-          </AreaChart>
-        </ResponsiveContainer>
-        <p className="text-[9px] text-bm-muted2 mt-1">
-          Lower = better. Red = coin flip baseline. Target: &lt;0.20
-        </p>
-      </div>
+      {/* Brier sparkline — only render with real data */}
+      {brierHist.length > 0 && (
+        <div>
+          <p className="text-[9px] text-bm-muted2 uppercase tracking-wider mb-1">
+            Calibration History (24w)
+          </p>
+          <ResponsiveContainer width="100%" height={80}>
+            <AreaChart
+              data={brierHist}
+              margin={{ top: 2, right: 4, left: 0, bottom: 2 }}
+            >
+              <CartesianGrid {...GRID_STYLE} />
+              <XAxis dataKey="w" tick={false} axisLine={false} />
+              <YAxis
+                tick={false}
+                axisLine={false}
+                domain={[0.05, 0.35]}
+                width={0}
+              />
+              <Tooltip contentStyle={TOOLTIP_STYLE} />
+              <Area
+                type="monotone"
+                dataKey="base"
+                stroke={CH.red}
+                fill={CH.red}
+                fillOpacity={0.04}
+                strokeDasharray="4 4"
+                name="Coin Flip"
+              />
+              <Area
+                type="monotone"
+                dataKey="agg"
+                stroke={CH.cyan}
+                fill={CH.cyan}
+                fillOpacity={0.08}
+                strokeWidth={1.5}
+                name="Aggregate"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+          <p className="text-[9px] text-bm-muted2 mt-1">
+            Lower = better. Red = coin flip baseline. Target: &lt;0.20
+          </p>
+        </div>
+      )}
     </Card>
   );
 }

--- a/repo-b/src/components/market/panels/TopAnalogCard.tsx
+++ b/repo-b/src/components/market/panels/TopAnalogCard.tsx
@@ -12,7 +12,8 @@ import {
   CHART_COLORS, TOOLTIP_STYLE, AXIS_TICK_STYLE, GRID_STYLE,
 } from "@/components/charts/chart-theme";
 import type { AnalogOverlayPoint, RadarDim } from "@/lib/trading-lab/decision-engine-types";
-import type { ApiAnalogMatch } from "@/components/market/hooks/useDecisionEngine";
+import type { ApiAnalogMatch, ApiEpisode } from "@/components/market/hooks/useDecisionEngine";
+import { safeStr, safeScore, isValid, hasData } from "@/lib/trading-lab/safe-display";
 
 const CH = {
   cyan: CHART_COLORS.scenario[0],
@@ -26,18 +27,39 @@ interface TopAnalogCardProps {
   analogOverlay: AnalogOverlayPoint[];
   radarDims: RadarDim[];
   topMatch?: ApiAnalogMatch | null;
+  episodes?: ApiEpisode[];
 }
 
-export function TopAnalogCard({ analogOverlay, radarDims, topMatch }: TopAnalogCardProps) {
+export function TopAnalogCard({ analogOverlay, radarDims, topMatch, episodes }: TopAnalogCardProps) {
   const topAnalog = topMatch?.matches?.[0];
-  const analogName = topAnalog?.episode_name ?? "2022 Rate Cycle";
-  const rhymeScore = topAnalog?.rhyme_score ?? 0.78;
-  const keySim = topAnalog?.key_similarity ?? "tightening + leverage stress";
-  const keyDiv = topAnalog?.key_divergence ?? "labor market holding longer this cycle";
+
+  // Don't render if no analog data exists
+  if (!topAnalog) return null;
+
+  const analogName = safeStr(topAnalog.episode_name);
+  const rhymeScore = topAnalog.rhyme_score;
+  const keySim = safeStr(topAnalog.key_similarity);
+  const keyDiv = safeStr(topAnalog.key_divergence);
   const isSeed = topMatch?.source === "seed";
 
+  // Find matching episode for forward outcome
+  const matchedEpisode = episodes?.find(
+    (e) => e.name === topAnalog.episode_name || e.id === topAnalog.episode_id,
+  );
+
+  const forwardOutcome = matchedEpisode
+    ? `Historically led to ${Math.abs(matchedEpisode.peak_to_trough_pct).toFixed(0)}% drawdown over ${matchedEpisode.duration_days} days${
+        matchedEpisode.recovery_duration_days
+          ? `. Recovery took ${matchedEpisode.recovery_duration_days} days`
+          : ""
+      }.`
+    : null;
+
+  const hasOverlayData = hasData(analogOverlay);
+  const hasRadarData = hasData(radarDims);
+
   return (
-    <Card className="p-4">
+    <Card className="p-4 border-l-4 border-l-bm-warning">
       <div className="flex items-center justify-between mb-3">
         <p className="text-[10px] font-bold uppercase tracking-wider text-bm-muted2">
           Top Analog
@@ -47,119 +69,145 @@ export function TopAnalogCard({ analogOverlay, radarDims, topMatch }: TopAnalogC
 
       {/* Analog callout */}
       <div className="flex items-start justify-between mb-4 pb-3 border-b border-bm-border/30">
-        <div>
-          <p className="text-sm font-semibold text-bm-text">
+        <div className="flex-1 min-w-0">
+          <p className="text-base font-semibold text-bm-text">
             {analogName}
           </p>
-          <p className="text-[10px] text-bm-muted mt-1">
-            Key similarity: {keySim}
-          </p>
-          <p className="text-[10px] text-bm-muted2 mt-0.5">
-            Key divergence: {keyDiv}
-          </p>
-        </div>
-        <div className="text-right">
-          <p className="text-[9px] text-bm-muted2 uppercase">Rhyme Score</p>
-          <p className="text-2xl font-bold font-mono text-bm-accent">{rhymeScore.toFixed(2)}</p>
+          {isValid(rhymeScore) && (
+            <p className="text-[10px] text-bm-muted2 mt-0.5">
+              Rhyme Score: <span className="font-mono font-bold text-bm-accent text-lg">{safeScore(rhymeScore)}</span>
+            </p>
+          )}
         </div>
       </div>
 
-      {/* Charts */}
-      <div className="grid grid-cols-1 lg:grid-cols-[1.4fr_1fr] gap-3">
-        <div>
-          <p className="text-[9px] font-bold uppercase tracking-wider text-bm-muted2 mb-2">
-            Trajectory Overlay (60d)
-          </p>
-          <ResponsiveContainer width="100%" height={180}>
-            <LineChart
-              data={analogOverlay}
-              margin={{ top: 5, right: 10, left: 0, bottom: 5 }}
-            >
-              <CartesianGrid {...GRID_STYLE} />
-              <XAxis
-                dataKey="day"
-                tick={AXIS_TICK_STYLE}
-                tickLine={false}
-                axisLine={{ stroke: CH.grid }}
-              />
-              <YAxis
-                tick={AXIS_TICK_STYLE}
-                tickLine={false}
-                axisLine={{ stroke: CH.grid }}
-                domain={["auto", "auto"]}
-              />
-              <Tooltip contentStyle={TOOLTIP_STYLE} />
-              <Line
-                type="monotone"
-                dataKey="current"
-                stroke={CH.cyan}
-                strokeWidth={2.5}
-                dot={false}
-                name="Current"
-              />
-              <Line
-                type="monotone"
-                dataKey="gfc"
-                stroke={CH.red}
-                strokeWidth={1.5}
-                strokeDasharray="6 3"
-                dot={false}
-                name="GFC 2008"
-                opacity={0.7}
-              />
-              <Line
-                type="monotone"
-                dataKey="crypto22"
-                stroke={CH.purple}
-                strokeWidth={1.5}
-                strokeDasharray="4 4"
-                dot={false}
-                name="Crypto 2022"
-                opacity={0.7}
-              />
-            </LineChart>
-          </ResponsiveContainer>
+      {/* Divergence + Similarity as first-class insights */}
+      <div className="grid grid-cols-2 gap-3 mb-4">
+        <div className="rounded-lg bg-emerald-500/5 border border-emerald-500/20 p-3">
+          <p className="text-[9px] text-emerald-400 uppercase font-bold mb-1">Key Similarities</p>
+          <p className="text-xs text-bm-text leading-relaxed">{keySim}</p>
         </div>
-        <div>
-          <p className="text-[9px] font-bold uppercase tracking-wider text-bm-muted2 mb-2">
-            5-Layer Match
-          </p>
-          <ResponsiveContainer width="100%" height={180}>
-            <RadarChart data={radarDims}>
-              <PolarGrid stroke={CH.grid} />
-              <PolarAngleAxis
-                dataKey="d"
-                tick={{ fill: CH.axis, fontSize: 9 }}
-              />
-              <PolarRadiusAxis tick={false} axisLine={false} domain={[0, 1]} />
-              <Radar
-                name="Current"
-                dataKey="current"
-                stroke={CH.cyan}
-                fill={CH.cyan}
-                fillOpacity={0.12}
-                strokeWidth={2}
-              />
-              <Radar
-                name="GFC"
-                dataKey="gfc"
-                stroke={CH.red}
-                fill="none"
-                strokeWidth={1.5}
-                strokeDasharray="4 2"
-              />
-              <Radar
-                name="Crypto 22"
-                dataKey="crypto22"
-                stroke={CH.purple}
-                fill="none"
-                strokeWidth={1.5}
-                strokeDasharray="4 2"
-              />
-            </RadarChart>
-          </ResponsiveContainer>
+        <div className="rounded-lg bg-amber-500/5 border border-amber-500/20 p-3">
+          <p className="text-[9px] text-amber-400 uppercase font-bold mb-1">Key Divergences</p>
+          <p className="text-xs text-bm-text leading-relaxed">{keyDiv}</p>
         </div>
       </div>
+
+      {/* What happened next — forward outcome */}
+      {forwardOutcome && (
+        <div className="rounded-lg bg-bm-surface/30 border border-bm-border/30 p-3 mb-4">
+          <p className="text-[9px] text-bm-muted2 uppercase font-bold mb-1">What Happened Next</p>
+          <p className="text-xs text-bm-text leading-relaxed">{forwardOutcome}</p>
+          {matchedEpisode?.modern_analog_thesis && (
+            <p className="text-[10px] text-bm-muted mt-2 italic leading-relaxed">
+              {matchedEpisode.modern_analog_thesis}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Charts — only render with real data */}
+      {(hasOverlayData || hasRadarData) && (
+        <div className="grid grid-cols-1 lg:grid-cols-[1.4fr_1fr] gap-3">
+          {hasOverlayData && (
+            <div>
+              <p className="text-[9px] font-bold uppercase tracking-wider text-bm-muted2 mb-2">
+                Trajectory Overlay (60d)
+              </p>
+              <ResponsiveContainer width="100%" height={180}>
+                <LineChart
+                  data={analogOverlay}
+                  margin={{ top: 5, right: 10, left: 0, bottom: 5 }}
+                >
+                  <CartesianGrid {...GRID_STYLE} />
+                  <XAxis
+                    dataKey="day"
+                    tick={AXIS_TICK_STYLE}
+                    tickLine={false}
+                    axisLine={{ stroke: CH.grid }}
+                  />
+                  <YAxis
+                    tick={AXIS_TICK_STYLE}
+                    tickLine={false}
+                    axisLine={{ stroke: CH.grid }}
+                    domain={["auto", "auto"]}
+                  />
+                  <Tooltip contentStyle={TOOLTIP_STYLE} />
+                  <Line
+                    type="monotone"
+                    dataKey="current"
+                    stroke={CH.cyan}
+                    strokeWidth={2.5}
+                    dot={false}
+                    name="Current"
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="gfc"
+                    stroke={CH.red}
+                    strokeWidth={1.5}
+                    strokeDasharray="6 3"
+                    dot={false}
+                    name="GFC 2008"
+                    opacity={0.7}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="crypto22"
+                    stroke={CH.purple}
+                    strokeWidth={1.5}
+                    strokeDasharray="4 4"
+                    dot={false}
+                    name="Crypto 2022"
+                    opacity={0.7}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+          {hasRadarData && (
+            <div>
+              <p className="text-[9px] font-bold uppercase tracking-wider text-bm-muted2 mb-2">
+                5-Layer Match
+              </p>
+              <ResponsiveContainer width="100%" height={180}>
+                <RadarChart data={radarDims}>
+                  <PolarGrid stroke={CH.grid} />
+                  <PolarAngleAxis
+                    dataKey="d"
+                    tick={{ fill: CH.axis, fontSize: 9 }}
+                  />
+                  <PolarRadiusAxis tick={false} axisLine={false} domain={[0, 1]} />
+                  <Radar
+                    name="Current"
+                    dataKey="current"
+                    stroke={CH.cyan}
+                    fill={CH.cyan}
+                    fillOpacity={0.12}
+                    strokeWidth={2}
+                  />
+                  <Radar
+                    name="GFC"
+                    dataKey="gfc"
+                    stroke={CH.red}
+                    fill="none"
+                    strokeWidth={1.5}
+                    strokeDasharray="4 2"
+                  />
+                  <Radar
+                    name="Crypto 22"
+                    dataKey="crypto22"
+                    stroke={CH.purple}
+                    fill="none"
+                    strokeWidth={1.5}
+                    strokeDasharray="4 2"
+                  />
+                </RadarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </div>
+      )}
     </Card>
   );
 }

--- a/repo-b/src/components/market/panels/TrapDetectionPanel.tsx
+++ b/repo-b/src/components/market/panels/TrapDetectionPanel.tsx
@@ -40,11 +40,15 @@ interface TrapDetectionPanelProps {
 export function TrapDetectionPanel({ trapChecks, positioningData }: TrapDetectionPanelProps) {
   const activeTraps = trapChecks.filter(
     (t) => t.variant === "warning" || t.variant === "danger"
-  ).length;
+  );
+
+  // If no trap checks at all, don't render
+  if (trapChecks.length === 0) return null;
 
   const extremePositions = positioningData.filter((p) => p.extreme);
-  const avgCrowding =
-    positioningData.reduce((s, p) => s + p.crowding, 0) / positioningData.length;
+  const avgCrowding = positioningData.length > 0
+    ? positioningData.reduce((s, p) => s + p.crowding, 0) / positioningData.length
+    : NaN;
 
   return (
     <Card className="p-4">
@@ -52,39 +56,44 @@ export function TrapDetectionPanel({ trapChecks, positioningData }: TrapDetectio
         <p className="text-[10px] font-bold uppercase tracking-wider text-bm-muted2">
           Trap Detector
         </p>
-        <Badge variant={activeTraps > 2 ? "danger" : activeTraps > 0 ? "warning" : "success"}>
-          {activeTraps} ACTIVE
+        <Badge variant={activeTraps.length > 2 ? "danger" : activeTraps.length > 0 ? "warning" : "success"}>
+          {activeTraps.length} ACTIVE
         </Badge>
       </div>
 
-      {/* Summary strip */}
-      <div className="flex items-center gap-4 mb-4 pb-3 border-b border-bm-border/30">
-        <div>
-          <p className="text-[9px] text-bm-muted2 uppercase">Avg Crowding</p>
-          <p
-            className={`text-lg font-mono font-bold ${
-              avgCrowding > 65
-                ? "text-red-400"
-                : avgCrowding > 45
-                  ? "text-amber-400"
-                  : "text-emerald-400"
-            }`}
-          >
-            {avgCrowding.toFixed(0)}
-          </p>
+      {/* Summary strip — only if data exists */}
+      {(Number.isFinite(avgCrowding) || extremePositions.length > 0) && (
+        <div className="flex items-center gap-4 mb-4 pb-3 border-b border-bm-border/30">
+          {Number.isFinite(avgCrowding) && (
+            <div>
+              <p className="text-[9px] text-bm-muted2 uppercase">Avg Crowding</p>
+              <p
+                className={`text-lg font-mono font-bold ${
+                  avgCrowding > 65
+                    ? "text-red-400"
+                    : avgCrowding > 45
+                      ? "text-amber-400"
+                      : "text-emerald-400"
+                }`}
+              >
+                {avgCrowding.toFixed(0)}
+              </p>
+            </div>
+          )}
+          <div>
+            <p className="text-[9px] text-bm-muted2 uppercase">Extreme Positions</p>
+            <p className="text-lg font-mono font-bold text-bm-text">
+              {extremePositions.length}
+            </p>
+          </div>
         </div>
-        <div>
-          <p className="text-[9px] text-bm-muted2 uppercase">Extreme Positions</p>
-          <p className="text-lg font-mono font-bold text-bm-text">
-            {extremePositions.length}
-          </p>
-        </div>
-      </div>
+      )}
 
-      {/* Trap checks */}
+      {/* Trap checks — narrative output instead of raw values */}
       <div className="space-y-1">
         {trapChecks.map((t) => {
           const meta = TRAP_EXPLANATIONS[t.check];
+          const isActive = t.variant === "warning" || t.variant === "danger";
           return (
             <div
               key={t.check}
@@ -96,17 +105,12 @@ export function TrapDetectionPanel({ trapChecks, positioningData }: TrapDetectio
                 </span>
                 <Badge variant={t.variant}>{t.status}</Badge>
               </div>
-              <p className="text-[10px] text-bm-muted2 mb-1">{t.value}</p>
-              {meta && (
-                <p className="text-[10px] text-bm-muted leading-relaxed">
-                  {meta.explanation}
-                </p>
-              )}
-              {meta?.actionAdjustment && (
-                <p className="text-[10px] text-amber-400 mt-1 font-medium">
-                  Action: {meta.actionAdjustment}
-                </p>
-              )}
+              {/* Narrative reasoning instead of raw numeric values */}
+              <p className="text-[10px] text-bm-muted leading-relaxed">
+                {isActive && meta?.actionAdjustment
+                  ? meta.actionAdjustment
+                  : meta?.explanation ?? t.value}
+              </p>
             </div>
           );
         })}

--- a/repo-b/src/components/market/panels/WhatChangedPanel.tsx
+++ b/repo-b/src/components/market/panels/WhatChangedPanel.tsx
@@ -76,7 +76,7 @@ export function WhatChangedPanel({ realitySignals, dataSignals }: WhatChangedPan
       </div>
 
       {deltas.length === 0 ? (
-        <p className="text-xs text-bm-muted2 italic">No significant changes today.</p>
+        <p className="text-xs text-bm-muted2">No material changes.</p>
       ) : (
         <div className="space-y-1.5">
           {deltas.map((d) => {

--- a/repo-b/src/lib/trading-lab/safe-display.ts
+++ b/repo-b/src/lib/trading-lab/safe-display.ts
@@ -1,0 +1,57 @@
+/**
+ * Safe display utilities for the Decision Engine.
+ * Prevents NaN, null, undefined from ever reaching the UI.
+ */
+
+/** Display a numeric value or "Not available" */
+export function safeNum(
+  value: unknown,
+  formatter?: (n: number) => string,
+): string {
+  if (value == null) return "Not available";
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return "Not available";
+  return formatter ? formatter(n) : String(n);
+}
+
+/** Display a percentage or "Not available" */
+export function safePct(value: unknown, decimals = 0): string {
+  if (value == null) return "Not available";
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return "Not available";
+  return `${n.toFixed(decimals)}%`;
+}
+
+/** Display a score (0–1 range) or "Not available" */
+export function safeScore(value: unknown, decimals = 2): string {
+  if (value == null) return "Not available";
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return "Not available";
+  return n.toFixed(decimals);
+}
+
+/** Check if a value is valid (not null, undefined, NaN) */
+export function isValid(value: unknown): boolean {
+  if (value == null) return false;
+  if (typeof value === "number" && !Number.isFinite(value)) return false;
+  return true;
+}
+
+/** Check if an array has real data */
+export function hasData<T>(arr: T[] | null | undefined): arr is T[] {
+  return Array.isArray(arr) && arr.length > 0;
+}
+
+/** Safe string display */
+export function safeStr(value: unknown, fallback = "Not available"): string {
+  if (value == null) return fallback;
+  const s = String(value).trim();
+  return s.length > 0 ? s : fallback;
+}
+
+/** Validate scenario probabilities sum to ~100% */
+export function scenariosValid(bull: number, base: number, bear: number): boolean {
+  if (!Number.isFinite(bull) || !Number.isFinite(base) || !Number.isFinite(bear)) return false;
+  const sum = bull + base + bear;
+  return sum >= 95 && sum <= 105; // Allow small rounding tolerance
+}


### PR DESCRIPTION
Replace sidebar nav with segmented scope control on mobile. Reorder
layout to Decision Block (sticky) > What Changed > History Rhymes >
Scenarios > Trap Detector > Model Transparency > Signal Layers.

Key fixes:
- Eliminate all NaN/null/undefined rendering via safe-display utilities
- Scenario probabilities hidden when data doesn't validate (~100% sum)
- Trap detector outputs narrative reasoning, hides when no active traps
- Model transparency collapses with no agent data, no empty charts
- TopAnalogCard shows forward outcome ("what happened next") and
  elevates divergence as first-class insight
- Confidence displays "Not available" instead of NaN when uncalibrated
- Conditional rendering throughout: missing data = hidden section

https://claude.ai/code/session_01Yb4iVKcvE1PiXuq95C5E2u