### PR TITLE
feat(resume): Winston public resume agent with LLM streaming and intent router

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -126,6 +126,11 @@ PSYCHRAG_EMBEDDING_DIMENSION: int = int(os.getenv("PSYCHRAG_EMBEDDING_DIMENSION"
 PSYCHRAG_TOP_K: int = int(os.getenv("PSYCHRAG_TOP_K", "5"))
 PSYCHRAG_SUPPORT_EMAIL: str = os.getenv("PSYCHRAG_SUPPORT_EMAIL", "support@example.com")
 
+# ── Resume LLM (public resume agent on /paul) ─────────────────────
+RESUME_LLM_MODEL: str = os.getenv("RESUME_LLM_MODEL", "claude-sonnet-4-20250514")
+RESUME_LLM_MAX_TOKENS: int = int(os.getenv("RESUME_LLM_MAX_TOKENS", "800"))
+RESUME_LLM_ENABLED: bool = os.getenv("RESUME_LLM_ENABLED", "true").lower() == "true"
+
 # ── Trade execution layer ───────────────────────────────────────────
 IBKR_HOST: str = os.getenv("IBKR_HOST", "127.0.0.1")
 IBKR_PAPER_PORT: int = int(os.getenv("IBKR_PAPER_PORT", "4002"))

--- a/backend/app/routes/resume_chat.py
+++ b/backend/app/routes/resume_chat.py
@@ -4,6 +4,7 @@ Public endpoint — no authentication required.
 Mode: public_resume (enforced server-side).
 Rate limit: 10 requests/minute per IP (token bucket).
 Persona: advocate, persuasive, no citations.
+LLM-powered via Claude with deterministic fallback.
 """
 from __future__ import annotations
 
@@ -17,6 +18,9 @@ from typing import Any, Literal
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
+
+from app.config import RESUME_LLM_ENABLED
+from app.services.resume_llm import classify_resume_intent, stream_resume_response
 
 logger = logging.getLogger(__name__)
 
@@ -69,14 +73,14 @@ class ChatMessage(BaseModel):
 class ChatRequest(BaseModel):
     messages: list[ChatMessage]
     mode: Literal["public_resume"] = "public_resume"
+    scope: Literal["paul"] = "paul"
+    user: Literal["public"] = "public"
 
 
 SUGGESTED_QUESTIONS = [
-    "Walk me through the system architecture",
-    "What data platforms has Paul deployed?",
-    "Compare the Kayne Anderson and JLL deployments",
-    "What's the ROI on the automation work?",
-    "How does Winston's AI layer work?",
+    "Why is Paul a strong AI/data leader?",
+    "Compare JLL vs Kayne Anderson",
+    "What has Paul built end-to-end?",
     "Should I hire Paul?",
 ]
 
@@ -249,7 +253,11 @@ def _match_knowledge(question: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 async def _stream_chat(req: ChatRequest):
-    """Generator that yields SSE events for the chat response."""
+    """Generator that yields SSE events for the chat response.
+
+    Uses LLM streaming when RESUME_LLM_ENABLED and an API key is set.
+    Falls back to deterministic knowledge base otherwise.
+    """
     user_message = ""
     for msg in reversed(req.messages):
         if msg.role == "user":
@@ -257,25 +265,31 @@ async def _stream_chat(req: ChatRequest):
             break
 
     if not user_message:
-        yield _sse_text("Ask me anything about Paul's background, systems, or hiring fit.")
+        yield _sse_text("I'm Winston — ask me anything about Paul's background, systems, or hiring fit.")
         return
 
+    # Classify intent (always — used for both LLM and fallback paths)
+    intent = classify_resume_intent(user_message)
+
+    # LLM path — streaming Claude/OpenAI with full resume context
+    if RESUME_LLM_ENABLED:
+        history = [{"role": m.role, "content": m.content} for m in req.messages]
+        try:
+            async for token in stream_resume_response(history, intent):
+                yield _sse_text(token)
+            return
+        except Exception:
+            logger.exception("LLM streaming failed, falling back to deterministic")
+
+    # Deterministic fallback — regex → pre-built knowledge
     knowledge = _match_knowledge(user_message)
     if knowledge:
         yield _sse_text(_format_public_resume_response(knowledge))
         return
 
-    # Fallback — scope-restricted response
     yield _sse_text(
-        _format_public_resume_response(
-            "I can answer questions about Paul's **system architecture**, **data platforms**, "
-            "**deployment history**, **ROI metrics**, **hiring fit**, and **what he'd build for your firm**.\n\n"
-            "Try asking:\n"
-            "- \"Should I hire Paul?\"\n"
-            "- \"When did Paul start at Kayne Anderson?\"\n"
-            "- \"What's the ROI on the automation work?\"\n"
-            "- \"Walk me through the system architecture\""
-        )
+        "I focus on Paul's background and capabilities — try asking about his systems, "
+        "experience, or hiring fit."
     )
 
 

--- a/backend/app/services/resume_llm.py
+++ b/backend/app/services/resume_llm.py
@@ -1,0 +1,340 @@
+"""Resume LLM service — intent router + streaming Claude responses for /paul.
+
+Loads Paul's resume markdown at import time and uses it as system context
+for LLM-powered responses. Falls back to deterministic knowledge base
+when no API key is configured.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import AsyncGenerator
+
+import httpx
+
+from app.config import (
+    ANTHROPIC_API_KEY,
+    OPENAI_API_KEY,
+    RESUME_LLM_ENABLED,
+    RESUME_LLM_MAX_TOKENS,
+    RESUME_LLM_MODEL,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Resume corpus — loaded once at import time
+# ---------------------------------------------------------------------------
+
+_RESUME_PATH = Path(__file__).resolve().parents[3] / "docs" / "resume" / "paul-malmquist-resume-2026.md"
+
+try:
+    _RESUME_CORPUS: str = _RESUME_PATH.read_text(encoding="utf-8")
+except FileNotFoundError:
+    logger.warning("Resume markdown not found at %s — LLM responses will lack context", _RESUME_PATH)
+    _RESUME_CORPUS = ""
+
+
+# ---------------------------------------------------------------------------
+# System prompt — advocate persona
+# ---------------------------------------------------------------------------
+
+RESUME_SYSTEM_PROMPT = """You are Winston, Paul Malmquist's AI resume agent on his public resume page at paulmalmquist.com.
+Your purpose: persuade the reader that Paul is an exceptional hire.
+
+Rules:
+- Confident, persuasive, specific. You are Paul's advocate.
+- Never say "I don't have context", "I'm not sure", or "I don't know".
+- Never cite sources with [brackets], footnotes, or "according to".
+- Never use generic assistant phrasing like "I'd be happy to help" or "Great question!".
+- If asked about unrelated topics (weather, sports, random), redirect: "I focus on Paul's background and capabilities — happy to walk through his experience or fit for your team."
+- Use concrete numbers from the resume: $4B AUM, 500+ properties, 160 hrs/month automated, 83 MCP tools, 10-day reporting acceleration, 50% DDQ reduction, 75% reconciliation reduction, 95% error reduction, ~100x waterfall speedup.
+- Keep responses 2-4 paragraphs unless the user explicitly asks for more detail.
+- For comparisons, use a structured side-by-side format (table or parallel sections).
+- For "should I hire" questions, be unequivocally affirmative with evidence.
+- For skill/ranking questions, lead with the strongest evidence and stack proof points.
+- For timeline questions, provide specific dates, roles, and companies.
+- Write in clean markdown. Use bold for emphasis, headers for structure when needed.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Structured intent classification
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ResumeIntent:
+    subject: str = "person"          # person | experience | skill | career
+    metric: str | None = None        # duration | impact | timeline | comparison | null
+    transformation: str = "summary"  # summary | compare | rank | trend | explain
+    group_by: str | None = None      # company | role | skill | time | null
+    aggregation: str | None = None   # count | duration | max | latest | null
+    sort_by: str | None = None       # time | impact | null
+    sort_direction: str | None = None  # asc | desc | null
+    limit: int | None = None
+    timeframe: str | None = None
+    needs_clarification: bool = False
+
+    def to_instruction(self) -> str:
+        """Convert intent to a natural language instruction for the LLM."""
+        parts: list[str] = []
+
+        if self.transformation == "compare":
+            parts.append("Structure your response as a comparison. Use a table or side-by-side format.")
+        elif self.transformation == "rank":
+            parts.append("Rank the items from strongest to weakest with evidence for each.")
+            if self.limit:
+                parts.append(f"Limit to the top {self.limit}.")
+        elif self.transformation == "trend":
+            parts.append("Show the progression over time.")
+
+        if self.aggregation == "count":
+            parts.append("Include a specific count.")
+        elif self.aggregation == "duration":
+            parts.append("Include specific durations and date ranges.")
+
+        if self.group_by == "company":
+            parts.append("Organize by company/employer.")
+        elif self.group_by == "role":
+            parts.append("Organize by role/position.")
+        elif self.group_by == "time":
+            parts.append("Organize chronologically.")
+
+        if self.metric == "timeline":
+            parts.append("Focus on dates, start/end times, and career progression.")
+        elif self.metric == "impact":
+            parts.append("Lead with measurable outcomes and ROI.")
+
+        if self.sort_direction == "desc":
+            parts.append("Lead with the strongest/most impactful items.")
+        elif self.sort_direction == "asc":
+            parts.append("Start from the earliest/smallest and build up.")
+
+        if self.timeframe:
+            parts.append(f"Focus on the timeframe: {self.timeframe}.")
+
+        return " ".join(parts) if parts else "Provide a clear, concise summary."
+
+
+def classify_resume_intent(query: str) -> ResumeIntent:
+    """Rule-based intent classification from natural language query."""
+    q = query.lower().strip()
+    intent = ResumeIntent()
+
+    # --- Subject detection ---
+    if re.search(r"\b(skill|tech|stack|language|tool|framework|proficien)\b", q):
+        intent.subject = "skill"
+    elif re.search(r"\b(role|job|position|title|career|path)\b", q):
+        intent.subject = "career"
+    elif re.search(r"\b(built|shipped|deployed|system|project|experience|work|did)\b", q):
+        intent.subject = "experience"
+    else:
+        intent.subject = "person"
+
+    # --- Comparison detection ---
+    if re.search(r"\b(compare|vs\.?|versus|difference|between)\b", q):
+        intent.transformation = "compare"
+        intent.metric = "comparison"
+        intent.group_by = "company"
+
+    # --- Aggregation keywords ---
+    if re.search(r"\bhow many\b", q):
+        intent.aggregation = "count"
+    elif re.search(r"\bhow long\b", q):
+        intent.aggregation = "duration"
+        intent.metric = "duration"
+
+    # --- Ranking / superlatives ---
+    if re.search(r"\b(strongest|best|top|most|greatest|biggest|primary|main)\b", q):
+        intent.transformation = "rank"
+        intent.sort_by = "impact"
+        intent.sort_direction = "desc"
+
+    # --- "top N" pattern ---
+    top_match = re.search(r"\btop\s+(\d+)\b", q)
+    if top_match:
+        intent.limit = int(top_match.group(1))
+        intent.transformation = "rank"
+        intent.sort_by = "impact"
+        intent.sort_direction = "desc"
+
+    # --- Latest ---
+    if re.search(r"\b(latest|recent|current|now)\b", q):
+        intent.aggregation = "latest"
+        intent.sort_by = "time"
+        intent.sort_direction = "desc"
+
+    # --- Timeline / when ---
+    if re.search(r"\b(when|timeline|start|began|join|left|year|date)\b", q):
+        intent.metric = "timeline"
+
+    # --- Impact ---
+    if re.search(r"\b(impact|roi|result|outcome|value|saved|reduced|automated|accelerat)\b", q):
+        intent.metric = "impact"
+
+    # --- Group by ---
+    if re.search(r"\bby company\b|\bby (firm|employer|org)\b", q):
+        intent.group_by = "company"
+    elif re.search(r"\bby role\b|\bby (position|title)\b", q):
+        intent.group_by = "role"
+    elif re.search(r"\bover time\b|\bby (year|time|period)\b", q):
+        intent.group_by = "time"
+    elif re.search(r"\bby skill\b|\bby (tech|technology)\b", q):
+        intent.group_by = "skill"
+
+    # --- Timeframe extraction ---
+    year_match = re.search(r"\b(20\d{2})\b", q)
+    if year_match:
+        intent.timeframe = year_match.group(1)
+
+    company_patterns = {
+        "kayne": "Kayne Anderson (2018-2025)",
+        "novendor": "Novendor (2024-Present)",
+        "jll": "JLL",
+        "jones lang": "JLL",
+    }
+    for pattern, label in company_patterns.items():
+        if pattern in q:
+            if not intent.timeframe:
+                intent.timeframe = label
+            break
+
+    # --- Hire / fit questions ---
+    if re.search(r"\b(hire|fit|right person|recommend|should i|worth)\b", q):
+        intent.subject = "person"
+        intent.transformation = "explain"
+        intent.metric = "impact"
+
+    return intent
+
+
+# ---------------------------------------------------------------------------
+# Streaming LLM response
+# ---------------------------------------------------------------------------
+
+async def stream_resume_response(
+    messages: list[dict[str, str]],
+    intent: ResumeIntent,
+) -> AsyncGenerator[str, None]:
+    """Stream an LLM response using the resume as context.
+
+    Tries Anthropic first, falls back to OpenAI. Raises if neither is available.
+    """
+    if ANTHROPIC_API_KEY:
+        async for token in _stream_anthropic(messages, intent):
+            yield token
+        return
+
+    if OPENAI_API_KEY:
+        async for token in _stream_openai(messages, intent):
+            yield token
+        return
+
+    raise RuntimeError("No LLM API key configured")
+
+
+def _build_messages(messages: list[dict[str, str]], intent: ResumeIntent) -> list[dict[str, str]]:
+    """Build the message array for the LLM call."""
+    intent_instruction = intent.to_instruction()
+
+    # Start with resume context as first user message + assistant ack
+    built: list[dict[str, str]] = [
+        {
+            "role": "user",
+            "content": f"Here is Paul Malmquist's full resume for reference:\n\n{_RESUME_CORPUS}",
+        },
+        {
+            "role": "assistant",
+            "content": "I've reviewed Paul's complete resume. I'm ready to answer questions about his background, systems, and qualifications.",
+        },
+    ]
+
+    # Add conversation history (last 10 messages, excluding the current one)
+    history = messages[:-1] if messages else []
+    for msg in history[-10:]:
+        built.append({"role": msg["role"], "content": msg["content"]})
+
+    # Add current user message with intent instruction
+    current = messages[-1]["content"] if messages else ""
+    user_content = current
+    if intent_instruction and intent_instruction != "Provide a clear, concise summary.":
+        user_content += f"\n\n[Respond with this structure: {intent_instruction}]"
+
+    built.append({"role": "user", "content": user_content})
+    return built
+
+
+async def _stream_anthropic(
+    messages: list[dict[str, str]],
+    intent: ResumeIntent,
+) -> AsyncGenerator[str, None]:
+    """Stream from Anthropic Messages API."""
+    built = _build_messages(messages, intent)
+
+    async with httpx.AsyncClient(timeout=45.0) as client:
+        async with client.stream(
+            "POST",
+            "https://api.anthropic.com/v1/messages",
+            headers={
+                "x-api-key": ANTHROPIC_API_KEY,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            json={
+                "model": RESUME_LLM_MODEL,
+                "max_tokens": RESUME_LLM_MAX_TOKENS,
+                "system": RESUME_SYSTEM_PROMPT,
+                "messages": built,
+                "stream": True,
+            },
+        ) as resp:
+            if resp.status_code >= 400:
+                body = await resp.aread()
+                logger.error("Anthropic API error %d: %s", resp.status_code, body[:500])
+                raise RuntimeError(f"Anthropic API error: {resp.status_code}")
+
+            async for line in resp.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                data_str = line[6:]
+                if data_str == "[DONE]":
+                    break
+                try:
+                    data = json.loads(data_str)
+                except json.JSONDecodeError:
+                    continue
+
+                if data.get("type") == "content_block_delta":
+                    delta = data.get("delta", {})
+                    if delta.get("type") == "text_delta":
+                        text = delta.get("text", "")
+                        if text:
+                            yield text
+
+
+async def _stream_openai(
+    messages: list[dict[str, str]],
+    intent: ResumeIntent,
+) -> AsyncGenerator[str, None]:
+    """Stream from OpenAI Chat Completions API (fallback)."""
+    import openai
+
+    built = _build_messages(messages, intent)
+    oai_messages = [{"role": "system", "content": RESUME_SYSTEM_PROMPT}] + built
+
+    client = openai.AsyncOpenAI(api_key=OPENAI_API_KEY)
+    stream = await client.chat.completions.create(
+        model="gpt-4o",
+        temperature=0.4,
+        max_tokens=RESUME_LLM_MAX_TOKENS,
+        messages=oai_messages,
+        stream=True,
+    )
+
+    async for chunk in stream:
+        delta = chunk.choices[0].delta if chunk.choices else None
+        if delta and delta.content:
+            yield delta.content

--- a/repo-b/src/app/paul/ResumeChat.tsx
+++ b/repo-b/src/app/paul/ResumeChat.tsx
@@ -10,7 +10,7 @@ interface Message {
 const MAX_MESSAGES = 20;
 
 export default function ResumeChat() {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
@@ -23,7 +23,7 @@ export default function ResumeChat() {
 
   // Load suggestions on first open
   useEffect(() => {
-    if (!isOpen || suggestionsLoaded) return;
+    if (suggestionsLoaded) return;
     setSuggestionsLoaded(true);
     fetch("/api/resume/suggestions")
       .then((r) => r.json())
@@ -31,7 +31,7 @@ export default function ResumeChat() {
         if (Array.isArray(data.suggestions)) setSuggestions(data.suggestions);
       })
       .catch(() => {/* silently ignore */});
-  }, [isOpen, suggestionsLoaded]);
+  }, [suggestionsLoaded]);
 
   // Scroll to bottom when messages change
   useEffect(() => {
@@ -70,7 +70,7 @@ export default function ResumeChat() {
       const res = await fetch("/api/resume/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ messages: next, mode: "public_resume" }),
+        body: JSON.stringify({ messages: next, mode: "public_resume", scope: "paul", user: "public" }),
         signal: controller.signal,
       });
 
@@ -142,7 +142,7 @@ export default function ResumeChat() {
       {!isOpen && (
         <button
           type="button"
-          aria-label="Ask about Paul"
+          aria-label="Ask Winston"
           onClick={() => setIsOpen(true)}
           style={{
             position: "fixed",
@@ -170,7 +170,7 @@ export default function ResumeChat() {
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
             <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
           </svg>
-          Ask about Paul
+          Ask Winston
         </button>
       )}
 
@@ -227,7 +227,7 @@ export default function ResumeChat() {
                   color: "var(--ros-text-muted, rgba(255,255,255,0.55))",
                 }}
               >
-                Paul&rsquo;s AI
+                Winston
               </span>
             </div>
             <button


### PR DESCRIPTION
Replace deterministic regex→template resume chat with an LLM-powered Winston
agent on /paul. Adds structured intent classification (subject, metric,
transformation, group_by, aggregation, sort), Claude streaming via Anthropic
Messages API, and advocate-persona system prompt. Keeps deterministic knowledge
base as fallback when no API key is set. Frontend auto-opens Winston panel on
page load with updated branding and suggestions.

https://claude.ai/code/session_017eHfjTA3P59v5eN5gvM1uE