### PR TITLE
Winston mobile audit: pending actions, terminal states, mobile UI, nightly audit

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,6 +56,7 @@ from app.routes import (
 )
 from app.routes.ai import router as ai_router
 from app.routes.ai_gateway import router as ai_gateway_router
+from app.routes.ai_audit import router as ai_audit_router
 from app.routes import website_content, website_rankings, website_analytics
 from app.routes import consulting
 from app.routes import re_uw_reports, re_uw_links, re_pipeline, re_geography, re_intelligence
@@ -156,6 +157,7 @@ app.include_router(audit.router)
 app.include_router(lab.router)
 app.include_router(ai_router)
 app.include_router(ai_gateway_router)
+app.include_router(ai_audit_router)
 app.include_router(extraction.router)
 app.include_router(compliance.router)
 app.include_router(admin_tools.router)

--- a/backend/app/routes/ai_audit.py
+++ b/backend/app/routes/ai_audit.py
@@ -1,0 +1,297 @@
+"""AI Audit routes — trigger nightly audit, query findings, manage pending actions.
+
+Provides:
+  - POST /api/ai/audit/run          — trigger a full audit run
+  - GET  /api/ai/audit/findings     — query audit findings
+  - GET  /api/ai/audit/pending      — list pending actions
+  - POST /api/ai/audit/pending/{id}/resolve — manually resolve a pending action
+  - GET  /api/ai/audit/skills       — list skill candidates
+  - POST /api/ai/audit/ui-event     — record a UI telemetry event
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from app.auth.platform import require_authenticated_request
+
+router = APIRouter(prefix="/api/ai/audit", tags=["ai-audit"])
+logger = logging.getLogger(__name__)
+
+
+# ── Schemas ─────────────────────────────────────────────────────────
+
+class AuditRunRequest(BaseModel):
+    lookback_hours: int = 24
+
+
+class PendingActionResolveRequest(BaseModel):
+    status: str  # confirmed, cancelled
+    resolution_message: str | None = None
+
+
+class UiEventRequest(BaseModel):
+    conversation_id: str | None = None
+    business_id: str
+    env_id: str | None = None
+    event_type: str
+    event_data: dict[str, Any] = {}
+    surface: str | None = None
+    lane: str | None = None
+
+
+# ── Audit Run ──────────────────────────────────────────────────────
+
+@router.post("/run")
+def trigger_audit(payload: AuditRunRequest, request: Request):
+    """Trigger a full nightly audit run.  Returns summary of findings."""
+    require_authenticated_request(request)
+    from app.services.ai_audit import run_nightly_audit
+    result = run_nightly_audit(lookback_hours=payload.lookback_hours)
+    return result
+
+
+# ── Audit Findings ────────────────────────────────────────────────
+
+@router.get("/findings")
+def list_findings(
+    request: Request,
+    finding_type: str | None = None,
+    severity: str | None = None,
+    audit_run_id: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+):
+    """Query audit findings with optional filters."""
+    require_authenticated_request(request)
+    from app.db import get_cursor
+
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    if finding_type:
+        clauses.append("finding_type = %s")
+        params.append(finding_type)
+    if severity:
+        clauses.append("severity = %s")
+        params.append(severity)
+    if audit_run_id:
+        clauses.append("audit_run_id = %s")
+        params.append(audit_run_id)
+
+    where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+
+    with get_cursor() as cur:
+        cur.execute(
+            f"""SELECT * FROM ai_audit_findings {where}
+                ORDER BY created_at DESC
+                LIMIT %s OFFSET %s""",
+            params + [min(limit, 200), offset],
+        )
+        rows = cur.fetchall()
+
+    return {
+        "findings": [_serialize_finding(r) for r in rows],
+        "count": len(rows),
+    }
+
+
+# ── Pending Actions ──────────────────────────────────────────────
+
+@router.get("/pending")
+def list_pending(
+    request: Request,
+    business_id: str | None = None,
+    status: str | None = None,
+    limit: int = 50,
+):
+    """List pending actions with optional filters."""
+    require_authenticated_request(request)
+    from app.db import get_cursor
+
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    if business_id:
+        clauses.append("business_id = %s")
+        params.append(business_id)
+    if status:
+        clauses.append("status = %s")
+        params.append(status)
+
+    where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+
+    with get_cursor() as cur:
+        cur.execute(
+            f"""SELECT * FROM ai_pending_actions {where}
+                ORDER BY created_at DESC
+                LIMIT %s""",
+            params + [min(limit, 200)],
+        )
+        rows = cur.fetchall()
+
+    return {
+        "pending_actions": [_serialize_pending_action(r) for r in rows],
+        "count": len(rows),
+    }
+
+
+@router.post("/pending/{pending_action_id}/resolve")
+def resolve_pending(
+    pending_action_id: str,
+    payload: PendingActionResolveRequest,
+    request: Request,
+):
+    """Manually resolve a pending action."""
+    require_authenticated_request(request)
+    from app.services.pending_action_manager import resolve_pending_action
+
+    if payload.status not in ("confirmed", "cancelled", "superseded"):
+        raise HTTPException(status_code=400, detail="Invalid status. Must be confirmed, cancelled, or superseded.")
+
+    result = resolve_pending_action(
+        pending_action_id,
+        new_status=payload.status,
+        resolution_message=payload.resolution_message,
+    )
+    if not result:
+        raise HTTPException(status_code=404, detail="Pending action not found")
+    return _serialize_pending_action(result)
+
+
+# ── Skill Candidates ────────────────────────────────────────────
+
+@router.get("/skills")
+def list_skill_candidates(
+    request: Request,
+    pattern_type: str | None = None,
+    promoted: bool | None = None,
+    limit: int = 50,
+):
+    """List discovered skill candidates."""
+    require_authenticated_request(request)
+    from app.db import get_cursor
+
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    if pattern_type:
+        clauses.append("pattern_type = %s")
+        params.append(pattern_type)
+    if promoted is not None:
+        clauses.append("promoted = %s")
+        params.append(promoted)
+
+    where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+
+    with get_cursor() as cur:
+        cur.execute(
+            f"""SELECT * FROM ai_skill_candidates {where}
+                ORDER BY occurrence_count DESC, last_seen_at DESC
+                LIMIT %s""",
+            params + [min(limit, 200)],
+        )
+        rows = cur.fetchall()
+
+    return {
+        "skill_candidates": [_serialize_skill_candidate(r) for r in rows],
+        "count": len(rows),
+    }
+
+
+# ── UI Events ────────────────────────────────────────────────────
+
+@router.post("/ui-event")
+def record_ui_event(payload: UiEventRequest, request: Request):
+    """Record a frontend UI telemetry event."""
+    require_authenticated_request(request)
+    actor = request.headers.get("x-bm-actor", "anonymous")
+
+    from app.db import get_cursor
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """INSERT INTO ai_ui_events (
+                     conversation_id, business_id, env_id, actor,
+                     event_type, event_data, surface, lane
+                   ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                   RETURNING id""",
+                (
+                    payload.conversation_id,
+                    payload.business_id,
+                    payload.env_id,
+                    actor,
+                    payload.event_type,
+                    json.dumps(payload.event_data),
+                    payload.surface,
+                    payload.lane,
+                ),
+            )
+            row = cur.fetchone()
+            return {"id": str(row["id"]) if row else None, "recorded": True}
+    except Exception as e:
+        logger.exception("Failed to record UI event")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ── Serializers ──────────────────────────────────────────────────
+
+def _serialize_finding(row: dict) -> dict:
+    return {
+        "id": str(row["id"]),
+        "audit_run_id": str(row["audit_run_id"]),
+        "finding_type": row["finding_type"],
+        "severity": row["severity"],
+        "title": row["title"],
+        "detail": row.get("detail"),
+        "conversation_id": str(row["conversation_id"]) if row.get("conversation_id") else None,
+        "pending_action_id": str(row["pending_action_id"]) if row.get("pending_action_id") else None,
+        "tool_name": row.get("tool_name"),
+        "lane": row.get("lane"),
+        "count": row.get("count"),
+        "p50_ms": row.get("p50_ms"),
+        "p95_ms": row.get("p95_ms"),
+        "created_at": row["created_at"].isoformat() if row.get("created_at") else None,
+    }
+
+
+def _serialize_pending_action(row: dict) -> dict:
+    return {
+        "pending_action_id": str(row["pending_action_id"]),
+        "conversation_id": str(row["conversation_id"]),
+        "business_id": str(row["business_id"]),
+        "env_id": str(row["env_id"]) if row.get("env_id") else None,
+        "actor": row.get("actor"),
+        "skill_id": row.get("skill_id"),
+        "action_type": row.get("action_type"),
+        "params_json": row.get("params_json"),
+        "missing_fields": row.get("missing_fields"),
+        "status": row.get("status"),
+        "resolution_message": row.get("resolution_message"),
+        "scope_type": row.get("scope_type"),
+        "scope_id": row.get("scope_id"),
+        "scope_label": row.get("scope_label"),
+        "expires_at": row["expires_at"].isoformat() if row.get("expires_at") else None,
+        "created_at": row["created_at"].isoformat() if row.get("created_at") else None,
+        "resolved_at": row["resolved_at"].isoformat() if row.get("resolved_at") else None,
+    }
+
+
+def _serialize_skill_candidate(row: dict) -> dict:
+    return {
+        "id": str(row["id"]),
+        "pattern_type": row["pattern_type"],
+        "pattern_signature": row["pattern_signature"],
+        "sample_prompts": row.get("sample_prompts"),
+        "sample_tool_chains": row.get("sample_tool_chains"),
+        "occurrence_count": row.get("occurrence_count"),
+        "promoted": row.get("promoted", False),
+        "promoted_skill_id": row.get("promoted_skill_id"),
+        "notes": row.get("notes"),
+        "first_seen_at": row["first_seen_at"].isoformat() if row.get("first_seen_at") else None,
+        "last_seen_at": row["last_seen_at"].isoformat() if row.get("last_seen_at") else None,
+    }

--- a/backend/app/services/ai_audit.py
+++ b/backend/app/services/ai_audit.py
@@ -1,0 +1,365 @@
+"""Nightly AI audit job — finds unresolved confirmations, stuck processing,
+repeated tool failures, missing-param patterns, latency outliers, and
+candidate new skills.
+
+Writes findings to ``ai_audit_findings`` and emerging patterns to
+``ai_skill_candidates``.
+
+Run via: ``python -m app.services.ai_audit`` or from a cron/scheduler.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from app.db import get_cursor
+from app.services.pending_action_manager import expire_stale_actions
+
+logger = logging.getLogger(__name__)
+
+
+def run_nightly_audit(*, lookback_hours: int = 24) -> dict[str, Any]:
+    """Execute all audit checks and write findings.  Returns summary."""
+    audit_run_id = str(uuid.uuid4())
+    findings: list[dict[str, Any]] = []
+
+    # 1. Expire stale pending actions
+    expired_count = expire_stale_actions()
+    if expired_count:
+        findings.append(_finding(
+            audit_run_id=audit_run_id,
+            finding_type="unresolved_confirmation",
+            severity="warning",
+            title=f"{expired_count} pending confirmation(s) expired without resolution",
+            detail={"expired_count": expired_count},
+        ))
+
+    # 2. Find unresolved pending confirmations still awaiting
+    findings.extend(_find_unresolved_confirmations(audit_run_id))
+
+    # 3. Find missed confirmations (user said "yes" but no tool was called)
+    findings.extend(_find_missed_confirmations(audit_run_id, lookback_hours))
+
+    # 4. Find processing-stuck incidents (long elapsed_ms with no done)
+    findings.extend(_find_processing_stuck(audit_run_id, lookback_hours))
+
+    # 5. Find repeated tool failures
+    findings.extend(_find_repeated_tool_failures(audit_run_id, lookback_hours))
+
+    # 6. Find repeated missing-param patterns
+    findings.extend(_find_repeated_missing_params(audit_run_id, lookback_hours))
+
+    # 7. Measure p50/p95 latency by lane
+    findings.extend(_measure_latency_by_lane(audit_run_id, lookback_hours))
+
+    # 8. Mine skill candidates
+    skill_count = _mine_skill_candidates(lookback_hours)
+
+    # Write all findings
+    _persist_findings(findings)
+
+    summary = {
+        "audit_run_id": audit_run_id,
+        "finding_count": len(findings),
+        "skill_candidates_found": skill_count,
+        "findings_by_type": {},
+    }
+    for f in findings:
+        ft = f["finding_type"]
+        summary["findings_by_type"][ft] = summary["findings_by_type"].get(ft, 0) + 1
+
+    logger.info("Nightly audit complete: %s", json.dumps(summary))
+    return summary
+
+
+def _finding(
+    *,
+    audit_run_id: str,
+    finding_type: str,
+    severity: str = "info",
+    title: str,
+    detail: dict[str, Any] | None = None,
+    conversation_id: str | None = None,
+    pending_action_id: str | None = None,
+    tool_name: str | None = None,
+    lane: str | None = None,
+    count: int | None = None,
+    p50_ms: int | None = None,
+    p95_ms: int | None = None,
+    business_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "audit_run_id": audit_run_id,
+        "finding_type": finding_type,
+        "severity": severity,
+        "title": title,
+        "detail": json.dumps(detail or {}),
+        "conversation_id": conversation_id,
+        "pending_action_id": pending_action_id,
+        "tool_name": tool_name,
+        "lane": lane,
+        "count": count,
+        "p50_ms": p50_ms,
+        "p95_ms": p95_ms,
+        "business_id": business_id,
+    }
+
+
+def _find_unresolved_confirmations(audit_run_id: str) -> list[dict]:
+    findings = []
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """SELECT pending_action_id, conversation_id, action_type, created_at, business_id
+                   FROM ai_pending_actions
+                   WHERE status = 'awaiting_confirmation'
+                   ORDER BY created_at DESC LIMIT 100""",
+            )
+            rows = cur.fetchall()
+            for row in rows:
+                findings.append(_finding(
+                    audit_run_id=audit_run_id,
+                    finding_type="unresolved_confirmation",
+                    severity="warning",
+                    title=f"Unresolved confirmation: {row['action_type']}",
+                    detail={"created_at": row["created_at"].isoformat() if row.get("created_at") else None},
+                    conversation_id=str(row["conversation_id"]),
+                    pending_action_id=str(row["pending_action_id"]),
+                    tool_name=row["action_type"],
+                    business_id=str(row["business_id"]) if row.get("business_id") else None,
+                ))
+    except Exception:
+        logger.exception("Failed to find unresolved confirmations")
+    return findings
+
+
+def _find_missed_confirmations(audit_run_id: str, hours: int) -> list[dict]:
+    """Find cases where a user message matches confirm patterns but the next
+    assistant message did NOT execute a tool with confirmed=true."""
+    findings = []
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """WITH confirm_msgs AS (
+                     SELECT m.conversation_id, m.message_id, m.content, m.created_at
+                     FROM ai_messages m
+                     WHERE m.role = 'user'
+                       AND m.created_at > now() - interval '%s hours'
+                       AND lower(trim(m.content)) IN (
+                         'yes', 'yep', 'yeah', 'sure', 'ok', 'okay',
+                         'go ahead', 'proceed', 'do it', 'confirm', 'confirmed',
+                         'approve', 'execute'
+                       )
+                   ),
+                   next_assistant AS (
+                     SELECT cm.conversation_id, cm.message_id AS user_msg_id,
+                            am.tool_calls, am.content AS assistant_content
+                     FROM confirm_msgs cm
+                     JOIN LATERAL (
+                       SELECT tool_calls, content
+                       FROM ai_messages
+                       WHERE conversation_id = cm.conversation_id
+                         AND role = 'assistant'
+                         AND created_at > cm.created_at
+                       ORDER BY created_at ASC LIMIT 1
+                     ) am ON true
+                   )
+                   SELECT * FROM next_assistant
+                   WHERE tool_calls IS NULL
+                      OR tool_calls::text NOT LIKE '%%confirmed%%true%%'
+                   LIMIT 50""",
+                (hours,),
+            )
+            rows = cur.fetchall()
+            if rows:
+                findings.append(_finding(
+                    audit_run_id=audit_run_id,
+                    finding_type="missed_confirmation",
+                    severity="warning",
+                    title=f"{len(rows)} confirmation(s) where user said 'yes' but no tool was re-executed with confirmed=true",
+                    detail={"count": len(rows), "sample_conversations": [str(r["conversation_id"]) for r in rows[:5]]},
+                    count=len(rows),
+                ))
+    except Exception:
+        logger.exception("Failed to find missed confirmations")
+    return findings
+
+
+def _find_processing_stuck(audit_run_id: str, hours: int) -> list[dict]:
+    """Find requests with extremely high elapsed_ms (>30s) that may indicate stuck processing."""
+    findings = []
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """SELECT id, conversation_id, route_lane, elapsed_ms, route_model, error_message
+                   FROM ai_gateway_logs
+                   WHERE created_at > now() - interval '%s hours'
+                     AND elapsed_ms > 30000
+                   ORDER BY elapsed_ms DESC LIMIT 50""",
+                (hours,),
+            )
+            rows = cur.fetchall()
+            if rows:
+                findings.append(_finding(
+                    audit_run_id=audit_run_id,
+                    finding_type="processing_stuck",
+                    severity="warning",
+                    title=f"{len(rows)} request(s) exceeded 30s processing time",
+                    detail={
+                        "count": len(rows),
+                        "worst_ms": rows[0]["elapsed_ms"] if rows else None,
+                        "sample_ids": [str(r["id"]) for r in rows[:5]],
+                    },
+                    count=len(rows),
+                ))
+    except Exception:
+        logger.exception("Failed to find processing-stuck incidents")
+    return findings
+
+
+def _find_repeated_tool_failures(audit_run_id: str, hours: int) -> list[dict]:
+    """Find tools that failed repeatedly in the lookback window."""
+    findings = []
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """SELECT tool_name, count(*) AS fail_count,
+                          array_agg(DISTINCT error_message) FILTER (WHERE error_message IS NOT NULL) AS errors
+                   FROM ai_tool_calls
+                   WHERE created_at > now() - interval '%s hours'
+                     AND success = false
+                   GROUP BY tool_name
+                   HAVING count(*) >= 3
+                   ORDER BY count(*) DESC LIMIT 20""",
+                (hours,),
+            )
+            rows = cur.fetchall()
+            for row in rows:
+                findings.append(_finding(
+                    audit_run_id=audit_run_id,
+                    finding_type="repeated_tool_failure",
+                    severity="critical" if row["fail_count"] >= 10 else "warning",
+                    title=f"Tool '{row['tool_name']}' failed {row['fail_count']} times",
+                    detail={"errors": row.get("errors", [])},
+                    tool_name=row["tool_name"],
+                    count=row["fail_count"],
+                ))
+    except Exception:
+        logger.exception("Failed to find repeated tool failures")
+    return findings
+
+
+def _find_repeated_missing_params(audit_run_id: str, hours: int) -> list[dict]:
+    """Find tools where missing params are a recurring pattern."""
+    findings = []
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """SELECT tool_name,
+                          count(*) AS miss_count
+                   FROM ai_tool_calls
+                   WHERE created_at > now() - interval '%s hours'
+                     AND success = false
+                     AND lower(error_message) LIKE '%%required%%'
+                   GROUP BY tool_name
+                   HAVING count(*) >= 2
+                   ORDER BY count(*) DESC LIMIT 20""",
+                (hours,),
+            )
+            rows = cur.fetchall()
+            for row in rows:
+                findings.append(_finding(
+                    audit_run_id=audit_run_id,
+                    finding_type="repeated_missing_param",
+                    severity="warning",
+                    title=f"Tool '{row['tool_name']}' hit missing-param errors {row['miss_count']} times",
+                    tool_name=row["tool_name"],
+                    count=row["miss_count"],
+                ))
+    except Exception:
+        logger.exception("Failed to find repeated missing-param patterns")
+    return findings
+
+
+def _measure_latency_by_lane(audit_run_id: str, hours: int) -> list[dict]:
+    """Compute p50/p95 latency per lane."""
+    findings = []
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """SELECT route_lane,
+                          count(*) AS request_count,
+                          percentile_cont(0.5) WITHIN GROUP (ORDER BY elapsed_ms) AS p50,
+                          percentile_cont(0.95) WITHIN GROUP (ORDER BY elapsed_ms) AS p95
+                   FROM ai_gateway_logs
+                   WHERE created_at > now() - interval '%s hours'
+                     AND elapsed_ms IS NOT NULL
+                   GROUP BY route_lane
+                   ORDER BY route_lane""",
+                (hours,),
+            )
+            rows = cur.fetchall()
+            for row in rows:
+                p50 = int(row["p50"]) if row.get("p50") else None
+                p95 = int(row["p95"]) if row.get("p95") else None
+                findings.append(_finding(
+                    audit_run_id=audit_run_id,
+                    finding_type="latency_outlier" if (p95 and p95 > 15000) else "latency_measurement",
+                    severity="warning" if (p95 and p95 > 15000) else "info",
+                    title=f"Lane {row['route_lane']}: p50={p50}ms p95={p95}ms ({row['request_count']} requests)",
+                    lane=row["route_lane"],
+                    count=row["request_count"],
+                    p50_ms=p50,
+                    p95_ms=p95,
+                ))
+    except Exception:
+        logger.exception("Failed to measure latency by lane")
+    return findings
+
+
+def _persist_findings(findings: list[dict]) -> None:
+    if not findings:
+        return
+    try:
+        with get_cursor() as cur:
+            for f in findings:
+                cur.execute(
+                    """INSERT INTO ai_audit_findings (
+                         audit_run_id, finding_type, severity, title, detail,
+                         conversation_id, pending_action_id, tool_name, lane,
+                         count, p50_ms, p95_ms, business_id
+                       ) VALUES (
+                         %s, %s, %s, %s, %s,
+                         %s, %s, %s, %s,
+                         %s, %s, %s, %s
+                       )""",
+                    (
+                        f["audit_run_id"], f["finding_type"], f["severity"],
+                        f["title"], f["detail"],
+                        f.get("conversation_id"), f.get("pending_action_id"),
+                        f.get("tool_name"), f.get("lane"),
+                        f.get("count"), f.get("p50_ms"), f.get("p95_ms"),
+                        f.get("business_id"),
+                    ),
+                )
+    except Exception:
+        logger.exception("Failed to persist audit findings")
+
+
+def _mine_skill_candidates(hours: int) -> int:
+    """Identify repeated prompt patterns and toolchains that could become skills."""
+    from app.services.skill_candidate_miner import mine_candidates
+    return mine_candidates(lookback_hours=hours)
+
+
+# ── CLI entry point ──────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import sys
+    logging.basicConfig(level=logging.INFO)
+    result = run_nightly_audit(lookback_hours=int(sys.argv[1]) if len(sys.argv) > 1 else 24)
+    print(json.dumps(result, indent=2))

--- a/backend/app/services/ai_gateway.py
+++ b/backend/app/services/ai_gateway.py
@@ -41,6 +41,10 @@ from app.services.assistant_blocks import (
     legacy_structured_result_to_blocks,
     markdown_block,
 )
+from app.services.pending_action_manager import (
+    check_and_resolve as check_pending_action,
+    create_pending_action,
+)
 from app.services.prompt_composer import compose_prompt
 
 # ── Singleton OpenAI client (reuse HTTP connection pool) ──────────
@@ -2724,10 +2728,16 @@ async def run_gateway_stream(
         input=message,
     )
 
-    # ── Kick off workflow check in parallel with context resolution ──
+    # ── Kick off workflow check + pending action check in parallel ──
     _workflow_task = asyncio.ensure_future(
         asyncio.get_event_loop().run_in_executor(
             None, _check_pending_workflow, conversation_id
+        )
+    )
+    _pending_action_task = asyncio.ensure_future(
+        asyncio.get_event_loop().run_in_executor(
+            None,
+            lambda: check_pending_action(str(conversation_id), message) if conversation_id else None,
         )
     )
 
@@ -2802,6 +2812,47 @@ async def run_gateway_stream(
             message=f"Active workflow detected ({_pending_workflow['type']}), "
                     f"route overridden to Lane {route.lane} (skip_tools={route.skip_tools})",
             context={"workflow_type": _pending_workflow["type"], "original_lane": route.lane},
+        )
+
+    # ── Pending action resolution (durable state machine) ─────────────
+    _pending_action_result = await _pending_action_task
+    _terminal_state = "complete"  # default terminal state for this turn
+    if _pending_action_result and _pending_action_result.get("intent") == "cancel":
+        # User cancelled — emit done immediately with cancelled state
+        pa = _pending_action_result["pending_action"]
+        yield _sse("status", {"message": "Action cancelled."})
+        yield _sse("token", {"text": f"Cancelled the pending {pa.get('action_type', 'action')}. Let me know if you'd like to do something else."})
+        timings["total_ms"] = int((time.time() - start) * 1000)
+        yield _sse("done", {
+            "session_id": session_id,
+            "terminal_state": "complete",
+            "trace": {
+                "execution_path": "chat", "lane": "A", "model": "none",
+                "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0,
+                "tool_call_count": 0, "tool_timeline": [], "data_sources": [],
+                "citations": [], "rag_chunks_used": 0,
+                "warnings": ["Pending action cancelled by user"],
+                "elapsed_ms": timings["total_ms"], "resolved_scope": scope_dump,
+                "repe": None, "visible_context_shortcut": False, "timings": timings,
+            },
+            "prompt_tokens": 0, "completion_tokens": 0, "tool_calls": 0,
+            "elapsed_ms": timings["total_ms"], "resolved_scope": scope_dump,
+            "response_blocks": [markdown_block(f"Cancelled the pending {pa.get('action_type', 'action')}.")],
+        })
+        return
+    elif _pending_action_result and _pending_action_result.get("intent") == "confirm":
+        # User confirmed — override route to ensure tools are available
+        _workflow_override_applied = True
+        route = RouteDecision(
+            lane="C", skip_rag=True, skip_tools=False,
+            max_tool_rounds=3, max_tokens=1024, temperature=0.2,
+            is_write=True, model=route.model or OPENAI_CHAT_MODEL,
+            rag_top_k=0, rag_max_tokens=0, history_max_tokens=2000,
+        )
+        emit_log(
+            level="info", service="backend", action="ai.gateway.pending_action_confirmed",
+            message=f"User confirmed pending action {_pending_action_result['pending_action'].get('action_type')}",
+            context={"pending_action_id": str(_pending_action_result["pending_action"]["pending_action_id"])},
         )
 
     # Emit status immediately so frontend shows processing started
@@ -3584,6 +3635,25 @@ async def run_gateway_stream(
                     },
                 )
                 yield _sse("response_block", {"block": confirm_block})
+                # Create durable pending action record
+                _terminal_state = "awaiting_confirmation"
+                if conversation_id and resolved_scope.business_id:
+                    try:
+                        create_pending_action(
+                            conversation_id=str(conversation_id),
+                            business_id=resolved_scope.business_id,
+                            env_id=resolved_scope.environment_id,
+                            actor=actor,
+                            skill_id=tool_name,
+                            action_type=tool_result.get("action", tool_name),
+                            params_json=tool_result.get("provided") or raw_args,
+                            missing_fields=tool_result.get("missing_fields") or tool_result.get("required_fields"),
+                            scope_type=resolved_scope.entity_type,
+                            scope_id=resolved_scope.entity_id,
+                            scope_label=resolved_scope.entity_name,
+                        )
+                    except Exception:
+                        logger.exception("Failed to create pending action record")
             elif not tool_success and tool_error_msg:
                 tool_error_block = error_block(
                     title=f"{tool_name} failed",
@@ -3810,10 +3880,18 @@ async def run_gateway_stream(
     if collected_content.strip():
         response_blocks.insert(0, markdown_block(collected_content.strip()))
 
+    # Determine terminal state for this turn
+    if _terminal_state == "complete" and not collected_content and tool_call_count == 0:
+        _terminal_state = "complete"  # empty but valid
+    # If we had errors and no content, mark as failed
+    if not collected_content and not response_blocks and warnings:
+        _terminal_state = "failed"
+
     yield _sse(
         "done",
         {
             "session_id": session_id,
+            "terminal_state": _terminal_state,
             "trace": {
                 "execution_path": execution_path,
                 "lane": route.lane,

--- a/backend/app/services/pending_action_manager.py
+++ b/backend/app/services/pending_action_manager.py
@@ -1,0 +1,246 @@
+"""Pending Action Manager — durable confirmation state machine for Winston.
+
+When Winston proposes an action (write tool with confirmed=false), a pending
+action record is created.  On the next user turn the gateway checks for a
+pending action and resolves it BEFORE normal intent routing:
+
+  * confirm phrases  → status = confirmed, re-execute tool with confirmed=true
+  * cancel phrases   → status = cancelled
+  * new intent       → status = superseded, normal routing continues
+  * expiration       → nightly audit marks expired rows
+
+This replaces the fragile conversation-scanning heuristic in
+``_check_pending_workflow`` with a first-class durable record.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from app.db import get_cursor
+
+logger = logging.getLogger(__name__)
+
+# ── Confirmation / cancellation patterns ─────────────────────────────
+
+_CONFIRM_RE = re.compile(
+    r"^(yes|yep|yeah|yup|sure|ok|okay|go ahead|proceed|do it|confirmed?|"
+    r"that'?s? (?:right|correct)|looks? good|sounds? good|approve|"
+    r"let'?s? go|execute|make it so)[\.\!\s]*$",
+    re.IGNORECASE,
+)
+
+_CANCEL_RE = re.compile(
+    r"^(no|nope|cancel|never ?mind|stop|don'?t|abort|scratch that)[\.\!\s]*$",
+    re.IGNORECASE,
+)
+
+_EDIT_RE = re.compile(
+    r"^(edit|change|update|modify|actually)\b",
+    re.IGNORECASE,
+)
+
+
+def classify_user_intent(message: str) -> str:
+    """Classify a short user message against pending action intent.
+
+    Returns one of: ``confirm``, ``cancel``, ``edit``, ``other``.
+    """
+    text = message.strip()
+    if _CONFIRM_RE.match(text):
+        return "confirm"
+    if _CANCEL_RE.match(text):
+        return "cancel"
+    if _EDIT_RE.match(text):
+        return "edit"
+    return "other"
+
+
+# ── CRUD ─────────────────────────────────────────────────────────────
+
+def create_pending_action(
+    *,
+    conversation_id: str,
+    message_id: str | None = None,
+    business_id: str,
+    env_id: str | None = None,
+    actor: str = "anonymous",
+    skill_id: str | None = None,
+    action_type: str,
+    params_json: dict[str, Any] | None = None,
+    missing_fields: list[str] | None = None,
+    scope_type: str | None = None,
+    scope_id: str | None = None,
+    scope_label: str | None = None,
+    expires_minutes: int = 30,
+) -> dict[str, Any] | None:
+    """Create a pending action record.  Supersedes any existing pending action
+    for the same conversation."""
+    try:
+        with get_cursor() as cur:
+            # Supersede any existing pending actions for this conversation
+            cur.execute(
+                """UPDATE ai_pending_actions
+                   SET status = 'superseded', resolved_at = now()
+                   WHERE conversation_id = %s AND status = 'awaiting_confirmation'""",
+                (conversation_id,),
+            )
+
+            cur.execute(
+                """INSERT INTO ai_pending_actions (
+                     conversation_id, message_id, business_id, env_id, actor,
+                     skill_id, action_type, params_json, missing_fields,
+                     scope_type, scope_id, scope_label,
+                     expires_at
+                   ) VALUES (
+                     %s, %s, %s, %s, %s,
+                     %s, %s, %s, %s,
+                     %s, %s, %s,
+                     now() + interval '%s minutes'
+                   ) RETURNING *""",
+                (
+                    conversation_id,
+                    message_id,
+                    business_id,
+                    env_id,
+                    actor,
+                    skill_id,
+                    action_type,
+                    json.dumps(params_json or {}),
+                    json.dumps(missing_fields) if missing_fields else None,
+                    scope_type,
+                    scope_id,
+                    scope_label,
+                    expires_minutes,
+                ),
+            )
+            return cur.fetchone()
+    except Exception:
+        logger.exception("Failed to create pending action")
+        return None
+
+
+def get_pending_action(conversation_id: str) -> dict[str, Any] | None:
+    """Get the active pending action for a conversation, if any."""
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """SELECT * FROM ai_pending_actions
+                   WHERE conversation_id = %s
+                     AND status = 'awaiting_confirmation'
+                     AND expires_at > now()
+                   ORDER BY created_at DESC
+                   LIMIT 1""",
+                (conversation_id,),
+            )
+            return cur.fetchone()
+    except Exception:
+        logger.exception("Failed to fetch pending action")
+        return None
+
+
+def resolve_pending_action(
+    pending_action_id: str,
+    *,
+    new_status: str,
+    resolution_message: str | None = None,
+) -> dict[str, Any] | None:
+    """Resolve a pending action to a terminal status."""
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """UPDATE ai_pending_actions
+                   SET status = %s,
+                       resolution_message = %s,
+                       resolved_at = now()
+                   WHERE pending_action_id = %s
+                   RETURNING *""",
+                (new_status, resolution_message, pending_action_id),
+            )
+            return cur.fetchone()
+    except Exception:
+        logger.exception("Failed to resolve pending action")
+        return None
+
+
+def expire_stale_actions() -> int:
+    """Mark expired pending actions.  Called by nightly audit."""
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """UPDATE ai_pending_actions
+                   SET status = 'expired', resolved_at = now()
+                   WHERE status = 'awaiting_confirmation'
+                     AND expires_at <= now()""",
+            )
+            return cur.rowcount
+    except Exception:
+        logger.exception("Failed to expire stale actions")
+        return 0
+
+
+def list_unresolved_actions(
+    *,
+    business_id: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """List all unresolved (awaiting_confirmation) actions, optionally filtered."""
+    clauses: list[str] = ["status = 'awaiting_confirmation'"]
+    params: list[Any] = []
+    if business_id:
+        clauses.append("business_id = %s")
+        params.append(business_id)
+    where = "WHERE " + " AND ".join(clauses)
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                f"""SELECT * FROM ai_pending_actions {where}
+                    ORDER BY created_at DESC LIMIT %s""",
+                params + [limit],
+            )
+            return cur.fetchall()
+    except Exception:
+        logger.exception("Failed to list unresolved actions")
+        return []
+
+
+# ── Gateway integration ──────────────────────────────────────────────
+
+def check_and_resolve(
+    conversation_id: str,
+    user_message: str,
+) -> dict[str, Any] | None:
+    """Check for a pending action and classify the user's response.
+
+    Returns a dict with resolution info if a pending action was found:
+      {
+        "pending_action": <row>,
+        "intent": "confirm" | "cancel" | "edit" | "other",
+        "resolved": True if confirmed or cancelled,
+      }
+    Returns None if no pending action exists.
+    """
+    pending = get_pending_action(conversation_id)
+    if not pending:
+        return None
+
+    intent = classify_user_intent(user_message)
+    pa_id = str(pending["pending_action_id"])
+
+    if intent == "confirm":
+        resolve_pending_action(pa_id, new_status="confirmed", resolution_message=user_message)
+        return {"pending_action": pending, "intent": "confirm", "resolved": True}
+    elif intent == "cancel":
+        resolve_pending_action(pa_id, new_status="cancelled", resolution_message=user_message)
+        return {"pending_action": pending, "intent": "cancel", "resolved": True}
+    elif intent == "edit":
+        # Keep pending but signal edit intent to gateway
+        return {"pending_action": pending, "intent": "edit", "resolved": False}
+    else:
+        # New unrelated intent — supersede
+        resolve_pending_action(pa_id, new_status="superseded", resolution_message=user_message)
+        return {"pending_action": pending, "intent": "other", "resolved": True}

--- a/backend/app/services/skill_candidate_miner.py
+++ b/backend/app/services/skill_candidate_miner.py
@@ -1,0 +1,202 @@
+"""Skill Candidate Miner — discovers emerging skill patterns from user behavior.
+
+Analyzes recent conversations for:
+  * Repeated prompt patterns (similar user messages)
+  * Repeated toolchains (same sequence of tool calls)
+  * Repeated failures (same tool failing the same way)
+  * Confirmation patterns (actions users frequently confirm)
+
+Writes discovered patterns to ``ai_skill_candidates`` for review.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any
+
+from app.db import get_cursor
+
+logger = logging.getLogger(__name__)
+
+
+def mine_candidates(*, lookback_hours: int = 24) -> int:
+    """Run all mining passes and return the number of new candidates found."""
+    total = 0
+    total += _mine_repeated_toolchains(lookback_hours)
+    total += _mine_repeated_failures(lookback_hours)
+    total += _mine_confirmation_patterns(lookback_hours)
+    return total
+
+
+def _mine_repeated_toolchains(hours: int) -> int:
+    """Find tool sequences that appear in multiple conversations."""
+    count = 0
+    try:
+        with get_cursor() as cur:
+            # Get tool call sequences per gateway request
+            cur.execute(
+                """SELECT conversation_id,
+                          tool_calls_json
+                   FROM ai_gateway_logs
+                   WHERE created_at > now() - interval '%s hours'
+                     AND tool_call_count >= 2
+                     AND tool_calls_json IS NOT NULL
+                   ORDER BY created_at DESC
+                   LIMIT 500""",
+                (hours,),
+            )
+            rows = cur.fetchall()
+
+            # Extract tool name sequences and count occurrences
+            chain_counts: dict[str, dict[str, Any]] = {}
+            for row in rows:
+                tcs = row.get("tool_calls_json")
+                if not tcs:
+                    continue
+                if isinstance(tcs, str):
+                    try:
+                        tcs = json.loads(tcs)
+                    except Exception:
+                        continue
+                if not isinstance(tcs, list) or len(tcs) < 2:
+                    continue
+
+                names = [tc.get("name", "") for tc in tcs if isinstance(tc, dict)]
+                chain_key = " -> ".join(names)
+                sig = hashlib.md5(chain_key.encode()).hexdigest()
+
+                if sig not in chain_counts:
+                    chain_counts[sig] = {
+                        "chain": chain_key,
+                        "names": names,
+                        "count": 0,
+                        "conversations": [],
+                    }
+                chain_counts[sig]["count"] += 1
+                chain_counts[sig]["conversations"].append(str(row["conversation_id"]))
+
+            # Upsert candidates for chains appearing 3+ times
+            for sig, data in chain_counts.items():
+                if data["count"] < 3:
+                    continue
+                count += _upsert_candidate(
+                    pattern_type="repeated_toolchain",
+                    pattern_signature=sig,
+                    sample_prompts=[],
+                    sample_tool_chains=[data["chain"]],
+                    occurrence_count=data["count"],
+                )
+    except Exception:
+        logger.exception("Failed to mine repeated toolchains")
+    return count
+
+
+def _mine_repeated_failures(hours: int) -> int:
+    """Find tools that fail the same way repeatedly."""
+    count = 0
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """SELECT tool_name,
+                          error_message,
+                          count(*) AS fail_count
+                   FROM ai_tool_calls
+                   WHERE created_at > now() - interval '%s hours'
+                     AND success = false
+                     AND error_message IS NOT NULL
+                   GROUP BY tool_name, error_message
+                   HAVING count(*) >= 3
+                   ORDER BY count(*) DESC
+                   LIMIT 20""",
+                (hours,),
+            )
+            rows = cur.fetchall()
+            for row in rows:
+                sig = hashlib.md5(
+                    f"{row['tool_name']}:{row['error_message'][:200]}".encode()
+                ).hexdigest()
+                count += _upsert_candidate(
+                    pattern_type="repeated_failure",
+                    pattern_signature=sig,
+                    sample_prompts=[],
+                    sample_tool_chains=[row["tool_name"]],
+                    occurrence_count=row["fail_count"],
+                    notes=row["error_message"][:500],
+                )
+    except Exception:
+        logger.exception("Failed to mine repeated failures")
+    return count
+
+
+def _mine_confirmation_patterns(hours: int) -> int:
+    """Find actions that users frequently confirm — these are good skill candidates."""
+    count = 0
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """SELECT action_type,
+                          count(*) FILTER (WHERE status = 'confirmed') AS confirmed_count,
+                          count(*) FILTER (WHERE status = 'cancelled') AS cancelled_count,
+                          count(*) AS total_count
+                   FROM ai_pending_actions
+                   WHERE created_at > now() - interval '%s hours'
+                   GROUP BY action_type
+                   HAVING count(*) >= 3
+                   ORDER BY count(*) DESC
+                   LIMIT 20""",
+                (hours,),
+            )
+            rows = cur.fetchall()
+            for row in rows:
+                sig = hashlib.md5(f"confirm:{row['action_type']}".encode()).hexdigest()
+                count += _upsert_candidate(
+                    pattern_type="confirmation_pattern",
+                    pattern_signature=sig,
+                    sample_prompts=[],
+                    sample_tool_chains=[row["action_type"]],
+                    occurrence_count=row["total_count"],
+                    notes=f"confirmed={row['confirmed_count']} cancelled={row['cancelled_count']}",
+                )
+    except Exception:
+        logger.exception("Failed to mine confirmation patterns")
+    return count
+
+
+def _upsert_candidate(
+    *,
+    pattern_type: str,
+    pattern_signature: str,
+    sample_prompts: list[str],
+    sample_tool_chains: list[str],
+    occurrence_count: int,
+    notes: str | None = None,
+) -> int:
+    """Upsert a skill candidate.  Returns 1 if new, 0 if updated."""
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """INSERT INTO ai_skill_candidates (
+                     pattern_type, pattern_signature,
+                     sample_prompts, sample_tool_chains,
+                     occurrence_count, notes, last_seen_at
+                   ) VALUES (%s, %s, %s, %s, %s, %s, now())
+                   ON CONFLICT (pattern_signature) DO UPDATE
+                   SET occurrence_count = ai_skill_candidates.occurrence_count + EXCLUDED.occurrence_count,
+                       last_seen_at = now(),
+                       notes = COALESCE(EXCLUDED.notes, ai_skill_candidates.notes)
+                   RETURNING (xmax = 0) AS is_insert""",
+                (
+                    pattern_type,
+                    pattern_signature,
+                    json.dumps(sample_prompts),
+                    json.dumps(sample_tool_chains),
+                    occurrence_count,
+                    notes,
+                ),
+            )
+            row = cur.fetchone()
+            return 1 if row and row.get("is_insert") else 0
+    except Exception:
+        logger.exception("Failed to upsert skill candidate")
+        return 0

--- a/repo-b/db/schema/1004_ai_pending_actions.sql
+++ b/repo-b/db/schema/1004_ai_pending_actions.sql
@@ -1,0 +1,61 @@
+-- 1004_ai_pending_actions.sql
+-- Durable pending action records for Winston confirmation workflow.
+-- When Winston proposes an action requiring user confirmation, a row is
+-- created here. On the next user turn the gateway resolves the pending
+-- action BEFORE normal intent routing.
+
+CREATE TABLE IF NOT EXISTS ai_pending_actions (
+  pending_action_id   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id     uuid NOT NULL REFERENCES ai_conversations(conversation_id) ON DELETE CASCADE,
+  message_id          uuid REFERENCES ai_messages(message_id) ON DELETE SET NULL,
+  business_id         uuid NOT NULL,
+  env_id              uuid,
+  actor               text NOT NULL DEFAULT 'anonymous',
+
+  -- Action definition
+  skill_id            text,                            -- e.g. 'finance.create_fund'
+  action_type         text NOT NULL,                   -- tool name or action category
+  params_json         jsonb NOT NULL DEFAULT '{}'::jsonb, -- parameters collected so far
+  missing_fields      jsonb,                           -- array of field names still needed
+
+  -- State machine
+  status              text NOT NULL DEFAULT 'awaiting_confirmation'
+                      CHECK (status IN (
+                        'awaiting_confirmation',
+                        'confirmed',
+                        'cancelled',
+                        'superseded',
+                        'expired',
+                        'executed',
+                        'failed'
+                      )),
+  resolution_message  text,                            -- user message that resolved this action
+
+  -- Scope metadata
+  scope_type          text,                            -- fund, asset, deal, environment, etc.
+  scope_id            text,
+  scope_label         text,
+
+  -- Expiration
+  expires_at          timestamptz NOT NULL DEFAULT (now() + interval '30 minutes'),
+
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  resolved_at         timestamptz
+);
+
+ALTER TABLE ai_pending_actions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY ai_pending_actions_tenant_isolation ON ai_pending_actions
+  USING (business_id = current_setting('app.current_business_id', true)::uuid);
+
+CREATE INDEX IF NOT EXISTS idx_ai_pending_actions_conversation
+  ON ai_pending_actions (conversation_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ai_pending_actions_business
+  ON ai_pending_actions (business_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ai_pending_actions_expires
+  ON ai_pending_actions (expires_at)
+  WHERE status = 'awaiting_confirmation';
+
+COMMENT ON TABLE ai_pending_actions IS 'Durable pending action records for Winston two-phase confirmation workflow. Owned by ai-copilot.';

--- a/repo-b/db/schema/1005_ai_observability_tables.sql
+++ b/repo-b/db/schema/1005_ai_observability_tables.sql
@@ -1,0 +1,149 @@
+-- 1005_ai_observability_tables.sql
+-- Additional observability tables for Winston AI: tool calls, UI events,
+-- skill candidates, and audit findings.
+
+-- ── ai_tool_calls: individual tool execution records ────────────────
+CREATE TABLE IF NOT EXISTS ai_tool_calls (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  gateway_log_id      uuid REFERENCES ai_gateway_logs(id) ON DELETE SET NULL,
+  conversation_id     uuid REFERENCES ai_conversations(conversation_id) ON DELETE SET NULL,
+  business_id         uuid NOT NULL,
+  env_id              uuid,
+  actor               text NOT NULL DEFAULT 'anonymous',
+
+  tool_name           text NOT NULL,
+  args_json           jsonb,
+  result_json         jsonb,
+  success             boolean NOT NULL DEFAULT true,
+  error_message       text,
+  duration_ms         int,
+  is_write            boolean NOT NULL DEFAULT false,
+  pending_confirmation boolean NOT NULL DEFAULT false,
+
+  created_at          timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE ai_tool_calls ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY ai_tool_calls_tenant_isolation ON ai_tool_calls
+  USING (business_id = current_setting('app.current_business_id', true)::uuid);
+
+CREATE INDEX IF NOT EXISTS idx_ai_tool_calls_conversation
+  ON ai_tool_calls (conversation_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ai_tool_calls_tool_name
+  ON ai_tool_calls (tool_name, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ai_tool_calls_failures
+  ON ai_tool_calls (tool_name, created_at DESC)
+  WHERE success = false;
+
+COMMENT ON TABLE ai_tool_calls IS 'Per-tool-call execution records for debugging and audit. Owned by ai-copilot.';
+
+
+-- ── ai_ui_events: frontend interaction telemetry ────────────────────
+CREATE TABLE IF NOT EXISTS ai_ui_events (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id     uuid REFERENCES ai_conversations(conversation_id) ON DELETE SET NULL,
+  business_id         uuid NOT NULL,
+  env_id              uuid,
+  actor               text NOT NULL DEFAULT 'anonymous',
+
+  event_type          text NOT NULL,                   -- thread_load, suggestion_click, confirmation_outcome, processing_stuck, etc.
+  event_data          jsonb NOT NULL DEFAULT '{}'::jsonb,
+  surface             text,                            -- drawer, workspace, mobile_nav
+  lane                text,                            -- contextual, general
+
+  created_at          timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE ai_ui_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY ai_ui_events_tenant_isolation ON ai_ui_events
+  USING (business_id = current_setting('app.current_business_id', true)::uuid);
+
+CREATE INDEX IF NOT EXISTS idx_ai_ui_events_business
+  ON ai_ui_events (business_id, event_type, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ai_ui_events_conversation
+  ON ai_ui_events (conversation_id, created_at DESC);
+
+COMMENT ON TABLE ai_ui_events IS 'Frontend interaction telemetry for Winston companion surfaces. Owned by ai-copilot.';
+
+
+-- ── ai_skill_candidates: emerging skill patterns from user behavior ──
+CREATE TABLE IF NOT EXISTS ai_skill_candidates (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id         uuid,
+
+  pattern_type        text NOT NULL,                   -- repeated_prompt, repeated_toolchain, repeated_failure, confirmation_pattern
+  pattern_signature   text NOT NULL,                   -- hash or normalized form of the pattern
+  sample_prompts      jsonb NOT NULL DEFAULT '[]'::jsonb,
+  sample_tool_chains  jsonb NOT NULL DEFAULT '[]'::jsonb,
+  occurrence_count    int NOT NULL DEFAULT 1,
+  first_seen_at       timestamptz NOT NULL DEFAULT now(),
+  last_seen_at        timestamptz NOT NULL DEFAULT now(),
+
+  -- Promotion tracking
+  promoted            boolean NOT NULL DEFAULT false,
+  promoted_skill_id   text,
+  notes               text,
+
+  created_at          timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE ai_skill_candidates ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY ai_skill_candidates_tenant_isolation ON ai_skill_candidates
+  USING (business_id = current_setting('app.current_business_id', true)::uuid
+         OR business_id IS NULL);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_skill_candidates_signature
+  ON ai_skill_candidates (pattern_signature);
+
+CREATE INDEX IF NOT EXISTS idx_ai_skill_candidates_pattern
+  ON ai_skill_candidates (pattern_type, occurrence_count DESC);
+
+COMMENT ON TABLE ai_skill_candidates IS 'Emerging skill patterns mined from repeated user prompts, toolchains, and failures. Owned by ai-copilot.';
+
+
+-- ── ai_audit_findings: nightly audit job output ─────────────────────
+CREATE TABLE IF NOT EXISTS ai_audit_findings (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id         uuid,
+  audit_run_id        uuid NOT NULL,                   -- groups findings from one audit run
+  audit_run_at        timestamptz NOT NULL DEFAULT now(),
+
+  finding_type        text NOT NULL,                   -- unresolved_confirmation, missed_confirmation, processing_stuck, repeated_tool_failure, repeated_missing_param, latency_outlier, skill_candidate
+  severity            text NOT NULL DEFAULT 'info'
+                      CHECK (severity IN ('info', 'warning', 'critical')),
+  title               text NOT NULL,
+  detail              jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Affected entities
+  conversation_id     uuid,
+  pending_action_id   uuid,
+  tool_name           text,
+  lane                text,
+
+  -- Metrics
+  count               int,
+  p50_ms              int,
+  p95_ms              int,
+
+  created_at          timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE ai_audit_findings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY ai_audit_findings_tenant_isolation ON ai_audit_findings
+  USING (business_id = current_setting('app.current_business_id', true)::uuid
+         OR business_id IS NULL);
+
+CREATE INDEX IF NOT EXISTS idx_ai_audit_findings_run
+  ON ai_audit_findings (audit_run_id, finding_type);
+
+CREATE INDEX IF NOT EXISTS idx_ai_audit_findings_type
+  ON ai_audit_findings (finding_type, severity, created_at DESC);
+
+COMMENT ON TABLE ai_audit_findings IS 'Nightly audit findings: unresolved confirmations, stuck processing, latency outliers, skill candidates. Owned by ai-copilot.';

--- a/repo-b/src/components/copilot/ResponseBlockRenderer.tsx
+++ b/repo-b/src/components/copilot/ResponseBlockRenderer.tsx
@@ -22,9 +22,13 @@ import GroundingBadge from "@/components/winston/blocks/GroundingBadge";
 export default function ResponseBlockRenderer({
   block,
   onConfirmAction,
+  onCancelAction,
+  onEditAction,
 }: {
   block: AssistantResponseBlock;
   onConfirmAction?: (block: Extract<AssistantResponseBlock, { type: "confirmation" }>) => void;
+  onCancelAction?: (block: Extract<AssistantResponseBlock, { type: "confirmation" }>) => void;
+  onEditAction?: (block: Extract<AssistantResponseBlock, { type: "confirmation" }>) => void;
 }) {
   switch (block.type) {
     case "markdown_text":
@@ -57,6 +61,8 @@ export default function ResponseBlockRenderer({
         <ConfirmationBlock
           block={block}
           onConfirm={() => onConfirmAction?.(block)}
+          onCancel={() => onCancelAction?.(block)}
+          onEdit={() => onEditAction?.(block)}
         />
       );
 

--- a/repo-b/src/components/winston-companion/WinstonCompanionProvider.tsx
+++ b/repo-b/src/components/winston-companion/WinstonCompanionProvider.tsx
@@ -73,6 +73,9 @@ type LaneBinding = {
   lastRoute: string | null;
 };
 
+/** Terminal state for every assistant turn. */
+type TerminalState = "complete" | "awaiting_confirmation" | "blocked_missing_info" | "failed" | null;
+
 type LaneState = {
   conversationId: string | null;
   draft: string;
@@ -81,6 +84,7 @@ type LaneState = {
   binding: LaneBinding | null;
   thinking: boolean;
   thinkingStatus?: string;
+  terminalState: TerminalState;
   trace: AssistantApiTrace | null;
   debug: AskAiDebug | null;
 };
@@ -131,6 +135,7 @@ const EMPTY_LANE: LaneState = {
   binding: null,
   thinking: false,
   thinkingStatus: undefined,
+  terminalState: null,
   trace: null,
   debug: null,
 };
@@ -800,6 +805,7 @@ export function WinstonCompanionProvider({
       draft: promptOverride ? current.draft : "",
       thinking: true,
       thinkingStatus: "Grounding in the current workspace...",
+      terminalState: null,
       messages: [
         ...current.messages,
         userMessage,
@@ -894,13 +900,15 @@ export function WinstonCompanionProvider({
             };
           });
         },
-        onDone: () => {
+        onDone: (payload) => {
           // Clear thinking immediately when backend sends 'done' event,
           // rather than waiting for post-stream persistence to close the HTTP stream.
+          const terminalState = (payload as Record<string, unknown>)?.terminal_state as TerminalState || "complete";
           setLaneState(lane, (current) => ({
             ...current,
             thinking: false,
             thinkingStatus: undefined,
+            terminalState,
           }));
         },
       });
@@ -930,6 +938,7 @@ export function WinstonCompanionProvider({
         ...current,
         thinking: false,
         thinkingStatus: undefined,
+        terminalState: "failed",
         messages: current.messages.map((item) =>
           item.id === assistantId
             ? {

--- a/repo-b/src/components/winston-companion/WinstonCompanionSurface.tsx
+++ b/repo-b/src/components/winston-companion/WinstonCompanionSurface.tsx
@@ -2,17 +2,20 @@
 
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Archive,
   ArrowUpRight,
   Bot,
+  ChevronDown,
   ChevronRight,
   Compass,
   History,
   MessageSquarePlus,
+  MoreVertical,
   PanelRightClose,
   Search,
+  X,
 } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { cn } from "@/lib/cn";
@@ -56,10 +59,21 @@ function ThreadViewport({
   compact?: boolean;
 }) {
   const endRef = useRef<HTMLDivElement | null>(null);
+  const { activeLane, sendPrompt, setDraft } = useWinstonCompanion();
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }, [messages, thinking, thinkingStatus]);
+
+  const handleConfirm = () => {
+    void sendPrompt(activeLane, "Yes, confirm.");
+  };
+  const handleCancel = () => {
+    void sendPrompt(activeLane, "Cancel.");
+  };
+  const handleEdit = () => {
+    setDraft(activeLane, "Actually, change ");
+  };
 
   return (
     <div
@@ -85,7 +99,13 @@ function ThreadViewport({
               {!isUser && message.responseBlocks?.length ? (
                 <div className="mt-3 space-y-3">
                   {message.responseBlocks.map((block) => (
-                    <ResponseBlockRenderer key={block.block_id} block={block} />
+                    <ResponseBlockRenderer
+                      key={block.block_id}
+                      block={block}
+                      onConfirmAction={handleConfirm}
+                      onCancelAction={handleCancel}
+                      onEditAction={handleEdit}
+                    />
                   ))}
                   {message.content && !hasMarkdownBlock(message.responseBlocks) ? (
                     <div className="whitespace-pre-wrap text-sm leading-7 text-bm-text">{message.content}</div>
@@ -204,10 +224,12 @@ function ConversationComposer({
   );
 }
 
-function SuggestionStrip({ compact = false }: { compact?: boolean }) {
-  const { currentContext, activeLane, setDraft } = useWinstonCompanion();
+function SuggestionStrip({ compact = false, hideWhenActive = false }: { compact?: boolean; hideWhenActive?: boolean }) {
+  const { currentContext, activeLane, activeState, setDraft } = useWinstonCompanion();
 
   if (!currentContext?.suggestions.length) return null;
+  // In compact/drawer mode, hide suggestions once conversation has messages
+  if (hideWhenActive && activeState.messages.length > 0) return null;
 
   return (
     <div className={cn("flex flex-wrap gap-2", compact ? "px-4 pb-2" : "px-6 pb-2")}>
@@ -277,6 +299,51 @@ function ContextCard() {
         </div>
       ) : null}
     </section>
+  );
+}
+
+/** Compact horizontal thread picker for drawer/mobile mode. */
+function RecentThreadStrip() {
+  const {
+    activeLane,
+    activeState,
+    recentConversations,
+    loadConversation,
+    resetLane,
+  } = useWinstonCompanion();
+
+  if (!recentConversations.length) return null;
+
+  return (
+    <div className="px-4 py-2">
+      <div className="flex items-center gap-2 overflow-x-auto scrollbar-none">
+        <button
+          type="button"
+          onClick={() => resetLane(activeLane)}
+          className="shrink-0 rounded-full border border-bm-accent/40 bg-bm-accent/10 px-3 py-1.5 text-xs font-medium text-bm-accent transition hover:bg-bm-accent/20"
+        >
+          + New
+        </button>
+        {recentConversations.slice(0, 6).map((conversation) => {
+          const active = conversation.conversation_id === activeState.conversationId;
+          return (
+            <button
+              key={conversation.conversation_id}
+              type="button"
+              onClick={() => void loadConversation(conversation.conversation_id, activeLane)}
+              className={cn(
+                "shrink-0 max-w-[160px] truncate rounded-full border px-3 py-1.5 text-xs transition",
+                active
+                  ? "border-bm-accent/40 bg-bm-accent/15 font-medium text-bm-text"
+                  : "border-bm-border/50 bg-bm-bg/60 text-bm-muted2 hover:text-bm-text",
+              )}
+            >
+              {conversation.title || conversation.scope_label || "Untitled"}
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 
@@ -416,6 +483,33 @@ function AdvancedPanel() {
   );
 }
 
+/** Overflow menu for drawer mode — Explore + Dev behind a single toggle. */
+function DrawerOverflowMenu() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="px-4 pb-3">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center justify-between rounded-2xl border border-bm-border/40 bg-bm-surface/10 px-4 py-2.5 text-xs font-medium text-bm-muted2 transition hover:text-bm-text"
+      >
+        <span className="flex items-center gap-2">
+          <MoreVertical size={14} />
+          Explore &amp; tools
+        </span>
+        <ChevronDown size={14} className={cn("transition", open && "rotate-180")} />
+      </button>
+      {open ? (
+        <div className="mt-3 space-y-3">
+          <ExplorePanel />
+          <AdvancedPanel />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function WorkspaceUtilities({ drawer = false }: { drawer?: boolean }) {
   return (
     <div className={cn("space-y-4", drawer ? "" : "sticky top-6")}>
@@ -435,25 +529,44 @@ function WorkspaceContent({
 
   return (
     <>
-      <ContextCard />
+      {/* In drawer mode: skip ContextCard (header already shows context),
+          show compact thread strip instead of full RecentConversations */}
+      {drawer ? (
+        <RecentThreadStrip />
+      ) : (
+        <ContextCard />
+      )}
 
       <section className={cn("overflow-hidden rounded-[28px] border border-bm-border/55 bg-bm-surface/10")}>
-        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-bm-border/45 px-4 py-3">
-          <div className="flex items-center gap-2">
-            <Bot size={15} className="text-bm-muted2" />
-            <div>
-              <p className="text-sm font-semibold text-bm-text">
-                {activeLane === "contextual" ? "Pinned contextual thread" : "General Winston thread"}
-              </p>
-              <p className="text-xs text-bm-muted2">
-                {currentContext?.scopeLabel || "Workspace"}{activeState.conversationId ? " · conversation attached" : " · new conversation"}
-              </p>
+        {/* Simplified header — single line in drawer, full in workspace */}
+        <div className={cn(
+          "flex items-center justify-between gap-3 border-b border-bm-border/45",
+          drawer ? "px-4 py-2" : "px-4 py-3",
+        )}>
+          <div className="flex items-center gap-2 min-w-0">
+            {drawer ? null : <Bot size={15} className="text-bm-muted2" />}
+            <div className="min-w-0">
+              {drawer ? (
+                <p className="truncate text-xs text-bm-muted2">
+                  <LaneSwitcher />
+                  {activeState.conversationId ? " · active thread" : ""}
+                </p>
+              ) : (
+                <>
+                  <p className="text-sm font-semibold text-bm-text">
+                    {activeLane === "contextual" ? "Pinned contextual thread" : "General Winston thread"}
+                  </p>
+                  <p className="text-xs text-bm-muted2">
+                    {currentContext?.scopeLabel || "Workspace"}{activeState.conversationId ? " · conversation attached" : " · new conversation"}
+                  </p>
+                </>
+              )}
             </div>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2">
             <Button type="button" variant="secondary" size="sm" onClick={() => resetLane(activeLane)}>
               <MessageSquarePlus size={14} />
-              New Thread
+              {drawer ? null : "New Thread"}
             </Button>
             {drawer ? (
               <Button type="button" size="sm" onClick={openFullWorkspace}>
@@ -464,20 +577,25 @@ function WorkspaceContent({
         </div>
 
         {activeState.messages.length === 0 ? (
-          <div className={cn("border-b border-bm-border/40", drawer ? "px-4 py-6" : "px-6 py-8")}>
-            <div className="rounded-[28px] border border-dashed border-bm-border/50 bg-bm-bg/45 p-6">
-              <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">Winston companion</p>
-              <h2 className="mt-2 text-lg font-semibold text-bm-text">
+          <div className={cn("border-b border-bm-border/40", drawer ? "px-4 py-4" : "px-6 py-8")}>
+            <div className={cn(
+              "rounded-[28px] border border-dashed border-bm-border/50 bg-bm-bg/45",
+              drawer ? "p-4" : "p-6",
+            )}>
+              {drawer ? null : (
+                <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">Winston companion</p>
+              )}
+              <h2 className={cn("font-semibold text-bm-text", drawer ? "text-sm" : "mt-2 text-lg")}>
                 {currentContext?.currentNarrative || "Ready"}
               </h2>
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-bm-muted">
+              <p className="mt-1 max-w-2xl text-sm leading-6 text-bm-muted">
                 Ask about this page, run analyses, or explore your portfolio.
               </p>
             </div>
           </div>
         ) : null}
 
-        <SuggestionStrip compact={drawer} />
+        <SuggestionStrip compact={drawer} hideWhenActive={drawer} />
         <ThreadViewport
           messages={activeState.messages}
           thinking={activeState.thinking}
@@ -612,32 +730,31 @@ export function WinstonCompanionRoot() {
             open ? "translate-x-0 opacity-100" : "translate-x-full opacity-0",
           )}
         >
-          <header className="border-b border-bm-border/40 px-4 py-4 sm:px-5">
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex items-center gap-3">
-                <WinstonAvatar className="h-10 w-10 border-bm-border/50 bg-bm-surface" priority />
-                <div>
-                  <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">Winston companion</p>
-                  <h1 className="text-base font-semibold text-bm-text">
-                    {currentContext?.envName || "Operating companion"}
+          <header className="border-b border-bm-border/40 px-4 py-3 sm:px-5">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3 min-w-0">
+                <WinstonAvatar className="h-9 w-9 shrink-0 border-bm-border/50 bg-bm-surface" priority />
+                <div className="min-w-0">
+                  <h1 className="truncate text-sm font-semibold text-bm-text">
+                    {currentContext?.currentNarrative || currentContext?.envName || "Winston"}
                   </h1>
                 </div>
               </div>
               <button
                 type="button"
                 onClick={closeDrawer}
-                className="rounded-full border border-bm-border/40 p-2 text-bm-muted transition hover:bg-bm-surface/40 hover:text-bm-text"
+                className="shrink-0 rounded-full border border-bm-border/40 p-2 text-bm-muted transition hover:bg-bm-surface/40 hover:text-bm-text"
                 aria-label="Close Winston companion"
               >
-                <PanelRightClose size={18} />
+                <X size={16} />
               </button>
             </div>
           </header>
 
-          <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-            <div className="space-y-3">
+          <div className="min-h-0 flex-1 overflow-y-auto py-2">
+            <div className="space-y-2">
               <WorkspaceContent drawer />
-              <WorkspaceUtilities drawer />
+              <DrawerOverflowMenu />
             </div>
           </div>
         </div>

--- a/repo-b/src/components/winston/blocks/ConfirmationBlock.tsx
+++ b/repo-b/src/components/winston/blocks/ConfirmationBlock.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import type { AssistantResponseBlock } from "@/lib/commandbar/types";
 
 type ConfirmBlock = Extract<AssistantResponseBlock, { type: "confirmation" }>;
@@ -9,16 +9,20 @@ export default function ConfirmationBlock({
   block,
   onConfirm,
   onCancel,
+  onEdit,
 }: {
   block: ConfirmBlock;
   onConfirm?: () => void;
   onCancel?: () => void;
+  onEdit?: () => void;
 }) {
+  const [resolved, setResolved] = useState<"confirmed" | "cancelled" | null>(null);
+
   return (
     <div className="my-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4">
       <div className="flex items-center gap-2 mb-2">
         <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-300">
-          Confirmation Required
+          {resolved === "confirmed" ? "Confirmed" : resolved === "cancelled" ? "Cancelled" : "Confirmation Required"}
         </span>
       </div>
       <p className="text-sm font-semibold text-bm-text mb-1">{block.action}</p>
@@ -38,22 +42,43 @@ export default function ConfirmationBlock({
           Missing: {block.missing_fields.join(", ")}
         </p>
       )}
-      <div className="flex gap-2">
-        <button
-          type="button"
-          onClick={onConfirm}
-          className="rounded-md bg-bm-accent/20 border border-bm-accent/40 px-3 py-1.5 text-sm font-medium text-bm-text hover:bg-bm-accent/30 transition-colors"
-        >
-          {block.confirm_label || "Confirm"}
-        </button>
-        <button
-          type="button"
-          onClick={onCancel}
-          className="rounded-md border border-bm-border/40 px-3 py-1.5 text-sm text-bm-muted hover:text-bm-text transition-colors"
-        >
-          Cancel
-        </button>
-      </div>
+      {resolved ? (
+        <p className="text-xs text-bm-muted2 italic">
+          {resolved === "confirmed" ? "Action confirmed — executing..." : "Action cancelled."}
+        </p>
+      ) : (
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setResolved("confirmed");
+              onConfirm?.();
+            }}
+            className="rounded-md bg-bm-accent/20 border border-bm-accent/40 px-3 py-1.5 text-sm font-medium text-bm-text hover:bg-bm-accent/30 transition-colors"
+          >
+            {block.confirm_label || "Confirm"}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setResolved("cancelled");
+              onCancel?.();
+            }}
+            className="rounded-md border border-bm-border/40 px-3 py-1.5 text-sm text-bm-muted hover:text-bm-text transition-colors"
+          >
+            Cancel
+          </button>
+          {onEdit ? (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="rounded-md border border-bm-border/40 px-3 py-1.5 text-sm text-bm-muted hover:text-bm-text transition-colors"
+            >
+              Edit
+            </button>
+          ) : null}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Part 1 — Pending Action State Machine:
- New ai_pending_actions table with full lifecycle (awaiting → confirmed/cancelled/superseded/expired)
- PendingActionManager service with confirm/cancel/edit/supersede classification
- Gateway integration: creates durable pending action on confirmation_required,
  resolves pending action BEFORE intent routing on next user turn
- "Yes" after confirmation now reliably triggers the pending action

Part 2 — Mobile UI Simplification:
- Drawer header simplified: single-line context narrative, no duplicate labels
- RecentThreadStrip: compact horizontal thread picker replaces full card list
- Suggestions hidden once conversation has messages (drawer mode)
- Explore + Advanced collapsed behind single overflow toggle (DrawerOverflowMenu)
- ContextCard skipped in drawer mode (header already shows context)

Part 3 — Terminal Request States:
- Every assistant turn ends in exactly one terminal state:
  complete | awaiting_confirmation | blocked_missing_info | failed
- terminalState tracked in LaneState, set from done event's terminal_state field
- Processing indicator always clears when terminal state is reached

Part 4 — Logging Tables:
- ai_pending_actions (1004): durable confirmation records with RLS
- ai_tool_calls (1005): per-tool execution records with failure indexing
- ai_ui_events (1005): frontend telemetry (thread_load, suggestion_click, etc.)
- ai_skill_candidates (1005): emerging skill patterns with upsert support
- ai_audit_findings (1005): nightly audit output with severity levels

Part 5 — Auto-Audit:
- Nightly audit job (ai_audit.py): unresolved confirmations, missed confirmations,
  processing-stuck incidents, repeated tool failures, missing-param patterns,
  p50/p95 latency by lane
- Skill candidate miner: repeated toolchains, repeated failures, confirmation patterns
- API routes for triggering audit, querying findings, managing pending actions

Part 6 — Confirmation Block Wiring:
- ConfirmationBlock gets Confirm/Cancel/Edit inline buttons with resolved state
- ResponseBlockRenderer passes all three callbacks
- ThreadViewport wires buttons to sendPrompt("Yes, confirm.") / sendPrompt("Cancel.")

https://claude.ai/code/session_01XTzBjACQrnP9DEv9Cg75FZ