### PR TITLE
fix(consulting): shell parity + data-driven workspace label

### DIFF
--- a/repo-b/src/app/lab/env/[envId]/consulting/contacts/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/consulting/contacts/page.tsx
@@ -3,8 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useConsultingEnv } from "@/components/consulting/ConsultingEnvProvider";
-import { LeftSidebar } from "@/components/operator/command-desk/layout/LeftSidebar";
-import { consultingSidebarSections } from "@/app/lab/env/[envId]/operator/_sidebar";
+import { ConsultingPageFrame } from "@/components/consulting/ConsultingPageFrame";
 import {
   createContact as apiCreateContact,
   fetchContacts,
@@ -34,21 +33,6 @@ function fmtRelDate(iso: string | null | undefined): string {
   return d.toLocaleDateString();
 }
 
-const winstonBrand: ReactNode = (
-  <span
-    className="font-command"
-    style={{
-      fontSize: "1rem",
-      fontWeight: 700,
-      letterSpacing: "0.08em",
-      textTransform: "uppercase",
-      color: "#ffffff",
-      textShadow: "0 0 12px rgba(255,255,255,0.07)",
-    }}
-  >
-    WINSTON
-  </span>
-);
 
 export default function ContactsPage({ params }: { params: { envId: string } }) {
   const { businessId, ready } = useConsultingEnv();
@@ -169,35 +153,11 @@ export default function ContactsPage({ params }: { params: { envId: string } }) 
   }
 
   return (
-    <div
-      style={{
-        display: "grid",
-        gridTemplateColumns: "240px minmax(0, 1fr)",
-        gridTemplateRows: "52px minmax(0, 1fr)",
-        height: "100%",
-        minHeight: 0,
-        background: "#05070B",
-      }}
-    >
-      <LeftSidebar
-        mode="brand"
-        brand={winstonBrand}
-        sections={consultingSidebarSections(params.envId)}
-        activeKey="contacts"
-      />
-
-      <div
-        style={{
-          height: 52,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          padding: "0 16px",
-          borderBottom: "1px solid rgba(255,255,255,0.07)",
-          minWidth: 0,
-          gap: 12,
-        }}
-      >
+    <ConsultingPageFrame
+      envId={params.envId}
+      activeKey="contacts"
+      headerContent={
+        <>
         <span
           style={{
             fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
@@ -252,14 +212,9 @@ export default function ContactsPage({ params }: { params: { envId: string } }) 
             {showAdd ? "Cancel" : "+ Contact"}
           </button>
         </div>
-      </div>
-
-      <LeftSidebar
-        mode="nav"
-        sections={consultingSidebarSections(params.envId)}
-        activeKey="contacts"
-      />
-
+        </>
+      }
+    >
       <div
         style={{
           minWidth: 0,
@@ -617,7 +572,7 @@ export default function ContactsPage({ params }: { params: { envId: string } }) 
           </div>
         )}
       </div>
-    </div>
+    </ConsultingPageFrame>
   );
 }
 

--- a/repo-b/src/app/lab/env/[envId]/consulting/pipeline/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/consulting/pipeline/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState, useCallback, useMemo, useRef, type ReactNode } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { Search, X as XIcon, ChevronLeft, ChevronRight } from "lucide-react";
 import { useConsultingEnv } from "@/components/consulting/ConsultingEnvProvider";
+import { winstonBrand } from "@/components/consulting/ConsultingPageFrame";
 import {
   DndContext,
   DragOverlay,
@@ -783,15 +784,6 @@ export default function PipelinePage({
     : dataError;
   const isLoading = contextLoading || (ready && loading);
   const openDeals = allCards.length;
-
-  const winstonBrand: ReactNode = (
-    <span
-      className="font-command"
-      style={{ fontSize: "1rem", fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "#ffffff", textShadow: "0 0 12px rgba(255,255,255,0.07)" }}
-    >
-      WINSTON
-    </span>
-  );
 
   if (isLoading) {
     return (

--- a/repo-b/src/app/lab/env/[envId]/consulting/tasks/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/consulting/tasks/page.tsx
@@ -1,34 +1,12 @@
 "use client";
 
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useState } from "react";
 import { useConsultingEnv } from "@/components/consulting/ConsultingEnvProvider";
-import { LeftSidebar } from "@/components/operator/command-desk/layout/LeftSidebar";
-import { consultingSidebarSections } from "@/app/lab/env/[envId]/operator/_sidebar";
+import {
+  ConsultingPageFrame,
+  consultingHeaderLabel,
+} from "@/components/consulting/ConsultingPageFrame";
 import { ExecutionBoard } from "@/components/consulting/execution/ExecutionBoard";
-
-const monoLabel: React.CSSProperties = {
-  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
-  fontSize: 12,
-  letterSpacing: "0.18em",
-  textTransform: "uppercase",
-  color: "rgba(220,230,240,0.72)",
-};
-
-const winstonBrand: ReactNode = (
-  <span
-    className="font-command"
-    style={{
-      fontSize: "1rem",
-      fontWeight: 700,
-      letterSpacing: "0.08em",
-      textTransform: "uppercase",
-      color: "#ffffff",
-      textShadow: "0 0 12px rgba(255,255,255,0.07)",
-    }}
-  >
-    WINSTON
-  </span>
-);
 
 export default function TasksPage({ params }: { params: { envId: string } }) {
   const { businessId, ready } = useConsultingEnv();
@@ -36,70 +14,24 @@ export default function TasksPage({ params }: { params: { envId: string } }) {
 
   const onReload = useCallback(() => setReloadKey((k) => k + 1), []);
 
-  const sections = useMemo(() => consultingSidebarSections(params.envId), [params.envId]);
-
   return (
-    <div
-      data-command-desk
-      style={{
-        display: "grid",
-        gridTemplateColumns: "240px minmax(0, 1fr)",
-        gridTemplateRows: "52px minmax(0, 1fr)",
-        height: "100%",
-        minHeight: 0,
-        background: "#05070B",
-      }}
+    <ConsultingPageFrame
+      envId={params.envId}
+      activeKey="tasks"
+      headerContent={<span style={consultingHeaderLabel}>Tasks</span>}
     >
-      <LeftSidebar
-        mode="brand"
-        brand={winstonBrand}
-        sections={sections}
-        activeKey="tasks"
-      />
-
-      <div
-        style={{
-          height: 52,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          padding: "0 16px",
-          borderBottom: "1px solid rgba(255,255,255,0.07)",
-          minWidth: 0,
-        }}
-      >
-        <span style={monoLabel}>Tasks</span>
-      </div>
-
-      <LeftSidebar
-        mode="nav"
-        sections={sections}
-        activeKey="tasks"
-      />
-
-      <div
-        style={{
-          minWidth: 0,
-          minHeight: 0,
-          overflow: "hidden",
-          display: "flex",
-          flexDirection: "column",
-          color: "#dce6f0",
-        }}
-      >
-        {ready && businessId ? (
-          <ExecutionBoard
-            key={reloadKey}
-            envId={params.envId}
-            businessId={businessId}
-            onReload={onReload}
-          />
-        ) : (
-          <div style={{ padding: 16, fontSize: 13, color: "rgba(220,230,240,0.55)" }}>
-            Resolving environment...
-          </div>
-        )}
-      </div>
-    </div>
+      {ready && businessId ? (
+        <ExecutionBoard
+          key={reloadKey}
+          envId={params.envId}
+          businessId={businessId}
+          onReload={onReload}
+        />
+      ) : (
+        <div style={{ padding: 16, fontSize: 13, color: "rgba(220,230,240,0.55)" }}>
+          Resolving environment...
+        </div>
+      )}
+    </ConsultingPageFrame>
   );
 }

--- a/repo-b/src/components/consulting/ConsultingPageFrame.tsx
+++ b/repo-b/src/components/consulting/ConsultingPageFrame.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+// ConsultingPageFrame — the shared shell for the dark Consulting Revenue OS
+// pages (Pipeline / Contacts / Tasks). Before this, each page hand-rolled its
+// own LeftSidebar + 52px header + grid, which drifted: different grid rows,
+// height (100% vs 100dvh), and brand-cell sticky behavior. This frame fixes
+// the chrome — brand cell, nav cell, the 52px header row, background, content
+// scroll region — so all three pages share one vertical rhythm.
+//
+// Per-page content stays the page's own: `headerContent` fills the 52px top
+// bar (a label, a search box, action buttons), `children` is the body, and an
+// optional `rightRail` keeps Pipeline's collapsible rail without forcing the
+// other pages into a 3-column grid.
+//
+// Accounting is intentionally NOT wrapped here — it lives on the separate
+// /operator/* route tree (OperatorShell) and is its own command-desk surface.
+
+import type { ReactNode } from "react";
+import { LeftSidebar } from "@/components/operator/command-desk/layout/LeftSidebar";
+import { consultingSidebarSections } from "@/app/lab/env/[envId]/operator/_sidebar";
+
+export const CONSULTING_FRAME_BG = "#05070B";
+export const CONSULTING_HEADER_HEIGHT = 52;
+
+// Shared WINSTON brand mark for the sidebar brand cell. Exported so pages
+// that keep a bespoke shell (Pipeline — it has a collapsible right rail and
+// sticky-scroll board the generic frame intentionally doesn't model) still
+// use the one brand mark and can't drift.
+export const winstonBrand: ReactNode = (
+  <span
+    className="font-command"
+    style={{
+      fontSize: "1rem",
+      fontWeight: 700,
+      letterSpacing: "0.08em",
+      textTransform: "uppercase",
+      color: "#ffffff",
+      textShadow: "0 0 12px rgba(255,255,255,0.07)",
+    }}
+  >
+    WINSTON
+  </span>
+);
+
+// Shared mono label style for the header zone (e.g. the page name).
+export const consultingHeaderLabel: React.CSSProperties = {
+  fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+  fontSize: 12,
+  letterSpacing: "0.18em",
+  textTransform: "uppercase",
+  color: "rgba(220,230,240,0.72)",
+};
+
+export function ConsultingPageFrame({
+  envId,
+  activeKey,
+  headerContent,
+  rightRail,
+  children,
+}: {
+  envId: string;
+  /** Which consulting nav item is active: pipeline | accounting | contacts | tasks */
+  activeKey: string;
+  /** Content of the 52px top bar — page label, search, action buttons. */
+  headerContent: ReactNode;
+  /** Optional collapsible right rail (Pipeline). Omit for a 2-column layout. */
+  rightRail?: ReactNode;
+  /** Page body. */
+  children: ReactNode;
+}) {
+  const sections = consultingSidebarSections(envId);
+  const columns = rightRail
+    ? "240px minmax(0, 1fr) auto"
+    : "240px minmax(0, 1fr)";
+
+  return (
+    <div
+      data-command-desk
+      style={{
+        display: "grid",
+        gridTemplateColumns: columns,
+        gridTemplateRows: `${CONSULTING_HEADER_HEIGHT}px minmax(0, 1fr)`,
+        height: "100%",
+        minHeight: 0,
+        background: CONSULTING_FRAME_BG,
+      }}
+    >
+      {/* Row 1 Col 1 — WINSTON brand cell */}
+      <LeftSidebar
+        mode="brand"
+        brand={winstonBrand}
+        sections={sections}
+        activeKey={activeKey}
+      />
+
+      {/* Row 1 Col 2 — shared 52px header; page supplies its own content */}
+      <div
+        style={{
+          height: CONSULTING_HEADER_HEIGHT,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          padding: "0 16px",
+          borderBottom: "1px solid rgba(255,255,255,0.07)",
+          background: CONSULTING_FRAME_BG,
+          minWidth: 0,
+        }}
+      >
+        {headerContent}
+      </div>
+
+      {/* Row 1 Col 3 — optional right rail header spacer (keeps grid square) */}
+      {rightRail ? (
+        <div
+          style={{
+            height: CONSULTING_HEADER_HEIGHT,
+            borderBottom: "1px solid rgba(255,255,255,0.07)",
+            background: CONSULTING_FRAME_BG,
+          }}
+        />
+      ) : null}
+
+      {/* Row 2 Col 1 — nav */}
+      <LeftSidebar mode="nav" sections={sections} activeKey={activeKey} />
+
+      {/* Row 2 Col 2 — page body */}
+      <div
+        style={{
+          minWidth: 0,
+          minHeight: 0,
+          overflow: "hidden",
+          display: "flex",
+          flexDirection: "column",
+          color: "#dce6f0",
+        }}
+      >
+        {children}
+      </div>
+
+      {/* Row 2 Col 3 — optional right rail body */}
+      {rightRail ? (
+        <div style={{ minHeight: 0, overflow: "hidden" }}>{rightRail}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/repo-b/src/components/operator/OperatorShell.tsx
+++ b/repo-b/src/components/operator/OperatorShell.tsx
@@ -145,6 +145,10 @@ export default function OperatorShell({ envId, children }: OperatorShellProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   const base = `/lab/env/${envId}/operator`;
+  // Workspace label is data-driven from the active environment — never a
+  // hardcoded tenant name. "Hall Boys" was stale demo copy that bled into
+  // every operator workspace regardless of the actual environment.
+  const workspaceName = environment?.client_name?.trim() || "Operator";
   const tabs = useMemo<NavItem[]>(
     () => [
       { href: base, label: "Executive", exact: true },
@@ -183,14 +187,14 @@ export default function OperatorShell({ envId, children }: OperatorShellProps) {
   }, [drawerOpen]);
 
   if (loading) {
-    return <WorkspaceContextLoader label="Loading Hall Boys operator workspace" />;
+    return <WorkspaceContextLoader label="Loading operator workspace" />;
   }
 
   if (error) {
     return (
       <div data-testid="operator-context-error">
         <OperatorUnavailableState
-          title="Unable to load Hall Boys operator workspace"
+          title="Unable to load operator workspace"
           detail={error}
           onRetry={() => void retry()}
           requestId={requestId}
@@ -209,10 +213,10 @@ export default function OperatorShell({ envId, children }: OperatorShellProps) {
               title={`Business ID: ${businessId || "—"} · Industry: ${environment?.industry_type || environment?.industry || "multi_entity_operator"}`}
             >
               <Building2 size={12} />
-              Hall Boys Operating System
+              {workspaceName} Operating System
             </span>
             <h1 className="truncate text-lg font-semibold text-bm-text sm:text-xl">
-              {environment?.client_name || "Hall Boys Holdings"}
+              {environment?.client_name || workspaceName}
             </h1>
           </div>
           <div className="flex items-center gap-3">
@@ -265,7 +269,7 @@ export default function OperatorShell({ envId, children }: OperatorShellProps) {
           <div className="absolute right-0 top-0 flex h-full w-80 max-w-[92vw] flex-col border-l border-bm-border/70 bg-bm-bg p-4">
             <div className="flex items-center justify-between border-b border-bm-border/50 pb-3">
               <div>
-                <p className="text-[10px] uppercase tracking-[0.18em] text-bm-muted2">Hall Boys</p>
+                <p className="text-[10px] uppercase tracking-[0.18em] text-bm-muted2">{workspaceName}</p>
                 <p className="text-sm font-semibold text-bm-text">Operator Navigation</p>
               </div>
               <button


### PR DESCRIPTION
## Problem
The Consulting Revenue OS shell is inconsistent across the four nav items, and the Accounting page shows a stale **"Hall Boys Operating System"** label inside Novendor's own workspace.

**Root cause (investigated):**
1. **Shell divergence** — Pipeline/Contacts/Tasks each hand-roll their own `LeftSidebar` + 52px header + grid. They drifted: different grid rows, `height:100%` vs `minHeight:100dvh`, different brand-cell sticky behavior.
2. **Wrong tenant label** — the consulting sidebar's "Accounting" item deep-links into the **`/operator/*`** route tree, which renders `OperatorShell` — and `OperatorShell.tsx` **hardcoded "Hall Boys"** in 5 places. Hall Boys is a *different* client environment; the label bled into every operator workspace including Paul's own Novendor accounting.

## Fix (frontend shell/layout only — no backend, no schema, no behavior change)

**Shared `ConsultingPageFrame`** (`repo-b/src/components/consulting/ConsultingPageFrame.tsx`, new): unifies the chrome — brand cell, nav cell, 52px header row, background, content region — with an optional `rightRail` slot and a `headerContent` slot for per-page controls. **Tasks** and **Contacts** now use it (−117 net lines of duplicated shell). Their content (ExecutionBoard, contacts UI) is untouched.

**Pipeline keeps its bespoke 3-column shell — on purpose.** It has a collapsible right rail toggled from the header *and* a sticky-scroll board that the generic frame intentionally doesn't model; forcing it into the frame would special-case the frame into incoherence. Pipeline now imports the shared `winstonBrand` so the brand mark can't drift, and its header chrome values (52px, `#05070B`, border) already matched the frame's constants.

**Data-driven workspace label** — `OperatorShell.tsx`: all 5 hardcoded "Hall Boys" strings replaced. A `workspaceName` derives from `environment.client_name` (the active env record) with a generic `"Operator"` fallback; used for the chip ("`{workspaceName}` Operating System"), the heading, and the drawer label. Loading/error labels (which fire before `environment` resolves) just drop the tenant word. The `/operator/accounting` surface itself is left in place — only the label is corrected.

## Scope
Frontend only. No DB, no migration, no task/assistant feature work, no History Rhymes. Dark operator styling preserved.

## Hall Boys verdict
**Stale hardcoded copy, not env metadata.** It was a literal string in `OperatorShell.tsx` (lines 186/193/212/215/268), never sourced from the environment record. Fixed.

## Tests
Typecheck deferred to CI **Frontend Lint + Typecheck + Unit** (fresh worktree has no `node_modules` — tips #20); changes are structural JSX, manually reviewed for type-correctness (`ConsultingPageFrame` props all typed; `React.CSSProperties` used as the repo-wide global-namespace pattern; no dead imports — verified). Visual smoke of all 4 routes runs after deploy.

## Notes for review
- Contacts `internal server error` (if still seen) is a separate backend/data issue — **not** touched here; the page shell renders regardless.
- Next recommended: if full Accounting visual parity is wanted, that's a separate ticket to re-home `/operator/accounting` under `/consulting/*` — deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)