### PR TITLE
fix(operator): coerce optional metrics to null for type compatibility

### DIFF
--- a/repo-b/src/components/operator/OperatorPages.tsx
+++ b/repo-b/src/components/operator/OperatorPages.tsx
@@ -1414,9 +1414,9 @@ export function OperatorSiteDetailPage({ siteId }: { siteId: string }) {
       visible_data: {
         metrics: {
           predev_cost: detail.predev_cost_to_date,
-          predev_budget: detail.predev_budget,
+          predev_budget: detail.predev_budget ?? null,
           risk_score: detail.risk_score,
-          timeline_days: detail.estimated_timeline_days,
+          timeline_days: detail.estimated_timeline_days ?? null,
         },
         notes: [...detail.blockers, ...detail.recommended_actions],
         site_detail: detail,


### PR DESCRIPTION
predev_budget and estimated_timeline_days are optional (number | null | undefined)
on OperatorSiteDetail, but the assistant page context metrics field requires
string | number | null. Coerce undefined to null with ?? to satisfy the type.

https://claude.ai/code/session_01S2XJciXKgWZyUKAnA4AjnG