### PR TITLE
feat(resume): replace Linked Evidence with interactive Skills capability map

### DIFF
--- a/repo-b/src/components/resume/ResumeWorkspace.tsx
+++ b/repo-b/src/components/resume/ResumeWorkspace.tsx
@@ -19,7 +19,7 @@ import ResumeContextRail from "./ResumeContextRail";
 import ResumeAssistantDock from "./ResumeAssistantDock";
 import ResumeExportPdf from "./ResumeExportPdf";
 import ResumeModuleBoundary from "./ResumeModuleBoundary";
-import LinkedContextBar from "./LinkedContextBar";
+import SkillsCapabilityMap from "./SkillsCapabilityMap";
 import { useResumeWorkspaceStore } from "./useResumeWorkspaceStore";
 import type { ResumeWorkspaceViewModel } from "@/lib/resume/workspace";
 
@@ -306,7 +306,7 @@ export default function ResumeWorkspace({
           </div>
         </div>
 
-        <LinkedContextBar />
+        <SkillsCapabilityMap />
       </section>
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">

--- a/repo-b/src/components/resume/SkillDetailView.tsx
+++ b/repo-b/src/components/resume/SkillDetailView.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useCallback } from "react";
+import type { SkillDefinition } from "./skillsData";
+
+/** Skill icon SVGs — minimal monochrome logos at consistent 28×28 visual weight. */
+function SkillLogo({ skillId, size = 28 }: { skillId: string; size?: number }) {
+  const s = size;
+  const common = { width: s, height: s, viewBox: "0 0 28 28", fill: "none", xmlns: "http://www.w3.org/2000/svg" };
+
+  switch (skillId) {
+    case "python":
+      return (
+        <svg {...common}>
+          <path d="M14 3C9.03 3 9.5 5.2 9.5 5.2l.005 2.28H14.2v.69H7.37S4 7.78 4 14.03s2.94 6.04 2.94 6.04h1.75v-2.91s-.09-2.94 2.89-2.94h4.98s2.8.05 2.8-2.71V7.12S19.77 3 14 3zm-2.77 2.38a.9.9 0 110 1.8.9.9 0 010-1.8z" fill="currentColor" opacity=".85"/>
+          <path d="M14 25c4.97 0 4.5-2.2 4.5-2.2l-.005-2.28H13.8v-.69h6.83S24 20.22 24 13.97s-2.94-6.04-2.94-6.04h-1.75v2.91s.09 2.94-2.89 2.94h-4.98s-2.8-.05-2.8 2.71v4.39S8.23 25 14 25zm2.77-2.38a.9.9 0 110-1.8.9.9 0 010 1.8z" fill="currentColor" opacity=".65"/>
+        </svg>
+      );
+    case "pyspark":
+      return (
+        <svg {...common}>
+          <path d="M14 4l-8 5v10l8 5 8-5V9l-8-5zm0 2.3L19.7 9 14 11.7 8.3 9 14 6.3zM7.5 10.3l5.5 3v7.3l-5.5-3.3v-7zm13 0v7l-5.5 3.3v-7.3l5.5-3z" fill="currentColor" opacity=".8"/>
+          <circle cx="14" cy="14" r="2.5" fill="currentColor" opacity=".5"/>
+        </svg>
+      );
+    case "sql":
+      return (
+        <svg {...common}>
+          <ellipse cx="14" cy="8" rx="8" ry="3.5" fill="currentColor" opacity=".3"/>
+          <path d="M6 8v12c0 1.93 3.58 3.5 8 3.5s8-1.57 8-3.5V8" stroke="currentColor" strokeWidth="1.5" fill="none" opacity=".7"/>
+          <ellipse cx="14" cy="8" rx="8" ry="3.5" stroke="currentColor" strokeWidth="1.5" fill="none" opacity=".7"/>
+          <path d="M6 13.5c0 1.93 3.58 3.5 8 3.5s8-1.57 8-3.5" stroke="currentColor" strokeWidth="1" opacity=".35"/>
+          <path d="M6 18.5c0 1.93 3.58 3.5 8 3.5s8-1.57 8-3.5" stroke="currentColor" strokeWidth="1" opacity=".35"/>
+        </svg>
+      );
+    case "databricks":
+      return (
+        <svg {...common}>
+          <path d="M14 3L3 9l11 6 11-6-11-6z" fill="currentColor" opacity=".8"/>
+          <path d="M3 14l11 6 11-6" stroke="currentColor" strokeWidth="1.5" fill="none" opacity=".5"/>
+          <path d="M3 19l11 6 11-6" stroke="currentColor" strokeWidth="1.5" fill="none" opacity=".35"/>
+        </svg>
+      );
+    case "azure":
+      return (
+        <svg {...common}>
+          <path d="M7.5 5h5.2L8.3 23H3L7.5 5z" fill="currentColor" opacity=".6"/>
+          <path d="M15.7 9.2L12 23h13l-5.3-8.8-4 5-4-10z" fill="currentColor" opacity=".85"/>
+        </svg>
+      );
+    case "power_bi":
+      return (
+        <svg {...common}>
+          <rect x="5" y="14" width="4" height="10" rx="1" fill="currentColor" opacity=".5"/>
+          <rect x="12" y="9" width="4" height="15" rx="1" fill="currentColor" opacity=".7"/>
+          <rect x="19" y="4" width="4" height="20" rx="1" fill="currentColor" opacity=".9"/>
+        </svg>
+      );
+    case "tableau":
+      return (
+        <svg {...common}>
+          <path d="M14 3v5M14 20v5M3 14h5M20 14h5" stroke="currentColor" strokeWidth="2.5" opacity=".8"/>
+          <path d="M7 7l3 3M18 18l3 3M7 21l3-3M18 10l3-3" stroke="currentColor" strokeWidth="1.5" opacity=".45"/>
+          <circle cx="14" cy="14" r="2" fill="currentColor" opacity=".7"/>
+        </svg>
+      );
+    case "tabular_editor":
+      return (
+        <svg {...common}>
+          <rect x="4" y="4" width="20" height="20" rx="3" stroke="currentColor" strokeWidth="1.5" fill="none" opacity=".5"/>
+          <path d="M4 10h20M12 10v14" stroke="currentColor" strokeWidth="1.2" opacity=".5"/>
+          <path d="M8 14h2M8 18h2M15 14h6M15 18h4" stroke="currentColor" strokeWidth="1.5" opacity=".7"/>
+        </svg>
+      );
+    case "snowflake":
+      return (
+        <svg {...common}>
+          <path d="M14 3v22M5 8.8l18 10.4M5 19.2l18-10.4" stroke="currentColor" strokeWidth="1.8" opacity=".7"/>
+          <circle cx="14" cy="3" r="1.5" fill="currentColor" opacity=".5"/>
+          <circle cx="14" cy="25" r="1.5" fill="currentColor" opacity=".5"/>
+          <circle cx="5" cy="8.8" r="1.5" fill="currentColor" opacity=".5"/>
+          <circle cx="23" cy="19.2" r="1.5" fill="currentColor" opacity=".5"/>
+          <circle cx="5" cy="19.2" r="1.5" fill="currentColor" opacity=".5"/>
+          <circle cx="23" cy="8.8" r="1.5" fill="currentColor" opacity=".5"/>
+        </svg>
+      );
+    case "openai":
+      return (
+        <svg {...common}>
+          <path d="M21.5 12.6a5.1 5.1 0 00-.44-4.2 5.16 5.16 0 00-5.56-2.52 5.12 5.12 0 00-3.86-1.72 5.17 5.17 0 00-4.94 3.6 5.1 5.1 0 00-3.42 2.48 5.17 5.17 0 00.64 6.06A5.1 5.1 0 004.36 20.5a5.16 5.16 0 005.56 2.52 5.12 5.12 0 003.86 1.72 5.17 5.17 0 004.94-3.6 5.1 5.1 0 003.42-2.48 5.17 5.17 0 00-.64-6.06z" stroke="currentColor" strokeWidth="1.3" fill="none" opacity=".75"/>
+        </svg>
+      );
+    case "langchain":
+      return (
+        <svg {...common}>
+          <path d="M8 6h12v4H8z" fill="currentColor" opacity=".4" rx="1"/>
+          <path d="M8 12h12v4H8z" fill="currentColor" opacity=".6" rx="1"/>
+          <path d="M8 18h12v4H8z" fill="currentColor" opacity=".8" rx="1"/>
+          <path d="M14 10v2M10 16v2M18 16v2" stroke="currentColor" strokeWidth="1.5" opacity=".6"/>
+        </svg>
+      );
+    default:
+      return (
+        <svg {...common}>
+          <rect x="6" y="6" width="16" height="16" rx="3" stroke="currentColor" strokeWidth="1.5" fill="none" opacity=".5"/>
+        </svg>
+      );
+  }
+}
+
+export { SkillLogo };
+
+interface SkillDetailViewProps {
+  skill: SkillDefinition;
+  onBack: () => void;
+  /** Highlighted from timeline selection */
+  isHighlighted?: boolean;
+}
+
+export default function SkillDetailView({ skill, onBack, isHighlighted }: SkillDetailViewProps) {
+  const handleBack = useCallback(
+    (e: React.MouseEvent | React.KeyboardEvent) => {
+      e.stopPropagation();
+      onBack();
+    },
+    [onBack],
+  );
+
+  return (
+    <div
+      className={`animate-in fade-in slide-in-from-right-2 duration-200 rounded-xl border px-4 py-4 transition-colors ${
+        isHighlighted
+          ? "border-sky-400/30 bg-sky-400/5"
+          : "border-bm-border/30 bg-bm-surface/20"
+      }`}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handleBack}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-bm-border/30 bg-white/5 text-bm-muted transition hover:bg-white/10 hover:text-bm-text"
+          aria-label="Back to skills"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path d="M9 3L5 7l4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </button>
+        <div className="flex items-center gap-2.5">
+          <div className="text-bm-text" style={{ color: skill.color }}>
+            <SkillLogo skillId={skill.id} size={24} />
+          </div>
+          <h3 className="text-sm font-semibold tracking-wide text-bm-text">
+            {skill.name}
+          </h3>
+        </div>
+        {isHighlighted && (
+          <span className="ml-auto h-1.5 w-1.5 rounded-full bg-sky-400" title="Linked from timeline" />
+        )}
+      </div>
+
+      {/* Bullets — [action] + [system built] + [outcome] */}
+      <ul className="mt-3 space-y-2">
+        {skill.bullets.map((bullet) => (
+          <li
+            key={bullet.text}
+            className="flex items-start gap-2 text-[12.5px] leading-[1.4] text-bm-muted"
+          >
+            <span
+              className="mt-[6px] h-1.5 w-1.5 shrink-0 rounded-full"
+              style={{ backgroundColor: skill.color, opacity: 0.6 }}
+            />
+            <span>{bullet.text}</span>
+          </li>
+        ))}
+      </ul>
+
+      {/* Capability tags */}
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {skill.capabilityTags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded-full border border-bm-border/25 bg-white/5 px-2 py-0.5 text-[10px] uppercase tracking-wider text-bm-muted2"
+          >
+            {tag.replace(/_/g, " ")}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/resume/SkillsCapabilityMap.tsx
+++ b/repo-b/src/components/resume/SkillsCapabilityMap.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useResumeWorkspaceStore } from "./useResumeWorkspaceStore";
+import { SKILLS, getSkillsByMilestoneId, getSkillsByPhaseId, getSkillsByCapabilityTag } from "./skillsData";
+import type { SkillId, SkillDefinition } from "./skillsData";
+import SkillDetailView, { SkillLogo } from "./SkillDetailView";
+
+/**
+ * Replaces LinkedContextBar with an interactive skills capability map.
+ *
+ * - Icon grid: 2 rows on mobile, evenly spaced logos only (no pills)
+ * - Clicking an icon navigates to a skill detail view
+ * - Timeline selection highlights relevant skills
+ * - Skill selection can filter/annotate the timeline via capability layer toggles
+ */
+export default function SkillsCapabilityMap() {
+  const {
+    selectedSkillId,
+    setSelectedSkillId,
+    selectedNarrativeKind,
+    selectedNarrativeId,
+    workspace,
+    toggleCapabilityLayer,
+    enabledCapabilityLayerIds,
+  } = useResumeWorkspaceStore(
+    useShallow((state) => ({
+      selectedSkillId: state.selectedSkillId,
+      setSelectedSkillId: state.setSelectedSkillId,
+      selectedNarrativeKind: state.selectedNarrativeKind,
+      selectedNarrativeId: state.selectedNarrativeId,
+      workspace: state.workspace,
+      toggleCapabilityLayer: state.toggleCapabilityLayer,
+      enabledCapabilityLayerIds: state.enabledCapabilityLayerIds,
+    })),
+  );
+
+  /** Skills highlighted by current timeline selection */
+  const highlightedSkillIds = useMemo(() => {
+    if (!selectedNarrativeId || !workspace) return new Set<SkillId>();
+
+    let matched: SkillDefinition[] = [];
+
+    if (selectedNarrativeKind === "milestone") {
+      matched = getSkillsByMilestoneId(selectedNarrativeId);
+    } else if (selectedNarrativeKind === "phase") {
+      matched = getSkillsByPhaseId(selectedNarrativeId);
+    } else if (selectedNarrativeKind === "layer") {
+      matched = getSkillsByCapabilityTag(selectedNarrativeId);
+    } else if (selectedNarrativeKind === "initiative") {
+      // Find milestones linked to this initiative and map skills
+      const initiative = workspace.timeline.initiatives.find(
+        (i) => i.initiative_id === selectedNarrativeId,
+      );
+      if (initiative) {
+        const fromTags = initiative.capability_tags.flatMap((tag) => getSkillsByCapabilityTag(tag));
+        matched = [...new Map(fromTags.map((s) => [s.id, s])).values()];
+      }
+    } else if (selectedNarrativeKind === "role") {
+      // Match by phase
+      const role = workspace.timeline.roles.find(
+        (r) => r.timeline_role_id === selectedNarrativeId,
+      );
+      if (role) {
+        const fromPhase = workspace.timeline.phases.find(
+          (p) =>
+            p.start_date <= role.start_date &&
+            (!p.end_date || p.end_date >= (role.end_date ?? "9999")),
+        );
+        if (fromPhase) {
+          matched = getSkillsByPhaseId(fromPhase.phase_id);
+        }
+      }
+    }
+
+    return new Set(matched.map((s) => s.id));
+  }, [selectedNarrativeKind, selectedNarrativeId, workspace]);
+
+  const selectedSkill = useMemo(
+    () => (selectedSkillId ? SKILLS.find((s) => s.id === selectedSkillId) ?? null : null),
+    [selectedSkillId],
+  );
+
+  const handleSkillClick = useCallback(
+    (skillId: SkillId) => {
+      if (selectedSkillId === skillId) {
+        // Deselect
+        setSelectedSkillId(null);
+        return;
+      }
+      setSelectedSkillId(skillId);
+
+      // When selecting a skill, ensure its capability layers are visible on the timeline
+      const skill = SKILLS.find((s) => s.id === skillId);
+      if (skill) {
+        for (const tag of skill.capabilityTags) {
+          if (!enabledCapabilityLayerIds.includes(tag)) {
+            toggleCapabilityLayer(tag);
+          }
+        }
+      }
+    },
+    [selectedSkillId, setSelectedSkillId, enabledCapabilityLayerIds, toggleCapabilityLayer],
+  );
+
+  const handleBack = useCallback(() => {
+    setSelectedSkillId(null);
+  }, [setSelectedSkillId]);
+
+  // If a skill is selected, show the detail view
+  if (selectedSkill) {
+    return (
+      <div className="pt-3">
+        <SkillDetailView
+          skill={selectedSkill}
+          onBack={handleBack}
+          isHighlighted={highlightedSkillIds.has(selectedSkill.id)}
+        />
+      </div>
+    );
+  }
+
+  // Icon grid — logos only, 2 rows on mobile, evenly spaced
+  return (
+    <div className="pt-3">
+      <p className="mb-2.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-bm-muted2">
+        Relevant Skills
+      </p>
+      <div className="grid grid-cols-6 gap-x-2 gap-y-3 md:flex md:flex-wrap md:gap-3">
+        {SKILLS.map((skill) => {
+          const isHighlighted = highlightedSkillIds.has(skill.id);
+          return (
+            <button
+              key={skill.id}
+              type="button"
+              onClick={() => handleSkillClick(skill.id)}
+              title={skill.name}
+              className={`group relative flex flex-col items-center gap-1.5 rounded-lg p-2 transition ${
+                isHighlighted
+                  ? "bg-sky-400/10 ring-1 ring-sky-400/30"
+                  : "bg-white/[0.03] hover:bg-white/[0.08]"
+              }`}
+            >
+              <div
+                className={`transition ${
+                  isHighlighted
+                    ? "text-bm-text"
+                    : "text-bm-muted group-hover:text-bm-text"
+                }`}
+                style={isHighlighted ? { color: skill.color } : undefined}
+              >
+                <SkillLogo skillId={skill.id} size={28} />
+              </div>
+              <span
+                className={`text-[9px] font-medium uppercase tracking-wider transition md:text-[10px] ${
+                  isHighlighted ? "text-bm-text/90" : "text-bm-muted2 group-hover:text-bm-muted"
+                }`}
+              >
+                {skill.shortName}
+              </span>
+              {isHighlighted && (
+                <span className="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full bg-sky-400" />
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/resume/skillsData.ts
+++ b/repo-b/src/components/resume/skillsData.ts
@@ -1,0 +1,219 @@
+/** Skill definitions derived from real resume content — proof of execution, not definitions. */
+
+export type SkillId =
+  | "python"
+  | "pyspark"
+  | "sql"
+  | "databricks"
+  | "azure"
+  | "power_bi"
+  | "tableau"
+  | "tabular_editor"
+  | "snowflake"
+  | "openai"
+  | "langchain";
+
+export interface SkillBullet {
+  /** [action] + [system built] + [outcome] */
+  text: string;
+}
+
+export interface SkillDefinition {
+  id: SkillId;
+  name: string;
+  /** Short label for the icon grid */
+  shortName: string;
+  /** Capability layer IDs from the timeline this skill maps to */
+  capabilityTags: string[];
+  /** Timeline milestone IDs this skill is linked to */
+  linkedMilestoneIds: string[];
+  /** Phase IDs where this skill was primarily used */
+  linkedPhaseIds: string[];
+  /** Resume-derived bullets: [action] + [system built] + [outcome] */
+  bullets: SkillBullet[];
+  /** Icon color for the grid */
+  color: string;
+}
+
+export const SKILLS: SkillDefinition[] = [
+  {
+    id: "python",
+    name: "Python",
+    shortName: "Python",
+    capabilityTags: ["financial_modeling", "automation_workflow", "ai_agentic"],
+    linkedMilestoneIds: ["milestone-waterfall-engine", "milestone-winston-ai-platform"],
+    linkedPhaseIds: ["phase-kayne-2018-2025", "phase-jll-2025-present"],
+    bullets: [
+      { text: "Built deterministic waterfall engine replacing Excel — near-instant LP/GP distribution runtime" },
+      { text: "Automated 500+ property ingestion pipelines — 160 hrs/month reduced to 30 minutes" },
+      { text: "Engineered 83-tool MCP platform — domain-specific REPE actions with audit trails" },
+      { text: "Created scenario analysis engine — reusable allocation logic across fund structures" },
+    ],
+    color: "#3776AB",
+  },
+  {
+    id: "pyspark",
+    name: "PySpark",
+    shortName: "PySpark",
+    capabilityTags: ["data_platform", "automation_workflow"],
+    linkedMilestoneIds: ["milestone-kayne-ingestion-automation", "milestone-kayne-warehouse-semantic"],
+    linkedPhaseIds: ["phase-kayne-2018-2025"],
+    bullets: [
+      { text: "Built medallion ETL pipelines on Databricks — bronze/silver/gold architecture across $4B+ AUM" },
+      { text: "Automated partner accounting transforms — replaced manual flat-file reconciliation" },
+      { text: "Processed 500+ property data feeds — validation gates at every ingestion stage" },
+      { text: "Unified DealCloud, MRI, and Yardi sources — single governed data lineage" },
+    ],
+    color: "#E25A1C",
+  },
+  {
+    id: "sql",
+    name: "SQL",
+    shortName: "SQL",
+    capabilityTags: ["data_platform", "bi_reporting", "financial_modeling"],
+    linkedMilestoneIds: ["milestone-kayne-warehouse-semantic", "milestone-expanded-bi-scope"],
+    linkedPhaseIds: ["phase-jll-2014-2018", "phase-kayne-2018-2025", "phase-jll-2025-present"],
+    bullets: [
+      { text: "Designed semantic layer across 6 business units — single source of truth for all reporting" },
+      { text: "Built validation layer for ingestion pipelines — error rates dropped to near zero" },
+      { text: "Engineered gold tables powering DDQ workflows — 50% faster investor turnaround" },
+      { text: "Created governed data contracts — 10+ client accounts standardized" },
+    ],
+    color: "#336791",
+  },
+  {
+    id: "databricks",
+    name: "Databricks",
+    shortName: "Databricks",
+    capabilityTags: ["data_platform", "automation_workflow", "ai_agentic"],
+    linkedMilestoneIds: ["milestone-kayne-warehouse-semantic", "milestone-rejoined-jll-2025"],
+    linkedPhaseIds: ["phase-kayne-2018-2025", "phase-jll-2025-present"],
+    bullets: [
+      { text: "Architected $4B+ AUM lakehouse — unified investment, property, and operational data" },
+      { text: "Built medallion architecture — governed bronze/silver/gold pipeline across all source systems" },
+      { text: "Deployed semantic models via Unity Catalog — self-serve analytics for portfolio ops" },
+      { text: "Scaled platform to JLL PDS Americas — 10+ client accounts on same foundation" },
+    ],
+    color: "#FF3621",
+  },
+  {
+    id: "azure",
+    name: "Azure",
+    shortName: "Azure",
+    capabilityTags: ["data_platform", "automation_workflow"],
+    linkedMilestoneIds: ["milestone-kayne-ingestion-automation", "milestone-kayne-warehouse-semantic"],
+    linkedPhaseIds: ["phase-kayne-2018-2025"],
+    bullets: [
+      { text: "Deployed Azure Logic Apps file watchers — automated partner accounting across 500+ properties" },
+      { text: "Built Azure Data Lake storage layer — centralized raw and curated data zones" },
+      { text: "Integrated Azure with Databricks compute — seamless ETL orchestration at scale" },
+      { text: "Implemented governed ingestion contracts — 160 hrs/month manual entry eliminated" },
+    ],
+    color: "#0078D4",
+  },
+  {
+    id: "power_bi",
+    name: "Power BI",
+    shortName: "Power BI",
+    capabilityTags: ["bi_reporting", "executive_decision_support"],
+    linkedMilestoneIds: ["milestone-kayne-acquisition-vba", "milestone-kayne-warehouse-semantic"],
+    linkedPhaseIds: ["phase-kayne-2018-2025"],
+    bullets: [
+      { text: "Delivered governed dashboards for 500+ assets — first executive programmatic reporting" },
+      { text: "Reduced ad hoc reporting requests by 50% — self-serve analytics for leadership" },
+      { text: "Built acquisition tracking dashboards — 40+ deals/week visualized in real time" },
+      { text: "Enabled portfolio-level drill-through — fund to asset transparency" },
+    ],
+    color: "#F2C811",
+  },
+  {
+    id: "tableau",
+    name: "Tableau",
+    shortName: "Tableau",
+    capabilityTags: ["bi_reporting", "executive_decision_support"],
+    linkedMilestoneIds: ["milestone-expanded-bi-scope"],
+    linkedPhaseIds: ["phase-jll-2014-2018"],
+    bullets: [
+      { text: "Built JLL's first BI service line for JPMC — repeatable dashboard delivery established" },
+      { text: "Created executive-ready reporting systems — national account analytics capability" },
+      { text: "Replaced fragmented manual pulls — governed data extracts with SQL validation" },
+    ],
+    color: "#E97627",
+  },
+  {
+    id: "tabular_editor",
+    name: "Tabular Editor",
+    shortName: "Tabular",
+    capabilityTags: ["bi_reporting", "data_platform"],
+    linkedMilestoneIds: ["milestone-kayne-warehouse-semantic"],
+    linkedPhaseIds: ["phase-kayne-2018-2025"],
+    bullets: [
+      { text: "Engineered semantic models for lakehouse — business logic layer across 6 units" },
+      { text: "Built reusable DAX measures — standardized KPI calculations firm-wide" },
+      { text: "Enabled self-serve exploration — analysts query governed models directly" },
+    ],
+    color: "#6DB33F",
+  },
+  {
+    id: "snowflake",
+    name: "Snowflake",
+    shortName: "Snowflake",
+    capabilityTags: ["data_platform", "bi_reporting"],
+    linkedMilestoneIds: ["milestone-rejoined-jll-2025"],
+    linkedPhaseIds: ["phase-jll-2025-present"],
+    bullets: [
+      { text: "Extended governed data delivery to Snowflake environments — multi-cloud readiness" },
+      { text: "Built cross-platform semantic contracts — portable across Databricks and Snowflake" },
+      { text: "Enabled client-specific data zones — tenant isolation with shared governance" },
+    ],
+    color: "#29B5E8",
+  },
+  {
+    id: "openai",
+    name: "OpenAI",
+    shortName: "OpenAI",
+    capabilityTags: ["ai_agentic", "executive_decision_support"],
+    linkedMilestoneIds: ["milestone-winston-ai-platform", "milestone-rejoined-jll-2025"],
+    linkedPhaseIds: ["phase-jll-2025-present"],
+    bullets: [
+      { text: "Built conversational analytics layer — business users query governed data directly" },
+      { text: "Deployed 83 MCP tools with OpenAI orchestration — domain REPE actions with structured outputs" },
+      { text: "Engineered RAG pipelines for investment documents — DDQ and LP reporting accelerated" },
+      { text: "Created AI query orchestration for PDS — 10+ client accounts served" },
+    ],
+    color: "#412991",
+  },
+  {
+    id: "langchain",
+    name: "LangChain",
+    shortName: "LangChain",
+    capabilityTags: ["ai_agentic", "executive_decision_support"],
+    linkedMilestoneIds: ["milestone-winston-ai-platform"],
+    linkedPhaseIds: ["phase-jll-2025-present"],
+    bullets: [
+      { text: "Orchestrated multi-step agent workflows — tool selection, memory, and audit chains" },
+      { text: "Built streaming AI interfaces — real-time response rendering for complex queries" },
+      { text: "Implemented retrieval-augmented generation — corpus-grounded answers with citation chains" },
+      { text: "Designed prompt routing architecture — model dispatch based on task complexity" },
+    ],
+    color: "#1C3C3C",
+  },
+];
+
+/** Map of skill IDs to definitions for fast lookup */
+export const SKILL_MAP = new Map(SKILLS.map((s) => [s.id, s]));
+
+/** Get skills relevant to a given capability layer */
+export function getSkillsByCapabilityTag(tag: string): SkillDefinition[] {
+  return SKILLS.filter((s) => s.capabilityTags.includes(tag));
+}
+
+/** Get skills linked to a specific milestone */
+export function getSkillsByMilestoneId(milestoneId: string): SkillDefinition[] {
+  return SKILLS.filter((s) => s.linkedMilestoneIds.includes(milestoneId));
+}
+
+/** Get skills linked to a specific phase */
+export function getSkillsByPhaseId(phaseId: string): SkillDefinition[] {
+  return SKILLS.filter((s) => s.linkedPhaseIds.includes(phaseId));
+}

--- a/repo-b/src/components/resume/useResumeWorkspaceStore.ts
+++ b/repo-b/src/components/resume/useResumeWorkspaceStore.ts
@@ -15,6 +15,7 @@ import type {
   ImpactMetricKey,
   NarrativeSelectionKind,
 } from "./capabilityGraphData";
+import type { SkillId } from "./skillsData";
 
 type ResumeModule = "timeline" | "architecture" | "modeling" | "bi";
 
@@ -43,9 +44,11 @@ type ResumeWorkspaceState = {
   capabilityHoveredLayer: string | null;
   enabledCapabilityLayerIds: string[];
   selectedImpactMetric: ImpactMetricKey;
+  selectedSkillId: SkillId | null;
   lastBiEntitySource: "timeline" | "bi" | "init";
   lastModelPresetSource: "timeline" | "modeling" | "init";
   initialize: (workspace: ResumeWorkspaceViewModel) => void;
+  setSelectedSkillId: (skillId: SkillId | null) => void;
   setActiveModule: (module: ResumeModule) => void;
   setTimelineView: (view: ResumeTimelineViewMode) => void;
   togglePlayStory: () => void;
@@ -216,8 +219,10 @@ export const useResumeWorkspaceStore = create<ResumeWorkspaceState>((set, get) =
   capabilityHoveredLayer: null,
   enabledCapabilityLayerIds: [],
   selectedImpactMetric: "impact_composite",
+  selectedSkillId: null,
   lastBiEntitySource: "init",
   lastModelPresetSource: "init",
+  setSelectedSkillId: (skillId) => set({ selectedSkillId: skillId }),
   initialize: (workspace) => {
     // Pick the strongest milestone as default — warehouse/semantic layer milestone shows the most
     // cross-module connections (architecture, BI, modeling). Fall back to first play step or first milestone.
@@ -259,6 +264,7 @@ export const useResumeWorkspaceStore = create<ResumeWorkspaceState>((set, get) =
       capabilityHoveredLayer: null,
       enabledCapabilityLayerIds: getVisibleCapabilityLayerIds(workspace.timeline),
       selectedImpactMetric: "impact_composite",
+      selectedSkillId: null,
       lastBiEntitySource: "init",
       lastModelPresetSource: "init",
     });


### PR DESCRIPTION
- Add 11-skill icon grid (Python, PySpark, SQL, Databricks, Azure, Power BI, Tableau, Tabular Editor, Snowflake, OpenAI, LangChain) — no DealCloud
- Each skill clickable into a detail view with 3-6 resume-derived bullets following [action] + [system built] + [outcome] structure
- Timeline selection highlights relevant skills; skill selection enables matching capability layers
- 2-row mobile grid, evenly spaced with consistent icon sizing
- All bullets derived from real resume content (500+ properties, 160 hrs/month, 50% reduction, etc.)

https://claude.ai/code/session_01MkTEhggbuAgLeFguD9SiPs