### PR TITLE
fix: consulting health check missing migration 457, causing false "not initialized" banner

### DIFF
--- a/repo-b/src/app/bos/api/consulting/health/route.ts
+++ b/repo-b/src/app/bos/api/consulting/health/route.ts
@@ -57,6 +57,10 @@ const MIGRATION_TABLE_MAP: Record<string, { migration: string; tables: string[] 
     migration: "431_consulting_proof_assets_objections.sql",
     tables: ["cro_proof_asset", "cro_objection", "cro_demo_readiness"],
   },
+  "457": {
+    migration: "457_pipeline_operator_layer.sql",
+    tables: ["cro_execution_profile", "cro_execution_audit"],
+  },
 };
 
 const ALL_REQUIRED_TABLES = Object.values(MIGRATION_TABLE_MAP).flatMap((m) => m.tables);
@@ -115,7 +119,7 @@ export async function GET(_request: NextRequest) {
     if (existingSet.has("crm_activity")) {
       try {
         const { rows } = await pool.query(
-          `SELECT MAX(activity_date)::text AS last_at FROM crm_activity`,
+          `SELECT MAX(activity_at)::text AS last_at FROM crm_activity`,
         );
         lastActivity = rows[0]?.last_at ?? null;
       } catch {

--- a/repo-b/src/app/lab/env/[envId]/consulting/pipeline/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/consulting/pipeline/page.tsx
@@ -100,12 +100,15 @@ function SchemaErrorBanner({ envId, onRetry }: { envId: string; onRetry: () => v
       const h = await fetchSchemaHealth();
       setHealth(h);
       setChecked(new Date().toLocaleTimeString());
+      if (h.schema_ready) {
+        onRetry();
+      }
     } catch {
       setHealth(null);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [onRetry]);
 
   useEffect(() => { checkHealth(); }, [checkHealth]);
 


### PR DESCRIPTION
The health check validated 29 tables but missed cro_execution_profile and
cro_execution_audit (migration 457). The execution board query references
cro_execution_profile, so when that table is absent PostgreSQL raises
UndefinedTable → backend returns SCHEMA_NOT_MIGRATED → banner shows "not
initialized" while the health indicator shows 29/29 green.

Fixes:
- Add migration 457 tables to the frontend health check (29→31 total)
- Fix activity_date→activity_at column name typo in health check
- Auto-retry data load when health check confirms schema_ready

https://claude.ai/code/session_013g4avNcGSqkgR3YgAyfYRC