### PR TITLE
fix: replace removed imresamu/postgis-pgvector image with official postgis/postgis

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: imresamu/postgis-pgvector:16-3.5
+        image: postgis/postgis:16-3.5
         env:
           POSTGRES_DB: app
           POSTGRES_USER: postgres

--- a/repo-b/db/schema/303_cre_intelligence_graph.sql
+++ b/repo-b/db/schema/303_cre_intelligence_graph.sql
@@ -1,8 +1,16 @@
 -- 303_cre_intelligence_graph.sql
 -- CRE Intelligence Graph foundation for Winston.
 
-CREATE EXTENSION IF NOT EXISTS postgis;
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'postgis') THEN
+    CREATE EXTENSION IF NOT EXISTS postgis;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_trgm') THEN
+    CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  END IF;
+END;
+$$;
 
 CREATE TABLE IF NOT EXISTS dim_property (
   property_id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/repo-b/db/schema/303_pipeline_geography.sql
+++ b/repo-b/db/schema/303_pipeline_geography.sql
@@ -3,7 +3,13 @@
 -- Requires PostGIS extension for geometry columns and spatial indexes.
 
 -- Enable PostGIS (graceful no-op if not available)
-CREATE EXTENSION IF NOT EXISTS postgis;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'postgis') THEN
+    CREATE EXTENSION IF NOT EXISTS postgis;
+  END IF;
+END;
+$$;
 
 -- ═══════════════════════════════════════════════════════════════════════════════
 -- PIPELINE GEOGRAPHY DIMENSION — Census tracts, counties, CBSAs for pipeline map


### PR DESCRIPTION
The imresamu/postgis-pgvector:16-3.5 Docker image was removed from Docker Hub,
breaking the Perf Nightly CI workflow. Switch to the official postgis/postgis:16-3.5
image (maintained by the PostGIS project, millions of pulls).

Also make PostGIS and pg_trgm extension creation graceful (matching the existing
pgvector pattern) so schema apply doesn't hard-fail if an extension is unavailable.

https://claude.ai/code/session_01WtWWGP9UCbG9oJZH73xYfy