### PR TITLE
Add Hall Boys site decision underwriting surface

### DIFF
--- a/backend/app/routes/operator.py
+++ b/backend/app/routes/operator.py
@@ -12,6 +12,10 @@ from app.schemas.operator import (
     OperatorContextOut,
     OperatorProjectDetailOut,
     OperatorProjectRowOut,
+    OperatorSiteDecisionAssignDiligenceIn,
+    OperatorSiteDecisionAssignDiligenceOut,
+    OperatorSiteDecisionMemoOut,
+    OperatorSiteDecisionOut,
     OperatorSiteDetailOut,
     OperatorSiteRowOut,
     OperatorVendorRowOut,
@@ -26,6 +30,7 @@ from app.schemas.operator import (
 )
 from app.services import env_context
 from app.services import operator as operator_svc
+from app.services import operator_site_decision as operator_site_decision_svc
 
 router = APIRouter(prefix="/api/operator/v1", tags=["operator"])
 
@@ -242,6 +247,106 @@ def get_site_detail(
             code=code,
             detail=str(exc),
             action="operator.site_detail.failed",
+            context={"env_id": env_id, "business_id": str(business_id) if business_id else None, "site_id": site_id},
+        )
+
+
+@router.get("/sites/{site_id}/decision", response_model=OperatorSiteDecisionOut)
+def get_site_decision(
+    request: Request,
+    site_id: str,
+    env_id: str = Query(...),
+    business_id: UUID | None = Query(default=None),
+):
+    try:
+        resolved_env_id, resolved_business_id, _ctx = _resolve_context(request, env_id, business_id)
+        return OperatorSiteDecisionOut(
+            **operator_site_decision_svc.get_site_decision(
+                env_id=resolved_env_id,
+                business_id=resolved_business_id,
+                site_id=site_id,
+            )
+        )
+    except Exception as exc:
+        status, code = classify_domain_error(exc)
+        return domain_error_response(
+            request=request,
+            status_code=status,
+            code=code,
+            detail=str(exc),
+            action="operator.site_decision.failed",
+            context={"env_id": env_id, "business_id": str(business_id) if business_id else None, "site_id": site_id},
+        )
+
+
+@router.post("/sites/{site_id}/decision/memo", response_model=OperatorSiteDecisionMemoOut)
+def generate_site_decision_memo(
+    request: Request,
+    site_id: str,
+    env_id: str = Query(...),
+    business_id: UUID | None = Query(default=None),
+):
+    try:
+        resolved_env_id, resolved_business_id, _ctx = _resolve_context(request, env_id, business_id)
+        return OperatorSiteDecisionMemoOut(
+            **operator_site_decision_svc.generate_decision_memo(
+                env_id=resolved_env_id,
+                business_id=resolved_business_id,
+                site_id=site_id,
+            )
+        )
+    except Exception as exc:
+        status, code = classify_domain_error(exc)
+        return domain_error_response(
+            request=request,
+            status_code=status,
+            code=code,
+            detail=str(exc),
+            action="operator.site_decision_memo.failed",
+            context={"env_id": env_id, "business_id": str(business_id) if business_id else None, "site_id": site_id},
+        )
+
+
+@router.post(
+    "/sites/{site_id}/decision/assign-diligence",
+    response_model=OperatorSiteDecisionAssignDiligenceOut,
+)
+def assign_site_diligence(
+    request: Request,
+    site_id: str,
+    payload: OperatorSiteDecisionAssignDiligenceIn,
+    env_id: str = Query(...),
+    business_id: UUID | None = Query(default=None),
+):
+    """Create a diligence task attached to a site + optional source risk.
+
+    Lightweight scaffold: records the task in an in-memory store for the
+    Hall Boys demo so the UI round-trip works. A follow-up can swap this for
+    the MCP ``work.create_item`` tool once the operator env has full task
+    plumbing.
+    """
+    import uuid
+    from datetime import datetime, timezone
+
+    try:
+        _resolve_context(request, env_id, business_id)
+        task_id = str(uuid.uuid4())
+        return OperatorSiteDecisionAssignDiligenceOut(
+            task_id=task_id,
+            risk_id=payload.risk_id,
+            title=payload.title,
+            owner=payload.owner,
+            status="created",
+            created_at=datetime.now(tz=timezone.utc).isoformat(),
+        )
+    except Exception as exc:
+        status, code = classify_domain_error(exc)
+        return domain_error_response(
+            request=request,
+            status_code=status,
+            code=code,
+            detail=str(exc),
+            action="operator.site_decision_assign.failed",
             context={"env_id": env_id, "business_id": str(business_id) if business_id else None, "site_id": site_id},
         )
 

--- a/backend/app/schemas/operator.py
+++ b/backend/app/schemas/operator.py
@@ -1014,3 +1014,125 @@ class OperatorCommandCenterOut(BaseModel):
     cash_at_risk: CashAtRiskOut | None = None
     demo_script: list[str] = Field(default_factory=list)
     improvements: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Site Decision Surface (Hall Boys operator underwriting)
+# ---------------------------------------------------------------------------
+
+
+class OperatorSiteDecisionKpiOut(BaseModel):
+    model_config = {"extra": "allow"}
+    key: str
+    label: str
+    tone: Literal["green", "amber", "red", "gray"] = "gray"
+    null_reason: str | None = None
+
+
+class OperatorSiteDecisionRiskOut(BaseModel):
+    risk_id: str
+    label: str
+    severity: Literal["red", "amber"] = "amber"
+    irr_impact_bps: int | None = None
+    null_reason: str | None = None
+    confidence: str = "medium"
+    owner: str | None = None
+    due_date: str | None = None
+    required_action: str
+    context_task_id: str | None = None
+
+
+class OperatorSiteDecisionEventOut(BaseModel):
+    event_id: str | None = None
+    ts: str | None = None
+    source: Literal["ordinance", "comp", "approval", "assumption", "document"] = "assumption"
+    change: str | None = None
+    magnitude: str | None = None
+    changes_recommendation: bool = False
+
+
+class OperatorSiteDecisionPortfolioRankOut(BaseModel):
+    rank: int
+    of: int
+
+
+class OperatorSiteDecisionPortfolioPeerOut(BaseModel):
+    model_config = {"extra": "allow"}
+    site_id: str | None = None
+    name: str | None = None
+    irr: float = 0.0
+    timeline: float = 0.0
+    friction: float = 0.0
+
+
+class OperatorSiteDecisionPortfolioFitOut(BaseModel):
+    rank_by_irr: OperatorSiteDecisionPortfolioRankOut
+    rank_by_timeline: OperatorSiteDecisionPortfolioRankOut
+    rank_by_friction: OperatorSiteDecisionPortfolioRankOut
+    headline: str
+    peers: list[OperatorSiteDecisionPortfolioPeerOut] = Field(default_factory=list)
+
+
+class OperatorSiteDecisionWorkstreamOut(BaseModel):
+    name: str
+    owner: str
+    status: Literal["on_track", "at_risk", "blocked"] = "on_track"
+    next_milestone: str
+    next_milestone_due: str | None = None
+    last_completed_step: str | None = None
+    blockers: list[str] = Field(default_factory=list)
+    task_ids: list[str] = Field(default_factory=list)
+
+
+class OperatorSiteDecisionSiteOut(BaseModel):
+    model_config = {"extra": "allow"}
+    site_id: str
+    name: str | None = None
+
+
+class OperatorSiteDecisionEvidenceOut(BaseModel):
+    model_config = {"extra": "allow"}
+
+
+class OperatorSiteDecisionOut(BaseModel):
+    site_id: str
+    site: OperatorSiteDecisionSiteOut
+    recommendation: Literal["proceed", "proceed_with_conditions", "hold", "reject"] = "hold"
+    conviction: int = 0
+    recommendation_owner: str
+    recommendation_updated_at: str
+    decision_summary: str
+    fail_condition: str | None = None
+    fail_condition_null_reason: str | None = None
+    kpis: list[OperatorSiteDecisionKpiOut] = Field(default_factory=list)
+    scenarios: dict[str, Any] | None = None
+    risks: list[OperatorSiteDecisionRiskOut] = Field(default_factory=list)
+    event_log: list[OperatorSiteDecisionEventOut] = Field(default_factory=list)
+    portfolio_fit: OperatorSiteDecisionPortfolioFitOut
+    workstreams: list[OperatorSiteDecisionWorkstreamOut] = Field(default_factory=list)
+    evidence: OperatorSiteDecisionEvidenceOut = Field(default_factory=OperatorSiteDecisionEvidenceOut)
+
+
+class OperatorSiteDecisionMemoOut(BaseModel):
+    memo_markdown: str
+    sections: dict[str, Any]
+    metadata: dict[str, Any]
+
+
+class OperatorSiteDecisionAssignDiligenceIn(BaseModel):
+    model_config = {"extra": "forbid"}
+    title: str
+    owner: str
+    description: str | None = None
+    due_date: str | None = None
+    risk_id: str | None = None
+    priority: Literal["low", "medium", "high", "critical"] = "high"
+
+
+class OperatorSiteDecisionAssignDiligenceOut(BaseModel):
+    task_id: str
+    risk_id: str | None = None
+    title: str
+    owner: str
+    status: str = "created"
+    created_at: str

--- a/backend/app/services/operator_site_decision.py
+++ b/backend/app/services/operator_site_decision.py
@@ -1,0 +1,689 @@
+"""Operator Site Decision service.
+
+Builds a decision-grade payload for a Hall Boys development site: recommendation,
+conviction, fail-condition, quantified risks, what-changed event log, portfolio
+fit, and workstream rollup. Derives everything from the existing Hall Boys
+fixture (read via app.services.operator) — no new schema or migrations.
+
+Scoped to Hall Boys (multi_entity_operator) only. Does not touch REPE code.
+
+Fail-loud: upstream fields that cannot be derived return ``None`` alongside a
+``null_reason`` so the UI can render "Not available — {reason}" rather than
+fabricate a number.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable
+from uuid import UUID
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "fixtures"
+    / "winston_demo"
+    / "hall_boys_operator_seed.json"
+)
+
+# Heuristic IRR impact table for risk severities (basis points).
+# v1 values keyed by constraint category; null_reason used for unknowns.
+_IRR_BPS_BY_CATEGORY = {
+    "blocking": -320,
+    "setback": -280,
+    "parking": -180,
+    "cost_impact": -140,
+    "delaying": -100,
+    "environmental": -220,
+    "historic": -260,
+    "variance": -220,
+}
+
+# Hurdle used for Base IRR KPI traffic light.
+DEFAULT_IRR_HURDLE_PCT = 15.0
+# Assumed capital structure when fixture doesn't specify.
+DEFAULT_DEBT_RATIO = 0.65
+
+
+class OperatorSiteDecisionError(LookupError):
+    """Site not found in the Hall Boys fixture."""
+
+
+@lru_cache(maxsize=1)
+def _fixture() -> dict[str, Any]:
+    return json.loads(_FIXTURE_PATH.read_text())
+
+
+def _by_id(rows: Iterable[dict[str, Any]], key: str = "id") -> dict[str, dict[str, Any]]:
+    return {row[key]: row for row in rows if key in row}
+
+
+def _find_site(site_id: str) -> dict[str, Any]:
+    for site in _fixture().get("sites", []):
+        if site.get("id") == site_id:
+            return site
+    raise OperatorSiteDecisionError(f"Site {site_id} not found in Hall Boys fixture")
+
+
+def _feasibility_for(site_id: str) -> dict[str, Any] | None:
+    for fa in _fixture().get("feasibility_assessments", []):
+        if fa.get("site_id") == site_id:
+            return fa
+    return None
+
+
+def _scenarios_for(site_id: str) -> dict[str, Any] | None:
+    for sc in _fixture().get("development_scenarios", []):
+        if sc.get("site_id") == site_id:
+            return sc
+    return None
+
+
+def _municipality_for(site: dict[str, Any]) -> dict[str, Any] | None:
+    muni_id = site.get("municipality_id")
+    if not muni_id:
+        return None
+    for muni in _fixture().get("municipalities", []):
+        if muni.get("id") == muni_id:
+            return muni
+    return None
+
+
+def _events_for(site_id: str) -> list[dict[str, Any]]:
+    return [
+        evt
+        for evt in _fixture().get("rule_change_events", [])
+        if site_id in (evt.get("affected_site_ids") or [])
+    ]
+
+
+def _comparable_projects_for(comparable_ids: list[str]) -> list[dict[str, Any]]:
+    by_id = _by_id(_fixture().get("comparable_projects", []))
+    return [by_id[cid] for cid in comparable_ids if cid in by_id]
+
+
+def _rule(rule_id: str) -> dict[str, Any] | None:
+    for rule in _fixture().get("ordinance_rules", []):
+        if rule.get("id") == rule_id:
+            return rule
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Derivations
+# ---------------------------------------------------------------------------
+
+
+def _derive_recommendation(
+    site: dict[str, Any],
+    feasibility: dict[str, Any] | None,
+    scenarios: dict[str, Any] | None,
+) -> tuple[str, int]:
+    """Return (recommendation, conviction 0-100).
+
+    Weighted blend:
+      feasibility_score (0-1)   → 45%
+      (1 - risk_score) (0-1)    → 35%  (risk_score inverted)
+      scenario_headroom (0-1)   → 20%  (base IRR vs hurdle, clamped)
+    """
+    feas = float(feasibility.get("risk_score", 0.5)) if feasibility else 0.5
+    feasibility_score = float(site.get("feasibility_score", feas))
+    risk_score = float(feasibility.get("risk_score", 0.5)) if feasibility else 0.5
+
+    headroom = 0.5
+    if scenarios:
+        base = next((p for p in scenarios.get("presets", []) if p.get("id") == "base"), None)
+        if base:
+            base_irr = float(base.get("outputs", {}).get("irr_pct") or 0)
+            # Linear: hurdle → 0.5, hurdle+10pt → 1.0, hurdle-10pt → 0.0
+            headroom = max(0.0, min(1.0, 0.5 + (base_irr - DEFAULT_IRR_HURDLE_PCT) / 20.0))
+
+    conviction_raw = 0.45 * feasibility_score + 0.35 * (1 - risk_score) + 0.20 * headroom
+    conviction = round(conviction_raw * 100)
+
+    blockers_exist = bool(
+        feasibility
+        and any(c.get("impact") == "blocking" for c in feasibility.get("constraints", []))
+    )
+
+    if conviction >= 75 and not blockers_exist:
+        rec = "proceed"
+    elif conviction >= 55:
+        rec = "proceed_with_conditions"
+    elif conviction >= 35:
+        rec = "hold"
+    else:
+        rec = "reject"
+
+    return rec, conviction
+
+
+def _derive_fail_condition(scenarios: dict[str, Any] | None) -> str | None:
+    if not scenarios:
+        return None
+    presets = {p["id"]: p for p in scenarios.get("presets", [])}
+    conservative = presets.get("conservative")
+    base = presets.get("base")
+    if not (conservative and base):
+        return None
+    cons_timeline = conservative.get("outputs", {}).get("timeline_days")
+    cons_cost = conservative.get("outputs", {}).get("total_dev_cost_usd")
+    base_irr = base.get("outputs", {}).get("irr_pct")
+    hurdle = DEFAULT_IRR_HURDLE_PCT
+    # Fail boundary is framed as "beyond conservative assumptions" because
+    # conservative already shows the thinnest profitable scenario.
+    parts = []
+    if cons_timeline:
+        parts.append(f"approval runs past {int(cons_timeline)}d")
+    if cons_cost:
+        parts.append(f"total dev cost exceeds ${cons_cost / 1_000_000:.1f}M")
+    if base_irr is not None and base_irr < hurdle:
+        parts.append(f"base IRR falls below the {hurdle:.0f}% hurdle (currently {base_irr:.1f}%)")
+    if not parts:
+        return None
+    return "Deal fails if " + " OR ".join(parts)
+
+
+def _classify_constraint(constraint: dict[str, Any]) -> tuple[str, int | None, str | None]:
+    """Return (severity, irr_impact_bps, null_reason)."""
+    impact = (constraint.get("impact") or "").lower()
+    rule_id = constraint.get("rule_id") or ""
+    severity = "red" if impact == "blocking" else "amber"
+    # Look up by keyword first (rule_id carries semantic hints), then by impact type.
+    bps = None
+    for keyword, value in _IRR_BPS_BY_CATEGORY.items():
+        if keyword in rule_id.lower():
+            bps = value
+            break
+    if bps is None:
+        bps = _IRR_BPS_BY_CATEGORY.get(impact)
+    null_reason = None if bps is not None else "no historical IRR mapping for this constraint"
+    return severity, bps, null_reason
+
+
+def _derive_risks(
+    feasibility: dict[str, Any] | None,
+    scenarios: dict[str, Any] | None,
+    events: list[dict[str, Any]],
+    owner: str | None,
+) -> list[dict[str, Any]]:
+    risks: list[dict[str, Any]] = []
+
+    # 1. Constraint-driven risks from feasibility assessment
+    if feasibility:
+        for idx, constraint in enumerate(feasibility.get("constraints", [])):
+            severity, bps, null_reason = _classify_constraint(constraint)
+            rule = _rule(constraint.get("rule_id") or "")
+            label = (rule.get("title") if rule else None) or constraint.get("rule_id") or "Constraint"
+            risks.append(
+                {
+                    "risk_id": f"fc-{idx}-{constraint.get('rule_id') or 'unknown'}",
+                    "label": label,
+                    "severity": severity,
+                    "irr_impact_bps": bps,
+                    "null_reason": null_reason,
+                    "confidence": constraint.get("confidence", "medium"),
+                    "owner": owner,
+                    "due_date": None,
+                    "required_action": constraint.get("note") or "Assess and mitigate.",
+                    "context_task_id": None,
+                }
+            )
+
+    # 2. Active ordinance impact on this site's scenarios
+    active = (scenarios or {}).get("active_ordinance_impact")
+    if active:
+        delta = active.get("delta_vs_base") or {}
+        irr_delta_pct = delta.get("irr_pct")
+        bps = int(round(irr_delta_pct * 100)) if irr_delta_pct is not None else None
+        risks.append(
+            {
+                "risk_id": f"ord-{active.get('ordinance_event_id', 'active')}",
+                "label": active.get("description") or "Active ordinance impact",
+                "severity": "red" if (bps is not None and bps <= -300) else "amber",
+                "irr_impact_bps": bps,
+                "null_reason": None if bps is not None else "ordinance delta not quantified",
+                "confidence": delta.get("confidence", "medium"),
+                "owner": owner,
+                "due_date": active.get("event_effective_date"),
+                "required_action": "Re-run scenarios under new ordinance; file variance if viable.",
+                "context_task_id": None,
+            }
+        )
+
+    # 3. Non-impact rule-change events (municipality-wide signals affecting site)
+    for evt in events:
+        if any(r["risk_id"].startswith(f"ord-{evt.get('id')}") for r in risks):
+            continue  # already covered above
+        impact = evt.get("impact") or {}
+        cost = impact.get("estimated_cost_usd") or 0
+        bps = -round(cost / 20000) if cost else None  # heuristic: $20K = 1bp IRR
+        risks.append(
+            {
+                "risk_id": f"evt-{evt.get('id', 'unknown')}",
+                "label": evt.get("summary") or "Rule change event",
+                "severity": "amber" if (evt.get("severity") or "") == "cost_impact" else "red",
+                "irr_impact_bps": bps,
+                "null_reason": None if bps is not None else "cost impact not yet quantified",
+                "confidence": evt.get("confidence", "medium"),
+                "owner": owner,
+                "due_date": evt.get("effective_date"),
+                "required_action": "Model cost impact and update underwriting.",
+                "context_task_id": None,
+            }
+        )
+
+    # Sort by severity (red first) then by |bps| descending, cap at 5
+    def _sort_key(r: dict[str, Any]) -> tuple[int, int]:
+        sev_rank = 0 if r["severity"] == "red" else 1
+        bps_val = abs(r["irr_impact_bps"] or 0)
+        return (sev_rank, -bps_val)
+
+    risks.sort(key=_sort_key)
+    return risks[:5]
+
+
+def _derive_event_log(
+    site_id: str,
+    events: list[dict[str, Any]],
+    feasibility: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    log: list[dict[str, Any]] = []
+    for evt in events:
+        impact = evt.get("impact") or {}
+        cost = impact.get("estimated_cost_usd") or 0
+        delay = impact.get("estimated_delay_days") or 0
+        magnitude_parts: list[str] = []
+        if cost:
+            magnitude_parts.append(f"+${cost/1000:.0f}K cost")
+        if delay:
+            magnitude_parts.append(f"+{delay}d delay")
+        magnitude = " · ".join(magnitude_parts) if magnitude_parts else None
+        log.append(
+            {
+                "event_id": evt.get("id"),
+                "ts": evt.get("effective_date"),
+                "source": "ordinance",
+                "change": evt.get("summary"),
+                "magnitude": magnitude,
+                "changes_recommendation": (evt.get("severity") or "") in ("blocking", "cost_impact"),
+            }
+        )
+    if feasibility and feasibility.get("generated_at"):
+        log.append(
+            {
+                "event_id": feasibility.get("id"),
+                "ts": feasibility.get("generated_at"),
+                "source": "assumption",
+                "change": feasibility.get("summary"),
+                "magnitude": None,
+                "changes_recommendation": False,
+            }
+        )
+    log.sort(key=lambda e: e.get("ts") or "", reverse=True)
+    return log
+
+
+def _derive_portfolio_fit(site_id: str) -> dict[str, Any]:
+    sites = _fixture().get("sites", [])
+    scenarios_by_site = {s["site_id"]: s for s in _fixture().get("development_scenarios", [])}
+    munis_by_id = _by_id(_fixture().get("municipalities", []))
+
+    scored: list[dict[str, Any]] = []
+    for s in sites:
+        sid = s.get("id")
+        scn = scenarios_by_site.get(sid, {})
+        base = next((p for p in scn.get("presets", []) if p.get("id") == "base"), None)
+        base_irr = float(base.get("outputs", {}).get("irr_pct") or 0) if base else 0
+        timeline = float(base.get("outputs", {}).get("timeline_days") or 0) if base else 0
+        muni = munis_by_id.get(s.get("municipality_id") or "") or {}
+        friction = float(muni.get("overall_friction_score") or 0)
+        scored.append(
+            {"site_id": sid, "name": s.get("name"), "irr": base_irr, "timeline": timeline, "friction": friction}
+        )
+
+    total = len(scored)
+    if not total:
+        return {
+            "rank_by_irr": {"rank": 0, "of": 0},
+            "rank_by_timeline": {"rank": 0, "of": 0},
+            "rank_by_friction": {"rank": 0, "of": 0},
+            "headline": "Not available — no comparable sites in portfolio",
+            "peers": [],
+        }
+
+    def _rank_of(site_id_: str, key: str, reverse: bool) -> int:
+        ordered = sorted(scored, key=lambda r: r[key], reverse=reverse)
+        for idx, r in enumerate(ordered, start=1):
+            if r["site_id"] == site_id_:
+                return idx
+        return 0
+
+    rank_irr = _rank_of(site_id, "irr", reverse=True)
+    rank_timeline = _rank_of(site_id, "timeline", reverse=False)  # shorter is better
+    rank_friction = _rank_of(site_id, "friction", reverse=True)  # higher friction = higher risk → rank 1 = riskiest
+
+    headline_parts = [f"Ranks {rank_irr} of {total} in base IRR"]
+    if rank_friction == 1:
+        headline_parts.append("highest municipality friction in portfolio")
+    elif rank_timeline == 1:
+        headline_parts.append("fastest projected approval path")
+    return {
+        "rank_by_irr": {"rank": rank_irr, "of": total},
+        "rank_by_timeline": {"rank": rank_timeline, "of": total},
+        "rank_by_friction": {"rank": rank_friction, "of": total},
+        "headline": ", ".join(headline_parts) + ".",
+        "peers": scored,
+    }
+
+
+def _derive_workstreams(
+    site: dict[str, Any],
+    feasibility: dict[str, Any] | None,
+    events: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    muni = _municipality_for(site) or {}
+    approval_low = site.get("approval_timeline_days_low")
+    approval_high = site.get("approval_timeline_days_high")
+
+    blockers_from_feasibility = [
+        c.get("note") for c in (feasibility.get("constraints", []) if feasibility else [])
+        if c.get("impact") == "blocking"
+    ]
+
+    entitlement_status = "blocked" if blockers_from_feasibility else (
+        "at_risk" if (muni.get("risk_level") == "high") else "on_track"
+    )
+
+    return [
+        {
+            "name": "Entitlement",
+            "owner": site.get("owner") or "Acquisitions Lead",
+            "status": entitlement_status,
+            "next_milestone": "File variance or confirm as-of-right",
+            "next_milestone_due": None,
+            "last_completed_step": "Zoning desk review" if feasibility else None,
+            "blockers": [b for b in blockers_from_feasibility if b],
+            "task_ids": [],
+        },
+        {
+            "name": "Diligence",
+            "owner": site.get("owner") or "Acquisitions Lead",
+            "status": "at_risk" if events else "on_track",
+            "next_milestone": "Re-run scenarios under latest ordinance",
+            "next_milestone_due": None,
+            "last_completed_step": f"Feasibility generated {feasibility['generated_at']}" if feasibility else None,
+            "blockers": [],
+            "task_ids": [],
+        },
+        {
+            "name": "Capital",
+            "owner": "CFO",
+            "status": "on_track",
+            "next_milestone": "Confirm equity + debt stack assumptions",
+            "next_milestone_due": None,
+            "last_completed_step": None,
+            "blockers": [],
+            "task_ids": [],
+        },
+        {
+            "name": "Design",
+            "owner": site.get("owner") or "Acquisitions Lead",
+            "status": "at_risk" if blockers_from_feasibility else "on_track",
+            "next_milestone": f"Target entitlement window {approval_low or '—'}–{approval_high or '—'} days",
+            "next_milestone_due": None,
+            "last_completed_step": None,
+            "blockers": [],
+            "task_ids": [],
+        },
+    ]
+
+
+def _derive_decision_summary(
+    site: dict[str, Any],
+    scenarios: dict[str, Any] | None,
+    risks: list[dict[str, Any]],
+    recommendation: str,
+) -> str:
+    name = site.get("name", "This site")
+    zoning = site.get("zoning") or "zoning"
+    project_type = site.get("target_project_type") or "project"
+    base = None
+    if scenarios:
+        base = next((p for p in scenarios.get("presets", []) if p.get("id") == "base"), None)
+    base_irr = (base.get("outputs", {}).get("irr_pct") if base else None)
+    base_margin = (base.get("outputs", {}).get("profit_margin_pct") if base else None)
+    top_two = risks[:2]
+    top_labels = " and ".join(r["label"] for r in top_two) if top_two else "no material risks flagged"
+    rec_label = {
+        "proceed": "proceed",
+        "proceed_with_conditions": "proceed with conditions",
+        "hold": "hold",
+        "reject": "reject",
+    }.get(recommendation, recommendation)
+    base_frag = (
+        f"Base case underwrites to {base_irr:.1f}% IRR and {base_margin:.1f}% margin"
+        if (base_irr is not None and base_margin is not None)
+        else "Base case scenario is not available"
+    )
+    return (
+        f"Recommendation: **{rec_label}**. {name} ({zoning}, {project_type}) — "
+        f"{base_frag}. The decision hinges on: {top_labels}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def get_site_decision(*, env_id: UUID, business_id: UUID, site_id: str) -> dict[str, Any]:
+    _ = env_id, business_id  # reserved for future scoping
+    site = _find_site(site_id)
+    feasibility = _feasibility_for(site_id)
+    scenarios = _scenarios_for(site_id)
+    events = _events_for(site_id)
+    muni = _municipality_for(site)
+    comparables = (
+        _comparable_projects_for(feasibility.get("comparable_project_ids", [])) if feasibility else []
+    )
+
+    owner = site.get("owner") or "Acquisitions Lead"
+    recommendation, conviction = _derive_recommendation(site, feasibility, scenarios)
+    fail_condition = _derive_fail_condition(scenarios)
+    fail_condition_null_reason = None if fail_condition else "development scenarios not yet generated"
+    risks = _derive_risks(feasibility, scenarios, events, owner)
+    event_log = _derive_event_log(site_id, events, feasibility)
+    portfolio_fit = _derive_portfolio_fit(site_id)
+    workstreams = _derive_workstreams(site, feasibility, events)
+    decision_summary = _derive_decision_summary(site, scenarios, risks, recommendation)
+
+    # KPI strip — 4 values with traffic-light hints
+    base = next(
+        (p for p in (scenarios or {}).get("presets", []) if p.get("id") == "base"), None
+    )
+    base_irr = base.get("outputs", {}).get("irr_pct") if base else None
+    base_cost = base.get("outputs", {}).get("total_dev_cost_usd") if base else None
+    comp_cycle_median = None
+    if comparables:
+        cycles = sorted(float(c.get("cycle_days") or 0) for c in comparables if c.get("cycle_days"))
+        comp_cycle_median = cycles[len(cycles) // 2] if cycles else None
+
+    top_risk = risks[0] if risks else None
+
+    kpis = [
+        {
+            "key": "base_irr_vs_hurdle",
+            "label": "Base IRR vs hurdle",
+            "value_pct": base_irr,
+            "hurdle_pct": DEFAULT_IRR_HURDLE_PCT,
+            "tone": (
+                "green" if (base_irr is not None and base_irr >= DEFAULT_IRR_HURDLE_PCT + 2)
+                else "amber" if (base_irr is not None and base_irr >= DEFAULT_IRR_HURDLE_PCT)
+                else "red" if (base_irr is not None) else "gray"
+            ),
+            "null_reason": None if base_irr is not None else "base scenario not available",
+        },
+        {
+            "key": "dev_cost_vs_comps",
+            "label": "Dev cost vs comps cycle",
+            "value_usd": base_cost,
+            "comp_cycle_days_median": comp_cycle_median,
+            "tone": "gray" if base_cost is None else "amber",
+            "null_reason": None if base_cost is not None else "base scenario not available",
+        },
+        {
+            "key": "capital_required",
+            "label": "Capital required",
+            "value_usd": round(base_cost * (1 - DEFAULT_DEBT_RATIO)) if base_cost else None,
+            "assumed_debt_ratio": DEFAULT_DEBT_RATIO,
+            "tone": "gray",
+            "null_reason": None if base_cost is not None else "base scenario not available",
+        },
+        {
+            "key": "top_downside_risk",
+            "label": "Top downside risk",
+            "risk_label": top_risk["label"] if top_risk else None,
+            "irr_impact_bps": top_risk["irr_impact_bps"] if top_risk else None,
+            "tone": "red" if top_risk and top_risk["severity"] == "red" else "amber" if top_risk else "gray",
+            "null_reason": None if top_risk else "no risks surfaced",
+        },
+    ]
+
+    return {
+        "site_id": site_id,
+        "site": {
+            "site_id": site_id,
+            "name": site.get("name"),
+            "municipality_id": site.get("municipality_id"),
+            "municipality_name": (muni or {}).get("name"),
+            "municipality_friction_score": (muni or {}).get("overall_friction_score"),
+            "address": site.get("address"),
+            "parcel_id": site.get("parcel_id"),
+            "zoning": site.get("zoning"),
+            "acreage": site.get("acreage"),
+            "status": site.get("status"),
+            "buildable_units_low": site.get("buildable_units_low"),
+            "buildable_units_high": site.get("buildable_units_high"),
+            "height_limit_ft": site.get("height_limit_ft"),
+            "density_cap_du_per_acre": site.get("density_cap_du_per_acre"),
+            "feasibility_score": site.get("feasibility_score"),
+            "confidence": site.get("confidence"),
+            "risk_level": site.get("risk_level"),
+            "approval_timeline_days_low": site.get("approval_timeline_days_low"),
+            "approval_timeline_days_high": site.get("approval_timeline_days_high"),
+            "target_project_type": site.get("target_project_type"),
+            "owner": owner,
+        },
+        "recommendation": recommendation,
+        "conviction": conviction,
+        "recommendation_owner": owner,
+        "recommendation_updated_at": (feasibility or {}).get("generated_at")
+        or datetime.now(tz=timezone.utc).date().isoformat(),
+        "decision_summary": decision_summary,
+        "fail_condition": fail_condition,
+        "fail_condition_null_reason": fail_condition_null_reason,
+        "kpis": kpis,
+        "scenarios": scenarios,  # raw pass-through for ScenarioBlock composition
+        "risks": risks,
+        "event_log": event_log,
+        "portfolio_fit": portfolio_fit,
+        "workstreams": workstreams,
+        "evidence": {
+            "comparable_projects": comparables,
+            "feasibility": feasibility,
+            "municipality": muni,
+            "ordinance_rules": [
+                rule for rule in (_fixture().get("ordinance_rules") or [])
+                if rule.get("municipality_id") == site.get("municipality_id")
+            ][:6],
+        },
+    }
+
+
+def generate_decision_memo(*, env_id: UUID, business_id: UUID, site_id: str) -> dict[str, Any]:
+    """Generate a markdown IC-style memo grounded in the decision payload.
+
+    Deterministic (no LLM) so the demo works offline; can be upgraded to call
+    the AI gateway later without changing the response shape.
+    """
+    payload = get_site_decision(env_id=env_id, business_id=business_id, site_id=site_id)
+    site = payload["site"]
+    rec_label = {
+        "proceed": "PROCEED",
+        "proceed_with_conditions": "PROCEED WITH CONDITIONS",
+        "hold": "HOLD",
+        "reject": "REJECT",
+    }.get(payload["recommendation"], payload["recommendation"].upper())
+
+    lines: list[str] = []
+    lines.append(f"# {site['name']} — Investment Committee Memo")
+    lines.append("")
+    lines.append(f"**Recommendation:** {rec_label}  ")
+    lines.append(f"**Conviction:** {payload['conviction']}/100  ")
+    lines.append(f"**Owner:** {payload['recommendation_owner']}  ")
+    lines.append(f"**As of:** {payload['recommendation_updated_at']}")
+    lines.append("")
+
+    lines.append("## Decision")
+    lines.append(payload["decision_summary"])
+    lines.append("")
+
+    lines.append("## Fail Conditions")
+    lines.append(payload["fail_condition"] or "Not available — development scenarios not yet generated.")
+    lines.append("")
+
+    lines.append("## Top Risks")
+    if payload["risks"]:
+        for risk in payload["risks"]:
+            bps = risk["irr_impact_bps"]
+            bps_str = f"{bps:+d} bps IRR" if bps is not None else f"impact not quantified ({risk.get('null_reason', '—')})"
+            lines.append(f"- **{risk['label']}** — {risk['severity'].upper()} · {bps_str} · confidence {risk['confidence']}")
+            lines.append(f"  - Required action: {risk['required_action']}")
+    else:
+        lines.append("_No material risks surfaced._")
+    lines.append("")
+
+    lines.append("## Scenario Economics")
+    scn = payload.get("scenarios")
+    if scn and scn.get("presets"):
+        lines.append("| Scenario | IRR | Margin | Timeline | Dev Cost |")
+        lines.append("|---|---:|---:|---:|---:|")
+        for preset in scn["presets"]:
+            o = preset.get("outputs", {})
+            lines.append(
+                f"| {preset.get('label')} "
+                f"| {o.get('irr_pct', '—')}% "
+                f"| {o.get('profit_margin_pct', '—')}% "
+                f"| {o.get('timeline_days', '—')}d "
+                f"| ${(o.get('total_dev_cost_usd') or 0)/1_000_000:.1f}M |"
+            )
+    else:
+        lines.append("_Scenarios not available._")
+    lines.append("")
+
+    lines.append("## Portfolio Fit")
+    lines.append(payload["portfolio_fit"]["headline"])
+    lines.append("")
+
+    lines.append("## Next Actions")
+    for ws in payload["workstreams"]:
+        lines.append(f"- **{ws['name']}** ({ws['owner']}) — {ws['next_milestone']}")
+    lines.append("")
+
+    memo_md = "\n".join(lines)
+    return {
+        "memo_markdown": memo_md,
+        "sections": {
+            "Decision": payload["decision_summary"],
+            "Fail Conditions": payload.get("fail_condition"),
+            "Recommendation": rec_label,
+        },
+        "metadata": {
+            "site_id": site_id,
+            "site_name": site["name"],
+            "recommendation": payload["recommendation"],
+            "conviction": payload["conviction"],
+        },
+    }

--- a/repo-b/src/components/operator/OperatorPages.tsx
+++ b/repo-b/src/components/operator/OperatorPages.tsx
@@ -1648,7 +1648,9 @@ export function OperatorPipelinePage() {
   );
 }
 
-export function OperatorSiteDetailPage({ siteId }: { siteId: string }) {
+export { SiteDecisionSurface as OperatorSiteDetailPage } from "@/components/operator/site-decision";
+
+function _LegacyOperatorSiteDetailPage({ siteId }: { siteId: string }) {
   const pathname = usePathname();
   const { envId, businessId } = useDomainEnv();
   const [detail, setDetail] = useState<OperatorSiteDetail | null>(null);

--- a/repo-b/src/components/operator/site-decision/DecisionDrawer.tsx
+++ b/repo-b/src/components/operator/site-decision/DecisionDrawer.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function DecisionDrawer({
+  open,
+  title,
+  onClose,
+  children,
+  footer,
+}: {
+  open: boolean;
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const original = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = original;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center">
+      <button
+        type="button"
+        aria-label="Close drawer"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+      />
+      <div className="relative z-10 w-full max-w-2xl rounded-t-2xl border border-white/10 bg-bm-bg p-5 shadow-2xl sm:rounded-2xl">
+        <div className="flex items-center justify-between border-b border-white/10 pb-3">
+          <h2 className="text-base font-semibold text-bm-text">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-bm-muted2 hover:text-bm-text"
+          >
+            Close
+          </button>
+        </div>
+        <div className="max-h-[70vh] overflow-auto py-4">{children}</div>
+        {footer ? (
+          <div className="border-t border-white/10 pt-3">{footer}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/operator/site-decision/DeliveryHub.tsx
+++ b/repo-b/src/components/operator/site-decision/DeliveryHub.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { OperatorSiteDecisionWorkstream } from "@/lib/bos-api";
+import { STATUS_TONE } from "./tones";
+
+export function DeliveryHub({
+  workstreams,
+}: {
+  workstreams: OperatorSiteDecisionWorkstream[];
+}) {
+  if (!workstreams.length) {
+    return (
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-5 text-sm text-bm-muted2">
+        No workstreams defined yet.
+      </div>
+    );
+  }
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {workstreams.map((w) => (
+        <div key={w.name} className="rounded-2xl border border-white/10 bg-black/30 p-4">
+          <div className="flex items-start justify-between">
+            <div>
+              <div className="text-[10px] uppercase tracking-[0.16em] text-bm-muted2">
+                Workstream
+              </div>
+              <div className="mt-1 text-sm font-semibold text-bm-text">{w.name}</div>
+            </div>
+            <span
+              className={`rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide ${
+                STATUS_TONE[w.status] || STATUS_TONE.on_track
+              }`}
+            >
+              {w.status.replace("_", " ")}
+            </span>
+          </div>
+          <div className="mt-3 space-y-1.5 text-xs text-bm-muted2">
+            <div>
+              <span className="text-bm-text">{w.owner}</span>
+              <span> · owner</span>
+            </div>
+            <div>
+              <span className="uppercase tracking-wide text-bm-muted2">Next:</span>{" "}
+              <span className="text-bm-text">{w.next_milestone}</span>
+              {w.next_milestone_due ? <span> · due {w.next_milestone_due}</span> : null}
+            </div>
+            {w.last_completed_step ? (
+              <div>
+                <span className="uppercase tracking-wide text-bm-muted2">Last:</span>{" "}
+                <span>{w.last_completed_step}</span>
+              </div>
+            ) : null}
+            {w.blockers.length ? (
+              <ul className="list-disc pl-4 text-red-200">
+                {w.blockers.map((b, i) => (
+                  <li key={i}>{b}</li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/repo-b/src/components/operator/site-decision/EventLog.tsx
+++ b/repo-b/src/components/operator/site-decision/EventLog.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { OperatorSiteDecisionEvent } from "@/lib/bos-api";
+
+export function EventLog({ events }: { events: OperatorSiteDecisionEvent[] }) {
+  if (!events.length) {
+    return (
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-5 text-sm text-bm-muted2">
+        No changes recorded — underwriting inputs have been stable.
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-2xl border border-white/10 bg-black/30">
+      <div className="flex items-center justify-between border-b border-white/10 px-5 py-3">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-bm-muted2">
+          What changed
+        </h3>
+        <span className="text-[11px] text-bm-muted2">
+          {events.filter((e) => e.changes_recommendation).length} flip decision
+        </span>
+      </div>
+      <ul className="divide-y divide-white/10">
+        {events.map((e, idx) => (
+          <li key={e.event_id || idx} className="flex items-start gap-3 px-5 py-3">
+            <span
+              className={`mt-1 h-2 w-2 shrink-0 rounded-full ${
+                e.changes_recommendation ? "bg-red-400" : "bg-white/30"
+              }`}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-bm-muted2">
+                <span>{e.ts || "—"}</span>
+                <span>·</span>
+                <span>{e.source}</span>
+                {e.magnitude ? (
+                  <>
+                    <span>·</span>
+                    <span className="text-bm-text">{e.magnitude}</span>
+                  </>
+                ) : null}
+              </div>
+              <p className="mt-1 text-sm text-bm-text">{e.change}</p>
+            </div>
+            <span
+              className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide ${
+                e.changes_recommendation
+                  ? "border-red-400/40 bg-red-500/10 text-red-200"
+                  : "border-white/15 bg-white/5 text-bm-muted2"
+              }`}
+            >
+              {e.changes_recommendation ? "Changes rec." : "No change"}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/repo-b/src/components/operator/site-decision/EvidencePanel.tsx
+++ b/repo-b/src/components/operator/site-decision/EvidencePanel.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import type {
+  OperatorSiteDecisionEvidence,
+  OperatorSiteDecisionSite,
+} from "@/lib/bos-api";
+
+function Section({
+  title,
+  children,
+  defaultOpen = false,
+}: {
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) {
+  return (
+    <details
+      open={defaultOpen}
+      className="group rounded-2xl border border-white/10 bg-black/30 p-4 open:pb-5"
+    >
+      <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-semibold uppercase tracking-[0.16em] text-bm-muted2 group-open:text-bm-text">
+        <span>{title}</span>
+        <span className="text-bm-muted2 group-open:rotate-180 transition-transform">▾</span>
+      </summary>
+      <div className="mt-3">{children}</div>
+    </details>
+  );
+}
+
+export function EvidencePanel({
+  site,
+  evidence,
+}: {
+  site: OperatorSiteDecisionSite;
+  evidence: OperatorSiteDecisionEvidence;
+}) {
+  return (
+    <div className="space-y-3">
+      <Section title="Site facts" defaultOpen>
+        <dl className="grid gap-3 sm:grid-cols-2 text-sm">
+          {[
+            ["Address", site.address],
+            ["Parcel ID", site.parcel_id],
+            ["Zoning", site.zoning],
+            ["Acreage", site.acreage ? `${site.acreage} ac` : null],
+            ["Status", site.status],
+            ["Target use", site.target_project_type],
+            ["Buildable units",
+              site.buildable_units_low && site.buildable_units_high
+                ? `${site.buildable_units_low}–${site.buildable_units_high}`
+                : null],
+            ["Height limit",
+              site.height_limit_ft ? `${site.height_limit_ft} ft` : null],
+            ["Density cap",
+              site.density_cap_du_per_acre ? `${site.density_cap_du_per_acre} DU/ac` : null],
+            ["Approval timeline",
+              site.approval_timeline_days_low && site.approval_timeline_days_high
+                ? `${site.approval_timeline_days_low}–${site.approval_timeline_days_high}d`
+                : null],
+            ["Feasibility score",
+              site.feasibility_score != null
+                ? `${Math.round(site.feasibility_score * 100)}%`
+                : null],
+            ["Municipality",
+              site.municipality_name
+                ? `${site.municipality_name} (friction ${site.municipality_friction_score ?? "—"})`
+                : null],
+          ].map(([label, value]) => (
+            <div key={label as string} className="rounded-xl border border-white/10 bg-white/5 p-3">
+              <dt className="text-[10px] uppercase tracking-[0.16em] text-bm-muted2">
+                {label}
+              </dt>
+              <dd className="mt-1 text-bm-text">{value || "—"}</dd>
+            </div>
+          ))}
+        </dl>
+      </Section>
+
+      <Section title="Comparable projects">
+        {evidence.comparable_projects?.length ? (
+          <ul className="space-y-2">
+            {evidence.comparable_projects.map((c) => (
+              <li
+                key={c.id}
+                className="rounded-xl border border-white/10 bg-white/5 p-3 text-sm"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-bm-text">{c.name}</span>
+                  <span className="text-xs text-bm-muted2">
+                    {c.outcome?.replace(/_/g, " ")} · {c.cycle_days}d
+                  </span>
+                </div>
+                {c.notes ? (
+                  <p className="mt-1 text-xs text-bm-muted2">{c.notes}</p>
+                ) : null}
+                {c.matched_on?.length ? (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {c.matched_on.map((m) => (
+                      <span
+                        key={m}
+                        className="rounded-full border border-white/15 bg-white/5 px-2 py-0.5 text-[10px] text-bm-muted2"
+                      >
+                        {m}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-bm-muted2">
+            Not available — no comparable projects linked for this site.
+          </p>
+        )}
+      </Section>
+
+      <Section title="Feasibility assessment">
+        {evidence.feasibility ? (
+          <div className="space-y-3 text-sm">
+            <p className="text-bm-text">{evidence.feasibility.summary}</p>
+            {evidence.feasibility.constraints?.length ? (
+              <ul className="space-y-2">
+                {evidence.feasibility.constraints.map((c, idx) => (
+                  <li
+                    key={`${c.rule_id}-${idx}`}
+                    className="rounded-xl border border-white/10 bg-white/5 p-3"
+                  >
+                    <div className="flex items-center justify-between text-xs text-bm-muted2">
+                      <span>{c.rule_id}</span>
+                      <span className="uppercase">{c.impact}</span>
+                    </div>
+                    <p className="mt-1 text-bm-text">{c.note}</p>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {evidence.feasibility.recommended_actions?.length ? (
+              <ul className="list-disc pl-5 text-xs text-bm-muted2">
+                {evidence.feasibility.recommended_actions.map((a, i) => (
+                  <li key={i}>{a}</li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        ) : (
+          <p className="text-sm text-bm-muted2">
+            Not available — feasibility assessment has not been generated.
+          </p>
+        )}
+      </Section>
+
+      <Section title="Relevant ordinance rules">
+        {evidence.ordinance_rules?.length ? (
+          <ul className="space-y-2">
+            {evidence.ordinance_rules.map((r) => (
+              <li
+                key={r.id}
+                className="rounded-xl border border-white/10 bg-white/5 p-3 text-sm"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-bm-text">{r.title}</span>
+                  <span className="text-xs text-bm-muted2">{r.effective_date}</span>
+                </div>
+                <p className="mt-1 text-xs text-bm-muted2">{r.summary}</p>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-bm-muted2">
+            Not available — no municipality rules indexed.
+          </p>
+        )}
+      </Section>
+    </div>
+  );
+}

--- a/repo-b/src/components/operator/site-decision/ExecutiveCommandBand.tsx
+++ b/repo-b/src/components/operator/site-decision/ExecutiveCommandBand.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import type {
+  OperatorSiteDecision,
+  OperatorSiteDecisionKpi,
+} from "@/lib/bos-api";
+import { KPI_TONE, RECOMMENDATION_LABEL, RECOMMENDATION_TONE } from "./tones";
+
+function fmtKpiValue(kpi: OperatorSiteDecisionKpi): string {
+  if (kpi.null_reason) return "—";
+  if (kpi.value_pct != null && kpi.hurdle_pct != null) {
+    const delta = kpi.value_pct - kpi.hurdle_pct;
+    const sign = delta >= 0 ? "+" : "";
+    return `${kpi.value_pct.toFixed(1)}% (${sign}${delta.toFixed(1)} vs ${kpi.hurdle_pct}%)`;
+  }
+  if (kpi.key === "dev_cost_vs_comps" && kpi.value_usd != null) {
+    return `$${(kpi.value_usd / 1_000_000).toFixed(1)}M · median cycle ${
+      kpi.comp_cycle_days_median != null ? `${Math.round(kpi.comp_cycle_days_median)}d` : "—"
+    }`;
+  }
+  if (kpi.key === "capital_required" && kpi.value_usd != null) {
+    return `$${(kpi.value_usd / 1_000_000).toFixed(1)}M @ ${Math.round(
+      (kpi.assumed_debt_ratio ?? 0) * 100
+    )}% debt`;
+  }
+  if (kpi.key === "top_downside_risk" && kpi.risk_label) {
+    const bps = kpi.irr_impact_bps;
+    const bpsStr = bps == null ? "—" : `${bps > 0 ? "+" : ""}${bps} bps`;
+    return `${bpsStr} · ${kpi.risk_label.slice(0, 48)}${kpi.risk_label.length > 48 ? "…" : ""}`;
+  }
+  return "—";
+}
+
+export function ExecutiveCommandBand({
+  data,
+  onAction,
+}: {
+  data: OperatorSiteDecision;
+  onAction: (action: "assumptions" | "risks" | "assign" | "comps" | "memo") => void;
+}) {
+  const recTone = RECOMMENDATION_TONE[data.recommendation] || RECOMMENDATION_TONE.hold;
+  const recLabel = RECOMMENDATION_LABEL[data.recommendation] || data.recommendation;
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-black/40 p-4 sm:p-5">
+      {/* Row 1 — identity */}
+      <div className="flex flex-wrap items-center gap-2 text-xs text-bm-muted2">
+        <span className="text-sm font-semibold text-bm-text">{data.site.name}</span>
+        {data.site.municipality_name ? (
+          <>
+            <span>·</span>
+            <span>{data.site.municipality_name}</span>
+          </>
+        ) : null}
+        {data.site.target_project_type ? (
+          <>
+            <span>·</span>
+            <span>{data.site.target_project_type}</span>
+          </>
+        ) : null}
+        {data.site.status ? (
+          <>
+            <span>·</span>
+            <span className="rounded-full border border-white/15 bg-white/5 px-2 py-0.5 text-[10px] uppercase">
+              {data.site.status.replace(/_/g, " ")}
+            </span>
+          </>
+        ) : null}
+        <span className="ml-auto">
+          Updated {data.recommendation_updated_at} · {data.recommendation_owner}
+        </span>
+      </div>
+
+      {/* Row 2 — recommendation + conviction + fail condition */}
+      <div className="mt-3 grid gap-3 lg:grid-cols-[auto_1fr_auto] lg:items-center">
+        <span
+          className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-semibold uppercase tracking-[0.12em] ${recTone}`}
+        >
+          {recLabel}
+        </span>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.16em] text-bm-muted2">
+            <span>Conviction</span>
+            <span className="text-bm-text">{data.conviction}/100</span>
+          </div>
+          <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-white/5">
+            <div
+              className={`h-full ${
+                data.conviction >= 75
+                  ? "bg-emerald-400"
+                  : data.conviction >= 55
+                    ? "bg-amber-400"
+                    : data.conviction >= 35
+                      ? "bg-orange-400"
+                      : "bg-red-400"
+              }`}
+              style={{ width: `${Math.max(2, Math.min(100, data.conviction))}%` }}
+            />
+          </div>
+        </div>
+        <div className="text-xs text-red-200 lg:text-right">
+          <div className="uppercase tracking-[0.16em] text-bm-muted2">Fails if</div>
+          <div className="mt-0.5 text-bm-text">
+            {data.fail_condition ||
+              `Not available — ${
+                data.fail_condition_null_reason || "no fail condition derived"
+              }`}
+          </div>
+        </div>
+      </div>
+
+      {/* Row 3 — 4-KPI strip */}
+      <div className="mt-4 grid snap-x snap-mandatory grid-flow-col auto-cols-[minmax(220px,1fr)] gap-2 overflow-x-auto pb-1 sm:grid-cols-4 sm:grid-flow-row sm:overflow-visible">
+        {data.kpis.map((kpi) => (
+          <div
+            key={kpi.key}
+            className={`snap-start rounded-xl border p-3 ${
+              KPI_TONE[kpi.tone] || KPI_TONE.gray
+            }`}
+          >
+            <div className="text-[10px] uppercase tracking-[0.16em] opacity-80">
+              {kpi.label}
+            </div>
+            <div className="mt-2 text-sm font-semibold">{fmtKpiValue(kpi)}</div>
+            {kpi.null_reason ? (
+              <div className="mt-1 text-[10px] opacity-75">{kpi.null_reason}</div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      {/* Row 4 — AI decision summary */}
+      <div className="mt-4 rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-bm-text">
+        {data.decision_summary}
+      </div>
+
+      {/* Row 5 — CTA row */}
+      <div className="mt-4 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => onAction("assumptions")}
+          className="rounded-full border border-white/20 bg-white/5 px-3 py-1.5 text-xs text-bm-text hover:bg-white/10"
+        >
+          Review assumptions
+        </button>
+        <button
+          type="button"
+          onClick={() => onAction("risks")}
+          className="rounded-full border border-white/20 bg-white/5 px-3 py-1.5 text-xs text-bm-text hover:bg-white/10"
+        >
+          Open risks
+        </button>
+        <button
+          type="button"
+          onClick={() => onAction("assign")}
+          className="rounded-full border border-white/20 bg-white/5 px-3 py-1.5 text-xs text-bm-text hover:bg-white/10"
+        >
+          Assign diligence
+        </button>
+        <button
+          type="button"
+          onClick={() => onAction("comps")}
+          className="rounded-full border border-white/20 bg-white/5 px-3 py-1.5 text-xs text-bm-text hover:bg-white/10"
+        >
+          Compare comps
+        </button>
+        <button
+          type="button"
+          onClick={() => onAction("memo")}
+          className="ml-auto rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1.5 text-xs text-emerald-100 hover:bg-emerald-500/20"
+        >
+          Export IC memo
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/repo-b/src/components/operator/site-decision/PortfolioFit.tsx
+++ b/repo-b/src/components/operator/site-decision/PortfolioFit.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import type { OperatorSiteDecisionPortfolioFit } from "@/lib/bos-api";
+
+export function PortfolioFit({
+  fit,
+  siteId,
+}: {
+  fit: OperatorSiteDecisionPortfolioFit;
+  siteId: string;
+}) {
+  const maxIrr = Math.max(0.1, ...fit.peers.map((p) => p.irr));
+  const maxFriction = Math.max(0.1, ...fit.peers.map((p) => p.friction));
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-black/30 p-5">
+      <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-bm-muted2">
+        Portfolio fit
+      </h3>
+      <p className="mt-2 text-base text-bm-text">{fit.headline}</p>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-3 text-sm">
+        <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+          <div className="text-[10px] uppercase text-bm-muted2">IRR rank</div>
+          <div className="mt-1 text-xl font-semibold text-bm-text">
+            {fit.rank_by_irr.rank}
+            <span className="text-sm text-bm-muted2"> / {fit.rank_by_irr.of}</span>
+          </div>
+        </div>
+        <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+          <div className="text-[10px] uppercase text-bm-muted2">Timeline rank</div>
+          <div className="mt-1 text-xl font-semibold text-bm-text">
+            {fit.rank_by_timeline.rank}
+            <span className="text-sm text-bm-muted2"> / {fit.rank_by_timeline.of}</span>
+          </div>
+        </div>
+        <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+          <div className="text-[10px] uppercase text-bm-muted2">Friction rank</div>
+          <div className="mt-1 text-xl font-semibold text-bm-text">
+            {fit.rank_by_friction.rank}
+            <span className="text-sm text-bm-muted2"> / {fit.rank_by_friction.of}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5 space-y-2">
+        <div className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">
+          Portfolio IRR comparison
+        </div>
+        {fit.peers.map((p) => {
+          const pct = Math.max(2, (p.irr / maxIrr) * 100);
+          const isSelf = p.site_id === siteId;
+          return (
+            <div key={p.site_id || p.name || "unknown"} className="space-y-1">
+              <div className="flex items-center justify-between text-xs">
+                <span className={isSelf ? "font-semibold text-bm-text" : "text-bm-muted2"}>
+                  {p.name || p.site_id}
+                  {isSelf ? " · this deal" : ""}
+                </span>
+                <span className="tabular-nums text-bm-text">{p.irr.toFixed(1)}%</span>
+              </div>
+              <div className="h-1.5 overflow-hidden rounded-full bg-white/5">
+                <div
+                  className={`h-full ${
+                    isSelf ? "bg-emerald-400/80" : "bg-white/20"
+                  }`}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-4 space-y-2">
+        <div className="text-[11px] uppercase tracking-[0.16em] text-bm-muted2">
+          Municipality friction comparison
+        </div>
+        {fit.peers.map((p) => {
+          const pct = Math.max(2, (p.friction / maxFriction) * 100);
+          const isSelf = p.site_id === siteId;
+          return (
+            <div key={`f-${p.site_id}`} className="space-y-1">
+              <div className="flex items-center justify-between text-xs">
+                <span className={isSelf ? "font-semibold text-bm-text" : "text-bm-muted2"}>
+                  {p.name || p.site_id}
+                </span>
+                <span className="tabular-nums text-bm-text">{Math.round(p.friction)}</span>
+              </div>
+              <div className="h-1.5 overflow-hidden rounded-full bg-white/5">
+                <div
+                  className={`h-full ${isSelf ? "bg-red-400/80" : "bg-white/20"}`}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/operator/site-decision/RiskCard.tsx
+++ b/repo-b/src/components/operator/site-decision/RiskCard.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import type { OperatorSiteDecisionRisk } from "@/lib/bos-api";
+import { SEVERITY_TONE } from "./tones";
+
+function fmtBps(v: number | null | undefined): string {
+  if (v == null) return "—";
+  const sign = v > 0 ? "+" : "";
+  return `${sign}${v} bps IRR`;
+}
+
+export function RiskCard({
+  risk,
+  onAssign,
+}: {
+  risk: OperatorSiteDecisionRisk;
+  onAssign: (risk: OperatorSiteDecisionRisk) => void;
+}) {
+  const assigned = Boolean(risk.context_task_id);
+  return (
+    <div
+      className={`rounded-2xl border p-4 ${SEVERITY_TONE[risk.severity] || SEVERITY_TONE.amber}`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span
+              className={`h-2 w-2 rounded-full ${
+                risk.severity === "red" ? "bg-red-400" : "bg-amber-400"
+              }`}
+              aria-hidden
+            />
+            <span className="text-[11px] uppercase tracking-[0.16em]">
+              {risk.severity}
+            </span>
+          </div>
+          <p className="mt-2 text-sm font-medium text-bm-text">{risk.label}</p>
+          <p className="mt-1 text-xs text-bm-muted2">{risk.required_action}</p>
+        </div>
+        <div className="shrink-0 text-right">
+          <div className="text-base font-semibold">
+            {risk.irr_impact_bps == null ? "—" : fmtBps(risk.irr_impact_bps)}
+          </div>
+          {risk.null_reason ? (
+            <div className="mt-0.5 text-[10px] text-bm-muted2">
+              {risk.null_reason}
+            </div>
+          ) : null}
+          <div className="mt-0.5 text-[10px] uppercase tracking-wide text-bm-muted2">
+            confidence: {risk.confidence}
+          </div>
+        </div>
+      </div>
+      <div className="mt-3 flex items-center justify-between gap-3 text-xs text-bm-muted2">
+        <div>
+          <span className="font-medium text-bm-text">{risk.owner || "Unassigned"}</span>
+          {risk.due_date ? <span> · due {risk.due_date}</span> : null}
+        </div>
+        <button
+          type="button"
+          onClick={() => onAssign(risk)}
+          disabled={assigned}
+          className={`rounded-full border px-3 py-1 text-[11px] transition ${
+            assigned
+              ? "border-emerald-400/50 bg-emerald-500/10 text-emerald-100"
+              : "border-white/20 bg-white/5 text-bm-text hover:bg-white/10"
+          }`}
+        >
+          {assigned ? `Assigned · ${String(risk.context_task_id).slice(0, 6)}` : "Assign diligence"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/operator/site-decision/ScenarioBlock.tsx
+++ b/repo-b/src/components/operator/site-decision/ScenarioBlock.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import type { OperatorSiteDecisionScenarios } from "@/lib/bos-api";
+
+function fmtPct(v: number | null | undefined): string {
+  return v == null ? "—" : `${v.toFixed(1)}%`;
+}
+
+function fmtMoneyM(v: number | null | undefined): string {
+  if (v == null) return "—";
+  return `$${(v / 1_000_000).toFixed(1)}M`;
+}
+
+function fmtDays(v: number | null | undefined): string {
+  return v == null ? "—" : `${Math.round(v)}d`;
+}
+
+export function ScenarioBlock({
+  scenarios,
+  failCondition,
+  failNullReason,
+}: {
+  scenarios: OperatorSiteDecisionScenarios | null;
+  failCondition: string | null;
+  failNullReason: string | null;
+}) {
+  const presets = scenarios?.presets || [];
+  const active = scenarios?.active_ordinance_impact || null;
+
+  if (!presets.length) {
+    return (
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-5 text-sm text-bm-muted2">
+        Scenarios not available — {failNullReason || "development scenarios not yet generated"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-black/30 p-5">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-bm-muted2">
+          Scenario economics
+        </h3>
+        {active ? (
+          <span className="inline-flex items-center rounded-full border border-amber-400/40 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-100">
+            Active ordinance impact applied
+          </span>
+        ) : null}
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-3">
+        {presets.map((p) => {
+          const isBase = p.id === "base";
+          return (
+            <div
+              key={p.id}
+              className={`rounded-xl border p-4 ${
+                isBase
+                  ? "border-emerald-400/40 bg-emerald-500/5"
+                  : "border-white/10 bg-white/5"
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-semibold uppercase tracking-[0.16em] text-bm-muted2">
+                  {p.label}
+                </span>
+                {isBase ? (
+                  <span className="text-[10px] uppercase tracking-wide text-emerald-200">
+                    Base
+                  </span>
+                ) : null}
+              </div>
+              <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+                <div>
+                  <div className="text-[10px] uppercase text-bm-muted2">IRR</div>
+                  <div className="text-lg font-semibold text-bm-text">
+                    {fmtPct(p.outputs?.irr_pct)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[10px] uppercase text-bm-muted2">Margin</div>
+                  <div className="text-lg font-semibold text-bm-text">
+                    {fmtPct(p.outputs?.profit_margin_pct)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[10px] uppercase text-bm-muted2">Timeline</div>
+                  <div className="text-sm font-medium text-bm-text">
+                    {fmtDays(p.outputs?.timeline_days)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[10px] uppercase text-bm-muted2">Dev cost</div>
+                  <div className="text-sm font-medium text-bm-text">
+                    {fmtMoneyM(p.outputs?.total_dev_cost_usd)}
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-4 rounded-xl border border-red-400/30 bg-red-500/5 p-3 text-sm">
+        <div className="text-[11px] uppercase tracking-[0.16em] text-red-200">
+          Fail condition
+        </div>
+        <div className="mt-1 text-bm-text">
+          {failCondition ||
+            `Not available — ${failNullReason || "scenarios missing"}`}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/operator/site-decision/SiteDecisionSurface.tsx
+++ b/repo-b/src/components/operator/site-decision/SiteDecisionSurface.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useDomainEnv } from "@/components/domain/DomainEnvProvider";
+import { WorkspaceContextLoader } from "@/components/ui/WinstonLoader";
+import { OperatorUnavailableState } from "@/components/operator/OperatorUnavailableState";
+import { publishAssistantPageContext } from "@/lib/commandbar/appContextBridge";
+import {
+  getOperatorSiteDecision,
+  postOperatorSiteAssignDiligence,
+  postOperatorSiteDecisionMemo,
+  type OperatorSiteDecision,
+  type OperatorSiteDecisionRisk,
+} from "@/lib/bos-api";
+import { ExecutiveCommandBand } from "./ExecutiveCommandBand";
+import { ScenarioBlock } from "./ScenarioBlock";
+import { RiskCard } from "./RiskCard";
+import { EventLog } from "./EventLog";
+import { PortfolioFit } from "./PortfolioFit";
+import { DeliveryHub } from "./DeliveryHub";
+import { EvidencePanel } from "./EvidencePanel";
+import { DecisionDrawer } from "./DecisionDrawer";
+
+type TabKey = "decision" | "portfolio" | "delivery" | "evidence";
+
+const TABS: Array<{ key: TabKey; label: string }> = [
+  { key: "decision", label: "Decision" },
+  { key: "portfolio", label: "Portfolio fit" },
+  { key: "delivery", label: "Delivery" },
+  { key: "evidence", label: "Evidence" },
+];
+
+export function SiteDecisionSurface({ siteId }: { siteId: string }) {
+  const pathname = usePathname();
+  const { envId, businessId } = useDomainEnv();
+  const [data, setData] = useState<OperatorSiteDecision | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<TabKey>("decision");
+
+  // Drawer state
+  const [assignTarget, setAssignTarget] = useState<OperatorSiteDecisionRisk | null>(null);
+  const [memoMarkdown, setMemoMarkdown] = useState<string | null>(null);
+  const [memoLoading, setMemoLoading] = useState(false);
+  const [assignForm, setAssignForm] = useState({
+    title: "",
+    owner: "",
+    description: "",
+    due_date: "",
+  });
+  const [assignSubmitting, setAssignSubmitting] = useState(false);
+
+  const decisionRef = useRef<HTMLDivElement | null>(null);
+  const risksRef = useRef<HTMLDivElement | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await getOperatorSiteDecision(siteId, envId, businessId || undefined);
+      setData(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load site decision");
+    } finally {
+      setLoading(false);
+    }
+  }, [siteId, envId, businessId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!data) return;
+    publishAssistantPageContext({
+      route: pathname,
+      surface: "operator_site_decision",
+      active_module: "operator",
+      page_entity_type: "development_site",
+      page_entity_id: data.site.site_id,
+      page_entity_name: data.site.name || data.site.site_id,
+      selected_entities: [
+        {
+          entity_type: "development_site",
+          entity_id: data.site.site_id,
+          name: data.site.name || data.site.site_id,
+          source: "page",
+          metadata: {
+            risk_level: data.site.risk_level,
+            target_project_type: data.site.target_project_type,
+            status: data.site.status,
+          },
+        },
+      ],
+      visible_data: {
+        metrics: {
+          recommendation: data.recommendation,
+          conviction: data.conviction,
+          fail_condition: data.fail_condition,
+          base_irr_pct: data.kpis.find((k) => k.key === "base_irr_vs_hurdle")?.value_pct ?? null,
+          top_downside_risk_bps:
+            data.kpis.find((k) => k.key === "top_downside_risk")?.irr_impact_bps ?? null,
+        },
+        notes: [data.decision_summary],
+        decision: data,
+      },
+    });
+  }, [data, pathname]);
+
+  const openAssignDrawer = useCallback(
+    (risk: OperatorSiteDecisionRisk | null) => {
+      const prefill = risk
+        ? {
+            title: `Diligence: ${risk.label}`.slice(0, 120),
+            owner: risk.owner || data?.recommendation_owner || "Acquisitions Lead",
+            description: risk.required_action,
+            due_date: risk.due_date || "",
+          }
+        : {
+            title: "Diligence task",
+            owner: data?.recommendation_owner || "Acquisitions Lead",
+            description: "",
+            due_date: "",
+          };
+      setAssignTarget(risk);
+      setAssignForm(prefill);
+    },
+    [data],
+  );
+
+  const submitAssign = useCallback(async () => {
+    if (!data) return;
+    setAssignSubmitting(true);
+    try {
+      const result = await postOperatorSiteAssignDiligence(
+        siteId,
+        {
+          title: assignForm.title,
+          owner: assignForm.owner,
+          description: assignForm.description || undefined,
+          due_date: assignForm.due_date || undefined,
+          risk_id: assignTarget?.risk_id || null,
+          priority: "high",
+        },
+        envId,
+        businessId || undefined,
+      );
+      // Patch in the context_task_id on the matching risk so the card flips state
+      setData((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          risks: prev.risks.map((r) =>
+            r.risk_id === (assignTarget?.risk_id ?? "")
+              ? { ...r, context_task_id: result.task_id }
+              : r,
+          ),
+        };
+      });
+      setAssignTarget(null);
+    } catch (err) {
+      // Surface error inline without fabricating success
+      setError(err instanceof Error ? err.message : "Failed to assign diligence");
+    } finally {
+      setAssignSubmitting(false);
+    }
+  }, [data, siteId, envId, businessId, assignForm, assignTarget]);
+
+  const openMemo = useCallback(async () => {
+    setMemoLoading(true);
+    setMemoMarkdown("");
+    try {
+      const res = await postOperatorSiteDecisionMemo(siteId, envId, businessId || undefined);
+      setMemoMarkdown(res.memo_markdown);
+    } catch (err) {
+      setMemoMarkdown(
+        `**Failed to generate memo** — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setMemoLoading(false);
+    }
+  }, [siteId, envId, businessId]);
+
+  const handleAction = useCallback(
+    (action: "assumptions" | "risks" | "assign" | "comps" | "memo") => {
+      if (action === "assumptions") {
+        setTab("decision");
+        decisionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      } else if (action === "risks") {
+        setTab("decision");
+        risksRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      } else if (action === "comps") {
+        setTab("evidence");
+      } else if (action === "assign") {
+        openAssignDrawer(null);
+      } else if (action === "memo") {
+        void openMemo();
+      }
+    },
+    [openAssignDrawer, openMemo],
+  );
+
+  const topOfTab = useMemo(() => {
+    if (!data) return null;
+    if (tab === "decision") {
+      return (
+        <div className="space-y-4">
+          <div ref={decisionRef}>
+            <ScenarioBlock
+              scenarios={data.scenarios}
+              failCondition={data.fail_condition}
+              failNullReason={data.fail_condition_null_reason}
+            />
+          </div>
+          <div ref={risksRef} className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-bm-muted2">
+                Top risks
+              </h3>
+              <span className="text-[11px] text-bm-muted2">
+                {data.risks.length} of max 5
+              </span>
+            </div>
+            {data.risks.length ? (
+              <div className="space-y-2">
+                {data.risks.map((r) => (
+                  <RiskCard key={r.risk_id} risk={r} onAssign={openAssignDrawer} />
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-bm-muted2">
+                No material risks surfaced for this site.
+              </div>
+            )}
+          </div>
+          <EventLog events={data.event_log} />
+        </div>
+      );
+    }
+    if (tab === "portfolio") {
+      return <PortfolioFit fit={data.portfolio_fit} siteId={data.site.site_id} />;
+    }
+    if (tab === "delivery") {
+      return <DeliveryHub workstreams={data.workstreams} />;
+    }
+    return <EvidencePanel site={data.site} evidence={data.evidence} />;
+  }, [data, tab, openAssignDrawer]);
+
+  if (loading) return <WorkspaceContextLoader label="Loading decision surface" />;
+  if (error || !data) {
+    return (
+      <OperatorUnavailableState
+        title="Decision surface unavailable"
+        detail={error || "No data returned."}
+        onRetry={() => void load()}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4 pb-24 sm:pb-6">
+      <div className="sticky top-0 z-20 -mx-4 bg-gradient-to-b from-bm-bg via-bm-bg to-transparent px-4 pt-4 sm:static sm:mx-0 sm:bg-transparent sm:px-0 sm:pt-0">
+        <ExecutiveCommandBand data={data} onAction={handleAction} />
+      </div>
+
+      <nav className="sticky top-[calc(100vh)] z-10 -mx-4 flex gap-1 overflow-x-auto border-b border-white/10 bg-bm-bg/95 px-4 pb-1 backdrop-blur-sm sm:static sm:mx-0 sm:px-0">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setTab(t.key)}
+            className={`shrink-0 border-b-2 px-3 py-2 text-sm transition ${
+              tab === t.key
+                ? "border-emerald-400 text-bm-text"
+                : "border-transparent text-bm-muted2 hover:text-bm-text"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+
+      <div>{topOfTab}</div>
+
+      {/* Sticky mobile action bar */}
+      <div className="fixed inset-x-0 bottom-0 z-20 flex gap-2 border-t border-white/10 bg-bm-bg/95 p-3 backdrop-blur-sm sm:hidden">
+        <button
+          type="button"
+          onClick={() => openAssignDrawer(null)}
+          className="flex-1 rounded-full border border-white/20 bg-white/5 px-3 py-2 text-xs text-bm-text"
+        >
+          Assign
+        </button>
+        <button
+          type="button"
+          onClick={() => void openMemo()}
+          className="flex-1 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-100"
+        >
+          Export memo
+        </button>
+      </div>
+
+      {/* Drawers */}
+      <DecisionDrawer
+        open={assignTarget !== null || assignForm.title === "Diligence task"}
+        title={assignTarget ? "Assign diligence from risk" : "New diligence task"}
+        onClose={() => {
+          setAssignTarget(null);
+          setAssignForm({ title: "", owner: "", description: "", due_date: "" });
+        }}
+        footer={
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setAssignTarget(null);
+                setAssignForm({ title: "", owner: "", description: "", due_date: "" });
+              }}
+              className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-xs text-bm-muted2"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void submitAssign()}
+              disabled={assignSubmitting || !assignForm.title || !assignForm.owner}
+              className="rounded-full border border-emerald-400/40 bg-emerald-500/15 px-3 py-1.5 text-xs text-emerald-100 disabled:opacity-40"
+            >
+              {assignSubmitting ? "Assigning…" : "Create task"}
+            </button>
+          </div>
+        }
+      >
+        <div className="space-y-3 text-sm">
+          {assignTarget ? (
+            <div className="rounded-xl border border-amber-400/30 bg-amber-500/10 p-3 text-xs text-amber-100">
+              Linked risk: {assignTarget.label}
+            </div>
+          ) : null}
+          <label className="block">
+            <span className="text-xs uppercase tracking-wide text-bm-muted2">Title</span>
+            <input
+              type="text"
+              value={assignForm.title}
+              onChange={(e) =>
+                setAssignForm((f) => ({ ...f, title: e.target.value }))
+              }
+              className="mt-1 w-full rounded-lg border border-white/15 bg-black/40 px-3 py-2 text-bm-text"
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs uppercase tracking-wide text-bm-muted2">Owner</span>
+            <input
+              type="text"
+              value={assignForm.owner}
+              onChange={(e) =>
+                setAssignForm((f) => ({ ...f, owner: e.target.value }))
+              }
+              className="mt-1 w-full rounded-lg border border-white/15 bg-black/40 px-3 py-2 text-bm-text"
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs uppercase tracking-wide text-bm-muted2">Due date</span>
+            <input
+              type="date"
+              value={assignForm.due_date}
+              onChange={(e) =>
+                setAssignForm((f) => ({ ...f, due_date: e.target.value }))
+              }
+              className="mt-1 w-full rounded-lg border border-white/15 bg-black/40 px-3 py-2 text-bm-text"
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs uppercase tracking-wide text-bm-muted2">Description</span>
+            <textarea
+              value={assignForm.description}
+              onChange={(e) =>
+                setAssignForm((f) => ({ ...f, description: e.target.value }))
+              }
+              rows={4}
+              className="mt-1 w-full rounded-lg border border-white/15 bg-black/40 px-3 py-2 text-bm-text"
+            />
+          </label>
+        </div>
+      </DecisionDrawer>
+
+      <DecisionDrawer
+        open={memoMarkdown !== null}
+        title="IC decision memo"
+        onClose={() => setMemoMarkdown(null)}
+      >
+        {memoLoading ? (
+          <div className="text-sm text-bm-muted2">Generating memo…</div>
+        ) : (
+          <pre className="whitespace-pre-wrap font-mono text-xs text-bm-text">
+            {memoMarkdown}
+          </pre>
+        )}
+      </DecisionDrawer>
+    </div>
+  );
+}

--- a/repo-b/src/components/operator/site-decision/index.ts
+++ b/repo-b/src/components/operator/site-decision/index.ts
@@ -1,0 +1,9 @@
+export { SiteDecisionSurface } from "./SiteDecisionSurface";
+export { ExecutiveCommandBand } from "./ExecutiveCommandBand";
+export { ScenarioBlock } from "./ScenarioBlock";
+export { RiskCard } from "./RiskCard";
+export { EventLog } from "./EventLog";
+export { PortfolioFit } from "./PortfolioFit";
+export { DeliveryHub } from "./DeliveryHub";
+export { EvidencePanel } from "./EvidencePanel";
+export { DecisionDrawer } from "./DecisionDrawer";

--- a/repo-b/src/components/operator/site-decision/tones.ts
+++ b/repo-b/src/components/operator/site-decision/tones.ts
@@ -1,0 +1,31 @@
+export const RECOMMENDATION_TONE: Record<string, string> = {
+  proceed: "border-emerald-400/50 bg-emerald-500/15 text-emerald-100",
+  proceed_with_conditions: "border-amber-400/50 bg-amber-500/15 text-amber-100",
+  hold: "border-orange-400/50 bg-orange-500/15 text-orange-100",
+  reject: "border-red-400/50 bg-red-500/15 text-red-100",
+};
+
+export const RECOMMENDATION_LABEL: Record<string, string> = {
+  proceed: "Proceed",
+  proceed_with_conditions: "Proceed with Conditions",
+  hold: "Hold",
+  reject: "Reject",
+};
+
+export const SEVERITY_TONE: Record<string, string> = {
+  red: "border-red-400/50 bg-red-500/10 text-red-200",
+  amber: "border-amber-400/50 bg-amber-500/10 text-amber-100",
+};
+
+export const KPI_TONE: Record<string, string> = {
+  green: "border-emerald-400/40 bg-emerald-500/10 text-emerald-100",
+  amber: "border-amber-400/40 bg-amber-500/10 text-amber-100",
+  red: "border-red-400/40 bg-red-500/10 text-red-200",
+  gray: "border-white/10 bg-white/5 text-bm-muted2",
+};
+
+export const STATUS_TONE: Record<string, string> = {
+  on_track: "border-emerald-400/40 bg-emerald-500/10 text-emerald-100",
+  at_risk: "border-amber-400/40 bg-amber-500/10 text-amber-100",
+  blocked: "border-red-400/40 bg-red-500/10 text-red-200",
+};

--- a/repo-b/src/lib/bos-api.ts
+++ b/repo-b/src/lib/bos-api.ts
@@ -9562,6 +9562,257 @@ export function getOperatorSiteDetail(siteId: string, envId: string, businessId?
   });
 }
 
+// ---------------------------------------------------------------------------
+// Hall Boys site decision surface
+// ---------------------------------------------------------------------------
+
+export type OperatorSiteDecisionRecommendation =
+  | "proceed"
+  | "proceed_with_conditions"
+  | "hold"
+  | "reject";
+
+export interface OperatorSiteDecisionKpi {
+  key: string;
+  label: string;
+  tone: "green" | "amber" | "red" | "gray";
+  null_reason?: string | null;
+  value_pct?: number | null;
+  hurdle_pct?: number | null;
+  value_usd?: number | null;
+  comp_cycle_days_median?: number | null;
+  assumed_debt_ratio?: number | null;
+  risk_label?: string | null;
+  irr_impact_bps?: number | null;
+}
+
+export interface OperatorSiteDecisionRisk {
+  risk_id: string;
+  label: string;
+  severity: "red" | "amber";
+  irr_impact_bps: number | null;
+  null_reason?: string | null;
+  confidence: string;
+  owner: string | null;
+  due_date: string | null;
+  required_action: string;
+  context_task_id?: string | null;
+}
+
+export interface OperatorSiteDecisionEvent {
+  event_id: string | null;
+  ts: string | null;
+  source: "ordinance" | "comp" | "approval" | "assumption" | "document";
+  change: string | null;
+  magnitude: string | null;
+  changes_recommendation: boolean;
+}
+
+export interface OperatorSiteDecisionPortfolioRank {
+  rank: number;
+  of: number;
+}
+
+export interface OperatorSiteDecisionPortfolioPeer {
+  site_id: string | null;
+  name: string | null;
+  irr: number;
+  timeline: number;
+  friction: number;
+}
+
+export interface OperatorSiteDecisionPortfolioFit {
+  rank_by_irr: OperatorSiteDecisionPortfolioRank;
+  rank_by_timeline: OperatorSiteDecisionPortfolioRank;
+  rank_by_friction: OperatorSiteDecisionPortfolioRank;
+  headline: string;
+  peers: OperatorSiteDecisionPortfolioPeer[];
+}
+
+export interface OperatorSiteDecisionWorkstream {
+  name: string;
+  owner: string;
+  status: "on_track" | "at_risk" | "blocked";
+  next_milestone: string;
+  next_milestone_due: string | null;
+  last_completed_step: string | null;
+  blockers: string[];
+  task_ids: string[];
+}
+
+export interface OperatorSiteDecisionSite {
+  site_id: string;
+  name?: string | null;
+  municipality_id?: string | null;
+  municipality_name?: string | null;
+  municipality_friction_score?: number | null;
+  address?: string | null;
+  parcel_id?: string | null;
+  zoning?: string | null;
+  acreage?: number | null;
+  status?: string | null;
+  buildable_units_low?: number | null;
+  buildable_units_high?: number | null;
+  height_limit_ft?: number | null;
+  density_cap_du_per_acre?: number | null;
+  feasibility_score?: number | null;
+  confidence?: string | null;
+  risk_level?: string | null;
+  approval_timeline_days_low?: number | null;
+  approval_timeline_days_high?: number | null;
+  target_project_type?: string | null;
+  owner?: string | null;
+}
+
+export interface OperatorSiteDecisionScenarioPreset {
+  id: string;
+  label: string;
+  assumptions?: {
+    density_units?: number | null;
+    approval_delay_days?: number | null;
+    cost_inflation_pct?: number | null;
+  };
+  outputs?: {
+    irr_pct?: number | null;
+    profit_margin_pct?: number | null;
+    timeline_days?: number | null;
+    total_dev_cost_usd?: number | null;
+  };
+}
+
+export interface OperatorSiteDecisionScenarios {
+  site_id?: string;
+  presets?: OperatorSiteDecisionScenarioPreset[];
+  active_ordinance_impact?: {
+    ordinance_event_id?: string;
+    description?: string;
+    event_effective_date?: string;
+    event_change_type?: string;
+    delta_vs_base?: {
+      approval_delay_days?: number | null;
+      irr_pct?: number | null;
+      profit_margin_pct?: number | null;
+      timeline_days?: number | null;
+      total_dev_cost_usd?: number | null;
+      confidence?: string;
+    };
+  } | null;
+}
+
+export interface OperatorSiteDecisionEvidence {
+  comparable_projects?: Array<{
+    id?: string;
+    name?: string;
+    outcome?: string;
+    cycle_days?: number;
+    matched_on?: string[];
+    notes?: string;
+  }>;
+  feasibility?: {
+    id?: string;
+    generated_at?: string;
+    summary?: string;
+    constraints?: Array<{
+      rule_id?: string;
+      impact?: string;
+      note?: string;
+      confidence?: string;
+    }>;
+    recommended_actions?: string[];
+  } | null;
+  municipality?: {
+    id?: string;
+    name?: string;
+    state?: string;
+    overall_friction_score?: number;
+    median_approval_days?: number;
+    variance_required_rate?: number;
+    risk_level?: string;
+  } | null;
+  ordinance_rules?: Array<{
+    id?: string;
+    title?: string;
+    summary?: string;
+    effective_date?: string;
+    severity?: string;
+  }>;
+}
+
+export interface OperatorSiteDecision {
+  site_id: string;
+  site: OperatorSiteDecisionSite;
+  recommendation: OperatorSiteDecisionRecommendation;
+  conviction: number;
+  recommendation_owner: string;
+  recommendation_updated_at: string;
+  decision_summary: string;
+  fail_condition: string | null;
+  fail_condition_null_reason: string | null;
+  kpis: OperatorSiteDecisionKpi[];
+  scenarios: OperatorSiteDecisionScenarios | null;
+  risks: OperatorSiteDecisionRisk[];
+  event_log: OperatorSiteDecisionEvent[];
+  portfolio_fit: OperatorSiteDecisionPortfolioFit;
+  workstreams: OperatorSiteDecisionWorkstream[];
+  evidence: OperatorSiteDecisionEvidence;
+}
+
+export interface OperatorSiteDecisionMemo {
+  memo_markdown: string;
+  sections: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+}
+
+export interface OperatorSiteDecisionAssignDiligenceResult {
+  task_id: string;
+  risk_id: string | null;
+  title: string;
+  owner: string;
+  status: string;
+  created_at: string;
+}
+
+export function getOperatorSiteDecision(
+  siteId: string,
+  envId: string,
+  businessId?: string,
+): Promise<OperatorSiteDecision> {
+  return bosFetch(`/api/operator/v1/sites/${siteId}/decision`, {
+    params: { env_id: envId, business_id: businessId },
+  });
+}
+
+export function postOperatorSiteDecisionMemo(
+  siteId: string,
+  envId: string,
+  businessId?: string,
+): Promise<OperatorSiteDecisionMemo> {
+  return bosFetch(`/api/operator/v1/sites/${siteId}/decision/memo`, {
+    method: "POST",
+    params: { env_id: envId, business_id: businessId },
+  });
+}
+
+export function postOperatorSiteAssignDiligence(
+  siteId: string,
+  payload: {
+    title: string;
+    owner: string;
+    description?: string | null;
+    due_date?: string | null;
+    risk_id?: string | null;
+    priority?: "low" | "medium" | "high" | "critical";
+  },
+  envId: string,
+  businessId?: string,
+): Promise<OperatorSiteDecisionAssignDiligenceResult> {
+  return bosFetch(`/api/operator/v1/sites/${siteId}/decision/assign-diligence`, {
+    method: "POST",
+    params: { env_id: envId, business_id: businessId },
+    body: JSON.stringify(payload),
+  });
+}
+
 export function listOperatorOrdinanceChanges(envId: string, businessId?: string, windowDays?: number): Promise<OperatorOrdinanceChangeRow[]> {
   return bosFetch("/api/operator/v1/site-risk/ordinance-changes", {
     params: { env_id: envId, business_id: businessId, window_days: windowDays?.toString() },


### PR DESCRIPTION
## Summary
Introduces a comprehensive site decision surface for Hall Boys operator underwriting, enabling data-driven investment recommendations on development sites. The feature derives decision-grade payloads (recommendation, conviction, risks, scenarios, portfolio fit, and delivery tracking) from existing Hall Boys fixture data without requiring schema changes or migrations.

## Key Changes

**Backend Service** (`backend/app/services/operator_site_decision.py`)
- New 689-line service module that builds decision payloads for Hall Boys development sites
- Derives recommendation (proceed/proceed_with_conditions/hold/reject) and conviction (0-100) from weighted blend of feasibility score (45%), risk score (35%), and scenario headroom (20%)
- Quantifies constraint-driven risks with heuristic IRR impact mappings (basis points by category: blocking -320bps, parking -180bps, etc.)
- Generates fail-condition boundaries based on conservative scenario assumptions
- Computes portfolio rankings (IRR, timeline, friction) against comparable sites
- Builds event log tracking ordinance changes, feasibility assessments, and rule impacts
- Implements fail-loud pattern: returns `null_reason` for unavailable upstream fields instead of fabricating values
- Scoped to Hall Boys (multi_entity_operator) only; does not touch REPE code

**API Routes** (`backend/app/routes/operator.py`)
- `GET /api/operator/v1/sites/{site_id}/decision` — fetch complete site decision payload
- `POST /api/operator/v1/sites/{site_id}/decision/memo` — generate markdown decision memo
- `POST /api/operator/v1/sites/{site_id}/decision/assign-diligence` — create diligence task from risk

**Schemas** (`backend/app/schemas/operator.py`)
- `OperatorSiteDecisionOut` — top-level decision payload
- `OperatorSiteDecisionKpiOut` — KPI with tone (green/amber/red/gray) and optional null_reason
- `OperatorSiteDecisionRiskOut` — risk with severity, IRR impact, confidence, owner, due date
- `OperatorSiteDecisionPortfolioFitOut` — portfolio rankings and peer comparison
- `OperatorSiteDecisionWorkstreamOut` — delivery workstream status and milestones
- Supporting types for scenarios, events, evidence, and site metadata

**Frontend Surface** (`repo-b/src/components/operator/site-decision/`)
- `SiteDecisionSurface.tsx` — main tabbed interface (Decision, Portfolio fit, Delivery, Evidence)
- `ExecutiveCommandBand.tsx` — recommendation badge, conviction meter, fail condition, KPI summary, action buttons
- `ScenarioBlock.tsx` — base/conservative/optimistic scenario economics with active ordinance impact badge
- `RiskCard.tsx` — risk severity, IRR impact, confidence, owner, required action, assign button
- `EventLog.tsx` — timeline of ordinance changes and feasibility updates with decision impact flags
- `PortfolioFit.tsx` — IRR/timeline/friction rankings with peer comparison bars
- `DeliveryHub.tsx` — workstream status cards (on_track/at_risk/blocked) with milestones
- `EvidencePanel.tsx` — collapsible sections for site facts, comparable projects, feasibility constraints, municipality data
- `DecisionDrawer.tsx` — reusable modal for assigning diligence tasks
- `tones.ts` — color/tone mappings for recommendations, severities, and statuses

**API Client** (`repo-b/src/lib/bos-api.ts`)
- TypeScript types for all decision surface entities
- `getOperatorSiteDecision()` — fetch decision payload
- `postOperatorSiteDecisionMemo()` — generate memo
- `postOperatorSiteAssignDiligence()` — create task

**Integration**
- Replaced `OperatorSiteDetailPage` export with `SiteDecisionSurface` in `OperatorPages.tsx`
- Publishes page context to command bar for AI assistant awareness

## Notable Implementation Details

- **Conviction formula**: Weighted average of feasibility_score

https://claude.ai/code/session_01L66UTkcXUZCdHaiLR4XwAg