### PR TITLE
feat(operator): add development sites, pipeline pages, AI grounding, and MCP tools

### DIFF
--- a/backend/app/mcp/schemas/operator_tools.py
+++ b/backend/app/mcp/schemas/operator_tools.py
@@ -1,0 +1,42 @@
+"""Schemas for operator MCP tools."""
+
+from pydantic import BaseModel, Field
+
+
+class OperatorScopeInput(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    environment_id: str | None = None
+    business_id: str | None = None
+
+
+class GetCommandCenterInput(OperatorScopeInput):
+    """Get the operator executive command center."""
+
+
+class ListProjectsInput(OperatorScopeInput):
+    """List all projects across entities."""
+
+
+class GetProjectDetailInput(OperatorScopeInput):
+    """Get project detail by ID."""
+
+    project_id: str = Field(description="Project ID to retrieve detail for")
+
+
+class ListSitesInput(OperatorScopeInput):
+    """List development pipeline sites."""
+
+
+class GetSiteDetailInput(OperatorScopeInput):
+    """Get development site detail by ID."""
+
+    site_id: str = Field(description="Development site ID to retrieve detail for")
+
+
+class ListVendorsInput(OperatorScopeInput):
+    """List vendors with cross-entity spend."""
+
+
+class ListCloseTasksInput(OperatorScopeInput):
+    """List month-end close tasks."""

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -52,6 +52,7 @@ def _register_all_tools():
     from app.mcp.tools.sql_agent_tools import register_sql_agent_tools
     from app.mcp.tools.novendor_tools import register_novendor_tools
     from app.mcp.tools.repe_write_tools import register_repe_write_tools
+    from app.mcp.tools.operator_tools import register_operator_tools
 
     register_meta_tools()
     register_business_tools()
@@ -89,6 +90,7 @@ def _register_all_tools():
     register_sql_agent_tools()
     register_novendor_tools()
     register_repe_write_tools()
+    register_operator_tools()
 
 
 def _make_response(req_id, result=None, error=None):

--- a/backend/app/mcp/tools/operator_tools.py
+++ b/backend/app/mcp/tools/operator_tools.py
@@ -1,0 +1,149 @@
+"""Operator MCP tools — exposes command center, projects, sites, vendors,
+close tasks to the AI Gateway."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.mcp.auth import McpContext
+from app.mcp.registry import AuditPolicy, ToolDef, registry
+from app.mcp.schemas.operator_tools import (
+    GetCommandCenterInput,
+    GetProjectDetailInput,
+    GetSiteDetailInput,
+    ListCloseTasksInput,
+    ListProjectsInput,
+    ListSitesInput,
+    ListVendorsInput,
+)
+from app.mcp.tools.repe_tools import _require_uuid, _scope_value, _serialize
+from app.services import operator as operator_svc
+
+
+def _resolve_env_id(inp, ctx: McpContext) -> UUID:
+    return _require_uuid(_scope_value(inp, ctx, "environment_id"), "environment_id")
+
+
+def _resolve_business_id(inp, ctx: McpContext) -> UUID:
+    return _require_uuid(_scope_value(inp, ctx, "business_id"), "business_id")
+
+
+def _get_command_center(ctx: McpContext, inp: GetCommandCenterInput) -> dict:
+    env_id = _resolve_env_id(inp, ctx)
+    bid = _resolve_business_id(inp, ctx)
+    return _serialize(operator_svc.get_command_center(env_id=env_id, business_id=bid))
+
+
+def _list_projects(ctx: McpContext, inp: ListProjectsInput) -> dict:
+    env_id = _resolve_env_id(inp, ctx)
+    bid = _resolve_business_id(inp, ctx)
+    projects = operator_svc.list_projects(env_id=env_id, business_id=bid)
+    return {"projects": _serialize(projects), "total": len(projects)}
+
+
+def _get_project_detail(ctx: McpContext, inp: GetProjectDetailInput) -> dict:
+    env_id = _resolve_env_id(inp, ctx)
+    bid = _resolve_business_id(inp, ctx)
+    return _serialize(
+        operator_svc.get_project_detail(
+            env_id=env_id, business_id=bid, project_id=inp.project_id
+        )
+    )
+
+
+def _list_sites(ctx: McpContext, inp: ListSitesInput) -> dict:
+    env_id = _resolve_env_id(inp, ctx)
+    bid = _resolve_business_id(inp, ctx)
+    sites = operator_svc.list_sites(env_id=env_id, business_id=bid)
+    return {"sites": _serialize(sites), "total": len(sites)}
+
+
+def _get_site_detail(ctx: McpContext, inp: GetSiteDetailInput) -> dict:
+    env_id = _resolve_env_id(inp, ctx)
+    bid = _resolve_business_id(inp, ctx)
+    return _serialize(
+        operator_svc.get_site_detail(
+            env_id=env_id, business_id=bid, site_id=inp.site_id
+        )
+    )
+
+
+def _list_vendors(ctx: McpContext, inp: ListVendorsInput) -> dict:
+    env_id = _resolve_env_id(inp, ctx)
+    bid = _resolve_business_id(inp, ctx)
+    vendors = operator_svc.list_vendors(env_id=env_id, business_id=bid)
+    return {"vendors": _serialize(vendors), "total": len(vendors)}
+
+
+def _list_close_tasks(ctx: McpContext, inp: ListCloseTasksInput) -> dict:
+    env_id = _resolve_env_id(inp, ctx)
+    bid = _resolve_business_id(inp, ctx)
+    tasks = operator_svc.list_close_tasks(env_id=env_id, business_id=bid)
+    return {"tasks": _serialize(tasks), "total": len(tasks)}
+
+
+def register_operator_tools() -> None:
+    policy = AuditPolicy(
+        redact_keys=[],
+        max_input_bytes_to_log=5000,
+        max_output_bytes_to_log=10000,
+    )
+
+    _TOOLS: list[tuple[str, str, type, object]] = [
+        (
+            "operator.get_command_center",
+            "Get executive command center: KPIs, entity performance, at-risk projects, development sites, vendor alerts, close status, and AI focus priorities.",
+            GetCommandCenterInput,
+            _get_command_center,
+        ),
+        (
+            "operator.list_projects",
+            "List all projects across entities with budget, actual, variance, risk score, and status.",
+            ListProjectsInput,
+            _list_projects,
+        ),
+        (
+            "operator.get_project_detail",
+            "Get project detail: budget vs actual by month, timeline, linked documents, tasks, vendor breakdown, root causes, and recommended actions.",
+            GetProjectDetailInput,
+            _get_project_detail,
+        ),
+        (
+            "operator.list_sites",
+            "List development pipeline sites with zoning, status, predevelopment cost, risk score, and timeline.",
+            ListSitesInput,
+            _list_sites,
+        ),
+        (
+            "operator.get_site_detail",
+            "Get development site detail: zoning restrictions, approvals required, blockers, linked documents, and recommended actions.",
+            GetSiteDetailInput,
+            _get_site_detail,
+        ),
+        (
+            "operator.list_vendors",
+            "List vendors with cross-entity spend, contract value, overspend, duplication flags.",
+            ListVendorsInput,
+            _list_vendors,
+        ),
+        (
+            "operator.list_close_tasks",
+            "List month-end close tasks with status, owner, blockers, and due dates.",
+            ListCloseTasksInput,
+            _list_close_tasks,
+        ),
+    ]
+
+    for name, desc, inp_model, handler in _TOOLS:
+        registry.register(
+            ToolDef(
+                name=name,
+                description=desc,
+                module="operator",
+                permission="read",
+                input_model=inp_model,
+                audit_policy=policy,
+                handler=handler,
+                tags=frozenset({"operator"}),
+            )
+        )

--- a/backend/app/routes/operator.py
+++ b/backend/app/routes/operator.py
@@ -11,6 +11,8 @@ from app.schemas.operator import (
     OperatorContextOut,
     OperatorProjectDetailOut,
     OperatorProjectRowOut,
+    OperatorSiteDetailOut,
+    OperatorSiteRowOut,
     OperatorVendorRowOut,
 )
 from app.services import env_context
@@ -180,4 +182,56 @@ def list_close_tasks(
             detail=str(exc),
             action="operator.close.failed",
             context={"env_id": env_id, "business_id": str(business_id) if business_id else None},
+        )
+
+
+@router.get("/sites", response_model=list[OperatorSiteRowOut])
+def list_sites(
+    request: Request,
+    env_id: str = Query(...),
+    business_id: UUID | None = Query(default=None),
+):
+    try:
+        resolved_env_id, resolved_business_id, _ctx = _resolve_context(request, env_id, business_id)
+        return [
+            OperatorSiteRowOut(**row)
+            for row in operator_svc.list_sites(env_id=resolved_env_id, business_id=resolved_business_id)
+        ]
+    except Exception as exc:
+        status, code = classify_domain_error(exc)
+        return domain_error_response(
+            request=request,
+            status_code=status,
+            code=code,
+            detail=str(exc),
+            action="operator.sites.failed",
+            context={"env_id": env_id, "business_id": str(business_id) if business_id else None},
+        )
+
+
+@router.get("/sites/{site_id}", response_model=OperatorSiteDetailOut)
+def get_site_detail(
+    request: Request,
+    site_id: str,
+    env_id: str = Query(...),
+    business_id: UUID | None = Query(default=None),
+):
+    try:
+        resolved_env_id, resolved_business_id, _ctx = _resolve_context(request, env_id, business_id)
+        return OperatorSiteDetailOut(
+            **operator_svc.get_site_detail(
+                env_id=resolved_env_id,
+                business_id=resolved_business_id,
+                site_id=site_id,
+            )
+        )
+    except Exception as exc:
+        status, code = classify_domain_error(exc)
+        return domain_error_response(
+            request=request,
+            status_code=status,
+            code=code,
+            detail=str(exc),
+            action="operator.site_detail.failed",
+            context={"env_id": env_id, "business_id": str(business_id) if business_id else None, "site_id": site_id},
         )

--- a/backend/app/schemas/operator.py
+++ b/backend/app/schemas/operator.py
@@ -158,6 +158,46 @@ class OperatorVendorRowOut(BaseModel):
     linked_projects: list[str] = Field(default_factory=list)
 
 
+class OperatorSiteRestrictions(BaseModel):
+    height_limit_ft: float | None = None
+    FAR: float | None = None
+    setback_front_ft: float | None = None
+    setback_side_ft: float | None = None
+    parking_ratio: str | None = None
+    historic_overlay: bool = False
+    environmental_review_required: bool = False
+
+
+class OperatorSiteRowOut(BaseModel):
+    site_id: str
+    name: str
+    address: str | None = None
+    city: str | None = None
+    entity_id: str
+    entity_name: str
+    zoning_type: str | None = None
+    status: str = "scouting"
+    predev_cost_to_date: float = 0
+    predev_budget: float | None = None
+    risk_score: float = 0
+    risk_level: str = "low"
+    estimated_timeline_days: int | None = None
+    owner: str | None = None
+    summary: str | None = None
+    href: str | None = None
+
+
+class OperatorSiteDetailOut(OperatorSiteRowOut):
+    allowed_uses: list[str] = Field(default_factory=list)
+    restrictions: OperatorSiteRestrictions = Field(default_factory=OperatorSiteRestrictions)
+    approvals_required: list[str] = Field(default_factory=list)
+    blockers: list[str] = Field(default_factory=list)
+    linked_project_id: str | None = None
+    linked_project_name: str | None = None
+    documents: list[OperatorDocumentSummaryOut] = Field(default_factory=list)
+    recommended_actions: list[str] = Field(default_factory=list)
+
+
 class OperatorAssistantFocusOut(BaseModel):
     headline: str
     summary_lines: list[str] = Field(default_factory=list)
@@ -179,6 +219,7 @@ class OperatorCommandCenterOut(BaseModel):
     close_tasks: list[OperatorCloseTaskRowOut] = Field(default_factory=list)
     top_documents: list[OperatorDocumentSummaryOut] = Field(default_factory=list)
     vendor_alerts: list[OperatorVendorRowOut] = Field(default_factory=list)
+    development_sites: list[OperatorSiteRowOut] = Field(default_factory=list)
     assistant_focus: OperatorAssistantFocusOut
     demo_script: list[str] = Field(default_factory=list)
     improvements: list[str] = Field(default_factory=list)

--- a/backend/app/services/ai_gateway.py
+++ b/backend/app/services/ai_gateway.py
@@ -416,6 +416,47 @@ def _is_credit_environment(*, environment_name: str | None, environment_id: str 
     return any("credit" in value.lower() for value in haystacks)
 
 
+def _is_operator_environment(*, environment_name: str | None, environment_id: str | None, industry: str | None = None) -> bool:
+    if industry and industry.lower() in ("multi_entity_operator", "operator"):
+        return True
+    haystacks = [environment_name or "", environment_id or ""]
+    return any(kw in value.lower() for value in haystacks for kw in ("operator", "hall-boys", "hall_boys"))
+
+
+_OPERATOR_DOMAIN_BLOCK = """
+## Multi-Entity Operator Domain
+
+You are operating inside a multi-entity operating system for a holding company with multiple operating entities.
+The assistant has access to operator-specific MCP tools for querying real data.
+
+### Grounding Rules
+- ALWAYS reference specific entities, projects, development sites, vendors, and dollar amounts.
+- NEVER give generic business advice. Every answer must cite specific numbers from the operator data.
+- When discussing financials, reference the current period unless the user specifies otherwise.
+- When discussing projects, always include budget, actual, variance, and risk score.
+- When discussing development sites, include zoning type, approval status, predevelopment cost, and risk level.
+- When discussing vendors, call out cross-entity duplication and contract overspend amounts.
+- Quantify impact where possible. Prioritize actions. Avoid vague language.
+
+### Tool Routing
+- Executive / command center / "what's going wrong" questions -> operator.get_command_center
+- Project questions -> operator.list_projects or operator.get_project_detail
+- Development pipeline / site / zoning questions -> operator.list_sites or operator.get_site_detail
+- Vendor / duplication / spend questions -> operator.list_vendors
+- Close / workflow / blocker questions -> operator.list_close_tasks
+- "What should I focus on?" -> operator.get_command_center (use assistant_focus data)
+- "Should we pursue [site]?" -> operator.get_site_detail (cite zoning, approvals, cost, risk)
+- "What approvals are slowing us down?" -> operator.list_sites + operator.list_close_tasks
+- "Where are we wasting pre-development money?" -> operator.list_sites (compare predev_cost vs status)
+
+### Response Format
+- Lead with the most actionable insight.
+- Use specific entity names, project names, site names, vendor names.
+- Include dollar amounts and percentages.
+- End with 1-3 prioritized recommended actions.
+"""
+
+
 def _build_unified_metrics_block() -> str:
     """Build a system prompt block listing available metrics from the unified registry."""
     try:
@@ -446,6 +487,8 @@ def _build_system_prompt_for_context(*, environment_name: str | None, environmen
         base += "\n\n" + _CREDIT_DOMAIN_BLOCK
     if _is_resume_environment(environment_name=environment_name, environment_id=environment_id, industry=industry):
         base += "\n\n" + _RESUME_DOMAIN_BLOCK
+    if _is_operator_environment(environment_name=environment_name, environment_id=environment_id, industry=industry):
+        base += "\n\n" + _OPERATOR_DOMAIN_BLOCK
     # Inject unified metric registry context for all REPE environments
     metrics_block = _build_unified_metrics_block()
     if metrics_block:
@@ -3327,6 +3370,13 @@ async def _legacy_run_gateway_stream(
         _domain_blocks.append(("credit", _CREDIT_DOMAIN_BLOCK))
     if _is_resume:
         _domain_blocks.append(("resume", _RESUME_DOMAIN_BLOCK))
+    _is_operator = _is_operator_environment(
+        environment_name=normalized_envelope.ui.active_environment_name,
+        environment_id=normalized_envelope.ui.active_environment_id,
+        industry=getattr(normalized_envelope.ui, "industry", None),
+    )
+    if _is_operator:
+        _domain_blocks.append(("operator", _OPERATOR_DOMAIN_BLOCK))
 
     # ── Conversation history (token-budgeted per lane) ────────────
     _history_start = time.time()

--- a/backend/app/services/operator.py
+++ b/backend/app/services/operator.py
@@ -79,6 +79,11 @@ def _vendor_map() -> dict[str, dict[str, Any]]:
     return {vendor["id"]: vendor for vendor in fixture["vendors"]}
 
 
+def _site_map() -> dict[str, dict[str, Any]]:
+    fixture = _load_fixture()
+    return {site["id"]: site for site in fixture.get("development_sites", [])}
+
+
 def _document_map() -> dict[str, dict[str, Any]]:
     fixture = _load_fixture()
     return {document["id"]: document for document in fixture["documents"]}
@@ -322,6 +327,7 @@ def get_command_center(*, env_id: UUID, business_id: UUID) -> dict[str, Any]:
     at_risk_projects = [row for row in _build_project_rows(env_id=env_id) if row["risk_level"] == "high"]
     close_rows = _build_close_rows(env_id=env_id)
     vendor_rows = _build_vendor_rows()
+    site_rows = _build_site_rows(env_id=env_id)
     ai_grounding = fixture.get("ai_grounding", {})
     return {
         "env_id": str(env_id),
@@ -384,6 +390,7 @@ def get_command_center(*, env_id: UUID, business_id: UUID) -> dict[str, Any]:
         "close_tasks": close_rows,
         "top_documents": [_document_summary(document) for document in fixture["documents"]],
         "vendor_alerts": [row for row in vendor_rows if row["duplication_flag"] or (row["overspend_amount"] or 0) > 0],
+        "development_sites": [row for row in site_rows if row["risk_level"] in ("high", "medium")],
         "assistant_focus": {
             "headline": "Control the overrun, unblock close, then consolidate duplicated vendor spend.",
             "summary_lines": ai_grounding.get("what_is_going_wrong", []),
@@ -397,7 +404,9 @@ def get_command_center(*, env_id: UUID, business_id: UUID) -> dict[str, Any]:
             "prompt_suggestions": [
                 "What’s going wrong this month?",
                 "Where are we losing money?",
-                "Which projects are off track?",
+                "Which projects are at risk?",
+                "Should we pursue the Main St site?",
+                "What approvals are slowing us down?",
                 "What should I focus on today?",
             ],
         },
@@ -450,3 +459,71 @@ def list_vendors(*, env_id: UUID, business_id: UUID) -> list[dict[str, Any]]:
 def list_close_tasks(*, env_id: UUID, business_id: UUID) -> list[dict[str, Any]]:
     _ = business_id
     return _build_close_rows(env_id=env_id)
+
+
+# ---------------------------------------------------------------------------
+# Development Sites
+# ---------------------------------------------------------------------------
+
+
+def _site_row(site: dict[str, Any], *, env_id: UUID) -> dict[str, Any]:
+    entities = _entity_map()
+    entity = entities.get(site["entity_id"], {})
+    return {
+        "site_id": site["id"],
+        "name": site["name"],
+        "address": site.get("address"),
+        "city": site.get("city"),
+        "entity_id": site["entity_id"],
+        "entity_name": entity.get("name", site["entity_id"]),
+        "zoning_type": site.get("zoning_type"),
+        "status": site.get("status", "scouting"),
+        "predev_cost_to_date": float(site.get("predev_cost_to_date", 0)),
+        "predev_budget": site.get("predev_budget"),
+        "risk_score": float(site.get("risk_score", 0)),
+        "risk_level": site.get("risk_level", "low"),
+        "estimated_timeline_days": site.get("estimated_timeline_days"),
+        "owner": site.get("owner"),
+        "summary": site.get("summary"),
+        "href": f"/lab/env/{env_id}/operator/pipeline/{site['id']}",
+    }
+
+
+def _build_site_rows(*, env_id: UUID) -> list[dict[str, Any]]:
+    fixture = _load_fixture()
+    rows = [_site_row(site, env_id=env_id) for site in fixture.get("development_sites", [])]
+    return sorted(rows, key=lambda row: (-float(row["risk_score"]), row["name"]))
+
+
+def list_sites(*, env_id: UUID, business_id: UUID) -> list[dict[str, Any]]:
+    _ = business_id
+    return _build_site_rows(env_id=env_id)
+
+
+def get_site_detail(*, env_id: UUID, business_id: UUID, site_id: str) -> dict[str, Any]:
+    _ = business_id
+    sites = _site_map()
+    documents = _document_map()
+    projects = _project_map()
+    site = sites.get(site_id)
+    if not site:
+        raise LookupError("Site not found")
+    row = _site_row(site, env_id=env_id)
+    linked_project = projects.get(site.get("linked_project_id") or "", {})
+    row.update(
+        {
+            "allowed_uses": site.get("allowed_uses", []),
+            "restrictions": site.get("restrictions", {}),
+            "approvals_required": site.get("approvals_required", []),
+            "blockers": site.get("blockers", []),
+            "linked_project_id": site.get("linked_project_id"),
+            "linked_project_name": linked_project.get("name"),
+            "documents": [
+                _document_summary(documents[doc_id])
+                for doc_id in site.get("linked_document_ids", [])
+                if doc_id in documents
+            ],
+            "recommended_actions": site.get("recommended_actions", []),
+        }
+    )
+    return row

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -2300,3 +2300,12 @@ These are the questions to ask before any ML surface lands in front of executive
 - **Sign direction in explanation strips is harder to get right than it looks.** Under correlated features, sign can flip across near-identical inputs. Magnitude is usually safer; sign requires stability tests before it reaches non-technical audiences.
 - **Class-imbalance fixes (scale_pos_weight, SMOTE) make raw probabilities uncalibrated by construction.** You must calibrate afterwards. And you must calibrate on data not used for early stopping. Track both the raw AUC and the calibration Brier — AUC can hold steady while Brier rots.
 - **Threshold selection should fail loud.** If no PR-curve point meets the precision/recall floor and the code silently falls back to F1-optimal, you just deployed a different operating point than the team signed off on. Emit a warning metric when the fallback fires; consider making it a training-job failure.
+
+## Hall Boys Operating System — Environment Build Lessons
+
+- **Fixture-driven prototyping** is faster than database-first. Define the data model as JSON in `fixtures/winston_demo/`, build services that read from it, and iterate. Swap to DB reads later without changing the API contract.
+- **Domain block injection** (`_OPERATOR_DOMAIN_BLOCK` in `ai_gateway.py`) is the key to non-generic AI responses. Tell the assistant what tools to call, what grounding rules to follow, and what response format to use.
+- **MCP tool registration** follows a simple 3-file pattern: schemas in `mcp/schemas/`, handlers in `mcp/tools/`, and registration in `mcp/server.py`. Tag tools with the domain name for lane filtering.
+- **Context publishing** via `publishAssistantPageContext()` must include `visible_data` with the actual on-screen data. This prevents the AI from contradicting what the user sees.
+- **Seed data realism**: margin compression, budget overruns, vendor duplication, blocked workflows, and multi-stage pipeline sites produce better demos than happy-path data.
+- **Shell + anchor navigation** (tabs for pages, sidebar anchors for sections) scales cleanly for multi-page environments without custom routing complexity.

--- a/fixtures/winston_demo/hall_boys_operator_seed.json
+++ b/fixtures/winston_demo/hall_boys_operator_seed.json
@@ -764,6 +764,195 @@
         "revenue_recognition_hold": true,
         "notice_period_days": 15
       }
+    },
+    {
+      "id": "doc-zoning-main-st",
+      "title": "City of Springfield Zoning Ordinance — C-2 Commercial District",
+      "type": "zoning_ordinance",
+      "entity_id": "hb-development",
+      "project_id": null,
+      "vendor_id": null,
+      "site_id": "main-st-parcel",
+      "status": "extracted",
+      "created_at": "2026-03-25T09:30:00Z",
+      "risk_flags": [
+        "historic overlay",
+        "environmental review required",
+        "height restriction"
+      ],
+      "key_terms": [
+        "Maximum building height: 45 feet",
+        "Floor-area ratio: 2.5",
+        "Historic overlay zone requires HRB approval",
+        "Environmental impact review required for parcels over 0.5 acres"
+      ],
+      "extracted_json": {
+        "zoning_type": "C-2 Commercial",
+        "height_limit_ft": 45,
+        "FAR": 2.5,
+        "parking_requirements": "1 space per 500 SF of gross floor area",
+        "approvals_required": ["Planning Commission", "Historic Review Board", "Environmental Impact Review", "City Council"],
+        "risk_flags": ["historic overlay", "environmental review required", "height restriction"]
+      }
+    },
+    {
+      "id": "doc-zoning-airport",
+      "title": "County Airport District Zoning — I-1 Industrial/Aviation",
+      "type": "zoning_ordinance",
+      "entity_id": "hb-construction",
+      "project_id": "airport-expansion",
+      "vendor_id": null,
+      "site_id": "airport-expansion-site",
+      "status": "extracted",
+      "created_at": "2026-03-18T14:15:00Z",
+      "risk_flags": [
+        "FAA height limit",
+        "noise abatement zone"
+      ],
+      "key_terms": [
+        "FAA Part 77 height restrictions apply within 2-mile radius",
+        "Noise abatement overlay limits operating hours 10PM-6AM",
+        "Environmental assessment waived for existing footprint expansion"
+      ],
+      "extracted_json": {
+        "zoning_type": "I-1 Industrial/Aviation",
+        "height_limit_ft": 65,
+        "FAR": 3.0,
+        "parking_requirements": "1 space per 1000 SF for industrial use",
+        "approvals_required": ["Planning Commission", "FAA Review"],
+        "risk_flags": ["FAA height limit", "noise abatement zone"]
+      }
+    },
+    {
+      "id": "doc-zoning-industrial",
+      "title": "Riverside Industrial Park Development Standards — M-1 Light Manufacturing",
+      "type": "zoning_ordinance",
+      "entity_id": "hb-development",
+      "project_id": null,
+      "vendor_id": null,
+      "site_id": "industrial-park-lot",
+      "status": "extracted",
+      "created_at": "2026-03-10T11:00:00Z",
+      "risk_flags": [],
+      "key_terms": [
+        "By-right development permitted for light manufacturing",
+        "No special use permit required",
+        "Standard site plan review only"
+      ],
+      "extracted_json": {
+        "zoning_type": "M-1 Light Manufacturing",
+        "height_limit_ft": 55,
+        "FAR": 2.0,
+        "parking_requirements": "1 space per 800 SF",
+        "approvals_required": ["Planning Commission"],
+        "risk_flags": []
+      }
+    }
+  ],
+  "development_sites": [
+    {
+      "id": "main-st-parcel",
+      "name": "Main St Parcel",
+      "address": "1420 Main Street",
+      "city": "Springfield",
+      "entity_id": "hb-development",
+      "zoning_type": "C-2 Commercial",
+      "allowed_uses": ["retail", "office", "mixed-use residential"],
+      "restrictions": {
+        "height_limit_ft": 45,
+        "FAR": 2.5,
+        "setback_front_ft": 15,
+        "setback_side_ft": 10,
+        "parking_ratio": "1 per 500 SF",
+        "historic_overlay": true,
+        "environmental_review_required": true
+      },
+      "approvals_required": ["Planning Commission", "Historic Review Board", "Environmental Impact Review", "City Council"],
+      "estimated_timeline_days": 270,
+      "predev_cost_to_date": 120000,
+      "predev_budget": 180000,
+      "risk_score": 85,
+      "risk_level": "high",
+      "status": "review",
+      "owner": "Elena Brooks",
+      "summary": "Zoning constraints and historic overlay require extended review. Environmental impact study adds 3-4 months to the entitlement timeline.",
+      "blockers": ["Historic Review Board hearing not yet scheduled", "Environmental impact study incomplete"],
+      "linked_project_id": null,
+      "linked_document_ids": ["doc-zoning-main-st"],
+      "recommended_actions": [
+        "Schedule Historic Review Board hearing before May.",
+        "Expedite Phase 1 environmental review to unlock entitlement timeline.",
+        "Confirm parking variance strategy with zoning counsel."
+      ]
+    },
+    {
+      "id": "airport-expansion-site",
+      "name": "Airport Expansion Site",
+      "address": "8200 Aviation Boulevard",
+      "city": "Springfield",
+      "entity_id": "hb-construction",
+      "zoning_type": "I-1 Industrial/Aviation",
+      "allowed_uses": ["industrial", "aviation support", "logistics"],
+      "restrictions": {
+        "height_limit_ft": 65,
+        "FAR": 3.0,
+        "setback_front_ft": 25,
+        "setback_side_ft": 20,
+        "parking_ratio": "1 per 1000 SF",
+        "historic_overlay": false,
+        "environmental_review_required": false
+      },
+      "approvals_required": ["Planning Commission", "FAA Review"],
+      "estimated_timeline_days": 180,
+      "predev_cost_to_date": 400000,
+      "predev_budget": 500000,
+      "risk_score": 52,
+      "risk_level": "medium",
+      "status": "entitlement",
+      "owner": "Dana Holt",
+      "summary": "FAA Part 77 review is pending and adding 30-60 days to permitting timeline. Environmental assessment waived for existing footprint.",
+      "blockers": ["FAA Part 77 height review response pending"],
+      "linked_project_id": "airport-expansion",
+      "linked_document_ids": ["doc-zoning-airport"],
+      "recommended_actions": [
+        "Follow up on FAA Part 77 review response — expected within 30 days.",
+        "Coordinate noise abatement overlay requirements with airport authority.",
+        "Align entitlement timeline with Airport Expansion project schedule."
+      ]
+    },
+    {
+      "id": "industrial-park-lot",
+      "name": "Industrial Park Lot",
+      "address": "340 Riverside Commerce Drive",
+      "city": "Riverside",
+      "entity_id": "hb-development",
+      "zoning_type": "M-1 Light Manufacturing",
+      "allowed_uses": ["light manufacturing", "warehouse", "distribution"],
+      "restrictions": {
+        "height_limit_ft": 55,
+        "FAR": 2.0,
+        "setback_front_ft": 20,
+        "setback_side_ft": 15,
+        "parking_ratio": "1 per 800 SF",
+        "historic_overlay": false,
+        "environmental_review_required": false
+      },
+      "approvals_required": ["Planning Commission"],
+      "estimated_timeline_days": 90,
+      "predev_cost_to_date": 80000,
+      "predev_budget": 100000,
+      "risk_score": 18,
+      "risk_level": "low",
+      "status": "approved",
+      "owner": "Elena Brooks",
+      "summary": "By-right development with standard site plan review. Clean approvals with no special permits required.",
+      "blockers": [],
+      "linked_project_id": null,
+      "linked_document_ids": ["doc-zoning-industrial"],
+      "recommended_actions": [
+        "Finalize site plan and submit for administrative review.",
+        "Begin grading and utility coordination."
+      ]
     }
   ],
   "close_tasks": [
@@ -833,33 +1022,56 @@
       "HB Logistics margin fell to 4.8% in March from 8.3% in February because temporary labor and fuel costs ran above plan.",
       "Airport Expansion is $400K over budget, with electrical and materials spend driving the overrun.",
       "New Development Site A is $400K over budget and is blocking revenue recognition.",
-      "Month-end close is blocked by missing Logistics invoices and a late Development revenue recognition task."
+      "Month-end close is blocked by missing Logistics invoices and a late Development revenue recognition task.",
+      "Main St Parcel is stuck in review — historic overlay and environmental constraints are adding 3-4 months to the entitlement timeline.",
+      "Total predevelopment spend across the pipeline is $600K with only Industrial Park Lot fully approved."
     ],
     "where_money_is_lost": [
       "Airport Expansion overrun: $400K.",
       "New Development Site A overrun: $400K.",
       "Apex Electrical spend above contract: $150K.",
-      "Prime Staffing spend above contract: $80K."
+      "Prime Staffing spend above contract: $80K.",
+      "Main St Parcel predevelopment spend: $120K with no entitlement date in sight.",
+      "Airport Expansion Site predevelopment: $400K with FAA review still pending."
     ],
     "what_to_focus_on": [
       "Unblock Logistics invoice upload.",
       "Get the signed Site A change order into the close packet.",
       "Contain Airport Expansion electrical and materials overrun.",
-      "Consolidate duplicated vendor contracts across entities."
+      "Consolidate duplicated vendor contracts across entities.",
+      "Schedule the Historic Review Board hearing for Main St Parcel before May.",
+      "Confirm Airport Expansion Site FAA Part 77 review timeline."
+    ],
+    "development_pipeline_risks": [
+      "Main St Parcel: HIGH risk — historic overlay + environmental review. $120K of $180K budget spent. No entitlement date.",
+      "Airport Expansion Site: MEDIUM risk — FAA review pending. $400K of $500K budget spent. Linked to Airport Expansion project.",
+      "Industrial Park Lot: LOW risk — approved, by-right development. $80K of $100K budget spent."
+    ],
+    "site_approval_bottlenecks": [
+      "Historic Review Board hearing for Main St Parcel has not been scheduled.",
+      "Environmental impact study for Main St Parcel is incomplete.",
+      "FAA Part 77 height review for Airport Expansion Site is pending response.",
+      "Industrial Park Lot has no outstanding approvals — ready for site plan submission."
     ]
   },
   "demo_script": [
     "Open Hall Boys Operating System from the environment list and land on Executive.",
     "Call out consolidated March revenue of $12.5M, weighted margin of 12.0%, and two at-risk projects.",
+    "Point out the Development Site Risk panel showing Main St Parcel (HIGH) and Airport Expansion Site (MEDIUM).",
     "Click Airport Expansion to show budget vs actual, vendor overrun, linked contract, and close task.",
+    "Navigate to Pipeline to show all three development sites with risk scores, stages, and predevelopment costs.",
+    "Click Main St Parcel to show zoning restrictions, approvals required, and environmental review blocker.",
     "Jump to Vendors and show Apex Electrical and Prime Staffing duplicated across entities with overspend vs contract.",
     "Go to Documents, open the Apex contract, and point out the $250K due in 30 days plus the auto-renewal clause.",
-    "Ask Winston: What should I focus on today? and confirm the answer mentions Logistics close blockers, Site A revenue recognition, and the two red projects."
+    "Ask Winston: Should we pursue the Main St site? and confirm the answer references historic overlay, $120K spent, and environmental review timeline.",
+    "Ask Winston: What should I focus on today? and confirm the answer mentions Logistics close blockers, Site A revenue recognition, Main St approvals, and the two red projects."
   ],
   "improvements": [
     "Swap the seeded fixture for live finance, task, and vendor joins once the operator entities are modeled in canonical tables.",
     "Add owner-level drilldowns for project and close accountability.",
     "Persist uploaded operator documents back into project and vendor drilldowns automatically.",
-    "Add contract-versus-actual variance alerts that publish directly into the close surface."
+    "Add contract-versus-actual variance alerts that publish directly into the close surface.",
+    "Add GIS map integration for development sites with zoning overlay visualization.",
+    "Connect document extraction pipeline to auto-populate site restrictions from uploaded ordinance PDFs."
   ]
 }

--- a/repo-b/src/app/lab/env/[envId]/operator/pipeline/[siteId]/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/operator/pipeline/[siteId]/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { OperatorSiteDetailPage } from "@/components/operator/OperatorPages";
+
+export default function OperatorSiteDetailRoute() {
+  const params = useParams();
+  const siteId = params.siteId as string;
+  return <OperatorSiteDetailPage siteId={siteId} />;
+}

--- a/repo-b/src/app/lab/env/[envId]/operator/pipeline/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/operator/pipeline/page.tsx
@@ -1,0 +1,5 @@
+import { OperatorPipelinePage } from "@/components/operator/OperatorPages";
+
+export default function OperatorPipelineRoute() {
+  return <OperatorPipelinePage />;
+}

--- a/repo-b/src/components/operator/OperatorPages.tsx
+++ b/repo-b/src/components/operator/OperatorPages.tsx
@@ -19,11 +19,13 @@ import {
   computeSha256,
   getOperatorCommandCenter,
   getOperatorProjectDetail,
+  getOperatorSiteDetail,
   initExtraction,
   initUpload,
   listDocuments,
   listOperatorCloseTasks,
   listOperatorProjects,
+  listOperatorSites,
   listOperatorVendors,
   runExtraction,
   type DocumentItem,
@@ -32,6 +34,8 @@ import {
   type OperatorCommandCenter,
   type OperatorProjectDetail,
   type OperatorProjectRow,
+  type OperatorSiteDetail,
+  type OperatorSiteRow,
   type OperatorVendorRow,
 } from "@/lib/bos-api";
 import { fmtDate, fmtMoney, fmtNumber, fmtPctDirect, fmtText } from "@/lib/format-utils";
@@ -382,6 +386,35 @@ export function OperatorExecutivePage() {
               ))}
             </div>
           </SectionCard>
+
+          {data.development_sites.length > 0 ? (
+            <SectionCard id="site-risk" title="Development Site Risk" eyebrow="Pipeline Watch">
+              <div className="space-y-3">
+                {data.development_sites.map((site) => (
+                  <Link
+                    key={site.site_id}
+                    href={site.href || "#"}
+                    className="block rounded-2xl border border-bm-border/70 bg-black/20 p-4 transition hover:bg-black/30"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-medium text-bm-text">{site.name}</p>
+                        <p className="mt-1 text-sm text-bm-muted2">{site.entity_name}</p>
+                      </div>
+                      <span className={`rounded-full border px-2 py-1 text-[11px] ${toneClasses(site.risk_level)}`}>
+                        {site.risk_level}
+                      </span>
+                    </div>
+                    <p className="mt-3 text-sm text-bm-muted2">{site.summary}</p>
+                    <div className="mt-3 flex items-center justify-between text-sm text-bm-text">
+                      <span>Predev {fmtMoney(site.predev_cost_to_date)}</span>
+                      <span>Risk {fmtNumber(site.risk_score)}</span>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </SectionCard>
+          ) : null}
 
           <OperatorWinstonPanel
             headline={data.assistant_focus.headline}
@@ -1198,6 +1231,358 @@ export function OperatorClosePage() {
                 </span>
               </div>
               {task.blocker_reason ? <p className="mt-3 text-sm text-bm-muted2">{task.blocker_reason}</p> : null}
+            </div>
+          ))}
+        </div>
+      </SectionCard>
+    </div>
+  );
+}
+
+export function OperatorPipelinePage() {
+  const pathname = usePathname();
+  const { envId, businessId } = useDomainEnv();
+  const [sites, setSites] = useState<OperatorSiteRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setSites(await listOperatorSites(envId, businessId || undefined));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load development sites.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, [envId, businessId]);
+
+  useEffect(() => {
+    if (!sites.length) return;
+    publishAssistantPageContext({
+      route: pathname,
+      surface: "operator_pipeline",
+      active_module: "operator",
+      page_entity_type: "pipeline",
+      visible_data: {
+        development_sites: sites,
+      },
+    });
+  }, [sites, pathname]);
+
+  const highRiskSites = useMemo(() => sites.filter((site) => site.risk_level === "high"), [sites]);
+
+  if (loading) return <WorkspaceContextLoader label="Loading development pipeline" />;
+  if (error) return <OperatorErrorState title="Pipeline unavailable" detail={error} onRetry={() => void load()} />;
+
+  return (
+    <div className="space-y-4">
+      <SectionCard id="pipeline-tracker" title="Development Pipeline" eyebrow="Site Scouting + Entitlement">
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b border-bm-border/50 text-left text-[11px] uppercase tracking-[0.16em] text-bm-muted2">
+                <th className="px-3 py-2 font-medium">Site</th>
+                <th className="px-3 py-2 font-medium">Stage</th>
+                <th className="px-3 py-2 font-medium">Cost</th>
+                <th className="px-3 py-2 font-medium">Risk</th>
+                <th className="px-3 py-2 font-medium">Timeline</th>
+                <th className="px-3 py-2 font-medium">Entity</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-bm-border/40">
+              {sites.map((site) => (
+                <tr key={site.site_id}>
+                  <td className="px-3 py-3">
+                    <Link href={site.href || "#"} className="font-medium text-bm-text hover:underline">
+                      {site.name}
+                    </Link>
+                    <p className="mt-1 text-xs text-bm-muted2">{site.address}{site.city ? `, ${site.city}` : ""}</p>
+                  </td>
+                  <td className="px-3 py-3">
+                    <span className={`rounded-full border px-2 py-1 text-[11px] ${toneClasses(site.status)}`}>
+                      {site.status}
+                    </span>
+                  </td>
+                  <td className="px-3 py-3 text-bm-text">{fmtMoney(site.predev_cost_to_date)}</td>
+                  <td className="px-3 py-3">
+                    <span className={`rounded-full border px-2 py-1 text-[11px] ${toneClasses(site.risk_level)}`}>
+                      {site.risk_level} · {fmtNumber(site.risk_score)}
+                    </span>
+                  </td>
+                  <td className="px-3 py-3 text-bm-text">
+                    {site.estimated_timeline_days ? `${site.estimated_timeline_days} days` : "—"}
+                  </td>
+                  <td className="px-3 py-3 text-bm-muted2">{site.entity_name}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </SectionCard>
+
+      <SectionCard id="high-risk-sites" title="High Risk Sites" eyebrow="Requires Attention">
+        <div className="grid gap-3 lg:grid-cols-2">
+          {highRiskSites.length ? (
+            highRiskSites.map((site) => (
+              <Link
+                key={`${site.site_id}-risk`}
+                href={site.href || "#"}
+                className="rounded-2xl border border-bm-border/60 bg-black/20 p-4 transition hover:bg-black/30"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <p className="font-medium text-bm-text">{site.name}</p>
+                  <span className={`rounded-full border px-2 py-1 text-[11px] ${toneClasses(site.risk_level)}`}>
+                    {site.risk_level}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm text-bm-muted2">{site.entity_name} · {site.zoning_type}</p>
+                <p className="mt-3 text-sm text-bm-muted2">{site.summary}</p>
+                <div className="mt-3 flex items-center justify-between text-sm text-bm-text">
+                  <span>Predev {fmtMoney(site.predev_cost_to_date)}</span>
+                  <span>Risk {fmtNumber(site.risk_score)}</span>
+                </div>
+              </Link>
+            ))
+          ) : (
+            <p className="text-sm text-bm-muted2">No high-risk sites in the pipeline.</p>
+          )}
+        </div>
+      </SectionCard>
+    </div>
+  );
+}
+
+export function OperatorSiteDetailPage({ siteId }: { siteId: string }) {
+  const pathname = usePathname();
+  const { envId, businessId } = useDomainEnv();
+  const [detail, setDetail] = useState<OperatorSiteDetail | null>(null);
+  const [commandCenter, setCommandCenter] = useState<OperatorCommandCenter | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [siteDetail, center] = await Promise.all([
+        getOperatorSiteDetail(siteId, envId, businessId || undefined),
+        getOperatorCommandCenter(envId, businessId || undefined),
+      ]);
+      setDetail(siteDetail);
+      setCommandCenter(center);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load site detail.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, [siteId, envId, businessId]);
+
+  useEffect(() => {
+    if (!detail || !commandCenter) return;
+    publishAssistantPageContext({
+      route: pathname,
+      surface: "operator_site_detail",
+      active_module: "operator",
+      page_entity_type: "development_site",
+      page_entity_id: detail.site_id,
+      page_entity_name: detail.name,
+      selected_entities: [
+        {
+          entity_type: "business",
+          entity_id: commandCenter.business_id,
+          name: commandCenter.business_name,
+          source: "page",
+        },
+        {
+          entity_type: "development_site",
+          entity_id: detail.site_id,
+          name: detail.name,
+          source: "page",
+          metadata: { risk_level: detail.risk_level, zoning_type: detail.zoning_type, status: detail.status },
+        },
+      ],
+      visible_data: {
+        metrics: {
+          predev_cost: detail.predev_cost_to_date,
+          predev_budget: detail.predev_budget,
+          risk_score: detail.risk_score,
+          timeline_days: detail.estimated_timeline_days,
+        },
+        notes: [...detail.blockers, ...detail.recommended_actions],
+        site_detail: detail,
+        operator_command_center: commandCenter,
+      },
+    });
+  }, [detail, commandCenter, pathname]);
+
+  if (loading) return <WorkspaceContextLoader label="Loading site intelligence" />;
+  if (error || !detail || !commandCenter) {
+    return <OperatorErrorState title="Site detail unavailable" detail={error || "No data returned."} onRetry={() => void load()} />;
+  }
+
+  return (
+    <div className="space-y-4">
+      <SectionCard title={detail.name} eyebrow={`${detail.entity_name} · ${detail.city || ""}`}>
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_320px]">
+          <div className="space-y-4">
+            <p className="max-w-3xl text-sm text-bm-muted2">{detail.summary}</p>
+            <div className="grid gap-3 sm:grid-cols-4">
+              <div className="rounded-2xl border border-bm-border/60 bg-black/20 p-4">
+                <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">Predev Cost</p>
+                <p className="mt-2 text-xl font-semibold text-bm-text">{fmtMoney(detail.predev_cost_to_date)}</p>
+              </div>
+              <div className="rounded-2xl border border-bm-border/60 bg-black/20 p-4">
+                <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">Budget</p>
+                <p className="mt-2 text-xl font-semibold text-bm-text">{fmtMoney(detail.predev_budget)}</p>
+              </div>
+              <div className="rounded-2xl border border-bm-border/60 bg-black/20 p-4">
+                <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">Risk</p>
+                <div className="mt-2 inline-flex rounded-full border px-2 py-1 text-[11px] font-medium text-bm-text">
+                  {detail.risk_score} · {detail.risk_level}
+                </div>
+              </div>
+              <div className="rounded-2xl border border-bm-border/60 bg-black/20 p-4">
+                <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">Timeline</p>
+                <p className="mt-2 text-xl font-semibold text-bm-text">
+                  {detail.estimated_timeline_days ? `${detail.estimated_timeline_days}d` : "—"}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <OperatorWinstonPanel
+            headline={`${detail.name} — ${detail.risk_level} risk`}
+            lines={[detail.summary || "", ...detail.blockers].filter(Boolean)}
+            prompts={[
+              `What is the risk on ${detail.name}?`,
+              `What approvals are needed for ${detail.name}?`,
+              `Should we continue investing in ${detail.name}?`,
+            ]}
+          />
+        </div>
+      </SectionCard>
+
+      <SectionCard id="zoning-details" title="Zoning Details" eyebrow={detail.zoning_type || "Zoning"}>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="rounded-2xl border border-bm-border/60 bg-black/20 p-3">
+            <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">Zoning Type</p>
+            <p className="mt-1 text-sm text-bm-text">{detail.zoning_type || "—"}</p>
+          </div>
+          <div className="rounded-2xl border border-bm-border/60 bg-black/20 p-3">
+            <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">Height Limit</p>
+            <p className="mt-1 text-sm text-bm-text">
+              {detail.restrictions.height_limit_ft ? `${detail.restrictions.height_limit_ft} ft` : "—"}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-bm-border/60 bg-black/20 p-3">
+            <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">FAR</p>
+            <p className="mt-1 text-sm text-bm-text">{detail.restrictions.FAR ?? "—"}</p>
+          </div>
+          <div className="rounded-2xl border border-bm-border/60 bg-black/20 p-3">
+            <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">Parking</p>
+            <p className="mt-1 text-sm text-bm-text">{detail.restrictions.parking_ratio || "—"}</p>
+          </div>
+          <div className="rounded-2xl border border-bm-border/60 bg-black/20 p-3">
+            <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">Historic Overlay</p>
+            <p className="mt-1 text-sm text-bm-text">{detail.restrictions.historic_overlay ? "Yes" : "No"}</p>
+          </div>
+          <div className="rounded-2xl border border-bm-border/60 bg-black/20 p-3">
+            <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">Env Review</p>
+            <p className="mt-1 text-sm text-bm-text">{detail.restrictions.environmental_review_required ? "Required" : "Not required"}</p>
+          </div>
+        </div>
+        {detail.allowed_uses.length > 0 ? (
+          <div className="mt-4">
+            <p className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">Allowed Uses</p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {detail.allowed_uses.map((use) => (
+                <span key={use} className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-bm-text">
+                  {use}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </SectionCard>
+
+      <SectionCard id="approvals" title="Approvals Required" eyebrow="Entitlement Path">
+        <div className="space-y-3">
+          {detail.approvals_required.map((approval) => {
+            const isBlocker = detail.blockers.some((b) => b.toLowerCase().includes(approval.toLowerCase()));
+            return (
+              <div key={approval} className={`rounded-2xl border p-4 ${isBlocker ? "border-red-500/30 bg-red-500/10" : "border-bm-border/60 bg-black/20"}`}>
+                <div className="flex items-center justify-between gap-3">
+                  <p className="font-medium text-bm-text">{approval}</p>
+                  <span className={`rounded-full border px-2 py-1 text-[11px] ${isBlocker ? toneClasses("blocked") : toneClasses("on_track")}`}>
+                    {isBlocker ? "blocked" : "pending"}
+                  </span>
+                </div>
+                {isBlocker ? (
+                  <p className="mt-2 text-sm text-bm-muted2">
+                    {detail.blockers.find((b) => b.toLowerCase().includes(approval.toLowerCase()))}
+                  </p>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      </SectionCard>
+
+      {detail.documents.length > 0 ? (
+        <SectionCard id="documents" title="Zoning Documents" eyebrow="Extracted Intelligence">
+          <div className="grid gap-3 lg:grid-cols-2">
+            {detail.documents.map((document) => (
+              <div key={document.document_id} className="rounded-2xl border border-bm-border/60 bg-black/20 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-medium text-bm-text">{document.title}</p>
+                    <p className="mt-1 text-sm text-bm-muted2">
+                      {document.type} · {fmtDate(document.created_at)}
+                    </p>
+                  </div>
+                  <FileText size={18} className="text-bm-muted2" />
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {document.risk_flags.map((flag) => (
+                    <span key={`${document.document_id}-${flag}`} className={`rounded-full border px-2 py-1 text-[11px] ${toneClasses(flag)}`}>
+                      {flag}
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-4">{renderExtractedJson(document.extracted_json)}</div>
+              </div>
+            ))}
+          </div>
+        </SectionCard>
+      ) : null}
+
+      {detail.linked_project_name ? (
+        <SectionCard id="linked-project" title="Linked Project" eyebrow="Execution">
+          <Link
+            href={`/lab/env/${envId}/operator/projects/${detail.linked_project_id}`}
+            className="block rounded-2xl border border-bm-border/60 bg-black/20 p-4 transition hover:bg-black/30"
+          >
+            <p className="font-medium text-bm-text">{detail.linked_project_name}</p>
+            <p className="mt-1 text-sm text-bm-muted2">View project details, budget, timeline, and vendor breakdown.</p>
+          </Link>
+        </SectionCard>
+      ) : null}
+
+      <SectionCard id="actions" title="Recommended Actions" eyebrow="Next Steps">
+        <div className="space-y-3">
+          {detail.recommended_actions.map((action) => (
+            <div key={action} className="rounded-2xl border border-bm-border/60 bg-black/20 p-4">
+              <p className="text-sm text-bm-text">{action}</p>
             </div>
           ))}
         </div>

--- a/repo-b/src/components/operator/OperatorShell.tsx
+++ b/repo-b/src/components/operator/OperatorShell.tsx
@@ -59,6 +59,20 @@ function anchorSections(pathname: string): AnchorItem[] {
       { id: "upload", label: "Upload + Extract" },
     ];
   }
+  if (pathname.includes("/operator/pipeline/")) {
+    return [
+      { id: "zoning-details", label: "Zoning" },
+      { id: "approvals", label: "Approvals" },
+      { id: "documents", label: "Documents" },
+      { id: "actions", label: "Actions" },
+    ];
+  }
+  if (pathname.includes("/operator/pipeline")) {
+    return [
+      { id: "pipeline-tracker", label: "Tracker" },
+      { id: "high-risk-sites", label: "High Risk" },
+    ];
+  }
   if (pathname.includes("/operator/vendors")) {
     return [
       { id: "spend-aggregation", label: "Spend Aggregation" },
@@ -76,6 +90,7 @@ function anchorSections(pathname: string): AnchorItem[] {
     { id: "overview", label: "Overview" },
     { id: "entity-performance", label: "Entity Performance" },
     { id: "project-risk", label: "Project Risk" },
+    { id: "site-risk", label: "Site Risk" },
     { id: "winston", label: "Winston" },
   ];
 }
@@ -92,6 +107,7 @@ export default function OperatorShell({ envId, children }: OperatorShellProps) {
       { href: `${base}/finance`, label: "Finance" },
       { href: `${base}/projects`, label: "Projects" },
       { href: `${base}/documents`, label: "Documents" },
+      { href: `${base}/pipeline`, label: "Pipeline" },
       { href: `${base}/vendors`, label: "Vendors" },
       { href: `${base}/close`, label: "Close" },
     ],

--- a/repo-b/src/lib/bos-api.ts
+++ b/repo-b/src/lib/bos-api.ts
@@ -805,6 +805,46 @@ export interface OperatorAssistantFocus {
   prompt_suggestions: string[];
 }
 
+export interface OperatorSiteRestrictions {
+  height_limit_ft?: number | null;
+  FAR?: number | null;
+  setback_front_ft?: number | null;
+  setback_side_ft?: number | null;
+  parking_ratio?: string | null;
+  historic_overlay?: boolean;
+  environmental_review_required?: boolean;
+}
+
+export interface OperatorSiteRow {
+  site_id: string;
+  name: string;
+  address?: string | null;
+  city?: string | null;
+  entity_id: string;
+  entity_name: string;
+  zoning_type?: string | null;
+  status: string;
+  predev_cost_to_date: number;
+  predev_budget?: number | null;
+  risk_score: number;
+  risk_level: string;
+  estimated_timeline_days?: number | null;
+  owner?: string | null;
+  summary?: string | null;
+  href?: string | null;
+}
+
+export interface OperatorSiteDetail extends OperatorSiteRow {
+  allowed_uses: string[];
+  restrictions: OperatorSiteRestrictions;
+  approvals_required: string[];
+  blockers: string[];
+  linked_project_id?: string | null;
+  linked_project_name?: string | null;
+  documents: OperatorDocumentSummary[];
+  recommended_actions: string[];
+}
+
 export interface OperatorCommandCenter {
   env_id: string;
   business_id: string;
@@ -817,6 +857,7 @@ export interface OperatorCommandCenter {
   close_tasks: OperatorCloseTaskRow[];
   top_documents: OperatorDocumentSummary[];
   vendor_alerts: OperatorVendorRow[];
+  development_sites: OperatorSiteRow[];
   assistant_focus: OperatorAssistantFocus;
   demo_script: string[];
   improvements: string[];
@@ -8679,6 +8720,18 @@ export function listOperatorVendors(envId: string, businessId?: string): Promise
 
 export function listOperatorCloseTasks(envId: string, businessId?: string): Promise<OperatorCloseTaskRow[]> {
   return bosFetch("/api/operator/v1/close", {
+    params: { env_id: envId, business_id: businessId },
+  });
+}
+
+export function listOperatorSites(envId: string, businessId?: string): Promise<OperatorSiteRow[]> {
+  return bosFetch("/api/operator/v1/sites", {
+    params: { env_id: envId, business_id: businessId },
+  });
+}
+
+export function getOperatorSiteDetail(siteId: string, envId: string, businessId?: string): Promise<OperatorSiteDetail> {
+  return bosFetch(`/api/operator/v1/sites/${siteId}`, {
     params: { env_id: envId, business_id: businessId },
   });
 }


### PR DESCRIPTION
Add development_site as a first-class object in the Hall Boys Operating System
with 3 seeded sites (Main St Parcel HIGH risk, Airport Expansion Site MEDIUM,
Industrial Park Lot LOW), 3 zoning ordinance documents with structured extraction,
Pipeline + Site Intelligence UI pages, operator-specific AI domain block for
grounded non-generic responses, and 7 MCP tools for AI assistant data access.

https://claude.ai/code/session_018h72xodkHX8QH7i5H8wmf6