### PR TITLE
chore: remove duplicate DealOut import (F811) in consulting routes

### DIFF
--- a/backend/app/routes/consulting.py
+++ b/backend/app/routes/consulting.py
@@ -96,7 +96,6 @@ from app.schemas.consulting import (
     TriggerSignalCreateRequest,
     TriggerSignalOut,
     DailyBriefOut,
-    DealOut,
     ManualDealCreateRequest,
     AppInboxDiscardRequest,
     AppInboxItemCreateRequest,


### PR DESCRIPTION
## Summary
Pre-existing **Backend Lint** failure on `main`: `consulting.py:99:5 F811 Redefinition of unused 'DealOut' from line 23`. `DealOut` was imported twice from `app.schemas.consulting` in the same import block. This removes the redundant second occurrence (line 99). No behavior change — `DealOut` is still imported once at line 23.

Unblocks #67 (consulting task generation logging fix) so it can merge with green Backend Lint.

## Verification
- `cd backend && python -m ruff check app/routes/consulting.py` → All checks passed
- `DealOut` still imported exactly once; file parses (`ast.parse`).

## Note
The separate **Repo Guardrails** red ("duplicate schema prefix 1000") is a distinct pre-existing condition on `main` caused by `10000_*`/`10001_*` schema filenames both extracting prefix `1000` under the guardrail's 4-digit regex. It is out of scope for this lint fix and is documented in dispatch 0002 Ticket 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)