### PR TITLE
fix: consulting auto-gen proposal pass joins crm_pipeline_stage (Ticket 2B)

### DIFF
--- a/backend/app/services/execution_auto.py
+++ b/backend/app/services/execution_auto.py
@@ -332,9 +332,11 @@ def run_auto_generation(*, env_id: str, business_id: UUID) -> dict:
                 report["pipeline_no_outreach"] += 1
 
         # ── 8. Stage = proposal AND last touch > 2d → check response ────────
-        # Stage values come from crm_opportunity.stage. The 2-day window matches
-        # the no-reply pass; together they form a tight follow-up loop on the
-        # most-revenue-sensitive part of the funnel.
+        # Stage is a FK: crm_opportunity.crm_pipeline_stage_id → crm_pipeline_stage.
+        # There is no crm_opportunity.stage column; the proposal stage is
+        # crm_pipeline_stage.key = 'proposal' (stable machine key, not label).
+        # The 2-day window matches the no-reply pass; together they form a tight
+        # follow-up loop on the most-revenue-sensitive part of the funnel.
         cur.execute(
             """
             WITH proposal_deals AS (
@@ -349,9 +351,11 @@ def run_auto_generation(*, env_id: str, business_id: UUID) -> dict:
                        ) AS last_touch
                   FROM crm_opportunity o
              LEFT JOIN crm_account a ON a.crm_account_id = o.crm_account_id
+                  JOIN crm_pipeline_stage s
+                    ON s.crm_pipeline_stage_id = o.crm_pipeline_stage_id
                  WHERE o.business_id = %s
                    AND o.status = 'open'
-                   AND lower(o.stage) = 'proposal'
+                   AND lower(s.key) = 'proposal'
             )
             SELECT crm_opportunity_id, name, account_name, last_touch
               FROM proposal_deals

--- a/backend/tests/test_execution_auto_stage_query.py
+++ b/backend/tests/test_execution_auto_stage_query.py
@@ -1,0 +1,54 @@
+"""Regression guard for the consulting auto-generation stage query.
+
+History (Ticket 2B, 2026-05-19): execution_auto.run_auto_generation pass 8
+filtered `WHERE ... AND lower(o.stage) = 'proposal'`, but crm_opportunity has
+no `stage` column — stage is the FK crm_opportunity.crm_pipeline_stage_id ->
+crm_pipeline_stage. In production this raised
+`psycopg.errors.UndefinedColumn: column o.stage does not exist`, which the
+Ticket 1 logger fix surfaced as a clean fail-closed 500.
+
+Verified against the live schema (Supabase project ozboonlsplroialdwuxj):
+crm_opportunity has crm_pipeline_stage_id + status (NO stage); the proposal
+stage is crm_pipeline_stage.key = 'proposal'. The fix joins crm_pipeline_stage
+and filters lower(s.key) = 'proposal'.
+
+These are static source assertions (no DB needed) so the guard runs in CI:
+they fail loudly if anyone reintroduces the non-existent `o.stage` reference
+or drops the pipeline-stage join from the proposal pass.
+"""
+
+from pathlib import Path
+
+_SRC = (
+    Path(__file__).resolve().parents[1]
+    / "app"
+    / "services"
+    / "execution_auto.py"
+).read_text(encoding="utf-8")
+
+
+def test_no_nonexistent_stage_column_reference():
+    """crm_opportunity has no `stage` column — the SQL must not reference it.
+
+    Guards the actual bug shape (the `o.stage` / `o .stage` SQL column ref).
+    A comment may still *mention* `crm_opportunity.stage` to explain why it is
+    absent — that is documentation, not the defect — so we do not ban the bare
+    word, only the qualified-column reference that Postgres would resolve.
+    """
+    assert "o.stage" not in _SRC, (
+        "execution_auto.py references o.stage, but crm_opportunity has no "
+        "stage column (stage is the crm_pipeline_stage_id FK). Filter on "
+        "crm_pipeline_stage.key instead."
+    )
+    # The original stale comment that *asserted the column exists* must be gone.
+    assert "Stage values come from crm_opportunity.stage" not in _SRC
+
+
+def test_proposal_pass_joins_pipeline_stage_and_filters_key():
+    """The proposal-stage pass must resolve stage via the canonical FK join."""
+    assert "crm_pipeline_stage" in _SRC, (
+        "Proposal-stage auto-gen pass must JOIN crm_pipeline_stage to resolve "
+        "the stage; crm_opportunity.crm_pipeline_stage_id is the FK."
+    )
+    assert "s.crm_pipeline_stage_id = o.crm_pipeline_stage_id" in _SRC
+    assert "lower(s.key) = 'proposal'" in _SRC


### PR DESCRIPTION
## Summary
Fixes the production task-generation failure surfaced by Ticket 1:
`psycopg.errors.UndefinedColumn: column o.stage does not exist` at `backend/app/services/execution_auto.py:338` (proposal-stage follow-up pass).

`crm_opportunity` has **no `stage` column**. Stage is the FK `crm_opportunity.crm_pipeline_stage_id → crm_pipeline_stage`. The proposal stage is `crm_pipeline_stage.key = 'proposal'`.

**Fix:** `JOIN crm_pipeline_stage s ON s.crm_pipeline_stage_id = o.crm_pipeline_stage_id` and filter `lower(s.key) = 'proposal'`, replacing the invalid `lower(o.stage) = 'proposal'`. Inner join is intentional and correct — an opportunity with no stage cannot be in proposal; this matches the original filter's intent and preserves fail-closed zero-result behavior when there are no proposal deals.

## Schema finding (evidence-based, not guessed)
- Local canonical schema `repo-b/db/schema/260_crm_native.sql`: `crm_opportunity` → `crm_pipeline_stage_id uuid REFERENCES crm_pipeline_stage`; `crm_pipeline_stage` has `key` + `label`.
- **Live Supabase** (`ozboonlsplroialdwuxj`): confirmed `crm_opportunity` has `crm_pipeline_stage_id` + `status`, **no `stage`**; `crm_pipeline_stage` has a row `key='proposal'`, `label='Proposal'`.
- Fixed query run live: `proposal_open_deals: 1`, **no UndefinedColumn**.

## Scope
Localized to `execution_auto.py` + one new test. No migration. No frontend. No `cro_execution_task` hierarchy change. Fail-closed + structured logging preserved.

## Tests
- New `backend/tests/test_execution_auto_stage_query.py` (static guard vs. `o.stage` reintroduction + asserts the canonical join) — pass.
- `test_execution_board_route.py` + `test_executions.py` + `test_consulting_pipeline.py` + `test_pipeline_execution_engine.py` → 19 passed total.
- ruff + AST clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)