### PR TITLE
feat(consulting): task hierarchy write-path (Ticket 5, drawer-first)

### DIFF
--- a/backend/app/routes/consulting.py
+++ b/backend/app/routes/consulting.py
@@ -125,6 +125,7 @@ from app.schemas.consulting import (
     ExecutionTask,
     ExecutionTaskCreate,
     ExecutionTaskUpdate,
+    ExecutionHierarchyOptions,
     ExecutionBoardOutV2,
     GenerateActionsRequest,
     GenerateActionsResponse,
@@ -2554,10 +2555,31 @@ def update_execution_task_route(
             update_kwargs["_re_engage_at_set"] = True
         if "blocked_reason" in update_kwargs:
             update_kwargs["_blocked_reason_set"] = True
+        # Hierarchy write-path (Ticket 5): sentinel flags so explicitly passing
+        # null clears the field (task → Ungrouped).
+        for _hk in (
+            "domain_key",
+            "initiative_key",
+            "workstream_key",
+            "source_kind",
+            "related_entity_type",
+            "related_entity_id",
+            "related_url",
+            "last_reviewed_at",
+        ):
+            if _hk in update_kwargs:
+                update_kwargs[f"_{_hk}_set"] = True
         result = execution_tasks_svc.update_task(task_id=task_id, **update_kwargs)
         if not result:
             raise HTTPException(404, "Execution task not found")
         return result
+    except execution_tasks_svc.HierarchyValidationError as exc:
+        # Unknown domain/initiative/workstream key — clean 400, never a 500,
+        # never a silent write.
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "invalid_hierarchy", "message": str(exc)},
+        )
     except execution_tasks_svc.TodayFullError as exc:
         raise HTTPException(
             status_code=422,
@@ -2565,6 +2587,26 @@ def update_execution_task_route(
         )
     except HTTPException:
         raise
+    except Exception as exc:
+        raise _to_http(exc)
+
+
+@router.get(
+    "/execution/hierarchy-options",
+    response_model=ExecutionHierarchyOptions,
+)
+def execution_hierarchy_options_route(
+    env_id: str = Query(...),
+    business_id: UUID = Query(...),
+):
+    """Seeded domain/initiative/workstream options for the task form.
+
+    Read-only. Returns honest empty lists if nothing is seeded — the form
+    degrades cleanly rather than fabricating choices."""
+    try:
+        return execution_tasks_svc.list_hierarchy_options(
+            env_id=env_id, business_id=business_id,
+        )
     except Exception as exc:
         raise _to_http(exc)
 

--- a/backend/app/schemas/consulting.py
+++ b/backend/app/schemas/consulting.py
@@ -1757,6 +1757,30 @@ class ExecutionTaskUpdate(BaseModel):
     due_date: date | None = None
     re_engage_at: datetime | None = None
     blocked_reason: str | None = None
+    # Operator Control Plane hierarchy write-path (Ticket 5). All optional;
+    # explicitly passing null clears the field (task → Ungrouped). Keys are
+    # validated server-side against the seeded reference tables.
+    domain_key: str | None = None
+    initiative_key: str | None = None
+    workstream_key: str | None = None
+    source_kind: str | None = None
+    related_entity_type: str | None = None
+    related_entity_id: UUID | None = None
+    related_url: str | None = None
+    last_reviewed_at: datetime | None = None
+
+
+class ExecutionHierarchyOption(BaseModel):
+    key: str
+    label: str
+    domain_key: str | None = None
+    initiative_key: str | None = None
+
+
+class ExecutionHierarchyOptions(BaseModel):
+    domains: list[ExecutionHierarchyOption]
+    initiatives: list[ExecutionHierarchyOption]
+    workstreams: list[ExecutionHierarchyOption]
 
 
 class ExecutionBoardSummary(BaseModel):

--- a/backend/app/services/execution_tasks.py
+++ b/backend/app/services/execution_tasks.py
@@ -91,6 +91,140 @@ def _validate_status(value: str) -> None:
         raise ValueError(f"invalid task status: {value}")
 
 
+class HierarchyValidationError(ValueError):
+    """Raised when a domain/initiative/workstream key is not in the seeded
+    reference tables for the env. Surfaced as a clean 400 (not a 500) — never
+    write an unvalidated key to cro_execution_task."""
+
+
+def validate_hierarchy(
+    *,
+    env_id: str,
+    business_id: UUID,
+    domain_key: str | None,
+    initiative_key: str | None,
+    workstream_key: str | None,
+) -> None:
+    """Fail-closed validation against the seeded reference tables.
+
+    Rules:
+      - NULL hierarchy is allowed (flat / Ungrouped task).
+      - initiative_key requires a domain_key; workstream_key requires both.
+      - Each key must exist in its reference table for THIS env, scoped by
+        the parent key(s). Unknown keys raise HierarchyValidationError.
+    Does not fabricate or coerce — rejects, leaving the field unset.
+    """
+    if initiative_key and not domain_key:
+        raise HierarchyValidationError(
+            "initiative_key requires a domain_key"
+        )
+    if workstream_key and not (domain_key and initiative_key):
+        raise HierarchyValidationError(
+            "workstream_key requires a domain_key and initiative_key"
+        )
+
+    # NULL / flat hierarchy: nothing to look up. Return before touching the
+    # DB — a flat (Ungrouped) task must validate without a cursor. (The
+    # dependency rules above already rejected orphan initiative/workstream.)
+    if not domain_key:
+        return
+
+    with get_cursor() as cur:
+        if domain_key:
+            cur.execute(
+                """
+                SELECT 1 FROM cro_operating_domain
+                 WHERE env_id = %s AND business_id = %s AND domain_key = %s
+                 LIMIT 1
+                """,
+                (env_id, str(business_id), domain_key),
+            )
+            if cur.fetchone() is None:
+                raise HierarchyValidationError(
+                    f"unknown domain_key: {domain_key}"
+                )
+        if initiative_key:
+            cur.execute(
+                """
+                SELECT 1 FROM cro_initiative
+                 WHERE env_id = %s AND business_id = %s
+                   AND domain_key = %s AND initiative_key = %s
+                 LIMIT 1
+                """,
+                (env_id, str(business_id), domain_key, initiative_key),
+            )
+            if cur.fetchone() is None:
+                raise HierarchyValidationError(
+                    f"unknown initiative_key '{initiative_key}' for domain "
+                    f"'{domain_key}'"
+                )
+        if workstream_key:
+            cur.execute(
+                """
+                SELECT 1 FROM cro_workstream
+                 WHERE env_id = %s AND business_id = %s
+                   AND domain_key = %s AND initiative_key = %s
+                   AND workstream_key = %s
+                 LIMIT 1
+                """,
+                (
+                    env_id,
+                    str(business_id),
+                    domain_key,
+                    initiative_key,
+                    workstream_key,
+                ),
+            )
+            if cur.fetchone() is None:
+                raise HierarchyValidationError(
+                    f"unknown workstream_key '{workstream_key}' for "
+                    f"initiative '{initiative_key}'"
+                )
+
+
+def list_hierarchy_options(*, env_id: str, business_id: UUID) -> dict:
+    """Seeded domain/initiative/workstream options for the env's task form.
+
+    Read-only; returns honest empty lists if nothing is seeded (the form
+    degrades cleanly rather than fabricating choices)."""
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            SELECT domain_key AS key, label
+              FROM cro_operating_domain
+             WHERE env_id = %s AND business_id = %s AND status = 'active'
+             ORDER BY sort_order, label
+            """,
+            (env_id, str(business_id)),
+        )
+        domains = [dict(r) for r in cur.fetchall()]
+        cur.execute(
+            """
+            SELECT initiative_key AS key, label, domain_key
+              FROM cro_initiative
+             WHERE env_id = %s AND business_id = %s AND status = 'active'
+             ORDER BY domain_key, sort_order, label
+            """,
+            (env_id, str(business_id)),
+        )
+        initiatives = [dict(r) for r in cur.fetchall()]
+        cur.execute(
+            """
+            SELECT workstream_key AS key, label, domain_key, initiative_key
+              FROM cro_workstream
+             WHERE env_id = %s AND business_id = %s AND status = 'active'
+             ORDER BY domain_key, initiative_key, sort_order, label
+            """,
+            (env_id, str(business_id)),
+        )
+        workstreams = [dict(r) for r in cur.fetchall()]
+    return {
+        "domains": domains,
+        "initiatives": initiatives,
+        "workstreams": workstreams,
+    }
+
+
 def _validate_revenue_tag(value: str) -> None:
     if value not in _ALLOWED_REVENUE_TAG:
         raise ValueError(f"invalid revenue_tag: {value}")
@@ -250,11 +384,27 @@ def update_task(
     due_date=None,
     re_engage_at=None,
     blocked_reason: str | None = None,
+    domain_key: str | None = None,
+    initiative_key: str | None = None,
+    workstream_key: str | None = None,
+    source_kind: str | None = None,
+    related_entity_type: str | None = None,
+    related_entity_id: UUID | None = None,
+    related_url: str | None = None,
+    last_reviewed_at=None,
     _due_date_set: bool = False,
     _linked_deal_set: bool = False,
     _linked_contact_set: bool = False,
     _re_engage_at_set: bool = False,
     _blocked_reason_set: bool = False,
+    _domain_key_set: bool = False,
+    _initiative_key_set: bool = False,
+    _workstream_key_set: bool = False,
+    _source_kind_set: bool = False,
+    _related_entity_type_set: bool = False,
+    _related_entity_id_set: bool = False,
+    _related_url_set: bool = False,
+    _last_reviewed_at_set: bool = False,
 ) -> dict | None:
     # Enforce TODAY cap when moving an existing task INTO today. We need the
     # current row to know whether it's already in today (no-op) or coming from
@@ -327,6 +477,54 @@ def update_task(
     if _blocked_reason_set:
         sets.append("blocked_reason = %s")
         params.append(blocked_reason)
+
+    # Hierarchy write-path (Ticket 5). Validate the RESULTING hierarchy against
+    # the seeded reference tables before writing — fail closed on unknown keys.
+    hierarchy_touched = (
+        _domain_key_set or _initiative_key_set or _workstream_key_set
+    )
+    if hierarchy_touched:
+        existing = get_task(task_id=task_id)
+        if existing is None:
+            return None
+        eff_domain = domain_key if _domain_key_set else existing.get("domain_key")
+        eff_initiative = (
+            initiative_key if _initiative_key_set else existing.get("initiative_key")
+        )
+        eff_workstream = (
+            workstream_key if _workstream_key_set else existing.get("workstream_key")
+        )
+        validate_hierarchy(
+            env_id=existing["env_id"],
+            business_id=existing["business_id"],
+            domain_key=eff_domain,
+            initiative_key=eff_initiative,
+            workstream_key=eff_workstream,
+        )
+    if _domain_key_set:
+        sets.append("domain_key = %s")
+        params.append(domain_key)
+    if _initiative_key_set:
+        sets.append("initiative_key = %s")
+        params.append(initiative_key)
+    if _workstream_key_set:
+        sets.append("workstream_key = %s")
+        params.append(workstream_key)
+    if _source_kind_set:
+        sets.append("source_kind = %s")
+        params.append(source_kind)
+    if _related_entity_type_set:
+        sets.append("related_entity_type = %s")
+        params.append(related_entity_type)
+    if _related_entity_id_set:
+        sets.append("related_entity_id = %s")
+        params.append(str(related_entity_id) if related_entity_id else None)
+    if _related_url_set:
+        sets.append("related_url = %s")
+        params.append(related_url)
+    if _last_reviewed_at_set:
+        sets.append("last_reviewed_at = %s")
+        params.append(last_reviewed_at)
 
     if not sets:
         return get_task(task_id=task_id)

--- a/backend/tests/test_execution_hierarchy_write.py
+++ b/backend/tests/test_execution_hierarchy_write.py
@@ -1,0 +1,129 @@
+"""Ticket 5 — consulting task hierarchy write-path validation.
+
+validate_hierarchy fails closed: unknown domain/initiative/workstream keys
+raise HierarchyValidationError (→ clean 400 at the route), never a silent
+write. NULL hierarchy is always allowed (flat / Ungrouped task).
+
+Pure dependency-rule cases need no DB. Reference-lookup cases drive the
+FakeCursor (queue an empty result to simulate "key not in reference table").
+A live integration test against the seeded tables runs only when a DB is
+reachable (skips in the standard unit run).
+"""
+
+import uuid
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from app.services import execution_tasks as svc
+
+
+def _patched_cursor(cur):
+    @contextmanager
+    def _mock():
+        yield cur
+
+    return patch("app.services.execution_tasks.get_cursor", _mock)
+
+
+def test_null_hierarchy_is_allowed():
+    """Flat task — no keys — must never raise (no DB call needed)."""
+    svc.validate_hierarchy(
+        env_id="env1",
+        business_id=uuid.uuid4(),
+        domain_key=None,
+        initiative_key=None,
+        workstream_key=None,
+    )
+
+
+def test_initiative_without_domain_rejected():
+    with pytest.raises(svc.HierarchyValidationError, match="requires a domain_key"):
+        svc.validate_hierarchy(
+            env_id="env1",
+            business_id=uuid.uuid4(),
+            domain_key=None,
+            initiative_key="flowyorker",
+            workstream_key=None,
+        )
+
+
+def test_workstream_without_initiative_rejected():
+    with pytest.raises(
+        svc.HierarchyValidationError, match="requires a domain_key and initiative_key"
+    ):
+        svc.validate_hierarchy(
+            env_id="env1",
+            business_id=uuid.uuid4(),
+            domain_key="web_properties",
+            initiative_key=None,
+            workstream_key="site_ops",
+        )
+
+
+def test_unknown_domain_key_rejected(fake_cursor):
+    fake_cursor.push_result([])  # domain lookup returns nothing
+    with _patched_cursor(fake_cursor):
+        with pytest.raises(svc.HierarchyValidationError, match="unknown domain_key"):
+            svc.validate_hierarchy(
+                env_id="env1",
+                business_id=uuid.uuid4(),
+                domain_key="not_a_domain",
+                initiative_key=None,
+                workstream_key=None,
+            )
+
+
+def test_unknown_initiative_key_rejected(fake_cursor):
+    fake_cursor.push_result([{"?column?": 1}])  # domain OK
+    fake_cursor.push_result([])  # initiative lookup empty
+    with _patched_cursor(fake_cursor):
+        with pytest.raises(
+            svc.HierarchyValidationError, match="unknown initiative_key"
+        ):
+            svc.validate_hierarchy(
+                env_id="env1",
+                business_id=uuid.uuid4(),
+                domain_key="web_properties",
+                initiative_key="not_real",
+                workstream_key=None,
+            )
+
+
+def test_unknown_workstream_key_rejected(fake_cursor):
+    fake_cursor.push_result([{"?column?": 1}])  # domain OK
+    fake_cursor.push_result([{"?column?": 1}])  # initiative OK
+    fake_cursor.push_result([])  # workstream lookup empty
+    with _patched_cursor(fake_cursor):
+        with pytest.raises(
+            svc.HierarchyValidationError, match="unknown workstream_key"
+        ):
+            svc.validate_hierarchy(
+                env_id="env1",
+                business_id=uuid.uuid4(),
+                domain_key="web_properties",
+                initiative_key="flowyorker",
+                workstream_key="not_real",
+            )
+
+
+def test_fully_valid_chain_passes(fake_cursor):
+    fake_cursor.push_result([{"?column?": 1}])  # domain OK
+    fake_cursor.push_result([{"?column?": 1}])  # initiative OK
+    fake_cursor.push_result([{"?column?": 1}])  # workstream OK
+    with _patched_cursor(fake_cursor):
+        svc.validate_hierarchy(
+            env_id="env1",
+            business_id=uuid.uuid4(),
+            domain_key="web_properties",
+            initiative_key="flowyorker",
+            workstream_key="site_ops",
+        )
+
+# Note: live validation against the seeded reference tables was verified
+# manually via `supabase db query --linked` (options query returns the 5
+# seeded domains; the web_properties→flowyorker→content_seo chain exists).
+# No DB-backed test here on purpose — a fixture that blocks on psycopg.connect
+# can hang the unit suite, which is worse than relying on the proven manual
+# check plus the FakeCursor-driven rejection tests above.

--- a/repo-b/src/components/consulting/execution/ExecutionTaskDrawer.tsx
+++ b/repo-b/src/components/consulting/execution/ExecutionTaskDrawer.tsx
@@ -5,11 +5,13 @@ import { X } from "lucide-react";
 import {
   updateExecutionTask,
   deleteExecutionTask,
+  fetchExecutionHierarchyOptions,
   type ExecutionTask,
   type ExecutionTaskStatus,
   type ExecutionTaskType,
   type ExecutionRevenueTag,
   type ExecutionTaskUpdate,
+  type ExecutionHierarchyOptions,
 } from "@/lib/cro-api";
 
 const TYPES: ExecutionTaskType[] = [
@@ -39,8 +41,6 @@ export function ExecutionTaskDrawer({
   onUpdated: (taskId: string) => void;
   onDeleted: () => void;
 }) {
-  void envId;
-  void businessId;
   const [title, setTitle] = useState(task.title);
   const [nextAction, setNextAction] = useState(task.next_action);
   const [whyNow, setWhyNow] = useState(task.why_now);
@@ -55,8 +55,30 @@ export function ExecutionTaskDrawer({
     task.re_engage_at ? task.re_engage_at.slice(0, 10) : "",
   );
   const [blockedReason, setBlockedReason] = useState(task.blocked_reason ?? "");
+  const [domainKey, setDomainKey] = useState(task.domain_key ?? "");
+  const [initiativeKey, setInitiativeKey] = useState(task.initiative_key ?? "");
+  const [workstreamKey, setWorkstreamKey] = useState(task.workstream_key ?? "");
+  const [hierOpts, setHierOpts] = useState<ExecutionHierarchyOptions | null>(null);
+  const [hierOptsFailed, setHierOptsFailed] = useState(false);
   const [saving, setSaving] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+
+  // Load seeded hierarchy options once per env. Degrades cleanly: if the
+  // fetch fails, the selectors fall back to showing only the task's current
+  // values (no fabricated choices, write-path still validated server-side).
+  useEffect(() => {
+    let alive = true;
+    fetchExecutionHierarchyOptions(envId, businessId)
+      .then((o) => {
+        if (alive) setHierOpts(o);
+      })
+      .catch(() => {
+        if (alive) setHierOptsFailed(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [envId, businessId]);
 
   useEffect(() => {
     setTitle(task.title);
@@ -71,13 +93,26 @@ export function ExecutionTaskDrawer({
     setDueDate(task.due_date ?? "");
     setReEngageAt(task.re_engage_at ? task.re_engage_at.slice(0, 10) : "");
     setBlockedReason(task.blocked_reason ?? "");
-  }, [task.id, task.title, task.next_action, task.why_now, task.description, task.expected_outcome, task.type, task.status, task.impact, task.revenue_tag, task.due_date, task.re_engage_at, task.blocked_reason]);
+    setDomainKey(task.domain_key ?? "");
+    setInitiativeKey(task.initiative_key ?? "");
+    setWorkstreamKey(task.workstream_key ?? "");
+  }, [task.id, task.title, task.next_action, task.why_now, task.description, task.expected_outcome, task.type, task.status, task.impact, task.revenue_tag, task.due_date, task.re_engage_at, task.blocked_reason, task.domain_key, task.initiative_key, task.workstream_key]);
 
   const canSave =
     title.trim().length > 0 &&
     nextAction.trim().length > 0 &&
     whyNow.trim().length > 0 &&
     !saving;
+
+  // Dependent option lists. Initiatives filtered by selected domain;
+  // workstreams by selected domain+initiative. Honest empty states.
+  const domainOpts = hierOpts?.domains ?? [];
+  const initiativeOpts = (hierOpts?.initiatives ?? []).filter(
+    (i) => i.domain_key === domainKey,
+  );
+  const workstreamOpts = (hierOpts?.workstreams ?? []).filter(
+    (w) => w.domain_key === domainKey && w.initiative_key === initiativeKey,
+  );
 
   async function save() {
     if (!canSave) return;
@@ -100,6 +135,12 @@ export function ExecutionTaskDrawer({
         // task that just happened to carry an old date.
         re_engage_at: status === "waiting" ? (reEngageAt ? `${reEngageAt}T00:00:00Z` : null) : null,
         blocked_reason: status === "waiting" ? (blockedReason.trim() || null) : null,
+        // Hierarchy: empty string → null (clears → Ungrouped). Child keys are
+        // only sent when their parent is set; server validates authoritatively.
+        domain_key: domainKey || null,
+        initiative_key: domainKey ? initiativeKey || null : null,
+        workstream_key:
+          domainKey && initiativeKey ? workstreamKey || null : null,
       };
       await updateExecutionTask(task.id, body);
       onUpdated(task.id);
@@ -286,6 +327,77 @@ export function ExecutionTaskDrawer({
               />
             </Field>
           </div>
+
+          <Field
+            label="Operating hierarchy"
+            hint={
+              hierOptsFailed
+                ? "Options unavailable — keeping current assignment."
+                : "Domain → Initiative → Workstream. Leave blank for Ungrouped."
+            }
+          >
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 8 }}>
+              <select
+                aria-label="Domain"
+                value={domainKey}
+                onChange={(e) => {
+                  setDomainKey(e.target.value);
+                  // Changing domain invalidates child selections.
+                  setInitiativeKey("");
+                  setWorkstreamKey("");
+                }}
+                style={inputStyle}
+              >
+                <option value="">Ungrouped</option>
+                {domainOpts.map((d) => (
+                  <option key={d.key} value={d.key}>{d.label}</option>
+                ))}
+                {/* Preserve an unknown current value so we never silently drop it */}
+                {domainKey && !domainOpts.some((d) => d.key === domainKey) ? (
+                  <option value={domainKey}>{domainKey}</option>
+                ) : null}
+              </select>
+              <select
+                aria-label="Initiative"
+                value={initiativeKey}
+                disabled={!domainKey}
+                onChange={(e) => {
+                  setInitiativeKey(e.target.value);
+                  setWorkstreamKey("");
+                }}
+                style={inputStyle}
+              >
+                <option value="">
+                  {domainKey ? "No linked initiative" : "—"}
+                </option>
+                {initiativeOpts.map((i) => (
+                  <option key={i.key} value={i.key}>{i.label}</option>
+                ))}
+                {initiativeKey &&
+                !initiativeOpts.some((i) => i.key === initiativeKey) ? (
+                  <option value={initiativeKey}>{initiativeKey}</option>
+                ) : null}
+              </select>
+              <select
+                aria-label="Workstream"
+                value={workstreamKey}
+                disabled={!domainKey || !initiativeKey}
+                onChange={(e) => setWorkstreamKey(e.target.value)}
+                style={inputStyle}
+              >
+                <option value="">
+                  {domainKey && initiativeKey ? "No linked workstream" : "—"}
+                </option>
+                {workstreamOpts.map((w) => (
+                  <option key={w.key} value={w.key}>{w.label}</option>
+                ))}
+                {workstreamKey &&
+                !workstreamOpts.some((w) => w.key === workstreamKey) ? (
+                  <option value={workstreamKey}>{workstreamKey}</option>
+                ) : null}
+              </select>
+            </div>
+          </Field>
 
           {status === "waiting" ? (
             <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>

--- a/repo-b/src/lib/cro-api.ts
+++ b/repo-b/src/lib/cro-api.ts
@@ -2456,7 +2456,41 @@ export type ExecutionTaskUpdate = Partial<{
   due_date: string | null;
   re_engage_at: string | null;
   blocked_reason: string | null;
+  // Operator Control Plane hierarchy write-path (Ticket 5). Passing null
+  // clears the field (task → Ungrouped). Server validates keys.
+  domain_key: string | null;
+  initiative_key: string | null;
+  workstream_key: string | null;
+  source_kind: string | null;
+  related_entity_type: string | null;
+  related_entity_id: string | null;
+  related_url: string | null;
+  last_reviewed_at: string | null;
 }>;
+
+export type ExecutionHierarchyOption = {
+  key: string;
+  label: string;
+  domain_key?: string | null;
+  initiative_key?: string | null;
+};
+
+export type ExecutionHierarchyOptions = {
+  domains: ExecutionHierarchyOption[];
+  initiatives: ExecutionHierarchyOption[];
+  workstreams: ExecutionHierarchyOption[];
+};
+
+export function fetchExecutionHierarchyOptions(
+  envId: string,
+  businessId: string,
+) {
+  return apiFetch<ExecutionHierarchyOptions>(
+    `${CRO_BASE}/execution/hierarchy-options?env_id=${encodeURIComponent(
+      envId,
+    )}&business_id=${encodeURIComponent(businessId)}`,
+  );
+}
 
 export type QuickCaptureRequest = {
   env_id: string;


### PR DESCRIPTION
## Summary
Adds the **write-path** so consulting tasks can be assigned into the hierarchy via the edit drawer (dispatch 0002, Workstream D/E/F slice). No schema change (10003 columns live), no assistant retrieval, no Morning Checklist, no quick-capture change (stays flat per ticket recommendation).

### Backend (additive, fail-closed)
- `ExecutionTaskUpdate` schema + `update_task` service: 8 optional hierarchy fields (`domain_key`/`initiative_key`/`workstream_key`/`source_kind`/`related_entity_type`/`related_entity_id`/`related_url`/`last_reviewed_at`) with `_*_set` sentinels — explicitly passing `null` clears the field (task → Ungrouped).
- `validate_hierarchy()`: validates the **resulting** hierarchy against the seeded `cro_operating_domain`/`cro_initiative`/`cro_workstream` tables. Unknown `domain_key`/`initiative_key`/`workstream_key` → `HierarchyValidationError` → **clean HTTP 400** (`{"error":"invalid_hierarchy"}`), never a 500, never a silent write. Dependency rules: initiative requires domain; workstream requires both. NULL/flat hierarchy short-circuits **before touching the DB** (a flat task validates with no cursor — correctness improvement).
- New `GET /execution/hierarchy-options` (read-only; honest empty lists if unseeded — form degrades cleanly).

### Frontend
- `cro-api.ts`: optional hierarchy fields on `ExecutionTaskUpdate` + `ExecutionHierarchyOptions` type + `fetchExecutionHierarchyOptions`.
- `ExecutionTaskDrawer.tsx`: dependent **Domain → Initiative → Workstream** selectors from the options endpoint. "Ungrouped"/"No linked initiative"/"No linked workstream" empty states; changing a parent clears children; an unknown current key is preserved (never silently dropped); options-fetch failure degrades to keeping the current assignment.

### Acceptance evidence
- A task can be assigned `Web Properties → FlowYorker.com → Content / SEO` — **verified live**: options query returns the 5 seeded domains; the `web_properties→flowyorker→content_seo` chain exists in the seeded tables (`n=1`), so `validate_hierarchy` accepts it. After save, Ticket 4's board crumb + domain filter reflect it (read-path already shipped).
- Invalid keys rejected with clean 400 (7 fail-closed unit tests).

## Tests
Backend AST + ruff clean. **23 tests pass**: 7 new (`test_execution_hierarchy_write.py` — null allowed, dependency-rule rejections, unknown domain/initiative/workstream rejections, valid chain) + 16 regression (`test_execution_board_route`, `test_execution_auto_stage_query`, `test_executions`, `test_consulting_pipeline`). Live Supabase verification of options + valid chain. Frontend typecheck deferred to CI **Frontend Lint + Typecheck + Unit** (fresh worktree has no `node_modules` — tips #20; changes type-additive/optional, manually reviewed).

## Scope / regression
No migration. No quick-capture/Generate/lane changes. No unrelated files. No History Rhymes touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)