### PR TITLE
Add HappyCo Databricks proof receipt to gated package

### DIFF
--- a/docs/plans/03-implementation-plans/active/happyco-property-ops-intelligence-kit.md
+++ b/docs/plans/03-implementation-plans/active/happyco-property-ops-intelligence-kit.md
@@ -1,7 +1,7 @@
 # HappyCo Property Ops Intelligence Kit
 
 **Created:** 2026-05-20
-**Status:** Active - Tickets 2, 3A, 3, 3B, 4, 5/5A, 6, 7, 8, 9, and optional 10 complete
+**Status:** Active - Tickets 2, 3A, 3, 3B, 3C, 4, 5/5A, 6, 7, 8, 9, and optional 10 complete
 **Environment:** Operator lab / gated HappyCo proof package
 **Deliverable type:** Multi-ticket interview demonstration package
 
@@ -530,6 +530,49 @@ No receipt means `databricks_status: "not_run"`. Attempt receipts never produce
   property operations data.`
 - Still not allowed: real HappyCo production data/model, production deployment, or
   model registry/deployment claims.
+
+
+### Ticket 3C - Weather-aware maintenance risk Databricks proof integration
+
+**Goal:** integrate the completed weather + maintenance risk Databricks proof into
+the gated HappyCo package without exposing raw artifacts or making production
+claims.
+
+**Source proof:** commit `ad634bfa` from
+`feature/happyco-weather-maintenance-risk-ml`.
+
+**Completed Databricks run:**
+
+- Job ID: `172758362681895`
+- Run ID: `924781458483845`
+- Data: public weather + synthetic property operations
+- Output: predictions, metrics, MLflow run metadata, validated receipt
+- Allowed claim: `Databricks ML training run executed on public weather and synthetic property operations data.`
+
+**Claims still not allowed:**
+
+- HappyCo production data.
+- Production HappyCo model.
+- Production deployment.
+- Serving endpoint.
+
+**Technical caveats:**
+
+- The workspace used `hive_metastore.property_ops_risk_ml` because `main` catalog
+  was unavailable.
+- Serverless SparkML artifact logging was fail-soft without a UC Volume temp path,
+  but MLflow params/metrics/run IDs, tables, predictions, and receipt validation
+  completed.
+
+**Integration scope:**
+
+- `/happyco` shows a gated Databricks receipt card and Automation Control Room row.
+- The final HappyCo runbook records the allowed claim, run IDs, namespace fallback,
+  and UC Volume follow-up.
+- No public artifact downloads are added.
+- No backend route or DB behavior changes are required.
+
+**Risk:** Low, provided copy remains receipt-backed and caveated.
 
 ### Ticket 4 - Frontend Winston demo page
 

--- a/docs/runbooks/happyco/final-package-runbook.md
+++ b/docs/runbooks/happyco/final-package-runbook.md
@@ -1,8 +1,8 @@
 # HappyCo Property Ops Intelligence Kit - Runbook
 
-Last updated: 2026-05-20
+Last updated: 2026-05-21
 
-This is a demo-grade, role-specific proof package for the HappyCo Head of Data
+This is a private proof-of-work package for the HappyCo Head of Data
 role. It uses deterministic synthetic data only. It does not contain HappyCo
 production data, private recruiter email content, or secrets. Ticket 3B adds a
 receipt-backed live Databricks execution claim for synthetic demo data only.
@@ -90,6 +90,43 @@ python scripts/happyco/run_databricks_ml.py --profile PaulMain --execute --out a
 python scripts/happyco/build_property_ops_workbook.py
 python scripts/happyco/build_strategy_deck.py
 ```
+
+
+## Weather + Maintenance Risk Databricks Proof
+
+The newer weather-aware maintenance risk extension is a separate Databricks proof
+using public weather data and synthetic property operations data. It is source
+controlled in the proof branch commit `ad634bfa` and integrated into the gated
+HappyCo package only as sanitized receipt metadata.
+
+Allowed claim:
+
+> Databricks ML training run executed on public weather and synthetic property operations data.
+
+Run receipt summary:
+
+- Job ID: `172758362681895`
+- Run ID: `924781458483845`
+- Data: public weather + synthetic property operations
+- Output: predictions, metrics, MLflow run metadata, validated receipt
+- Local ignored receipt path:
+  `artifacts/happyco/weather-risk/databricks_run_receipt.json`
+
+Claims still not allowed:
+
+- HappyCo production data
+- Production HappyCo model
+- Production deployment
+- Serving endpoint
+
+Technical note:
+
+- The Databricks workspace did not expose `main`, so the job used the
+  `hive_metastore.property_ops_risk_ml` fallback namespace.
+- Future serverless SparkML model artifact logging should configure a UC Volume
+  path for `MLFLOW_DFS_TMP` or `dfs_tmpdir`.
+- MLflow params/metrics/run IDs, tables, predictions, and receipt validation
+  completed despite fail-soft SparkML artifact logging.
 
 ## Databricks Ticket 3B Runbook
 

--- a/repo-b/src/app/happyco/page.tsx
+++ b/repo-b/src/app/happyco/page.tsx
@@ -99,6 +99,61 @@ function PublicGate({ invalid }: { invalid: boolean }) {
 }
 
 function GatedPackage() {
+  const databricksReceipt = {
+    title: "Weather-aware maintenance risk Databricks run",
+    jobId: "172758362681895",
+    runId: "924781458483845",
+    data: "public weather + synthetic property operations",
+    output: "predictions, metrics, MLflow run metadata, validated receipt",
+    claim: "Databricks ML training run executed on public weather and synthetic property operations data.",
+    caveat: "Not HappyCo production data; not a production model; no serving endpoint.",
+  };
+
+  const automationRows = [
+    {
+      trigger: "recruiter/job context",
+      tool: "HappyCo prompt stack + Codex planning",
+      output: "role-specific proof scope and active implementation plan",
+      control: "human-approved scope; no private recruiter content committed",
+    },
+    {
+      trigger: "deterministic data fixture",
+      tool: "canonical fixture generator + operator service",
+      output: "property, unit, inspection, work-order, vendor, benchmark, and recommendation spine",
+      control: "synthetic data only; API payloads carry demo metadata and caveats",
+    },
+    {
+      trigger: "weather/property risk feature pipeline",
+      tool: "Databricks bundle/job",
+      output: "maintenance-risk predictions + MLflow metrics + run receipt",
+      control: "public weather + synthetic ops only; receipt-backed claim; no production serving endpoint",
+    },
+    {
+      trigger: "operator APIs",
+      tool: "FastAPI operator routes",
+      output: "entities, graph, benchmarks, recommendations, and ML-risk JSON",
+      control: "demo_mode/data_source/caveat fields on product-facing responses",
+    },
+    {
+      trigger: "artifact package",
+      tool: "Excel, PowerPoint, and architecture generators",
+      output: "workbook, strategy deck, and architecture diagram",
+      control: "local artifacts only; no public downloads from this route",
+    },
+    {
+      trigger: "Outlook follow-up workflow",
+      tool: "WinCOM params templates",
+      output: "draft-only recruiter follow-up workflow template",
+      control: "no send without explicit local confirmation",
+    },
+    {
+      trigger: "gated deployment",
+      tool: "Next.js invite-code route + deployment env vars",
+      output: "private proof package at /happyco",
+      control: "invite-gated access; invite code remains server-side",
+    },
+  ];
+
   const artifacts = [
     {
       icon: FileSpreadsheet,
@@ -145,31 +200,34 @@ function GatedPackage() {
     {
       icon: BrainCircuit,
       title: "ML proof",
-      body: "Receipt-backed Databricks notebook run on synthetic property ops data, plus local logistic model fallback, feature table, predictions, feature importance, model card, and registry record.",
+      body: "Receipt-backed Databricks run on public weather and synthetic property operations data, plus local logistic model fallback, feature table, predictions, feature importance, model card, and registry record.",
     },
   ];
 
   return (
     <main className="min-h-screen bg-[#FBFAF7] text-[#241437]">
-      <section className="mx-auto max-w-7xl px-5 pb-12 pt-8">
-        <div className="rounded-[34px] border border-[#DDD8EA] bg-[#C6F4DF] p-7">
-          <div className="flex flex-wrap items-center justify-between gap-4">
+      <section className="mx-auto max-w-[1600px] px-5 pb-12 pt-8 xl:px-8">
+        <div className="rounded-[34px] border border-[#DDD8EA] bg-[#C6F4DF] p-7 lg:p-9">
+          <div className="flex flex-wrap items-center justify-between gap-5">
             <div>
               <div className="text-xs font-black uppercase tracking-[0.22em] text-[#35146B]">HappyCo gated proof package</div>
               <h1 className="mt-3 text-4xl font-black tracking-tight text-[#35146B] sm:text-6xl">
                 Property Ops Intelligence Kit
               </h1>
-              <p className="mt-4 max-w-3xl text-base leading-7 text-[#241437]">
-                A demo-grade but hands-on Head of Data package spanning strategy, architecture, canonical modeling, graph APIs,
-                benchmark analytics, ML workflows, AI recommendations, Excel, PowerPoint, and Outlook automation.
+              <p className="mt-4 max-w-4xl text-base leading-7 text-[#241437]">
+                A private proof-of-work and hands-on architecture prototype for a Head of Data package spanning strategy,
+                canonical modeling, graph APIs, benchmark analytics, ML workflows, AI recommendations, Excel, PowerPoint,
+                and Outlook automation.
               </p>
             </div>
-            <Link
-              href={operatorDemoHref}
-              className="rounded-2xl bg-[#35146B] px-5 py-3 text-sm font-black text-white transition hover:bg-[#5430C0]"
-            >
-              Open Winston demo
-            </Link>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href={operatorDemoHref}
+                className="rounded-2xl bg-[#35146B] px-5 py-3 text-sm font-black text-white transition hover:bg-[#5430C0]"
+              >
+                Open Winston implementation view
+              </Link>
+            </div>
           </div>
         </div>
 
@@ -182,7 +240,10 @@ function GatedPackage() {
           <Card className="p-5">
             <StatusPill>Ready</StatusPill>
             <div className="mt-3 text-2xl font-black text-[#35146B]">ML artifacts</div>
-            <p className="mt-2 text-sm leading-6 text-[#6F6590]">Local fallback trained; Databricks run completed on synthetic property operations data with receipt-backed caveats.</p>
+            <p className="mt-2 text-sm leading-6 text-[#6F6590]">
+              Local fallback trained; Databricks runs completed with receipt-backed caveats, including the weather-aware
+              maintenance risk proof.
+            </p>
           </Card>
           <Card className="p-5">
             <StatusPill>Ready</StatusPill>
@@ -195,6 +256,46 @@ function GatedPackage() {
             <p className="mt-2 text-sm leading-6 text-[#6F6590]">Safe WinCOM params are draft-only by default.</p>
           </Card>
         </div>
+
+        <Card className="mt-6 p-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <StatusPill>Completed</StatusPill>
+              <h2 className="mt-3 text-2xl font-black text-[#35146B]">{databricksReceipt.title}</h2>
+              <p className="mt-2 max-w-4xl text-sm leading-6 text-[#4D426A]">
+                Receipt-backed Databricks ML proof showing how public weather signals can be joined with synthetic property
+                operations patterns to create maintenance-risk predictions and model evidence.
+              </p>
+            </div>
+            <BrainCircuit className="h-8 w-8 text-[#5430C0]" />
+          </div>
+          <dl className="mt-5 grid gap-3 lg:grid-cols-3">
+            <div className="rounded-3xl border border-[#DDD8EA] bg-[#FBFAF7] p-4">
+              <dt className="text-xs font-black uppercase tracking-[0.16em] text-[#6F6590]">Job ID</dt>
+              <dd className="mt-2 font-mono text-sm font-bold text-[#35146B]">{databricksReceipt.jobId}</dd>
+            </div>
+            <div className="rounded-3xl border border-[#DDD8EA] bg-[#FBFAF7] p-4">
+              <dt className="text-xs font-black uppercase tracking-[0.16em] text-[#6F6590]">Run ID</dt>
+              <dd className="mt-2 font-mono text-sm font-bold text-[#35146B]">{databricksReceipt.runId}</dd>
+            </div>
+            <div className="rounded-3xl border border-[#DDD8EA] bg-[#FBFAF7] p-4">
+              <dt className="text-xs font-black uppercase tracking-[0.16em] text-[#6F6590]">Data</dt>
+              <dd className="mt-2 text-sm font-bold text-[#35146B]">{databricksReceipt.data}</dd>
+            </div>
+            <div className="rounded-3xl border border-[#DDD8EA] bg-[#FBFAF7] p-4 lg:col-span-3">
+              <dt className="text-xs font-black uppercase tracking-[0.16em] text-[#6F6590]">Output</dt>
+              <dd className="mt-2 text-sm font-bold text-[#35146B]">{databricksReceipt.output}</dd>
+            </div>
+            <div className="rounded-3xl border border-[#DDD8EA] bg-[#FBFAF7] p-4 lg:col-span-2">
+              <dt className="text-xs font-black uppercase tracking-[0.16em] text-[#6F6590]">Claim</dt>
+              <dd className="mt-2 text-sm font-bold text-[#35146B]">{databricksReceipt.claim}</dd>
+            </div>
+            <div className="rounded-3xl border border-[#DDD8EA] bg-[#FBFAF7] p-4">
+              <dt className="text-xs font-black uppercase tracking-[0.16em] text-[#6F6590]">Caveat</dt>
+              <dd className="mt-2 text-sm font-bold text-[#35146B]">{databricksReceipt.caveat}</dd>
+            </div>
+          </dl>
+        </Card>
 
         <div className="mt-6 grid gap-6 lg:grid-cols-[1fr_0.82fr]">
           <Card className="p-6">
@@ -222,10 +323,11 @@ function GatedPackage() {
               <h2 className="text-2xl font-black text-[#35146B]">Controls and caveats</h2>
             </div>
             <ul className="space-y-3 text-sm leading-6 text-[#4D426A]">
-              <li><CheckCircle2 className="mr-2 inline h-4 w-4 text-emerald-700" />Synthetic data only; no HappyCo production data.</li>
+              <li><CheckCircle2 className="mr-2 inline h-4 w-4 text-emerald-700" />Synthetic property operations data only; no HappyCo production data.</li>
+              <li><CheckCircle2 className="mr-2 inline h-4 w-4 text-emerald-700" />Public weather signals are used only for proof-of-work feature engineering.</li>
               <li><CheckCircle2 className="mr-2 inline h-4 w-4 text-emerald-700" />Model metrics are demo-pipeline evidence, not expected real-world performance.</li>
-              <li><CheckCircle2 className="mr-2 inline h-4 w-4 text-emerald-700" />Databricks execution claim is limited to the completed synthetic-data run receipt.</li>
-              <li><CheckCircle2 className="mr-2 inline h-4 w-4 text-emerald-700" />No production Databricks deployment, real HappyCo data, or real HappyCo model claim.</li>
+              <li><CheckCircle2 className="mr-2 inline h-4 w-4 text-emerald-700" />Databricks execution claims are limited to completed, receipt-backed runs.</li>
+              <li><CheckCircle2 className="mr-2 inline h-4 w-4 text-emerald-700" />No production deployment or HappyCo model claim.</li>
               <li><CheckCircle2 className="mr-2 inline h-4 w-4 text-emerald-700" />Local artifacts are not public downloads from this route.</li>
               <li><CheckCircle2 className="mr-2 inline h-4 w-4 text-emerald-700" />Outlook send remains disabled unless explicitly requested locally.</li>
             </ul>
@@ -233,8 +335,44 @@ function GatedPackage() {
         </div>
 
         <Card className="mt-6 p-6">
+          <h2 className="text-2xl font-black text-[#35146B]">Automation Control Room</h2>
+          <p className="mt-2 max-w-4xl text-sm leading-6 text-[#4D426A]">
+            The package is itself an automation proof: planning, synthetic data, Databricks ML, API surfaces, artifacts,
+            deployment gates, and human-review controls are visible as receipts rather than hidden behind a slide.
+          </p>
+          <div className="mt-5 overflow-hidden rounded-3xl border border-[#DDD8EA]">
+            <div className="hidden grid-cols-[1fr_1fr_1.35fr_1.35fr] bg-[#35146B] px-4 py-3 text-xs font-black uppercase tracking-[0.16em] text-white lg:grid">
+              <div>Trigger</div>
+              <div>Tool / skill</div>
+              <div>Output</div>
+              <div>Safety / control</div>
+            </div>
+            {automationRows.map((row) => (
+              <div key={row.trigger} className="grid gap-3 border-t border-[#DDD8EA] bg-[#FBFAF7] px-4 py-4 text-sm text-[#4D426A] lg:grid-cols-[1fr_1fr_1.35fr_1.35fr] lg:items-start">
+                <div>
+                  <div className="text-xs font-black uppercase tracking-[0.14em] text-[#6F6590] lg:hidden">Trigger</div>
+                  <div className="font-bold text-[#35146B]">{row.trigger}</div>
+                </div>
+                <div>
+                  <div className="text-xs font-black uppercase tracking-[0.14em] text-[#6F6590] lg:hidden">Tool / skill</div>
+                  {row.tool}
+                </div>
+                <div>
+                  <div className="text-xs font-black uppercase tracking-[0.14em] text-[#6F6590] lg:hidden">Output</div>
+                  {row.output}
+                </div>
+                <div>
+                  <div className="text-xs font-black uppercase tracking-[0.14em] text-[#6F6590] lg:hidden">Safety / control</div>
+                  {row.control}
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+
+        <Card className="mt-6 p-6">
           <h2 className="text-2xl font-black text-[#35146B]">Artifact factory</h2>
-          <div className="mt-5 grid gap-4 md:grid-cols-2">
+          <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
             {artifacts.map((artifact) => {
               const Icon = artifact.icon;
               const planned = artifact.status.toLowerCase().includes("planned");


### PR DESCRIPTION
## Summary
Adds the completed Databricks weather-aware maintenance risk ML run proof to the gated HappyCo package.

## Changes
- Adds a gated receipt card to `/happyco`
- Adds Databricks Job ID `172758362681895` and Run ID `924781458483845`
- Adds the allowed claim: “Databricks ML training run executed on public weather and synthetic property operations data.”
- Adds caveats: not HappyCo production data, not a production model, no serving endpoint
- Adds Automation Control Room row for the weather/property risk feature pipeline
- Updates HappyCo runbook and active plan

## Validation
- `cd repo-b && npm run typecheck` passed
- `git diff --check` passed with line-ending warnings only
- Local browser smoke passed on port 3201 because 3200 was already in use: locked state, unlock, receipt card, Job ID, Run ID, exact claim/caveat, Automation Control Room row, and no public artifact/download links
- Claim scan found no secrets and no overclaims outside caveat/not-allowed contexts

## Notes
- No backend code changed
- No raw artifacts are publicly exposed
- `/happyco/demo` does not exist in this branch, so it was not updated