### PR TITLE
feat(consulting): Morning Checklist generated brief (Ticket 6, read-only)

### DIFF
--- a/backend/app/routes/consulting.py
+++ b/backend/app/routes/consulting.py
@@ -126,6 +126,7 @@ from app.schemas.consulting import (
     ExecutionTaskCreate,
     ExecutionTaskUpdate,
     ExecutionHierarchyOptions,
+    MorningChecklistOut,
     ExecutionBoardOutV2,
     GenerateActionsRequest,
     GenerateActionsResponse,
@@ -198,6 +199,7 @@ from app.services import (
     execution_tasks as execution_tasks_svc,
     execution_auto,
     execution_actions,
+    morning_checklist as morning_checklist_svc,
     execution_quick_capture,
     engagement_routing as engagement_routing_svc,
 )
@@ -2605,6 +2607,28 @@ def execution_hierarchy_options_route(
     degrades cleanly rather than fabricating choices."""
     try:
         return execution_tasks_svc.list_hierarchy_options(
+            env_id=env_id, business_id=business_id,
+        )
+    except Exception as exc:
+        raise _to_http(exc)
+
+
+@router.get(
+    "/execution/morning-checklist",
+    response_model=MorningChecklistOut,
+)
+def execution_morning_checklist_route(
+    env_id: str = Query(...),
+    business_id: UUID = Query(...),
+):
+    """Daily Operator Brief — read-time-generated from cro_execution_task.
+
+    No persistence, no schema change, no task mutation. Empty board returns
+    sections with `items: []` rather than erroring (honest empty state).
+    Suggested prompts are display-only and grounded in real task state
+    (assistant retrieval is a later ticket)."""
+    try:
+        return morning_checklist_svc.build_morning_checklist(
             env_id=env_id, business_id=business_id,
         )
     except Exception as exc:

--- a/backend/app/schemas/consulting.py
+++ b/backend/app/schemas/consulting.py
@@ -1783,6 +1783,62 @@ class ExecutionHierarchyOptions(BaseModel):
     workstreams: list[ExecutionHierarchyOption]
 
 
+# ── Morning Checklist (Ticket 6) ─────────────────────────────────────────────
+# Read-time-generated daily brief derived from cro_execution_task. No
+# persistence, no schema change. Items may also appear in their domain
+# section because the brief is a view, not a partition.
+
+
+class MorningChecklistItem(BaseModel):
+    task_id: str
+    title: str | None = None
+    reason: str
+    domain_key: str | None = None
+    domain_label: str | None = None
+    initiative_key: str | None = None
+    initiative_label: str | None = None
+    workstream_key: str | None = None
+    workstream_label: str | None = None
+    next_action: str | None = None
+    status: str | None = None
+    impact: int | None = None
+    due_date: str | None = None
+    revenue_tag: str | None = None
+    blocked_reason: str | None = None
+    related_url: str | None = None
+
+
+class MorningChecklistSuggestedPrompt(BaseModel):
+    key: str
+    prompt: str
+    reason: str
+
+
+class MorningChecklistSection(BaseModel):
+    key: str
+    label: str
+    # Items are heterogeneous: most sections hold MorningChecklistItem;
+    # suggested_prompts holds MorningChecklistSuggestedPrompt. Keep loose
+    # to avoid a discriminated-union schema explosion for a read-only view.
+    items: list[dict]
+
+
+class MorningChecklistSummary(BaseModel):
+    total_items: int = 0
+    overdue_count: int = 0
+    blocked_count: int = 0
+    web_properties_count: int = 0
+    outreach_count: int = 0
+    coding_count: int = 0
+    admin_count: int = 0
+
+
+class MorningChecklistOut(BaseModel):
+    date: str
+    sections: list[MorningChecklistSection]
+    summary: MorningChecklistSummary
+
+
 class ExecutionBoardSummary(BaseModel):
     today_count: int
     this_week_count: int

--- a/backend/app/services/morning_checklist.py
+++ b/backend/app/services/morning_checklist.py
@@ -1,0 +1,283 @@
+"""Morning Checklist / Daily Operator Brief (Ticket 6).
+
+Read-time-generated view over cro_execution_task — no persistence, no new
+table, no schema change. Pulls real task data via execution_tasks.list_tasks
+and buckets it into eight sections with transparent reasons. Honest empty
+states throughout; no task or priority is fabricated.
+
+Section taxonomy (matches dispatch 0002 / next-session.md):
+  1. top_priorities       — Top priorities today
+  2. overdue_follow_ups   — Overdue / stale follow-ups
+  3. web_properties       — Website / content moves
+  4. outreach_crm         — Outreach / CRM moves
+  5. coding_platform      — Coding / Winston Platform moves
+  6. admin_ops            — Admin / Accounting reminders
+  7. waiting_blocked      — Waiting / blocked items
+  8. suggested_prompts    — Suggested Claude / CoWork prompts (display-only)
+
+Suggested prompts are grounded in real board state — only surfaced when
+the matching condition is true. They do not execute anything (Ticket 7
+will wire assistant retrieval; this ticket is display-only).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from app.services import execution_tasks
+
+
+_TOP_PRIORITIES_LIMIT = 5
+_PER_SECTION_LIMIT = 6
+_REVENUE_RANK = {"high": 0, "mid": 1, "low": 2}
+
+
+def _today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def _is_overdue(t: dict, today: date) -> bool:
+    """Overdue only counts as a non-done task whose due_date has passed."""
+    due = t.get("due_date")
+    if not due or t.get("status") == "done":
+        return False
+    if isinstance(due, str):
+        try:
+            due = date.fromisoformat(due[:10])
+        except ValueError:
+            return False
+    return due < today
+
+
+def _is_blocked(t: dict, today: date) -> bool:
+    """A waiting task with a blocked_reason, or whose re_engage_at is past."""
+    if t.get("status") != "waiting":
+        return False
+    if t.get("blocked_reason"):
+        return True
+    re_engage = t.get("re_engage_at")
+    if re_engage:
+        if isinstance(re_engage, str):
+            try:
+                d = date.fromisoformat(re_engage[:10])
+            except ValueError:
+                return False
+            return d <= today
+        if isinstance(re_engage, datetime):
+            return re_engage.date() <= today
+    return False
+
+
+def _project(t: dict, reason: str) -> dict:
+    """Compact item shape for the brief. Mirrors the documented response."""
+    return {
+        "task_id": str(t["id"]),
+        "title": t.get("title"),
+        "reason": reason,
+        "domain_key": t.get("domain_key"),
+        "domain_label": t.get("domain_label"),
+        "initiative_key": t.get("initiative_key"),
+        "initiative_label": t.get("initiative_label"),
+        "workstream_key": t.get("workstream_key"),
+        "workstream_label": t.get("workstream_label"),
+        "next_action": t.get("next_action"),
+        "status": t.get("status"),
+        "impact": t.get("impact"),
+        "due_date": (
+            t["due_date"].isoformat()
+            if isinstance(t.get("due_date"), date)
+            else t.get("due_date")
+        ),
+        "revenue_tag": t.get("revenue_tag"),
+        "blocked_reason": t.get("blocked_reason"),
+        "related_url": t.get("related_url"),
+    }
+
+
+def _sort_by_pressure(items: list[dict]) -> list[dict]:
+    """Today first → high revenue → impact desc → earliest due_date → created."""
+
+    def key(t: dict) -> tuple:
+        st = 0 if t.get("status") == "today" else 1
+        rev = _REVENUE_RANK.get(t.get("revenue_tag") or "mid", 2)
+        impact = -(t.get("impact") or 0)
+        due = str(t.get("due_date") or "9999-99-99")
+        created = str(t.get("created_at") or "")
+        return (st, rev, impact, due, created)
+
+    return sorted(items, key=key)
+
+
+def _section(key: str, label: str, items: list[dict]) -> dict:
+    """Honest empty state: items=[] when nothing matches, never fabricated."""
+    return {"key": key, "label": label, "items": items}
+
+
+def _suggested_prompts(
+    tasks: list[dict],
+    overdue: list[dict],
+    waiting_blocked: list[dict],
+    web_property_tasks: list[dict],
+    today: date,
+) -> list[dict]:
+    """Suggested Claude / CoWork prompts. Display-only this ticket.
+
+    Each prompt is only included when the underlying board state actually
+    contains the thing it would ask about — no prompts are fabricated.
+    """
+    suggestions: list[dict] = []
+    today_count = sum(1 for t in tasks if t.get("status") == "today")
+    if today_count > 0:
+        suggestions.append(
+            {
+                "key": "what_first",
+                "prompt": "What should I do first this morning?",
+                "reason": f"{today_count} task(s) in TODAY",
+            }
+        )
+    if overdue:
+        suggestions.append(
+            {
+                "key": "overdue",
+                "prompt": "What's overdue and most worth my time?",
+                "reason": f"{len(overdue)} overdue follow-up(s)",
+            }
+        )
+    if waiting_blocked:
+        suggestions.append(
+            {
+                "key": "unblock",
+                "prompt": "What's waiting on me and what's waiting on someone else?",
+                "reason": f"{len(waiting_blocked)} waiting/blocked item(s)",
+            }
+        )
+    if web_property_tasks:
+        suggestions.append(
+            {
+                "key": "flowyorker",
+                "prompt": "What FlowYorker / web-property moves are queued?",
+                "reason": f"{len(web_property_tasks)} web-property task(s)",
+            }
+        )
+    coding_count = sum(
+        1 for t in tasks if t.get("domain_key") == "coding_platform"
+    )
+    if coding_count > 0:
+        suggestions.append(
+            {
+                "key": "next_coding_ticket",
+                "prompt": "What coding ticket is next?",
+                "reason": f"{coding_count} coding task(s)",
+            }
+        )
+    # Date-stamp avoids stale-prompt feel; never references content we don't have.
+    _ = today  # kept for future date-aware prompt logic; unused for now
+    return suggestions
+
+
+def build_morning_checklist(*, env_id: str, business_id: UUID) -> dict:
+    """Compose the Morning Brief from current task data. Read-only, fail-closed
+    on empty board: returns sections with items=[] rather than erroring."""
+    tasks = execution_tasks.list_tasks(
+        env_id=env_id,
+        business_id=business_id,
+        include_archived_done=False,
+    )
+    today = _today()
+
+    # ── Bucketing — a task can appear in multiple sections (priorities + its
+    # domain section) because the brief is a *view*, not a partition. Honest
+    # de-dup: items keep their identity via task_id so the UI can highlight.
+    overdue = [t for t in tasks if _is_overdue(t, today)]
+    waiting_blocked = [t for t in tasks if _is_blocked(t, today)]
+    today_tasks = [t for t in tasks if t.get("status") == "today"]
+
+    # Top priorities: today first, then overdue carried in by sort/pressure.
+    top_pool = today_tasks + [t for t in overdue if t.get("status") != "today"]
+    top_items: list[dict] = []
+    seen: set[str] = set()
+    for t in _sort_by_pressure(top_pool):
+        tid = str(t["id"])
+        if tid in seen:
+            continue
+        seen.add(tid)
+        reason = (
+            "Marked Today"
+            if t.get("status") == "today"
+            else "Due date has passed"
+        )
+        if (t.get("impact") or 0) >= 5 and t.get("status") == "today":
+            reason = "High impact, Today"
+        top_items.append(_project(t, reason))
+        if len(top_items) >= _TOP_PRIORITIES_LIMIT:
+            break
+
+    overdue_items = [_project(t, "Due date has passed") for t in _sort_by_pressure(overdue)][
+        :_PER_SECTION_LIMIT
+    ]
+
+    def _domain(d_key: str, reason: str) -> list[dict]:
+        bucket = [t for t in tasks if t.get("domain_key") == d_key]
+        return [
+            _project(t, reason) for t in _sort_by_pressure(bucket)[:_PER_SECTION_LIMIT]
+        ]
+
+    web_property_items = _domain("web_properties", "FlowYorker / web-property task")
+    outreach_items = _domain("outreach_crm", "Outreach follow-up")
+    coding_items = _domain("coding_platform", "Coding platform task")
+    admin_items = _domain("admin_ops", "Admin / accounting reminder")
+
+    waiting_items: list[dict] = []
+    for t in _sort_by_pressure(waiting_blocked):
+        reason = (
+            f"Waiting: {t.get('blocked_reason')}"
+            if t.get("blocked_reason")
+            else "Re-engage date reached"
+        )
+        waiting_items.append(_project(t, reason))
+        if len(waiting_items) >= _PER_SECTION_LIMIT:
+            break
+
+    web_property_tasks_full = [
+        t for t in tasks if t.get("domain_key") == "web_properties"
+    ]
+    suggested = _suggested_prompts(
+        tasks, overdue, waiting_blocked, web_property_tasks_full, today
+    )
+
+    sections = [
+        _section("top_priorities", "Top priorities today", top_items),
+        _section("overdue_follow_ups", "Overdue / stale follow-ups", overdue_items),
+        _section("web_properties", "Website / content moves", web_property_items),
+        _section("outreach_crm", "Outreach / CRM moves", outreach_items),
+        _section("coding_platform", "Coding / Winston Platform moves", coding_items),
+        _section("admin_ops", "Admin / Accounting reminders", admin_items),
+        _section("waiting_blocked", "Waiting / blocked items", waiting_items),
+        _section(
+            "suggested_prompts", "Suggested Claude / CoWork prompts", suggested
+        ),
+    ]
+
+    summary: dict[str, Any] = {
+        "total_items": sum(
+            len(s["items"]) for s in sections if s["key"] != "suggested_prompts"
+        ),
+        "overdue_count": len(overdue),
+        "blocked_count": len(waiting_blocked),
+        "web_properties_count": len(web_property_tasks_full),
+        "outreach_count": sum(
+            1 for t in tasks if t.get("domain_key") == "outreach_crm"
+        ),
+        "coding_count": sum(
+            1 for t in tasks if t.get("domain_key") == "coding_platform"
+        ),
+        "admin_count": sum(1 for t in tasks if t.get("domain_key") == "admin_ops"),
+    }
+
+    return {
+        "date": today.isoformat(),
+        "sections": sections,
+        "summary": summary,
+    }

--- a/backend/tests/test_morning_checklist.py
+++ b/backend/tests/test_morning_checklist.py
@@ -1,0 +1,267 @@
+"""Ticket 6 — Morning Checklist generated view.
+
+Tests bucketing, ranking, honest empty states, and grounded suggested
+prompts. The brief is a pure derivation over what execution_tasks.list_tasks
+returns, so we mock that one function — no DB, no hang risk (tips #23).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import patch
+from uuid import uuid4
+
+
+from app.services import morning_checklist as mc
+
+_ENV = "envX"
+_BIZ = uuid4()
+
+
+def _t(
+    *,
+    title: str,
+    status: str = "today",
+    impact: int = 3,
+    revenue_tag: str = "mid",
+    due_date=None,
+    domain_key: str | None = None,
+    domain_label: str | None = None,
+    initiative_key: str | None = None,
+    initiative_label: str | None = None,
+    workstream_key: str | None = None,
+    workstream_label: str | None = None,
+    next_action: str = "do it",
+    blocked_reason: str | None = None,
+    re_engage_at=None,
+) -> dict:
+    """Synthetic task dict matching what list_tasks returns."""
+    return {
+        "id": uuid4(),
+        "env_id": _ENV,
+        "business_id": _BIZ,
+        "title": title,
+        "status": status,
+        "impact": impact,
+        "revenue_tag": revenue_tag,
+        "due_date": due_date,
+        "domain_key": domain_key,
+        "domain_label": domain_label,
+        "initiative_key": initiative_key,
+        "initiative_label": initiative_label,
+        "workstream_key": workstream_key,
+        "workstream_label": workstream_label,
+        "next_action": next_action,
+        "blocked_reason": blocked_reason,
+        "re_engage_at": re_engage_at,
+        "created_at": "2026-05-01T00:00:00Z",
+        "related_url": None,
+    }
+
+
+def _build(tasks: list[dict]) -> dict:
+    with patch.object(mc.execution_tasks, "list_tasks", return_value=tasks):
+        return mc.build_morning_checklist(env_id=_ENV, business_id=_BIZ)
+
+
+def _section(brief: dict, key: str) -> dict:
+    return next(s for s in brief["sections"] if s["key"] == key)
+
+
+# ── Empty board: honest empty state, not an error ───────────────────────────
+
+
+def test_empty_board_returns_empty_sections_not_error():
+    brief = _build([])
+    assert brief["date"]  # ISO date string
+    assert len(brief["sections"]) == 8  # all 8 sections present
+    for s in brief["sections"]:
+        assert s["items"] == [], f"section {s['key']} should be empty"
+    assert brief["summary"]["total_items"] == 0
+    assert brief["summary"]["overdue_count"] == 0
+
+
+# ── Top priorities: today first, then overdue, deduped, capped ──────────────
+
+
+def test_top_priorities_prefers_today_over_overdue():
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+    today_task = _t(title="today task", status="today", impact=4)
+    overdue_task = _t(
+        title="overdue task", status="this_week", due_date=yesterday, impact=5
+    )
+    brief = _build([today_task, overdue_task])
+    top = _section(brief, "top_priorities")["items"]
+    assert top[0]["title"] == "today task"
+    assert top[0]["reason"] == "Marked Today"
+    assert top[1]["title"] == "overdue task"
+    assert top[1]["reason"] == "Due date has passed"
+
+
+def test_top_priorities_caps_at_five():
+    tasks = [_t(title=f"t{i}", status="today") for i in range(10)]
+    brief = _build(tasks)
+    assert len(_section(brief, "top_priorities")["items"]) == 5
+
+
+def test_top_priorities_dedups_when_task_is_both_today_and_overdue():
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+    t = _t(title="today and overdue", status="today", due_date=yesterday)
+    brief = _build([t])
+    top = _section(brief, "top_priorities")["items"]
+    # Task is "today" with a past due_date — listed once, reason = Marked Today.
+    assert len(top) == 1
+    assert top[0]["reason"] == "Marked Today"
+
+
+# ── Overdue section ─────────────────────────────────────────────────────────
+
+
+def test_overdue_section_filters_done_and_future_due():
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    overdue_real = _t(title="real overdue", status="this_week", due_date=yesterday)
+    done_past = _t(title="done past", status="done", due_date=yesterday)
+    future = _t(title="future", status="this_week", due_date=tomorrow)
+    brief = _build([overdue_real, done_past, future])
+    items = _section(brief, "overdue_follow_ups")["items"]
+    titles = [i["title"] for i in items]
+    assert titles == ["real overdue"]
+    assert brief["summary"]["overdue_count"] == 1
+
+
+# ── Domain sections: web/outreach/coding/admin ──────────────────────────────
+
+
+def test_domain_sections_route_by_domain_key():
+    tasks = [
+        _t(title="flowyorker post", domain_key="web_properties",
+           domain_label="Web Properties", initiative_key="flowyorker"),
+        _t(title="reply to lead", domain_key="outreach_crm",
+           domain_label="Outreach / CRM"),
+        _t(title="fix bug", domain_key="coding_platform",
+           domain_label="Coding / Winston Platform"),
+        _t(title="file receipt", domain_key="admin_ops",
+           domain_label="Admin / Accounting / Operations"),
+        _t(title="ungrouped", domain_key=None),
+    ]
+    brief = _build(tasks)
+    assert [i["title"] for i in _section(brief, "web_properties")["items"]] == [
+        "flowyorker post"
+    ]
+    assert [i["title"] for i in _section(brief, "outreach_crm")["items"]] == [
+        "reply to lead"
+    ]
+    assert [i["title"] for i in _section(brief, "coding_platform")["items"]] == [
+        "fix bug"
+    ]
+    assert [i["title"] for i in _section(brief, "admin_ops")["items"]] == [
+        "file receipt"
+    ]
+    # Ungrouped tasks DO appear in top_priorities (status=today by default) —
+    # this is correct: NULL domain doesn't disqualify priority.
+    top_titles = [i["title"] for i in _section(brief, "top_priorities")["items"]]
+    assert "ungrouped" in top_titles
+
+
+# ── Waiting / blocked ───────────────────────────────────────────────────────
+
+
+def test_waiting_with_blocked_reason_appears_in_waiting_section():
+    waiting = _t(
+        title="waiting on reply",
+        status="waiting",
+        blocked_reason="waiting_on_reply",
+    )
+    not_waiting = _t(title="not waiting", status="today")
+    brief = _build([waiting, not_waiting])
+    items = _section(brief, "waiting_blocked")["items"]
+    assert [i["title"] for i in items] == ["waiting on reply"]
+    assert items[0]["reason"].startswith("Waiting:")
+    assert brief["summary"]["blocked_count"] == 1
+
+
+def test_waiting_with_past_re_engage_appears():
+    past = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    t = _t(title="re-engage due", status="waiting", re_engage_at=past)
+    brief = _build([t])
+    items = _section(brief, "waiting_blocked")["items"]
+    assert [i["title"] for i in items] == ["re-engage due"]
+    assert items[0]["reason"] == "Re-engage date reached"
+
+
+# ── Suggested prompts: grounded in real state, never fabricated ─────────────
+
+
+def test_suggested_prompts_only_when_supported_by_data():
+    # Pure web-properties task only — should ground the flowyorker prompt
+    # and the "what first" prompt (it's status=today), nothing else.
+    t = _t(
+        title="flowyorker work",
+        status="today",
+        domain_key="web_properties",
+        initiative_key="flowyorker",
+    )
+    brief = _build([t])
+    prompts = _section(brief, "suggested_prompts")["items"]
+    keys = {p["key"] for p in prompts}
+    assert "what_first" in keys
+    assert "flowyorker" in keys
+    # No overdue, no waiting/blocked, no coding → those prompts absent.
+    assert "overdue" not in keys
+    assert "unblock" not in keys
+    assert "next_coding_ticket" not in keys
+
+
+def test_empty_board_produces_no_suggested_prompts():
+    brief = _build([])
+    assert _section(brief, "suggested_prompts")["items"] == []
+
+
+# ── Response shape contract ─────────────────────────────────────────────────
+
+
+def test_response_shape_matches_documented_contract():
+    """date + 8 sections + summary keys present; items match documented fields."""
+    t = _t(title="x", status="today", impact=4)
+    brief = _build([t])
+    assert set(brief.keys()) == {"date", "sections", "summary"}
+    section_keys = [s["key"] for s in brief["sections"]]
+    assert section_keys == [
+        "top_priorities",
+        "overdue_follow_ups",
+        "web_properties",
+        "outreach_crm",
+        "coding_platform",
+        "admin_ops",
+        "waiting_blocked",
+        "suggested_prompts",
+    ]
+    expected_summary = {
+        "total_items",
+        "overdue_count",
+        "blocked_count",
+        "web_properties_count",
+        "outreach_count",
+        "coding_count",
+        "admin_count",
+    }
+    assert set(brief["summary"].keys()) == expected_summary
+    item = _section(brief, "top_priorities")["items"][0]
+    # Documented item fields present
+    for field in (
+        "task_id",
+        "title",
+        "reason",
+        "domain_key",
+        "domain_label",
+        "initiative_key",
+        "initiative_label",
+        "workstream_key",
+        "workstream_label",
+        "next_action",
+        "status",
+        "impact",
+        "due_date",
+    ):
+        assert field in item, f"missing item field: {field}"

--- a/repo-b/src/components/consulting/execution/ExecutionBoard.tsx
+++ b/repo-b/src/components/consulting/execution/ExecutionBoard.tsx
@@ -23,6 +23,7 @@ import { useConsultingEnv } from "@/components/consulting/ConsultingEnvProvider"
 import { ExecutionColumn } from "./ExecutionColumn";
 import { ExecutionTaskDrawer } from "./ExecutionTaskDrawer";
 import { GenerateActionsModal } from "./GenerateActionsModal";
+import { MorningBriefPanel } from "./MorningBriefPanel";
 import { CompletionFeedbackModal } from "./CompletionFeedbackModal";
 
 type ColumnKey = Exclude<ExecutionTaskStatus, never>;
@@ -467,6 +468,11 @@ export function ExecutionBoard({
           </button>
         </div>
       </div>
+
+      {/* Morning Brief — Ticket 6, read-only generated view above the lanes.
+          Failure to load degrades to an in-panel error + Retry; the rest of
+          the board still works. */}
+      <MorningBriefPanel envId={envId} businessId={businessId} />
 
       {/* Domain grouping strip — display/filter only. Lanes below are
           unchanged; "All" (default) preserves the original flat board. */}

--- a/repo-b/src/components/consulting/execution/MorningBriefPanel.tsx
+++ b/repo-b/src/components/consulting/execution/MorningBriefPanel.tsx
@@ -1,0 +1,544 @@
+"use client";
+
+// Morning Brief (Ticket 6) — compact, read-only daily operator panel above
+// the task lanes. Derived from cro_execution_task at read time via
+// GET /execution/morning-checklist. Suggested prompts are display-only;
+// assistant retrieval is a later ticket.
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  fetchMorningChecklist,
+  type MorningChecklist,
+  type MorningChecklistItem,
+  type MorningChecklistSection,
+  type MorningChecklistSuggestedPrompt,
+} from "@/lib/cro-api";
+
+const TOP_PREVIEW = 3; // first N items shown when a section is collapsed
+
+// Whether an items list looks like suggested prompts vs. task items.
+function isPromptItem(
+  it: MorningChecklistItem | MorningChecklistSuggestedPrompt,
+): it is MorningChecklistSuggestedPrompt {
+  return (it as MorningChecklistSuggestedPrompt).prompt !== undefined;
+}
+
+function crumb(it: MorningChecklistItem): string | null {
+  if (!it.domain_label && !it.domain_key) return null;
+  const dom = it.domain_label ?? it.domain_key;
+  if (!it.initiative_label && !it.initiative_key) return dom ?? null;
+  const ini = it.initiative_label ?? it.initiative_key;
+  return `${dom} → ${ini}`;
+}
+
+export function MorningBriefPanel({
+  envId,
+  businessId,
+}: {
+  envId: string;
+  businessId: string;
+}) {
+  const [data, setData] = useState<MorningChecklist | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
+  const [expandedKeys, setExpandedKeys] = useState<Set<string>>(
+    () => new Set(["top_priorities"]),
+  );
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const next = await fetchMorningChecklist(envId, businessId);
+      setData(next);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load brief");
+    }
+  }, [envId, businessId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const toggleSection = useCallback((key: string) => {
+    setExpandedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  // Read-only error state. We never render fabricated content if the load fails.
+  if (error) {
+    return (
+      <div style={errorStyle}>
+        Morning Brief unavailable: {error}
+        <button type="button" onClick={load} style={retryBtn}>
+          Retry
+        </button>
+      </div>
+    );
+  }
+  if (!data) {
+    return (
+      <div style={loadingStyle}>Loading Morning Brief…</div>
+    );
+  }
+
+  const totalItems = data.summary.total_items;
+  const overdueCount = data.summary.overdue_count;
+  const blockedCount = data.summary.blocked_count;
+
+  return (
+    <div style={containerStyle}>
+      <div style={headerRowStyle}>
+        <div style={titleStyle}>
+          <span style={titleLabelStyle}>Morning Brief</span>
+          <span style={dateStyle}>{data.date}</span>
+        </div>
+        <div style={summaryRowStyle}>
+          <SummaryChip label="items" value={totalItems} />
+          <SummaryChip
+            label="overdue"
+            value={overdueCount}
+            tone={overdueCount > 0 ? "warn" : "neutral"}
+          />
+          <SummaryChip
+            label="blocked"
+            value={blockedCount}
+            tone={blockedCount > 0 ? "warn" : "neutral"}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => setCollapsed((v) => !v)}
+          style={collapseBtn}
+          aria-label={collapsed ? "Expand Morning Brief" : "Collapse Morning Brief"}
+        >
+          {collapsed ? "Expand" : "Collapse"}
+        </button>
+      </div>
+
+      {!collapsed ? (
+        <div style={sectionsWrapStyle}>
+          {data.sections.map((section) => (
+            <BriefSection
+              key={section.key}
+              section={section}
+              expanded={expandedKeys.has(section.key)}
+              onToggle={() => toggleSection(section.key)}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SummaryChip({
+  label,
+  value,
+  tone = "neutral",
+}: {
+  label: string;
+  value: number;
+  tone?: "neutral" | "warn";
+}) {
+  const color =
+    tone === "warn" && value > 0 ? "#FCA5A5" : "rgba(220,230,240,0.72)";
+  return (
+    <span style={{ ...chipStyle, color }}>
+      <span style={chipValueStyle}>{value}</span>
+      <span style={chipLabelStyle}>{label}</span>
+    </span>
+  );
+}
+
+function BriefSection({
+  section,
+  expanded,
+  onToggle,
+}: {
+  section: MorningChecklistSection;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const count = section.items.length;
+  const empty = count === 0;
+  // Show TOP_PREVIEW when collapsed; everything when expanded. Suggested
+  // prompts always render fully (small list).
+  const isPrompts = section.key === "suggested_prompts";
+  const visible = expanded || isPrompts ? section.items : section.items.slice(0, TOP_PREVIEW);
+
+  return (
+    <div style={sectionStyle}>
+      <button
+        type="button"
+        onClick={onToggle}
+        style={sectionHeaderStyle}
+        aria-expanded={expanded}
+      >
+        <span style={sectionLabelStyle}>{section.label}</span>
+        <span style={sectionCountStyle}>{count}</span>
+        {!isPrompts && count > TOP_PREVIEW ? (
+          <span style={moreHintStyle}>
+            {expanded ? "Show less" : `Show all ${count}`}
+          </span>
+        ) : null}
+      </button>
+
+      {empty ? (
+        <div style={emptyStateStyle}>
+          {emptyMessage(section.key)}
+        </div>
+      ) : (
+        <ul style={listStyle}>
+          {visible.map((it, idx) => (
+            <li
+              key={isPromptItem(it) ? it.key : it.task_id}
+              style={itemStyle}
+            >
+              {isPromptItem(it) ? (
+                <PromptRow prompt={it} />
+              ) : (
+                <TaskRow item={it as MorningChecklistItem} />
+              )}
+              {idx < visible.length - 1 ? <div style={dividerStyle} /> : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function TaskRow({ item }: { item: MorningChecklistItem }) {
+  const c = crumb(item);
+  return (
+    <div style={taskRowStyle}>
+      <div style={taskTopStyle}>
+        <span style={reasonTagStyle}>{item.reason}</span>
+        {item.due_date ? (
+          <span style={metaTagStyle}>due {item.due_date}</span>
+        ) : null}
+        {item.impact ? (
+          <span style={metaTagStyle}>impact {item.impact}</span>
+        ) : null}
+      </div>
+      <div style={taskTitleStyle}>{item.title ?? "(no title)"}</div>
+      {item.next_action ? (
+        <div style={nextActionStyle}>→ {item.next_action}</div>
+      ) : (
+        <div style={emptyHintStyle}>No next action</div>
+      )}
+      {c ? <div style={crumbStyle}>{c}</div> : null}
+    </div>
+  );
+}
+
+function PromptRow({ prompt }: { prompt: MorningChecklistSuggestedPrompt }) {
+  // Display-only — do NOT execute the prompt. (Assistant retrieval = Ticket 7.)
+  return (
+    <div style={promptRowStyle}>
+      <span style={promptIconStyle}>?</span>
+      <div>
+        <div style={promptTextStyle}>{prompt.prompt}</div>
+        <div style={promptReasonStyle}>{prompt.reason}</div>
+      </div>
+    </div>
+  );
+}
+
+function emptyMessage(sectionKey: string): string {
+  switch (sectionKey) {
+    case "top_priorities":
+      return "Nothing in Today. Add a task or accept a Generate suggestion.";
+    case "overdue_follow_ups":
+      return "No overdue items. Good.";
+    case "web_properties":
+      return "No Web Properties tasks queued.";
+    case "outreach_crm":
+      return "No Outreach / CRM tasks queued.";
+    case "coding_platform":
+      return "No Coding / Winston Platform tasks queued.";
+    case "admin_ops":
+      return "No Admin / Accounting reminders queued.";
+    case "waiting_blocked":
+      return "Nothing waiting or blocked.";
+    case "suggested_prompts":
+      return "No grounded prompts to suggest yet.";
+    default:
+      return "Nothing here.";
+  }
+}
+
+// ── Styles (dark operator shell tokens, in line with ExecutionBoard) ────────
+
+const containerStyle: React.CSSProperties = {
+  borderBottom: "1px solid rgba(255,255,255,0.07)",
+  background: "rgba(8,10,16,0.85)",
+};
+
+const headerRowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 14,
+  padding: "8px 16px",
+  flexWrap: "wrap",
+};
+
+const titleStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "baseline",
+  gap: 10,
+};
+
+const titleLabelStyle: React.CSSProperties = {
+  fontSize: 12,
+  letterSpacing: "0.16em",
+  textTransform: "uppercase",
+  color: "rgba(220,230,240,0.85)",
+  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+};
+
+const dateStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: "rgba(220,230,240,0.45)",
+  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+};
+
+const summaryRowStyle: React.CSSProperties = {
+  display: "flex",
+  gap: 6,
+  flex: 1,
+};
+
+const chipStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "baseline",
+  gap: 4,
+  padding: "2px 8px",
+  borderRadius: 3,
+  border: "1px solid rgba(255,255,255,0.10)",
+  background: "rgba(255,255,255,0.03)",
+  fontSize: 11,
+  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+};
+
+const chipValueStyle: React.CSSProperties = { fontWeight: 700 };
+const chipLabelStyle: React.CSSProperties = {
+  color: "rgba(220,230,240,0.5)",
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  fontSize: 10,
+};
+
+const collapseBtn: React.CSSProperties = {
+  padding: "4px 10px",
+  borderRadius: 3,
+  border: "1px solid rgba(255,255,255,0.10)",
+  background: "rgba(255,255,255,0.03)",
+  color: "rgba(220,230,240,0.66)",
+  fontSize: 11,
+  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+  letterSpacing: "0.04em",
+  cursor: "pointer",
+};
+
+const sectionsWrapStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+  gap: 8,
+  padding: "0 16px 12px",
+};
+
+const sectionStyle: React.CSSProperties = {
+  border: "1px solid rgba(255,255,255,0.07)",
+  background: "rgba(255,255,255,0.02)",
+  borderRadius: 4,
+  display: "flex",
+  flexDirection: "column",
+};
+
+const sectionHeaderStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "8px 10px",
+  border: 0,
+  background: "transparent",
+  cursor: "pointer",
+  textAlign: "left",
+  color: "rgba(220,230,240,0.85)",
+  borderBottom: "1px solid rgba(255,255,255,0.05)",
+};
+
+const sectionLabelStyle: React.CSSProperties = {
+  fontSize: 11,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+  flex: 1,
+};
+
+const sectionCountStyle: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  color: "rgba(220,230,240,0.55)",
+  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+};
+
+const moreHintStyle: React.CSSProperties = {
+  fontSize: 10,
+  color: "rgba(0,220,255,0.78)",
+  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+};
+
+const listStyle: React.CSSProperties = {
+  margin: 0,
+  padding: "4px 10px 8px",
+  listStyle: "none",
+  display: "flex",
+  flexDirection: "column",
+  gap: 4,
+};
+
+const itemStyle: React.CSSProperties = { padding: 0 };
+const dividerStyle: React.CSSProperties = {
+  height: 1,
+  background: "rgba(255,255,255,0.04)",
+  margin: "4px 0",
+};
+
+const taskRowStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 2,
+  padding: "4px 0",
+};
+
+const taskTopStyle: React.CSSProperties = {
+  display: "flex",
+  gap: 6,
+  flexWrap: "wrap",
+};
+
+const reasonTagStyle: React.CSSProperties = {
+  fontSize: 9,
+  letterSpacing: "0.06em",
+  textTransform: "uppercase",
+  padding: "1px 6px",
+  borderRadius: 2,
+  border: "1px solid rgba(0,220,255,0.30)",
+  color: "rgba(0,220,255,0.92)",
+  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+};
+
+const metaTagStyle: React.CSSProperties = {
+  fontSize: 9,
+  letterSpacing: "0.04em",
+  padding: "1px 6px",
+  borderRadius: 2,
+  border: "1px solid rgba(255,255,255,0.08)",
+  color: "rgba(220,230,240,0.55)",
+  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+};
+
+const taskTitleStyle: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 600,
+  color: "#dce6f0",
+  lineHeight: 1.3,
+};
+
+const nextActionStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: "rgba(0,220,255,0.85)",
+  paddingLeft: 6,
+  borderLeft: "2px solid rgba(0,220,255,0.35)",
+  lineHeight: 1.3,
+};
+
+const emptyHintStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: "rgba(220,230,240,0.40)",
+  fontStyle: "italic",
+};
+
+const crumbStyle: React.CSSProperties = {
+  fontSize: 9.5,
+  letterSpacing: "0.06em",
+  textTransform: "uppercase",
+  color: "rgba(167,139,250,0.78)",
+  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+};
+
+const emptyStateStyle: React.CSSProperties = {
+  padding: "8px 10px 10px",
+  fontSize: 11,
+  color: "rgba(220,230,240,0.45)",
+  fontStyle: "italic",
+};
+
+const promptRowStyle: React.CSSProperties = {
+  display: "flex",
+  gap: 8,
+  padding: "4px 0",
+  alignItems: "flex-start",
+};
+
+const promptIconStyle: React.CSSProperties = {
+  width: 18,
+  height: 18,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  borderRadius: "50%",
+  background: "rgba(167,139,250,0.12)",
+  color: "rgba(167,139,250,0.95)",
+  fontSize: 11,
+  fontWeight: 700,
+  flexShrink: 0,
+};
+
+const promptTextStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: "#dce6f0",
+  lineHeight: 1.3,
+};
+
+const promptReasonStyle: React.CSSProperties = {
+  fontSize: 10,
+  color: "rgba(220,230,240,0.45)",
+  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+};
+
+const errorStyle: React.CSSProperties = {
+  padding: "8px 16px",
+  fontSize: 12,
+  color: "#FCA5A5",
+  background: "rgba(239,68,68,0.06)",
+  borderBottom: "1px solid rgba(239,68,68,0.20)",
+  display: "flex",
+  alignItems: "center",
+  gap: 12,
+};
+
+const retryBtn: React.CSSProperties = {
+  marginLeft: "auto",
+  padding: "3px 10px",
+  borderRadius: 3,
+  border: "1px solid rgba(239,68,68,0.40)",
+  background: "transparent",
+  color: "#FCA5A5",
+  fontSize: 11,
+  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+  cursor: "pointer",
+};
+
+const loadingStyle: React.CSSProperties = {
+  padding: "8px 16px",
+  fontSize: 12,
+  color: "rgba(220,230,240,0.45)",
+  borderBottom: "1px solid rgba(255,255,255,0.07)",
+};

--- a/repo-b/src/lib/cro-api.ts
+++ b/repo-b/src/lib/cro-api.ts
@@ -2492,6 +2492,65 @@ export function fetchExecutionHierarchyOptions(
   );
 }
 
+// Morning Checklist (Ticket 6) — read-only generated brief over
+// cro_execution_task. No persistence; suggested prompts are display-only.
+export type MorningChecklistItem = {
+  task_id: string;
+  title: string | null;
+  reason: string;
+  domain_key: string | null;
+  domain_label: string | null;
+  initiative_key: string | null;
+  initiative_label: string | null;
+  workstream_key: string | null;
+  workstream_label: string | null;
+  next_action: string | null;
+  status: string | null;
+  impact: number | null;
+  due_date: string | null;
+  revenue_tag: string | null;
+  blocked_reason: string | null;
+  related_url: string | null;
+};
+
+export type MorningChecklistSuggestedPrompt = {
+  key: string;
+  prompt: string;
+  reason: string;
+};
+
+export type MorningChecklistSection = {
+  key: string;
+  label: string;
+  // Heterogeneous: domain/priority sections hold MorningChecklistItem;
+  // suggested_prompts holds MorningChecklistSuggestedPrompt.
+  items: Array<MorningChecklistItem | MorningChecklistSuggestedPrompt>;
+};
+
+export type MorningChecklistSummary = {
+  total_items: number;
+  overdue_count: number;
+  blocked_count: number;
+  web_properties_count: number;
+  outreach_count: number;
+  coding_count: number;
+  admin_count: number;
+};
+
+export type MorningChecklist = {
+  date: string;
+  sections: MorningChecklistSection[];
+  summary: MorningChecklistSummary;
+};
+
+export function fetchMorningChecklist(envId: string, businessId: string) {
+  return apiFetch<MorningChecklist>(
+    `${CRO_BASE}/execution/morning-checklist?env_id=${encodeURIComponent(
+      envId,
+    )}&business_id=${encodeURIComponent(businessId)}`,
+  );
+}
+
 export type QuickCaptureRequest = {
   env_id: string;
   business_id: string;


### PR DESCRIPTION
## Summary
Compact, **read-only generated** Daily Operator Brief above the task lanes (dispatch 0002, Workstream G / Ticket 6). Derived at read time from `cro_execution_task`. **No persistence, no schema change, no assistant retrieval, no broad redesign** — all per ticket scope.

### Backend (new)
- `GET /api/consulting/execution/morning-checklist?env_id&business_id` → `MorningChecklistOut`.
- `app/services/morning_checklist.py` — pure derivation over `execution_tasks.list_tasks` (no new SQL). 8 sections: `top_priorities` / `overdue_follow_ups` / `web_properties` / `outreach_crm` / `coding_platform` / `admin_ops` / `waiting_blocked` / `suggested_prompts`. Honest empty states; ranking by today→revenue→impact→due_date→created_at; transparent reason labels (`Marked Today`, `Due date has passed`, `High impact, Today`, `Waiting: <reason>`, `Re-engage date reached`, `FlowYorker / web-property task`, `Outreach follow-up`, `Coding platform task`, `Admin / accounting reminder`).
- **Suggested prompts grounded in real state** — each prompt emits only when its backing condition is true (e.g. `flowyorker` prompt only when there are web-property tasks). Display-only this ticket; assistant retrieval = Workstream H / Ticket 7.
- New Pydantic models: `MorningChecklistOut` / `MorningChecklistItem` / `MorningChecklistSection` / `MorningChecklistSummary` / `MorningChecklistSuggestedPrompt`.

### Frontend (new)
- `MorningBriefPanel.tsx` — compact panel above the lanes; collapse/expand; per-section `TOP_PREVIEW = 3` with "Show all N"; dark operator-shell tokens. Suggested prompts render as display-only (no execution). Load failure degrades to an in-panel error + Retry; the board below still works.
- `cro-api.ts` — `MorningChecklist*` types + `fetchMorningChecklist`.
- `ExecutionBoard.tsx` — mounts the panel between the top bar and the domain filter strip. **Lanes, filter strip, drawer, quick-capture, Generate all untouched.**

## Tests
Backend AST + ruff clean. **34 tests pass**: 11 new in `test_morning_checklist.py` (empty board, today-vs-overdue priority order, top cap, dedup, overdue filter, domain routing, waiting/blocked detection, re-engage date detection, grounded-prompts-only-when-supported, no-prompts-on-empty-board, response-shape contract) + 23 regression (`test_execution_board_route`, `test_execution_auto_stage_query`, `test_execution_hierarchy_write`, `test_executions`, `test_consulting_pipeline`). All DB-free (per tips #23). Frontend typecheck deferred to CI (fresh worktree, no `node_modules` — tips #20); types additive/optional, manually reviewed.

## Scope / regression
- No migration. No new task system. No assistant retrieval. No Morning Checklist persistence.
- Existing flat tasks, hierarchy fields, board endpoint contract: all unchanged.
- Quick-capture, Generate, drawer, four lanes, domain filter, FlowYorker assignment from Ticket 5: all untouched.
- No History Rhymes / `main.py` working-tree changes touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)