### PR TITLE
fix(login): roll back `/` to Mandalore login portal, drop hall-boys from bootstrap

### DIFF
--- a/repo-b/src/app/page.tsx
+++ b/repo-b/src/app/page.tsx
@@ -1,16 +1,10 @@
-import WinstonPublicHome from "@/components/public/WinstonPublicHome";
+import { WinstonLoginPortal } from "@/components/auth/WinstonLoginPortal";
 
-/**
- * Public homepage (`/`).
- *
- * Middleware handling (repo-b/src/middleware.ts:124):
- *   - unauthenticated visitors → render this page
- *   - authenticated visitors   → redirect to /app
- *
- * So this file only ever renders for a first-time / signed-out visitor.
- * Goal: <30-second explanation of Winston + clear CTAs. See WinstonPublicHome
- * for the legibility contract.
- */
-export default function HomePage() {
-  return <WinstonPublicHome />;
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ returnTo?: string }>;
+}) {
+  const resolvedSearchParams = await searchParams;
+  return <WinstonLoginPortal returnTo={resolvedSearchParams?.returnTo || null} />;
 }

--- a/repo-b/src/lib/server/platformAuth.ts
+++ b/repo-b/src/lib/server/platformAuth.ts
@@ -354,31 +354,7 @@ async function bootstrapOwnerMemberships(
         status = 'active',
         updated_at = now()
     `,
-    [platformUserId, ["novendor", "floyorker", "stone-pds", "meridian", "trading", "hall-boys", "ncf"]],
-  );
-
-  // Promote hall-boys to default only when the user has no default yet.
-  // Touching is_default during the bulk upsert above would collide with the
-  // partial unique index `idx_app_env_memberships_default` whenever an
-  // existing default already lives on a different env (see info@novendor.ai).
-  await client.query(
-    `
-      UPDATE app.environment_memberships m
-      SET is_default = true, updated_at = now()
-      FROM app.environments e
-      WHERE m.env_id = e.env_id
-        AND m.platform_user_id = $1::uuid
-        AND m.status = 'active'
-        AND e.slug = 'hall-boys'
-        AND NOT EXISTS (
-          SELECT 1
-          FROM app.environment_memberships existing
-          WHERE existing.platform_user_id = $1::uuid
-            AND existing.is_default = true
-            AND existing.status = 'active'
-        )
-    `,
-    [platformUserId],
+    [platformUserId, ["novendor", "floyorker", "stone-pds", "meridian", "trading", "ncf"]],
   );
 
   if (splitResumeHiddenDomains().has(emailDomain)) {


### PR DESCRIPTION
- `repo-b/src/app/page.tsx` renders `WinstonLoginPortal` again so signed-out
  visitors to paulmalmquist.com land on the Mandalore-font sign-in page with
  no environment cards. Authenticated visitors continue to redirect to `/app`
  via existing middleware, where the workspace list is rendered post-login.
- `repo-b/src/lib/server/platformAuth.ts` no longer bootstraps new admins
  into the `hall-boys` environment and no longer promotes it to their
  default. The slug is not in `SUPPORTED_ENVIRONMENT_SLUGS`, so surfacing it
  as a default was producing a "You do not have access to hall-boys" banner
  on `/app` for users whose is_default landed there.

`WinstonPublicHome.tsx` is left in place (unused) in case we want to bring
the marketing layout back at a non-root URL.

https://claude.ai/code/session_01HgWUApAfoHn9noP7t872HQ