### PR TITLE
docs: Ticket 3 (10003 hierarchy) shipped + verified; next = Ticket 4

### DIFF
--- a/docs/plans/03-implementation-plans/active/0002-novendor-daily-operator-control-plane.md
+++ b/docs/plans/03-implementation-plans/active/0002-novendor-daily-operator-control-plane.md
@@ -235,13 +235,46 @@ fail-closed-to-zero, not fabricated).
 **Ticket 3 (migration `10003`) is now safe to start** — no remaining live
 board fault.
 
-## Workstream B — Task hierarchy data model (deferred)
+## Workstream B / Ticket 3 — Task hierarchy data model — DONE & VERIFIED 2026-05-19
 
-Migration `10003_consulting_task_hierarchy.sql` per the Domain model section. Additive only,
-env-scoped, RLS on every new table, verification queries, seed the 5 domains + FlowYorker +
-industry initiatives. Schema discovery is sufficient for planning; **Ticket 3 must still verify
-current production schema** (`supabase db query --linked` against `ozboonlsplroialdwuxj`) before
-writing the migration — a stale local read must not become a bad prod migration.
+`repo-b/db/schema/10003_consulting_task_hierarchy.sql`. PR **#73** merged to `main`
+(merge commit `4a800d8ede60c6c02dde80906d4315e055e0dd45`). Schema-only — no app code, no
+deploy needed (migration applied directly to live Supabase + independently re-applied and
+verified by CI's **DB Schema Gate = SUCCESS**).
+
+**Live schema verification (before):** none of the 10 hierarchy columns existed on
+`cro_execution_task`; `cro_operating_domain`/`cro_initiative`/`cro_workstream` absent;
+`10003` was the free number; board SELECT uses explicit columns (additive-safe). Type
+discovery: `app.environments.env_id` is **uuid** while `cro_*.env_id` is **text** — the
+seed `business_id` lookup casts accordingly (a `uuid = text` operator error was caught and
+fixed during apply, not guessed).
+
+**What shipped:**
+- 10 nullable hierarchy columns on `cro_execution_task` (`domain_key`, `initiative_key`,
+  `workstream_key`, `parent_task_id` self-FK `ON DELETE SET NULL`, `source_kind`,
+  `related_entity_type/_id/_url`, `evidence`, `last_reviewed_at`) + 2 grouping indexes.
+  No status/type/impact/date columns duplicated — reuses existing.
+- `cro_operating_domain` / `cro_initiative` / `cro_workstream` — `env_id`+`business_id`,
+  RLS `USING (env_id = current_setting('app.env_id', true))` per ARCHITECTURE.md.
+- Seeds (env `62cfd59c…`, `business_id` `225f52ca-cdf4-4af9-a973-d1d310ddcba1` resolved
+  authoritatively from `app.environments` → `cro_outreach_log` → `cro_execution_task`,
+  self-skips rather than fabricate): 5 controlled domains, FlowYorker initiative + 7
+  workstreams, 6 Novendor industry initiatives.
+- 9 companion verification queries; idempotent (`IF NOT EXISTS` / `ON CONFLICT DO NOTHING`).
+
+**Verified live (post-apply):** 6a cols=10, 6b tables=3, 6c RLS=3, 6d domains=5,
+6e flowyorker=1, 6f industry=6, 6g workstreams=7, seed `business_id` single distinct =
+`225f52ca…`. `cro_execution_task` has 0 rows total (fresh board) so nothing was rewritten.
+Existing board endpoint still **HTTP 200** post-migration. 19 backend tests pass
+(`test_execution_board_route`, `test_execution_auto_stage_query`, `test_executions`,
+`test_consulting_pipeline`, `test_pipeline_execution_engine`).
+
+> Repo Guardrails `1000` duplicate-prefix is pre-existing baseline (`10000_`/`10001_`
+> collapse under `^(\d{4})`; tips #18). `10003` adds no new collision class. CI DB Schema
+> Gate (the authoritative migration check) passed.
+
+**Ticket 4 (UI domain grouping in `ExecutionBoard.tsx`) is now safe to start** — the
+hierarchy columns + reference tables + seeds exist and are verified live.
 
 ## Workstream C — Tasks page UI hierarchy (deferred)
 

--- a/docs/plans/novendor-crm-accounting/backlog.md
+++ b/docs/plans/novendor-crm-accounting/backlog.md
@@ -36,7 +36,7 @@
 
 ## Daily Operator Control Plane (dispatch 0002 — hierarchy buildout, deferred)
 Tracked in `docs/plans/03-implementation-plans/active/0002-novendor-daily-operator-control-plane.md`. Workstreams, in order:
-- [ ] **B — Hierarchy migration** `10003_consulting_task_hierarchy.sql` — additive columns on `cro_execution_task` (`domain_key`, `initiative_key`, `workstream_key`, `parent_task_id`, `source_kind`, `related_entity_type/_id/_url`, `evidence`, `last_reviewed_at`) + `cro_operating_domain` / `cro_initiative` / `cro_workstream` ref tables. Verify prod schema first.
+- [x] **B / Ticket 3 — Hierarchy migration** — **DONE & VERIFIED 2026-05-19.** `repo-b/db/schema/10003_consulting_task_hierarchy.sql`, PR #73 merged (`4a800d8e`), applied + verified live (CI DB Schema Gate SUCCESS). 10 additive columns on `cro_execution_task` + 3 RLS reference tables + seeds (5 domains / FlowYorker+7 workstreams / 6 industry initiatives). Board still HTTP 200, 19 tests pass. See dispatch `0002` Workstream B / Ticket 3.
 - [ ] **C — Tasks UI hierarchy** — domain grouping + initiative/workstream filter in `repo-b/src/components/consulting/execution/ExecutionBoard.tsx`, lanes preserved.
 - [ ] **D — FlowYorker / Web Properties** — FlowYorker.com as first `web_properties` initiative + 7 workstreams.
 - [ ] **E — Outreach/CRM linkage** — tasks ↔ `crm_account`/`crm_contact`/`crm_opportunity`/`crm_activity`.

--- a/docs/plans/novendor-crm-accounting/next-session.md
+++ b/docs/plans/novendor-crm-accounting/next-session.md
@@ -3,50 +3,51 @@
 **Last updated:** 2026-05-19
 **Priority:** High — this is Novendor's internal operating system
 
-## Copy-paste prompt for next Claude Code session (Ticket 3 — hierarchy migration)
+## Copy-paste prompt for next Claude Code session (Ticket 4 — Tasks UI domain grouping)
 
-Ticket 1 (logger bug) and the schema inventory are DONE. This session is **Ticket 3 only**.
-Read first: `docs/plans/03-implementation-plans/active/0002-novendor-daily-operator-control-plane.md`,
-`docs/plans/novendor-crm-accounting/{architecture,backlog}.md`, `ARCHITECTURE.md`,
-`repo-b/db/schema/525_execution_board.sql` + `604_cro_execution_task_re_engage.sql`,
-`repo-b/db/schema/10002_history_rhymes_research_planning.sql` (numbering convention).
+Tickets 1, 2, 2B, and 3 are DONE & production-verified: logger bug fixed, `o.stage` SQL
+fixed, board returns HTTP 200, and the additive hierarchy schema (`10003`) is applied +
+verified live (10 columns on `cro_execution_task` + `cro_operating_domain`/`cro_initiative`/
+`cro_workstream` ref tables + seeds for env `62cfd59c-a171-4224-ad1e-fffc35bd1ef4`,
+`business_id` `225f52ca-cdf4-4af9-a973-d1d310ddcba1`). This session is **Ticket 4 only**.
+
+Read first: `docs/plans/03-implementation-plans/active/0002-novendor-daily-operator-control-plane.md`
+(Workstream B/Ticket 3 result + Workstream C spec), `docs/plans/novendor-crm-accounting/{architecture,backlog}.md`,
+`docs/plans/01-shared-standards/design-system/shell-navigation-rules.md`,
+`repo-b/src/components/consulting/execution/ExecutionBoard.tsx`,
+`repo-b/src/app/lab/env/[envId]/consulting/tasks/page.tsx`,
+`backend/app/routes/consulting.py` (board route) + `backend/app/services/execution_tasks.py`.
 
 ```
-Before writing migration `10003_consulting_task_hierarchy.sql`, verify the current live
-schema for `cro_execution_task` in Supabase project `ozboonlsplroialdwuxj`.
+Add domain/initiative/workstream grouping to the Consulting Tasks board WITHOUT
+removing or breaking the existing Today / This Week / Waiting / Done lanes.
 
-Do not assume the local schema files perfectly match production.
+Backend first (read path only — no schema change, 10003 is already live):
+- Surface domain_key / initiative_key / workstream_key (+ the new fields) in the
+  board read API and join the cro_operating_domain / cro_initiative /
+  cro_workstream reference tables to resolve labels.
+- Missing reference rows must degrade to honest empty states ("No linked
+  initiative" / "Ungrouped"), never error. Preserve fail-closed behavior.
+- Do NOT duplicate status/type/impact/date fields — reuse existing.
 
-Confirm:
-- existing columns
-- existing enum/check constraints
-- existing indexes
-- existing RLS policies
-- env scoping pattern
-- current migration history / latest applied migration
+Frontend:
+- ExecutionBoard.tsx: add an optional domain grouping view + initiative/
+  workstream filter. The four status lanes must still work exactly as today
+  when no grouping is selected (default unchanged).
+- Dark operator shell preserved; left nav stays ≤7 items (Pipeline,
+  Accounting, Contacts, Tasks unchanged).
+- Honest empty states for ungrouped/NULL-hierarchy tasks.
 
-Then write an additive-only migration that:
-- extends `cro_execution_task` without duplicating existing status/type/priority/date fields
-- adds hierarchy fields only where missing
-- adds `cro_operating_domain`, `cro_initiative`, and `cro_workstream` reference tables if not already present
-- keeps RLS/env scoping consistent
-- seeds the five controlled domains
-- seeds FlowYorker under `web_properties`
-- seeds Novendor industry initiatives under `novendor_web`
-- includes verification queries
-- updates the active implementation plan and `docs/tips.md`
-
-Do not change frontend UI in this ticket.
-Do not add assistant retrieval yet.
-Do not persist Morning Checklist rows yet.
+Do NOT: persist Morning Checklist rows, add assistant/CoWork retrieval,
+change the schema, touch app.task_*/nv_tasks, or alter unrelated environments.
 ```
 
-Migration dry-run mindset (even without a formal dry-run tool): inspect live schema first,
-then write the migration, then verify against a Supabase branch / local test DB — or at
-minimum produce exact verification SQL in the migration file. Hierarchy column list and the
-five controlled domain keys are in dispatch `0002` ("Domain model"). Do NOT touch
-`app.task_*` or `nv_tasks` (unrelated task systems). The error-envelope normalization in
-backlog.md is explicitly out of scope for Ticket 3.
+Verification: typecheck (`cd repo-b && npm run typecheck`), relevant backend route
+tests + `test_execution_board_route.py`, Playwright smoke for `/consulting/tasks`,
+dark-mode visual check, and a production smoke that the board still returns 200 and
+existing lanes render. Work in a fresh `git worktree` off `origin/main` (the primary
+tree may carry unrelated concurrent work). Repo Guardrails `1000` red is documented
+pre-existing baseline (tips #18) — do not chase it.
 
 Update dispatch `0002`, `backlog.md`, `next-session.md`, and `docs/tips.md` before finishing.
 


### PR DESCRIPTION
Docs-only. Records the applied + production-verified 10003 hierarchy migration (PR #73) and rescopes next-session to Ticket 4 (UI domain grouping). No code. Excludes unrelated working-tree work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)