### PR TITLE
Fix clipped lifecycle pill artifact on workspace launcher cards

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -218,6 +218,7 @@ _(This section is appended by the research-architect after each successful inges
 
 - When reading or editing Next.js route files with shell commands, quote paths like `'repo-b/src/app/lab/env/[envId]/page.tsx'`. Unquoted brackets will be globbed by `zsh` and the command will fail before it reaches the file.
 - Run backend tests with `python3.11 -m pytest ...` in this repo. A bare `pytest` invocation may bind to an older interpreter and fail inside existing files before your feature code is even imported.
+- On mobile workspace cards (`repo-b/src/app/app/page.tsx`), treat the title row as `min-w-0` + `truncate` + chip `shrink-0` whenever a badge/chip sits next to a long client name. Without that trio, long names can clip a lifecycle pill into a tiny colored artifact.
 - OpenClaw now routes Telegram DMs from user `8672815280` to `dispatcher-winston`, not the legacy `winston` agent. The default `main` agent still stays on `~/.openclaw/workspace`.
 - OpenClaw is now Codex-first for non-Claude control agents: `agents.defaults.model.primary`, `dispatcher-winston`, `commander-winston`, `data-winston`, and the new Novendor business agents all use `codex-cli/gpt-5.4` instead of the OpenAI API-backed default.
 - Winston harness agents are split cleanly: `claude-winston` and `codex-winston` use ACP persistent runtimes, while `claude-cli-winston` and `codex-cli-winston` provide explicit OpenClaw CLI-backend fallback agents.

--- a/repo-b/src/app/app/page.tsx
+++ b/repo-b/src/app/app/page.tsx
@@ -31,6 +31,14 @@ function environmentTone(environment: { slug?: string | null }) {
   };
 }
 
+function assertEnvironmentClientName(environment: { env_id: string; client_name: string }) {
+  const clientName = environment.client_name?.trim();
+  if (!clientName) {
+    throw new Error(`Malformed environment card data: missing client_name for env ${environment.env_id}`);
+  }
+  return clientName;
+}
+
 const SYSTEM_LINKS = [
   { href: "/lab/system/control-tower", label: "Control Tower", detail: "Provision and monitor environments" },
   { href: "/lab/system/access", label: "Access", detail: "Grant memberships and workspace visibility" },
@@ -49,6 +57,9 @@ function AppIndexPageInner() {
     () => selectedEnv || environments[0] || null,
     [environments, selectedEnv],
   );
+  const selectedEnvironmentName = selectedEnvironment
+    ? assertEnvironmentClientName(selectedEnvironment)
+    : null;
 
   async function openEnvironment(envId: string, slug?: string | null) {
     setOpeningEnvId(envId);
@@ -129,7 +140,7 @@ function AppIndexPageInner() {
             <div className="space-y-1">
               <p className="text-[10px] uppercase tracking-[0.22em] text-white/42">Current workspace</p>
               <h2 className="text-[1.8rem] font-semibold tracking-tight text-white">
-                {selectedEnvironment ? selectedEnvironment.client_name : "No workspace selected"}
+                {selectedEnvironmentName ?? "No workspace selected"}
               </h2>
               <p className="text-sm leading-6 text-white/66">
                 {selectedEnvironment
@@ -193,6 +204,7 @@ function AppIndexPageInner() {
                   const isActive = selectedEnvironment?.env_id === environment.env_id;
                   const isOpening = openingEnvId === environment.env_id;
                   const lifecycle = deriveEnvLifecycleState(environment);
+                  const clientName = assertEnvironmentClientName(environment);
                   return (
                     <button
                       key={`mobile-${environment.env_id}`}
@@ -211,12 +223,12 @@ function AppIndexPageInner() {
                       }}
                     >
                       <div className="flex items-center justify-between gap-3">
-                        <div>
-                          <div className="flex items-center gap-2">
-                            <div className="text-sm font-semibold text-white">
-                              {environment.client_name}
+                        <div className="min-w-0">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <div className="truncate text-sm font-semibold text-white">
+                              {clientName}
                             </div>
-                            <EnvLifecyclePill state={lifecycle} />
+                            <EnvLifecyclePill state={lifecycle} className="shrink-0" />
                           </div>
                           <p className="mt-0.5 text-xs uppercase tracking-[0.18em] text-white/42">
                             {humanIndustry(environment.industry_type || environment.industry)}
@@ -282,6 +294,7 @@ function AppIndexPageInner() {
                   const isOpening = openingEnvId === environment.env_id;
                   const tone = environmentTone(environment);
                   const lifecycle = deriveEnvLifecycleState(environment);
+                  const clientName = assertEnvironmentClientName(environment);
                   return (
                     <button
                       key={environment.env_id}
@@ -301,12 +314,12 @@ function AppIndexPageInner() {
                       }}
                     >
                       <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <div className="flex flex-wrap items-center gap-2">
-                            <div className="text-sm font-semibold text-white">
-                              {environment.client_name}
+                        <div className="min-w-0">
+                          <div className="flex min-w-0 flex-wrap items-center gap-2">
+                            <div className="truncate text-sm font-semibold text-white">
+                              {clientName}
                             </div>
-                            <EnvLifecyclePill state={lifecycle} />
+                            <EnvLifecyclePill state={lifecycle} className="shrink-0" />
                           </div>
                           <p className="mt-1 text-xs leading-5 text-white/46">
                             {humanIndustry(environment.industry_type || environment.industry)}
@@ -365,7 +378,7 @@ function AppIndexPageInner() {
               <div className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-6 backdrop-blur-md lg:p-8">
                 <p className="text-[11px] uppercase tracking-[0.22em] text-white/42">Workspace access</p>
                 <h2 className="mt-3 text-[clamp(2rem,4vw,3rem)] font-semibold tracking-tight text-white">
-                  {selectedEnvironment ? selectedEnvironment.client_name : "No workspace selected"}
+                  {selectedEnvironmentName ?? "No workspace selected"}
                 </h2>
                 <p className="mt-4 max-w-2xl text-base leading-7 text-white/66">
                   {selectedEnvironment

--- a/repo-b/tests/app-public-mobile.spec.ts
+++ b/repo-b/tests/app-public-mobile.spec.ts
@@ -3,10 +3,11 @@ import { expect, test } from "@playwright/test";
 const adminEnvironments = [
   {
     env_id: "11111111-1111-4111-8111-111111111111",
-    slug: "novendor",
+    slug: "meridian",
     client_name: "Meridian Capital Management",
-    industry: "real_estate",
-    industry_type: "real_estate",
+    industry: "real_estate_pe",
+    industry_type: "repe",
+    repe_initialized: false,
     schema_name: "env_meridian_capital_management",
     is_active: true,
     created_at: "2026-02-25T00:00:00.000Z",
@@ -14,14 +15,36 @@ const adminEnvironments = [
   },
   {
     env_id: "22222222-2222-4222-8222-222222222222",
-    slug: "resume",
-    client_name: "Paul Malmquist Resume",
-    industry: "visual_resume",
-    industry_type: "visual_resume",
-    schema_name: "env_resume",
+    slug: "ncf",
+    client_name: "National Christian Foundation",
+    industry: "ncf",
+    industry_type: "ncf",
+    schema_name: "env_ncf",
     is_active: true,
     created_at: "2026-02-24T00:00:00.000Z",
-    business_id: "business-resume",
+    business_id: "business-ncf",
+  },
+  {
+    env_id: "33333333-3333-4333-8333-333333333333",
+    slug: "hall-boys",
+    client_name: "Hall Boys Operating System",
+    industry: "multi_entity_operator",
+    industry_type: "multi_entity_operator",
+    schema_name: "env_hall_boys",
+    is_active: true,
+    created_at: "2026-02-23T00:00:00.000Z",
+    business_id: "business-hall-boys",
+  },
+  {
+    env_id: "44444444-4444-4444-8444-444444444444",
+    slug: "novendor",
+    client_name: "Novendor",
+    industry: "consulting",
+    industry_type: "consulting",
+    schema_name: "env_novendor",
+    is_active: true,
+    created_at: "2026-02-22T00:00:00.000Z",
+    business_id: "business-novendor",
   },
 ];
 
@@ -47,14 +70,33 @@ test.describe("mobile entry surfaces", () => {
     await page.goto("/app");
 
     await expect(page.getByRole("heading", { name: "Winston" })).toBeVisible();
-    await expect(page.getByText("Current environment")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Open workspace" })).toBeVisible();
-    await expect(page.getByText("Provisioned workspaces")).toBeVisible();
+    await expect(page.getByText("Current workspace")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Tap to enter" })).toBeVisible();
+    await expect(page.getByText("Workspaces")).toBeVisible();
 
     const hasHorizontalOverflow = await page.evaluate(
       () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
     );
     expect(hasHorizontalOverflow).toBe(false);
+
+    const meridianCard = page
+      .locator("section")
+      .filter({ hasText: "Workspaces" })
+      .getByRole("button", { name: /Meridian Capital Management/i });
+    await expect(meridianCard).toBeVisible();
+    await expect(meridianCard.getByTestId("env-lifecycle-pill")).toBeVisible();
+
+    const [cardBox, pillBox] = await Promise.all([
+      meridianCard.boundingBox(),
+      meridianCard.getByTestId("env-lifecycle-pill").boundingBox(),
+    ]);
+    expect(cardBox).not.toBeNull();
+    expect(pillBox).not.toBeNull();
+
+    expect((pillBox?.x ?? 0) >= (cardBox?.x ?? 0)).toBe(true);
+    expect((pillBox?.y ?? 0) >= (cardBox?.y ?? 0)).toBe(true);
+    expect((pillBox?.x ?? 0) + (pillBox?.width ?? 0) <= (cardBox?.x ?? 0) + (cardBox?.width ?? 0)).toBe(true);
+    expect((pillBox?.y ?? 0) + (pillBox?.height ?? 0) <= (cardBox?.y ?? 0) + (cardBox?.height ?? 0)).toBe(true);
 
     await page.screenshot({
       path: testInfo.outputPath("app-mobile-selector.png"),


### PR DESCRIPTION
### Motivation
- Remove the small lavender/white chip fragment appearing on the Meridian Capital Management workspace card on mobile by fixing the card title / pill layout so badges cannot be visually clipped. 
- Harden the workspace card rendering so long client names cannot compress adjacent decorative/status chips into visible artifacts on any viewport.

### Description
- Constrained the card title row and pill layout in `repo-b/src/app/app/page.tsx` by adding a `min-w-0` container, `truncate` on the client name, and `shrink-0` on `EnvLifecyclePill` so the pill remains fully visible and the title truncates instead of pushing/bleeding the pill. 
- Added a loud guard `assertEnvironmentClientName(...)` in `repo-b/src/app/app/page.tsx` that throws when `client_name` is missing or blank so malformed data fails visibly instead of producing UI artifacts. 
- Updated mobile Playwright coverage in `repo-b/tests/app-public-mobile.spec.ts` to include realistic env fixtures (Meridian, NCF, Hall Boys, Novendor) and assert the Meridian lifecycle pill fully lies inside the card bounds as a regression guard. 
- Documented the anti-clipping pattern in `docs/tips.md` describing the `min-w-0` + `truncate` + pill `shrink-0` rule for long-title + chip rows.
- Files changed: `repo-b/src/app/app/page.tsx`, `repo-b/tests/app-public-mobile.spec.ts`, `docs/tips.md`.

### Testing
- Ran the updated Playwright spec with `pnpm playwright test tests/app-public-mobile.spec.ts`; the Playwright runner started but the run failed because required browser executables are not installed in this environment (`pnpm exec playwright install` needed), so the UI assertions could not be executed end-to-end. 
- Verified test code and TypeScript edits applied successfully and tests are updated to assert bounding-box containment for the lifecycle pill (test compilation reached the browser-launch phase before failing). 
- Ran `pnpm --version` to confirm the toolchain is present in the environment; Playwright browser binaries remain the only missing piece to complete automated verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e586f466f88331ad48f4df7da736ea)