### PR TITLE
fix(consulting): Ticket 7B — fix consulting router pool exhaustion incident

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -14,12 +14,18 @@ _pool: ConnectionPool | None = None
 def _get_pool() -> ConnectionPool:
     global _pool
     if _pool is None:
+        # Ticket 7B: max_size raised 10→20, timeout 5→10 as defense-in-depth
+        # headroom. Verified safe — Supabase Postgres max_connections=60
+        # (3 reserved, ~16 baseline in use), so 20 pool connections leave
+        # ample margin. NOTE: this is margin, not the fix — the real fix is
+        # scoping cursors per unit of work (see execution_auto.run_auto_generation)
+        # so a long multi-step run does not pin one connection for its whole span.
         _pool = ConnectionPool(
             prefer_ipv4_hostaddr(require_database_url()),
             min_size=2,
-            max_size=10,
+            max_size=20,
             open=False,
-            timeout=5,
+            timeout=10,
             kwargs={
                 "prepare_threshold": DB_PREPARE_THRESHOLD,
                 "row_factory": psycopg.rows.dict_row,

--- a/backend/app/services/execution_auto.py
+++ b/backend/app/services/execution_auto.py
@@ -64,7 +64,10 @@ def _safe_insert_auto(
 
 
 def run_auto_generation(*, env_id: str, business_id: UUID) -> dict:
-    """Run all five passes. Returns AutoGenerateReport-shaped dict."""
+    """Run all eight auto-generation passes. Returns AutoGenerateReport-shaped dict.
+
+    Each pass uses its own short-lived get_cursor() block so the pooled DB
+    connection is released between passes (Ticket 7B — see the comment below)."""
     report = {
         "pipeline_no_next_action": 0,
         "pipeline_stale_3d": 0,
@@ -76,8 +79,17 @@ def run_auto_generation(*, env_id: str, business_id: UUID) -> dict:
         "waiting_re_engaged": 0,
     }
 
+    # Ticket 7B: each pass below is independent (its own SELECT/UPDATE +
+    # optional insert loop, no cross-pass cursor state). Each pass gets its
+    # OWN short-lived `with get_cursor()` so the pooled connection is returned
+    # between passes — a board request must not pin one connection for the
+    # whole multi-pass run, which drains the pool and wedges the consulting
+    # router under concurrency. `report` (a plain dict) accumulates across
+    # passes as before; `_safe_insert_auto` takes `cur` and stays inside its
+    # pass's block.
+
+    # ── 1. Promote overdue This Week → Today ────────────────────────────────
     with get_cursor() as cur:
-        # ── 1. Promote overdue This Week → Today ────────────────────────────
         cur.execute(
             """
             UPDATE cro_execution_task
@@ -92,9 +104,10 @@ def run_auto_generation(*, env_id: str, business_id: UUID) -> dict:
         )
         report["promoted_to_today"] = len(cur.fetchall())
 
-        # ── 2. Open deals with no committed next action ──────────────────────
-        # An open deal has no open execution task. (Deals that already have a
-        # task in today/this_week/waiting are considered to have a next move.)
+    # ── 2. Open deals with no committed next action ─────────────────────────
+    # An open deal has no open execution task. (Deals that already have a
+    # task in today/this_week/waiting are considered to have a next move.)
+    with get_cursor() as cur:
         cur.execute(
             """
             SELECT o.crm_opportunity_id, o.name, a.name AS account_name
@@ -132,11 +145,12 @@ def run_auto_generation(*, env_id: str, business_id: UUID) -> dict:
             if inserted:
                 report["pipeline_no_next_action"] += 1
 
-        # ── 3. Open deals stale > 3 days ─────────────────────────────────────
-        # "Stale" = max(crm_activity.activity_at, cro_outreach_log.sent_at,
-        # cro_execution_task.completed_at, crm_opportunity.created_at) was
-        # > 3 days ago. Only fire when an open task isn't already pressuring
-        # the deal (the partial unique index handles dedupe per deal).
+    # ── 3. Open deals stale > 3 days ────────────────────────────────────────
+    # "Stale" = max(crm_activity.activity_at, cro_outreach_log.sent_at,
+    # cro_execution_task.completed_at, crm_opportunity.created_at) was
+    # > 3 days ago. Only fire when an open task isn't already pressuring
+    # the deal (the partial unique index handles dedupe per deal).
+    with get_cursor() as cur:
         cur.execute(
             """
             WITH last_activity AS (
@@ -184,7 +198,8 @@ def run_auto_generation(*, env_id: str, business_id: UUID) -> dict:
             if inserted:
                 report["pipeline_stale_3d"] += 1
 
-        # ── 4. Outbound outreach with no reply in 2 days ────────────────────
+    # ── 4. Outbound outreach with no reply in 2 days ────────────────────────
+    with get_cursor() as cur:
         cur.execute(
             """
             SELECT ol.id AS outreach_id, ol.crm_account_id, ol.crm_contact_id,
@@ -237,7 +252,8 @@ def run_auto_generation(*, env_id: str, business_id: UUID) -> dict:
             if inserted:
                 report["outreach_no_reply_2d"] += 1
 
-        # ── 5. Top of proof backlog ──────────────────────────────────────────
+    # ── 5. Top of proof backlog ─────────────────────────────────────────────
+    with get_cursor() as cur:
         cur.execute(
             """
             SELECT id, title
@@ -268,10 +284,11 @@ def run_auto_generation(*, env_id: str, business_id: UUID) -> dict:
             if inserted:
                 report["proof_backlog_top"] += 1
 
-        # ── 6. Waiting → Today when re_engage_at hits ───────────────────────
-        # The engine that keeps WAITING from becoming a graveyard. When the
-        # date the user picked at drag-to-WAITING arrives, the card returns
-        # to TODAY and re_engage_at is cleared so it doesn't bounce again.
+    # ── 6. Waiting → Today when re_engage_at hits ───────────────────────────
+    # The engine that keeps WAITING from becoming a graveyard. When the
+    # date the user picked at drag-to-WAITING arrives, the card returns
+    # to TODAY and re_engage_at is cleared so it doesn't bounce again.
+    with get_cursor() as cur:
         cur.execute(
             """
             UPDATE cro_execution_task
@@ -288,8 +305,9 @@ def run_auto_generation(*, env_id: str, business_id: UUID) -> dict:
         )
         report["waiting_re_engaged"] = len(cur.fetchall())
 
-        # ── 7. Open deals never touched ─────────────────────────────────────
-        # 12h grace before we nag — the user may have just created the deal.
+    # ── 7. Open deals never touched ─────────────────────────────────────────
+    # 12h grace before we nag — the user may have just created the deal.
+    with get_cursor() as cur:
         cur.execute(
             """
             SELECT o.crm_opportunity_id, o.name, a.name AS account_name
@@ -331,12 +349,13 @@ def run_auto_generation(*, env_id: str, business_id: UUID) -> dict:
             if inserted:
                 report["pipeline_no_outreach"] += 1
 
-        # ── 8. Stage = proposal AND last touch > 2d → check response ────────
-        # Stage is a FK: crm_opportunity.crm_pipeline_stage_id → crm_pipeline_stage.
-        # There is no crm_opportunity.stage column; the proposal stage is
-        # crm_pipeline_stage.key = 'proposal' (stable machine key, not label).
-        # The 2-day window matches the no-reply pass; together they form a tight
-        # follow-up loop on the most-revenue-sensitive part of the funnel.
+    # ── 8. Stage = proposal AND last touch > 2d → check response ────────────
+    # Stage is a FK: crm_opportunity.crm_pipeline_stage_id → crm_pipeline_stage.
+    # There is no crm_opportunity.stage column; the proposal stage is
+    # crm_pipeline_stage.key = 'proposal' (stable machine key, not label).
+    # The 2-day window matches the no-reply pass; together they form a tight
+    # follow-up loop on the most-revenue-sensitive part of the funnel.
+    with get_cursor() as cur:
         cur.execute(
             """
             WITH proposal_deals AS (

--- a/backend/tests/test_execution_auto_cursor_scoping.py
+++ b/backend/tests/test_execution_auto_cursor_scoping.py
@@ -1,0 +1,82 @@
+"""Ticket 7B regression guard — run_auto_generation must not hold a pooled
+DB connection across its passes.
+
+Incident: run_auto_generation opened ONE `with get_cursor()` and held it
+across all 8 passes. Every GET /execution/board pinned one of the 10 pool
+connections for the whole multi-pass run; under concurrency the pool drained
+and the entire /api/consulting/* router hung.
+
+Fix: each independent pass gets its own short-lived `with get_cursor()` so
+the connection returns to the pool between passes.
+
+This test wraps get_cursor with an instrumented context manager that tracks
+how many cursors are checked out *at the same time*. If any future change
+re-merges passes under one cursor, `max_concurrent` rises above 1 and this
+fails loudly. It also asserts the cursor is acquired once per pass (8×), not
+once total — proving the connection is genuinely released and re-acquired.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import patch
+from uuid import uuid4
+
+from app.services import execution_auto
+from tests.conftest import FakeCursor
+
+
+def test_run_auto_generation_releases_cursor_between_passes():
+    """No two passes may hold a cursor simultaneously; the pooled connection
+    must be released and re-acquired per pass."""
+    state = {"open": 0, "max_concurrent": 0, "acquisitions": 0}
+    cur = FakeCursor()
+
+    @contextmanager
+    def instrumented_get_cursor():
+        state["open"] += 1
+        state["acquisitions"] += 1
+        state["max_concurrent"] = max(state["max_concurrent"], state["open"])
+        try:
+            yield cur
+        finally:
+            state["open"] -= 1
+
+    with patch(
+        "app.services.execution_auto.get_cursor", instrumented_get_cursor
+    ):
+        report = execution_auto.run_auto_generation(
+            env_id="envX", business_id=uuid4()
+        )
+
+    # The core invariant: never more than one cursor open at a time. A value
+    # of 2+ means a pass nested or the old single-cursor-across-all-passes
+    # structure was reintroduced.
+    assert state["max_concurrent"] == 1, (
+        f"run_auto_generation held {state['max_concurrent']} cursors at once "
+        f"— passes must each scope their own get_cursor() so the pooled "
+        f"connection is released between passes (Ticket 7B)."
+    )
+    # All cursors must be closed when the function returns.
+    assert state["open"] == 0
+    # The connection must be acquired once PER PASS, not once total — proof
+    # the per-pass scoping is real. There are 8 passes today; if a pass is
+    # added/removed this bound updates, but it must never drop to 1 (that
+    # would mean a single cursor spans everything again).
+    assert state["acquisitions"] >= 8, (
+        f"expected one get_cursor() per pass (>=8), got "
+        f"{state['acquisitions']} — passes may have been merged under one cursor."
+    )
+    # Behavior unchanged: report still has the AutoGenerateReport shape.
+    for key in (
+        "pipeline_no_next_action",
+        "pipeline_stale_3d",
+        "pipeline_no_outreach",
+        "pipeline_proposal_sent_no_followup",
+        "outreach_no_reply_2d",
+        "proof_backlog_top",
+        "promoted_to_today",
+        "waiting_re_engaged",
+    ):
+        assert key in report, f"report missing key {key}"
+        assert isinstance(report[key], int)


### PR DESCRIPTION
## Production incident
The entire `/api/consulting/*` router hangs in production — `board`, `morning-checklist`, and `brief-assistant/ask` all time out (40–90s direct to backend; `502 UPSTREAM_UNREACHABLE` via the Vercel proxy). Sibling routers on the same process (`/api/operator/v1/property-ops/*`, `/api/tasks/projects`, `/api/templates`) stay fast (~100ms). The backend process is healthy — only the consulting router is wedged.

## Root cause
`run_auto_generation` (`backend/app/services/execution_auto.py`) opened **one** `with get_cursor()` and held that pooled connection across **all 8** auto-generation passes. `get_cursor()` checks out a whole connection; the pool is `max_size=10`. Every `GET /execution/board` calls `run_auto_generation` first, so each in-flight board request pinned 1 of 10 connections for the whole multi-second run. Under concurrency the pool drained → every consulting request (including light `morning-checklist`/`brief-assistant` that only call `list_tasks`) blocked on pool acquisition → router-wide hang. Self-reinforcing: slow board → proxy 502 → frontend retries → more board calls → pool stays drained.

## Fix

**Stage 1 — the real fix** (`execution_auto.py`): the 8 passes are independent (each its own SELECT/UPDATE + optional insert loop; no cross-pass cursor state; `report` is a plain dict). Each pass now gets its own short-lived `with get_cursor()` so the connection returns to the pool between passes. A board request holds a connection for ~one pass (tens of ms) instead of the whole run. **SQL, pass order, report shape, and fail-closed behavior are byte-for-byte unchanged — only cursor scoping + indentation changed** (verified: the only non-cursor/non-comment changed lines are the two intentional docstring lines).

**Stage 2 — defense in depth** (`db.py`): pool `max_size` 10→20, `timeout` 5→10. Verified safe against the live ceiling — Supabase Postgres `max_connections=60` (3 reserved, ~16 baseline in use), so 20 leaves ample margin. This is margin, **not** the fix — a long-held cursor still drains a bigger pool; Stage 1 is the fix.

**Regression guard** (`test_execution_auto_cursor_scoping.py`): instruments `get_cursor` to track concurrent checkouts; asserts `run_auto_generation` never holds >1 cursor at once and acquires one per pass (≥8). Fails loudly if a future change re-merges passes.

## Tests
**52 backend tests pass** — 1 new cursor-scoping guard + 51 regression (`test_execution_board_route`, `test_execution_auto_stage_query`, `test_morning_checklist`, `test_brief_assistant`, `test_execution_hierarchy_write`, `test_executions`, `test_consulting_pipeline`). AST + ruff clean.

## Scope
Backend-only. No frontend, no schema, no migration. Ticket 8 stays unstarted. Production smoke (incident-cleared concurrency test + the original Ticket 7 `/brief-assistant/ask` smoke) runs after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)