### PR TITLE
Support domain-based bootstrap admins and hide resume memberships for domains

### DIFF
--- a/repo-b/src/lib/server/platformAuth.ts
+++ b/repo-b/src/lib/server/platformAuth.ts
@@ -99,6 +99,34 @@ function splitBootstrapEmails() {
   );
 }
 
+function splitBootstrapDomains() {
+  const configured = (process.env.PLATFORM_BOOTSTRAP_ADMIN_DOMAINS || "")
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (configured.length === 0) {
+    return new Set(["novendor.ai"]);
+  }
+  return new Set(configured);
+}
+
+function splitResumeHiddenDomains() {
+  const configured = (process.env.PLATFORM_HIDE_RESUME_DOMAINS || "")
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (configured.length === 0) return new Set(["novendor.ai"]);
+  return new Set(configured);
+}
+
+function extractEmailDomain(email: string) {
+  const normalized = normalizeEmail(email);
+  const [, domain = ""] = normalized.split("@");
+  return domain.trim().toLowerCase();
+}
+
 function membershipToSummary(row: Record<string, unknown>): PlatformMembershipSummary {
   return {
     env_id: String(row.env_id),
@@ -295,7 +323,13 @@ async function bootstrapOwnerMemberships(
   platformUserId: string,
   email: string,
 ) {
-  if (!splitBootstrapEmails().has(normalizeEmail(email))) return;
+  const normalizedEmail = normalizeEmail(email);
+  const emailDomain = extractEmailDomain(email);
+  const shouldBootstrap =
+    splitBootstrapEmails().has(normalizedEmail)
+    || splitBootstrapDomains().has(emailDomain);
+
+  if (!shouldBootstrap) return;
 
   await client.query(
     `
@@ -311,7 +345,7 @@ async function bootstrapOwnerMemberships(
         e.env_id,
         'owner',
         'active',
-        e.slug = 'novendor'
+        e.slug = 'hall-boys'
       FROM app.environments e
       WHERE e.slug = ANY($2::text[])
       ON CONFLICT (platform_user_id, env_id)
@@ -320,8 +354,21 @@ async function bootstrapOwnerMemberships(
         status = 'active',
         updated_at = now()
     `,
-    [platformUserId, ["novendor", "floyorker", "stone-pds", "meridian", "trading"]],
+    [platformUserId, ["novendor", "floyorker", "stone-pds", "meridian", "trading", "hall-boys"]],
   );
+
+  if (splitResumeHiddenDomains().has(emailDomain)) {
+    await client.query(
+      `
+        DELETE FROM app.environment_memberships m
+        USING app.environments e
+        WHERE m.env_id = e.env_id
+          AND m.platform_user_id = $1::uuid
+          AND e.slug = 'resume'
+      `,
+      [platformUserId],
+    );
+  }
 }
 
 async function loadMemberships(client: PoolClient, platformUserId: string) {


### PR DESCRIPTION
### Motivation
- Allow platform owner/admin bootstrapping to be driven by email domain in addition to explicit email addresses so organizations can be onboarded by domain.
- Provide a configurable default domain and a separate configurable list for hiding `resume` environment memberships for certain domains.
- Adjust bootstrap target environments and ensure newly-bootstrapped users do not retain `resume` membership when their domain is configured to hide resumes.

### Description
- Added helpers `splitBootstrapDomains`, `splitResumeHiddenDomains`, and `extractEmailDomain` to parse and normalize domain lists from environment variables and extract domain from an email.
- Updated `bootstrapOwnerMemberships` to compute `shouldBootstrap` from either the normalized email list or the email domain, and to use the normalized email for checks.
- Modified the membership upsert SQL to target `e.slug = 'hall-boys'` and added `'hall-boys'` to the list of environment slugs passed to the query.
- When the email domain is present in `splitResumeHiddenDomains`, delete any `resume` environment membership for the bootstrapped user.

### Testing
- Ran TypeScript compilation with the repo build command (e.g. `yarn build`) and it completed successfully.
- Executed the existing automated test suite (e.g. `yarn test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8266828b88331966196505e1db5d5)