### PR TITLE
docs(happyco): automation cadence + Loom storyboard package (AB#396)

### DIFF
--- a/docs/plans/03-implementation-plans/active/happyco-property-ops-intelligence-kit.md
+++ b/docs/plans/03-implementation-plans/active/happyco-property-ops-intelligence-kit.md
@@ -857,3 +857,58 @@ Implement Ticket 10 for the HappyCo Property Ops Intelligence Kit:
 
 Report proposed reusable improvements, expected owning surfaces, and risks.
 ```
+
+---
+
+## Program status — 6-PR polish program (2026-05-22)
+
+The original ticket sequence above is complete. The package then moved into a
+six-PR polish program tracked in Azure DevOps under **Epic 386 → Feature 391**.
+The Novendor board uses Agile states New/Active/Resolved/Closed.
+
+| PR | ADO | Scope | Notes |
+|---|---|---|---|
+| #100 | AB#392 | Azure DevOps relay workflow | open |
+| #101 | AB#380 | HappyCo demo UX core | open |
+| #102 | AB#394 | Databricks modular refactor | open |
+| #103 | AB#395 | Databricks export contract + sample bundle | open |
+| #104 | AB#393 | Weather-risk surfacing | open |
+| PR-4 | AB#396 | Automation-cadence + Loom documentation package | docs-only |
+
+**PR-4 (AB#396) — this PR.** Docs-only. Authored the HappyCo automation-cadence
+and Loom documentation package under `docs/runbooks/happyco/`:
+`automation-cadence.md`, `claude-cowork-nightly-tasks.md`, `loom-storyboard.md`,
+`pre-recording-checklist.md`, `claims-and-caveats.md`, and
+`post-merge-deploy-smoke.md`; updated `final-package-runbook.md` with a package
+index. No runtime, pipeline, or routing code was touched.
+
+### Current route surface
+
+- `/happyco` — invite-gated landing (`happyco_demo_access` cookie).
+- `/happyco/demo` — clean demo; no Winston login, no Hall Boys shell.
+- `/happyco/artifacts` — gated artifact hub.
+- `/happyco/weather-risk` — KPI strip, risk table, market summary, model/run
+  receipt evidence, chart gallery.
+- `/lab/env/[envId]/operator/property-ops-intelligence` — implementation
+  evidence only.
+
+### Databricks state — verified
+
+- A modular `weather_risk` Python package plus a bundle.
+- `databricks bundle validate -t dev` PASSES against the workspace.
+- `bundle deploy` / `run` are NOT done — CLI v1.0.0 needs an interactive
+  `databricks auth login`.
+- The weather-risk sample bundle (`repo-b/public/happyco/weather-risk/latest/`)
+  is `mode: local_fallback`; its chart PNGs are local-contract placeholders
+  (~67 bytes), not real charts.
+- A prior receipt-backed Databricks run exists (job/run IDs in
+  `repo-b/src/lib/happyco/proof.ts`, `HAPPYCO_DATABRICKS_RECEIPT`).
+
+### Remaining gated steps
+
+- Live Databricks `bundle deploy` + score run for the weather-risk bundle.
+- Uploading local artifacts to gated storage for real downloads.
+- Turning the Claude CoWork cadence into a real recurring schedule — a separate
+  ADO Task, not part of any current PR.
+- Setting `HAPPYCO_DEMO_INVITE_CODE` and filling real recruiter fields before
+  any send.

--- a/docs/runbooks/happyco/automation-cadence.md
+++ b/docs/runbooks/happyco/automation-cadence.md
@@ -1,0 +1,111 @@
+# HappyCo Automation Cadence
+
+Last updated: 2026-05-22
+
+This document describes the nightly and weekly Claude CoWork operating cadence
+for the HappyCo Property Ops Intelligence Kit. It explains what each scheduled
+task does, how the tasks fit together, and how the cadence is meant to be
+scheduled later.
+
+This is a planning and operations document. No recurring schedule is created by
+this PR. Tasks run today only when triggered by hand.
+
+## Purpose
+
+The HappyCo package is a private, invite-gated proof-of-work built on
+deterministic synthetic data. Once the package is shared with a recruiter, it
+needs to stay accurate without a manual audit every day. The cadence keeps the
+gated routes, artifacts, Databricks evidence, and recruiter-facing copy honest
+between the moment the package is shared and the moment it is reviewed.
+
+The cadence does three things:
+
+1. Catches regressions early — a broken gate, a leaked artifact, an overclaim.
+2. Keeps receipts current — QA receipts, control-room status, Databricks state.
+3. Prepares review material — Loom storyboard, role-fit gap analysis, recruiter
+   draft — without ever sending anything automatically.
+
+## Cadence overview
+
+### Nightly (5 tasks)
+
+| # | Task | What it produces |
+|---|------|------------------|
+| 1 | HappyCo Proof Package Nightly QA | Dated QA receipt with route/API evidence |
+| 2 | Automation Control Room Refresh | Honest control-room status copy |
+| 3 | Databricks Weather Risk Run / Receipt Check | `bundle validate` result; run/receipt status |
+| 4 | Artifact Regeneration | Refreshed Excel, deck, SVG, API excerpts, ML files |
+| 5 | Recruiter Draft Prep — Draft Only | A follow-up draft, gated-link placeholder, proof points |
+
+### Weekly (2 tasks)
+
+| # | Task | What it produces |
+|---|------|------------------|
+| 6 | Weekly Role-Fit Gap Analysis | Coverage matrix vs. the Head-of-Data requirements |
+| 7 | Weekly Loom/Demo Storyboard Refresh | Refreshed 5-7 minute Loom script and claim sheet |
+
+The exact task prompts live in
+[`claude-cowork-nightly-tasks.md`](claude-cowork-nightly-tasks.md).
+
+## How the tasks relate
+
+The nightly tasks run in order. Task 1 establishes ground truth for the night;
+tasks 2-5 consume it.
+
+```
+Task 1 QA  ─┬─►  Task 2 Control Room (status copy reflects QA result)
+            ├─►  Task 4 Artifact Regeneration (skips if QA found a blocker)
+            └─►  Task 5 Recruiter Draft (proof points must match QA evidence)
+
+Task 3 Databricks ──►  Task 2 Control Room (Databricks row reflects run state)
+                  └──►  Task 5 Recruiter Draft (Databricks claim must match receipt)
+```
+
+Weekly task 6 reads the latest nightly QA receipt and the implementation plan to
+score role coverage. Weekly task 7 reads the QA receipt and the claims sheet to
+refresh the Loom storyboard.
+
+If task 1 reports a blocking failure — a broken gate, a leaked artifact, an
+overclaim in shipped copy — tasks 2, 4, and 5 should stop and surface the
+failure rather than refresh copy or drafts on top of a broken state.
+
+## Safety gates baked into the cadence
+
+These rules are non-negotiable and are repeated in each task prompt:
+
+- No task sends email. Task 5 produces a draft only.
+- No task creates a real recurring schedule.
+- No task exposes or prints an invite code.
+- No task claims a live Databricks run unless a fresh receipt proves it. The
+  current weather-risk sample bundle is `mode: local_fallback` with placeholder
+  chart PNGs — a task that calls it a live run is wrong.
+- No task publishes artifacts to a public path. Artifacts stay local/private or
+  behind the gated artifact API.
+- Every claim a task writes must match
+  [`claims-and-caveats.md`](claims-and-caveats.md).
+
+## How to schedule this later (not done in this PR)
+
+The cadence is designed to run unattended later. When it is time to schedule it:
+
+1. Pick a runner — the Claude CoWork scheduler, a cron job, or a CI nightly
+   workflow. The 22+ existing Novendor scheduled tasks (see `docs/LATEST.md`)
+   are the model to copy.
+2. Suggested timing: nightly tasks between 1 AM and 4 AM local so receipts are
+   ready before the morning. Stagger them so task 1 finishes before tasks 2-5
+   begin. Weekly tasks on a fixed weekday morning.
+3. Wire outputs into a dated receipt folder, for example
+   `docs/runbooks/happyco/receipts/<date>/`, mirroring how the Novendor
+   intelligence tasks write into `docs/`.
+4. Keep the gates above. The scheduler must never be granted an auto-send path
+   for email and must never be handed an invite code in plain text.
+5. Track the scheduling work itself through the `azure-devops-intake` skill as a
+   new Task under the HappyCo Feature before turning it on.
+
+Until those steps are done, treat every task as a manual, on-demand run.
+
+## Tracking
+
+This cadence is documented under PR-4 / AB#396 (Feature 391, Epic 386). The
+Novendor board uses Agile states New/Active/Resolved/Closed. Creating the real
+recurring schedule is a separate, still-gated Task that is not part of PR-4.

--- a/docs/runbooks/happyco/claims-and-caveats.md
+++ b/docs/runbooks/happyco/claims-and-caveats.md
@@ -1,0 +1,76 @@
+# HappyCo Claims and Caveats
+
+Last updated: 2026-05-22
+
+The single source of truth for what the HappyCo package may and may not claim.
+Every doc, every Loom script, every recruiter draft, every automation task, and
+every page of shipped copy must agree with this sheet.
+
+If a claim is not on the allowed list, it is not allowed. When in doubt, say
+less.
+
+## Allowed claims
+
+- This is private proof-of-work for the HappyCo Head-of-Data role.
+- It is a synthetic-data proof package — deterministic synthetic data only.
+- It is a receipt-backed automation package — the nightly/weekly Claude CoWork
+  cadence leaves dated receipts.
+- "Databricks ML training run executed on public weather and synthetic property
+  operations data." — ALLOWED, and ONLY in reference to the prior
+  receipt-backed run (job/run IDs in `repo-b/src/lib/happyco/proof.ts`,
+  `HAPPYCO_DATABRICKS_RECEIPT`).
+- "Databricks-validated modular pipeline with a local fallback export bundle."
+  — ALLOWED for the CURRENT weather-risk sample bundle. `databricks bundle
+  validate -t dev` passes; the bundle is `mode: local_fallback`.
+- The work is tracked end to end in Azure DevOps (Epic, Feature, User Stories,
+  six PRs).
+- The recruiter follow-up is a draft-only Outlook workflow — drafts are
+  prepared, never sent automatically.
+
+## Not allowed claims
+
+- Real HappyCo data, of any kind.
+- A production HappyCo model.
+- A production deployment.
+- A model serving endpoint.
+- Email sent automatically. The Outlook workflow is draft-only; sending is a
+  manual, confirmed action.
+- Public artifact downloads — unless a gated download path is actually
+  implemented and verified. Local/private artifacts are not public downloads.
+- Calling the current local-fallback weather-risk bundle a fresh live Databricks
+  run. `bundle validate` passing is not a training run.
+
+## The two Databricks claims — keep them separate
+
+These are easy to blur. They are different things.
+
+| | Prior receipt-backed run | Current sample bundle |
+|---|---|---|
+| What it is | A real Databricks ML training run that already executed | The weather-risk export bundle shipped in `repo-b/public/happyco/weather-risk/latest/` |
+| Mode | Completed run, receipt exists | `mode: local_fallback` |
+| Evidence | Job/run IDs in `proof.ts` `HAPPYCO_DATABRICKS_RECEIPT` | `bundle validate -t dev` passes |
+| Charts | Real run outputs | Placeholder PNGs, ~67 bytes — local-contract placeholders, not real charts |
+| Allowed claim | "Databricks ML training run executed on public weather and synthetic property operations data." | "Databricks-validated modular pipeline with a local fallback export bundle." |
+| Not allowed | Calling it a production model or deployment | Calling it a fresh live run |
+
+`bundle deploy` and `bundle run` for the current bundle are NOT done. Databricks
+CLI v1.0.0 needs an interactive `databricks auth login` first. The live score run
+is the next gated step.
+
+## The weather-risk state — exact wording
+
+When describing where the weather-risk feature stands, use this sentence
+verbatim:
+
+> "The site contract is wired. The local fallback bundle validates the
+> interface, and the live Databricks score run is the next gated step to
+> replace placeholder chart artifacts with real generated charts."
+
+## Quick test before you ship a claim
+
+1. Is the claim on the allowed list above? If not, cut it.
+2. Does it mention HappyCo data, a production model, a deployment, a serving
+   endpoint, or a sent email? If yes, cut it.
+3. Does it call the current sample bundle a live run? If yes, fix it.
+4. Is there a receipt or a validate result backing it? If not, soften it to
+   what is actually proven.

--- a/docs/runbooks/happyco/claude-cowork-nightly-tasks.md
+++ b/docs/runbooks/happyco/claude-cowork-nightly-tasks.md
@@ -1,0 +1,258 @@
+# Claude CoWork Task Prompts — HappyCo
+
+Last updated: 2026-05-22
+
+This file holds the copy-pasteable prompt blocks for the HappyCo automation
+cadence: 5 nightly tasks and 2 weekly tasks. See
+[`automation-cadence.md`](automation-cadence.md) for how the tasks fit together.
+
+Each prompt is self-contained. Paste one into a Claude CoWork session to run that
+task by hand. None of these prompts is wired to a recurring schedule by this PR.
+
+Shared rules every task must follow:
+
+- Synthetic data only. Never claim real HappyCo production data or a production
+  model, deployment, or serving endpoint.
+- Never send email. Never create a real recurring schedule. Never print or
+  expose an invite code.
+- Every written claim must match
+  [`claims-and-caveats.md`](claims-and-caveats.md).
+- This is DOCS/EVIDENCE work plus optional artifact regeneration. Do not change
+  runtime code, Databricks pipeline code, or Azure relay routing code.
+
+---
+
+## Nightly Task 1 — HappyCo Proof Package Nightly QA
+
+```text
+You are running the HappyCo Proof Package Nightly QA for the Consulting_app repo.
+
+Goal: confirm the gated HappyCo package is intact and honest, and leave a dated
+QA receipt.
+
+Checks:
+1. /happyco in its locked state — tailored content is hidden, no invite code is
+   visible in the page source.
+2. /happyco unlocked with a valid invite — tailored content renders.
+3. /happyco/demo — clean demo loads with no Winston login and no Hall Boys shell.
+4. /happyco/artifacts — gated; lists artifacts; no public artifact URL exposed.
+5. /happyco/weather-risk — KPI strip, risk table, market summary, model/run
+   receipt evidence, and chart gallery render or degrade honestly.
+6. Operator APIs under /api/operator/v1/property-ops/* return deterministic
+   synthetic JSON with demo metadata and caveats.
+7. The ml-risk endpoint reports its databricks_status and ml_status correctly.
+
+Assertions:
+- No public artifact path is reachable without the invite cookie.
+- No copy overclaims: scan shipped page text against claims-and-caveats.md.
+- The weather-risk sample bundle is described as mode: local_fallback with
+  placeholder charts — not as a live Databricks run.
+
+Output: capture screenshots or route-response evidence and write a dated QA
+receipt (date, each check pass/fail, evidence path, any blocker). If a blocker
+is found, mark it clearly so downstream tasks stop.
+
+Do not change runtime code. Do not send email. Do not expose invite codes.
+```
+
+---
+
+## Nightly Task 2 — Automation Control Room Refresh
+
+```text
+You are running the Automation Control Room Refresh for the HappyCo package.
+
+Goal: keep the Automation Room copy accurate without overclaiming.
+
+Inputs to inspect:
+- Latest commits on the HappyCo branches.
+- Open PR status and any deploy status (#100/AB#392 relay, #101/AB#380 demo UX,
+  #102/AB#394 Databricks refactor, #103/AB#395 export contract,
+  #104/AB#393 weather-risk, this PR-4/AB#396).
+- The Databricks receipt status from tonight's Task 3.
+- Artifact status from tonight's Task 4.
+- The latest QA receipt from tonight's Task 1.
+- Known limitations in final-package-runbook.md.
+
+Action:
+- Update the Automation Control Room copy ONLY if the new copy stays fully
+  honest. If anything is ambiguous, leave the copy unchanged and report why.
+- Never invent a run, a deploy, or a passing test that did not happen.
+
+Output: a short status summary — what changed in the copy, what was left alone,
+and why.
+
+Do not change runtime code. Do not send email. Do not expose invite codes.
+```
+
+---
+
+## Nightly Task 3 — Databricks Weather Risk Run / Receipt Check
+
+```text
+You are running the Databricks Weather Risk Run / Receipt Check.
+
+Goal: keep the weather-risk Databricks evidence current and honest.
+
+Steps:
+1. Run `databricks bundle validate -t dev` for the weather_risk bundle. This is
+   expected to PASS against the workspace.
+2. Run `databricks bundle deploy` and a score run ONLY if a Databricks auth
+   profile is available without interactive login. Databricks CLI v1.0.0 needs
+   an interactive `databricks auth login`; if that has not been done, do NOT
+   attempt a run — report "no new run, auth not available".
+3. If a run does execute, validate the outputs and confirm MLflow / run metadata
+   is present. Capture the job ID and run ID into a receipt.
+4. If no run executes, confirm the prior receipt-backed run is still the latest
+   evidence (job/run IDs in repo-b/src/lib/happyco/proof.ts
+   HAPPYCO_DATABRICKS_RECEIPT) and report the sample bundle state.
+
+Honesty rules:
+- The current weather-risk sample bundle at
+  repo-b/public/happyco/weather-risk/latest/ is mode: local_fallback. Its chart
+  PNGs are ~67-byte local-contract placeholders, NOT real charts.
+- Never describe `bundle validate` passing as a live training run.
+- Never claim a fresh live run unless this task actually executed one tonight
+  and has a receipt for it.
+
+Output: bundle validate result, run/no-run status with reason, receipt path or
+"no new receipt", and the current honest claim sentence.
+
+Do not change pipeline code. Do not send email. Do not expose invite codes.
+```
+
+---
+
+## Nightly Task 4 — Artifact Regeneration
+
+```text
+You are running HappyCo Artifact Regeneration.
+
+Goal: regenerate and validate the local proof artifacts so they match the
+current synthetic fixture and ML output.
+
+Artifacts:
+- Excel workbook: HappyCo_Property_Ops_Model.xlsx
+- PowerPoint deck: HappyCo_90_Day_Data_Strategy.pptx
+- Architecture diagram SVG
+- API excerpts JSON (artifacts/happyco/qa/api_excerpts.json)
+- ML model card and metrics
+- Screenshots, only if browser tooling is available in this environment
+
+Steps:
+1. Run the rebuild commands documented in final-package-runbook.md.
+2. Validate each artifact opens, has the expected sheets/slides/sections, and
+   carries the synthetic-data caveat.
+3. Confirm no regenerated artifact has been written to a public static path.
+   Artifacts stay under artifacts/happyco/ (git-ignored) or behind the gated
+   artifact API.
+
+Assertions:
+- No public artifact leak. The gated artifact hub stays the only access path.
+- No artifact claims real HappyCo data or production performance.
+
+Output: which artifacts were regenerated, validation results, and confirmation
+that nothing leaked to a public path.
+
+Do not change runtime code. Do not send email. Do not expose invite codes.
+```
+
+---
+
+## Nightly Task 5 — Recruiter Draft Prep — Draft Only
+
+```text
+You are preparing a HappyCo recruiter follow-up DRAFT. Draft only — never send.
+
+Goal: have a concise, honest follow-up ready for review.
+
+Produce:
+1. A short follow-up message draft (a few tight paragraphs, no fluff).
+2. A gated-link placeholder for /happyco — use a placeholder token, NOT a real
+   invite code. The real code is set by hand at send time.
+3. Top 3 proof points, each backed by evidence from tonight's QA receipt:
+   - the gated synthetic proof package and clean demo,
+   - the Databricks-validated modular weather-risk pipeline with a local
+     fallback export bundle,
+   - the receipt-backed prior Databricks training run on public weather and
+     synthetic property operations data.
+4. Top 3 caveats, matching claims-and-caveats.md:
+   - synthetic data only, no HappyCo production data,
+   - no production model, deployment, or serving endpoint,
+   - the current weather-risk sample bundle is a local-fallback bundle; the
+     live score run is the next gated step.
+5. Optional: Outlook WinCOM draft parameters using the tracked templates under
+   docs/runbooks/happyco/outlook-wincom/ — dry_run true, send_policy draft.
+
+Hard rules:
+- Do not send. Do not auto-send. Sending requires explicit human confirmation.
+- Do not embed a real invite code anywhere.
+- Every proof point must be true tonight per the QA receipt.
+
+Output: the draft, the placeholder link, proof points, caveats, and optional
+Outlook params — all marked DRAFT.
+```
+
+---
+
+## Weekly Task 6 — Weekly Role-Fit Gap Analysis
+
+```text
+You are running the Weekly HappyCo Role-Fit Gap Analysis.
+
+Goal: measure how well the proof package covers the HappyCo Head-of-Data role
+and surface the gaps.
+
+Compare the package against these role requirement areas:
+- data strategy
+- canonical entity model
+- property graph / knowledge layer
+- entity resolution
+- Databricks / modern data platform
+- data pipelines
+- analytics and benchmarking
+- machine learning
+- AI-enabled workflows
+- product-facing APIs
+- leadership artifacts (strategy deck, 30/60/90 plan)
+
+For each area, mark coverage as Strong / Partial / Gap with one line of evidence
+(route, artifact, PR, or receipt).
+
+Output:
+1. A coverage matrix across all areas.
+2. The current gaps, ranked.
+3. Suggested next tickets to close the top gaps, each phrased so it can be filed
+   through the azure-devops-intake skill as a Task.
+
+Use only honest, synthetic-data-backed evidence. Do not overclaim coverage.
+```
+
+---
+
+## Weekly Task 7 — Weekly Loom/Demo Storyboard Refresh
+
+```text
+You are refreshing the HappyCo Loom / demo storyboard.
+
+Goal: keep the recording script current with the latest package state.
+
+Inputs: the latest nightly QA receipt, claims-and-caveats.md, the current
+weather-risk bundle state, and any new PR/deploy status.
+
+Output:
+1. A 5-7 minute Loom script following the 7-beat flow in loom-storyboard.md.
+2. The exact browser tabs to open before recording.
+3. What NOT to show on screen (invite codes, local artifact paths, raw
+   git-ignored files).
+4. The allowed and disallowed claims for this recording, from
+   claims-and-caveats.md.
+5. The top 3 proof points and the top 3 caveats.
+
+When describing the weather-risk state, use this exact sentence:
+"The site contract is wired. The local fallback bundle validates the interface,
+and the live Databricks score run is the next gated step to replace placeholder
+chart artifacts with real generated charts."
+
+Do not invent capabilities. Keep every claim receipt-backed.
+```

--- a/docs/runbooks/happyco/final-package-runbook.md
+++ b/docs/runbooks/happyco/final-package-runbook.md
@@ -1,11 +1,72 @@
 # HappyCo Property Ops Intelligence Kit - Runbook
 
-Last updated: 2026-05-21
+Last updated: 2026-05-22
 
 This is a private proof-of-work package for the HappyCo Head of Data
 role. It uses deterministic synthetic data only. It does not contain HappyCo
 production data, private recruiter email content, or secrets. Ticket 3B adds a
 receipt-backed live Databricks execution claim for synthetic demo data only.
+
+## Package Index
+
+The HappyCo package spans routes, a Databricks pipeline, local artifacts, an
+ADO-tracked PR program, and a Claude CoWork automation cadence. This section is
+the map; the sections below it hold the detail.
+
+### Docs in this package
+
+| Doc | What it covers |
+|---|---|
+| `final-package-runbook.md` (this file) | Routes, APIs, artifacts, rebuild commands, Databricks proof, known limitations |
+| `automation-cadence.md` | The nightly + weekly Claude CoWork operating cadence and how to schedule it later |
+| `claude-cowork-nightly-tasks.md` | The 5 nightly + 2 weekly task prompts as copy-pasteable blocks |
+| `loom-storyboard.md` | The 5-7 minute, 7-beat Loom recording script |
+| `pre-recording-checklist.md` | What to open/close/verify before recording; what not to show |
+| `claims-and-caveats.md` | The allowed / not-allowed claim sheet — source of truth for all copy |
+| `post-merge-deploy-smoke.md` | The post-merge / post-deploy smoke checklist |
+| `reusable-proof-system-backlog.md` | Reusable Winston proof-system patterns from this build |
+| `outlook-wincom/` | Draft-only Outlook WinCOM recruiter workflow templates |
+
+### The 6-PR program (Feature 391, Epic 386)
+
+| PR | ADO | Scope |
+|---|---|---|
+| #100 | AB#392 | Azure DevOps relay workflow |
+| #101 | AB#380 | HappyCo demo UX core |
+| #102 | AB#394 | Databricks modular refactor |
+| #103 | AB#395 | Databricks export contract + sample bundle |
+| #104 | AB#393 | Weather-risk surfacing |
+| PR-4 | AB#396 | Automation-cadence + Loom documentation package (this docs PR) |
+
+### Routes at a glance
+
+- `/happyco` — invite-gated landing; sets the `happyco_demo_access` cookie.
+- `/happyco/demo` — clean demo; no Winston login, no Hall Boys shell.
+- `/happyco/artifacts` — gated artifact hub.
+- `/happyco/weather-risk` — KPI strip, risk table, market summary, model/run
+  receipt evidence, chart gallery.
+- `/lab/env/[envId]/operator/property-ops-intelligence` — implementation
+  evidence only; the env operator route behind the demo.
+
+### The cadence in one line
+
+Nightly: QA, control-room refresh, Databricks receipt check, artifact
+regeneration, recruiter draft prep. Weekly: role-fit gap analysis, Loom
+storyboard refresh. Full detail in `automation-cadence.md`.
+
+### Remaining gated steps
+
+These are deliberately not done and are the honest next steps:
+
+- Live Databricks `bundle deploy` + score run for the weather-risk bundle —
+  blocked on an interactive `databricks auth login` (CLI v1.0.0). The current
+  sample bundle is `mode: local_fallback` with placeholder chart PNGs.
+- Uploading local artifacts to gated storage so the artifact hub can serve real
+  downloads instead of local/private status.
+- Turning the Claude CoWork cadence into a real recurring schedule — a separate
+  ADO Task, not part of any current PR.
+- Setting `HAPPYCO_DEMO_INVITE_CODE` in the deployment environment and filling
+  real recruiter fields before any send.
 
 ## Routes
 
@@ -326,6 +387,56 @@ The templates are safe by default:
 - Local Excel workbook
 - Local PowerPoint deck and architecture SVG
 - Outlook WinCOM dry-run/draft templates
+
+## Weather-Risk Route And Sample Bundle
+
+`/happyco/weather-risk` surfaces a public NOAA/FEMA hazard layer joined to the
+synthetic property-ops layer. It shows a KPI strip, a risk table, a market
+summary, model/run-receipt evidence, and a chart gallery.
+
+The Databricks side is a modular `weather_risk` Python package plus a bundle.
+`databricks bundle validate -t dev` PASSES against the workspace — the bundle
+config is real and valid.
+
+`bundle deploy` and `bundle run` are NOT done. Databricks CLI v1.0.0 needs an
+interactive `databricks auth login` first.
+
+The weather-risk sample bundle at `repo-b/public/happyco/weather-risk/latest/` is
+`mode: local_fallback`. Its chart PNGs are local-contract placeholders
+(roughly 67 bytes), not real charts.
+
+Exact wording for the weather-risk state:
+
+> The site contract is wired. The local fallback bundle validates the interface,
+> and the live Databricks score run is the next gated step to replace
+> placeholder chart artifacts with real generated charts.
+
+Allowed claim for the current bundle:
+
+> Databricks-validated modular pipeline with a local fallback export bundle.
+
+A separate, prior receipt-backed Databricks run exists (job/run IDs in
+`repo-b/src/lib/happyco/proof.ts`, `HAPPYCO_DATABRICKS_RECEIPT`). Its allowed
+claim is:
+
+> Databricks ML training run executed on public weather and synthetic property
+> operations data.
+
+Keep these two claims separate — see `claims-and-caveats.md`.
+
+## Automation Cadence
+
+The package is kept honest after sharing by a Claude CoWork cadence: 5 nightly
+tasks and 2 weekly tasks. The cadence is documented, not yet scheduled. No
+recurring schedule is created by PR-4.
+
+- Nightly: Proof Package QA, Automation Control Room Refresh, Databricks Weather
+  Risk Run / Receipt Check, Artifact Regeneration, Recruiter Draft Prep.
+- Weekly: Role-Fit Gap Analysis, Loom/Demo Storyboard Refresh.
+
+Full design is in `automation-cadence.md`. The copy-pasteable task prompts are in
+`claude-cowork-nightly-tasks.md`. Safety gates: no auto-send, no fake runs, no
+exposed invite codes, no public artifact leaks.
 
 ## Manual Actions Before Recruiter Send
 

--- a/docs/runbooks/happyco/loom-storyboard.md
+++ b/docs/runbooks/happyco/loom-storyboard.md
@@ -1,0 +1,150 @@
+# HappyCo Loom Storyboard
+
+Last updated: 2026-05-22
+
+A 5-7 minute Loom recording script for the HappyCo Property Ops Intelligence Kit.
+The recording is private proof-of-work for the HappyCo Head-of-Data role. It runs
+on deterministic synthetic data and a local-fallback Databricks bundle.
+
+Pre-recording prep lives in
+[`pre-recording-checklist.md`](pre-recording-checklist.md). Claim boundaries live
+in [`claims-and-caveats.md`](claims-and-caveats.md). Read both before recording.
+
+## Recording at a glance
+
+- Target length: 5-7 minutes.
+- Tone: calm, specific, no hype. Show the work, name the caveats.
+- Structure: 7 beats. Roughly 45-60 seconds each.
+- Open every claim with what is real and what is synthetic. Say "synthetic" out
+  loud early so it frames the whole demo.
+
+## The 7-beat flow
+
+### Beat 1 — `/happyco` (about 45 sec)
+
+Open the gated landing page.
+
+- This is private proof-of-work for the HappyCo Head-of-Data role.
+- Access is invite-gated — a `happyco_demo_access` cookie set by an invite code.
+  Do not show or read the code on camera.
+- State plainly: every figure in this package is deterministic synthetic data,
+  not HappyCo production data.
+- One sentence on intent: this shows how I would approach HappyCo's data
+  platform, end to end.
+
+### Beat 2 — `/happyco/demo` (about 60 sec)
+
+Open the clean demo.
+
+- Point out it is a clean surface — no Winston login, no Hall Boys operator
+  shell. It is built to be shown directly.
+- Walk the property-ops intelligence view: the canonical property graph and
+  entity resolution.
+- Show benchmark variance — Parkline Commons reading clearly as the
+  underperformer against its peer group.
+- Show predictive maintenance risk — the ML risk scores per property.
+- Show the Automation Room — the controlled local-runner view with receipts and
+  explicit send/export gates.
+
+### Beat 3 — `/happyco/weather-risk` (about 60 sec)
+
+Open the weather-risk page.
+
+- This layer combines public NOAA/FEMA hazard data with the synthetic
+  property-ops layer.
+- Walk the KPI strip, the risk table, and the market summary.
+- Show the model and run-receipt evidence, then the chart gallery.
+- Be explicit about the charts. Say this exact sentence:
+
+  > "The site contract is wired. The local fallback bundle validates the
+  > interface, and the live Databricks score run is the next gated step to
+  > replace placeholder chart artifacts with real generated charts."
+
+- Do not present the placeholder charts as finished analytics output.
+
+### Beat 4 — Databricks evidence (about 60 sec)
+
+Show the Databricks side.
+
+- The weather-risk pipeline is a modular `weather_risk` Python package plus a
+  bundle.
+- `databricks bundle validate -t dev` PASSES against the workspace — the bundle
+  config is real and valid.
+- `bundle deploy` and `run` are not done; Databricks CLI v1.0.0 needs an
+  interactive `databricks auth login`. Say that honestly.
+- A prior receipt-backed Databricks run exists — public weather plus synthetic
+  property operations data — with real job and run IDs in the receipt.
+- Caveats: no HappyCo production data, no production model, no serving endpoint.
+
+### Beat 5 — Artifacts (about 45 sec)
+
+Show the artifact hub at `/happyco/artifacts`.
+
+- Walk the deliverables: the Excel property-ops model, the 90-day strategy
+  PowerPoint deck, and the architecture diagram.
+- The hub is invite-gated and serves files only through an allowlisted API.
+- Be honest about status: artifacts that exist locally but are not uploaded to
+  gated storage show as local/private rather than as public downloads. Nothing
+  here is a public download unless it actually is.
+
+### Beat 6 — ADO and automation (about 45 sec)
+
+Show the delivery loop.
+
+- The work is tracked in Azure DevOps: an Epic, a Feature, User Stories, and the
+  six PRs in this program.
+- The Claude CoWork nightly tasks keep the package honest — nightly QA, control
+  room refresh, Databricks receipt check, artifact regeneration, recruiter draft
+  prep — plus two weekly tasks.
+- Every task leaves receipts and runs behind safety gates: no auto-send, no fake
+  runs, no exposed invite codes.
+
+### Beat 7 — Close (about 30 sec)
+
+Land the point.
+
+> "This is AI attached to a delivery loop: plan, code, run, validate, generate
+> artifacts, deploy, and leave receipts."
+
+- One line on next gated steps: the live Databricks score run and uploading
+  artifacts to gated storage.
+- Thank the viewer. End the recording.
+
+## Tabs to open before recording
+
+Open and arrange these before starting (see the pre-recording checklist for the
+full setup):
+
+1. `/happyco` — already unlocked, with the invite-code field off screen.
+2. `/happyco/demo`
+3. `/happyco/weather-risk`
+4. The Databricks bundle / `bundle validate` output, or a terminal showing it.
+5. `/happyco/artifacts`
+6. The Azure DevOps board for the HappyCo Epic/Feature/Stories.
+
+## What not to show
+
+- The invite code, the invite-code input mid-typing, or any URL with the code in
+  a query string.
+- Local git-ignored artifact paths or a file explorer of `artifacts/happyco/`.
+- Any Databricks token, profile secret, or `.env` content.
+- The placeholder chart PNGs presented as real charts.
+- Any claim the claims sheet marks as not allowed.
+
+## Top 3 proof points
+
+1. A gated, synthetic proof package with a clean demo and property-ops
+   intelligence — graph, entity resolution, benchmarking, predictive risk.
+2. A Databricks-validated modular weather-risk pipeline with a local fallback
+   export bundle, plus a receipt-backed prior training run on public weather and
+   synthetic property operations data.
+3. An ADO-tracked delivery loop with nightly Claude CoWork automation that leaves
+   receipts and runs behind safety gates.
+
+## Top 3 caveats
+
+1. Synthetic data only. No HappyCo production data anywhere in the package.
+2. No production model, no production deployment, no serving endpoint.
+3. The current weather-risk sample bundle is a local-fallback bundle with
+   placeholder chart artifacts. The live Databricks score run is the next gated
+   step.

--- a/docs/runbooks/happyco/post-merge-deploy-smoke.md
+++ b/docs/runbooks/happyco/post-merge-deploy-smoke.md
@@ -1,0 +1,63 @@
+# HappyCo Post-Merge / Deploy Smoke Checklist
+
+Last updated: 2026-05-22
+
+Run this checklist after merging a HappyCo PR and after every deploy that
+touches the HappyCo package. It is a fast manual pass — gates, routes, copy
+honesty. It is not a substitute for the focused backend/frontend tests in
+[`final-package-runbook.md`](final-package-runbook.md).
+
+Mark each item pass or fail. If anything fails, stop and fix before sharing the
+package or recording a Loom.
+
+## Gate behavior
+
+- [ ] `/happyco` loads in its locked state — tailored HappyCo content is hidden.
+- [ ] An invalid invite code fails — access is denied, no content leaks.
+- [ ] A valid invite code unlocks — the `happyco_demo_access` cookie is set and
+      tailored content renders.
+- [ ] No invite code appears in the page source, in the HTML, or in any
+      client-side bundle.
+
+## Routes and navigation
+
+- [ ] The `/happyco` primary CTA opens `/happyco/demo`.
+- [ ] `/happyco/demo` has no Winston login and no Hall Boys operator shell — it
+      is the clean demo surface.
+- [ ] The benchmark variance visual on the demo reads clearly — Parkline Commons
+      is visibly the underperformer.
+- [ ] `/happyco/weather-risk` renders fully — KPI strip, risk table, market
+      summary, model/run-receipt evidence, chart gallery — or degrades honestly
+      if data is absent.
+- [ ] `/happyco/artifacts` is gated and shows honest artifact status —
+      local/private vs downloadable, no fake downloads.
+
+## Honesty checks
+
+- [ ] No invite code is exposed anywhere in source or rendered pages.
+- [ ] No false claims in shipped copy — scan against
+      [`claims-and-caveats.md`](claims-and-caveats.md).
+- [ ] The weather-risk page describes the sample bundle as a local-fallback
+      bundle with placeholder charts, not as a live Databricks run.
+- [ ] The Databricks evidence shown matches reality — `bundle validate` passes;
+      `deploy`/`run` not done; a prior receipt-backed run exists.
+
+## Infrastructure health
+
+- [ ] API and proxy routes are healthy — `/api/operator/v1/property-ops/*`
+      respond with deterministic synthetic JSON and demo caveats.
+- [ ] The gated artifact API verifies the invite cookie — unknown keys return
+      404, missing access returns 403.
+- [ ] No artifact is reachable on a public static path.
+
+## Sign-off
+
+- [ ] All items above pass.
+- [ ] Any failures are logged with the exact route/symptom and a fix is filed
+      through the `azure-devops-intake` skill.
+- [ ] A dated note of this smoke run is appended to the latest QA receipt or the
+      runbook.
+
+Note: repo-b on Vercel does not auto-deploy on push to `main`. After a merge
+that touches `repo-b/`, run the manual `repo-b` production deploy before running
+this checklist against the deployed site.

--- a/docs/runbooks/happyco/pre-recording-checklist.md
+++ b/docs/runbooks/happyco/pre-recording-checklist.md
@@ -1,0 +1,77 @@
+# HappyCo Pre-Recording Checklist
+
+Last updated: 2026-05-22
+
+Run this checklist before recording the HappyCo Loom. It covers what to open,
+what to close, what to verify, and what must never appear on screen. The script
+itself is in [`loom-storyboard.md`](loom-storyboard.md).
+
+The goal: a clean 5-7 minute recording with no leaked secrets, no broken routes,
+and no overclaims.
+
+## Environment
+
+- [ ] Decide where you are recording against — local dev or the deployed gated
+      site. Use whichever currently renders all 4 HappyCo routes cleanly.
+- [ ] If recording local: start the dev server and confirm it is up before
+      opening any tab.
+- [ ] If recording deployed: confirm the latest deploy is live and the gated
+      routes work.
+- [ ] Have the invite code ready in a password manager or a note that stays off
+      screen. Do not paste it into a visible field.
+
+## Open these tabs (in order)
+
+- [ ] `/happyco` — unlock it before recording so the invite-code field is never
+      on camera. Verify tailored content is visible.
+- [ ] `/happyco/demo` — confirm it loads with no Winston login and no Hall Boys
+      shell.
+- [ ] `/happyco/weather-risk` — confirm the KPI strip, risk table, market
+      summary, model/run-receipt evidence, and chart gallery all render.
+- [ ] Databricks `bundle validate` output — either a terminal with the passing
+      result or the bundle file open. Confirm it shows the validate PASS.
+- [ ] `/happyco/artifacts` — confirm the hub lists artifacts and shows honest
+      local/private vs downloadable status.
+- [ ] The Azure DevOps board — the HappyCo Epic 386, Feature 391, the User
+      Stories, and the six PRs.
+
+## Close or hide these
+
+- [ ] Any window, tab, or terminal showing the invite code.
+- [ ] Any `.env` file, Databricks token, or profile secret.
+- [ ] File explorer windows showing `artifacts/happyco/` or other git-ignored
+      local paths.
+- [ ] Email clients, personal messages, calendar notifications.
+- [ ] Unrelated browser tabs, bookmarks bars with sensitive links.
+- [ ] Desktop notifications — turn on do-not-disturb / focus mode.
+
+## Verify before you hit record
+
+- [ ] All 4 HappyCo routes render or degrade honestly — no error pages.
+- [ ] The weather-risk page shows the placeholder-chart state honestly; you are
+      ready to explain it, not hide it.
+- [ ] No HappyCo production claim is visible anywhere in the shipped copy.
+- [ ] The Databricks evidence on screen matches reality: `bundle validate`
+      passes; `bundle deploy`/`run` are not done; a prior receipt-backed run
+      exists.
+- [ ] Your script matches [`claims-and-caveats.md`](claims-and-caveats.md).
+- [ ] You have rehearsed the weather-risk sentence:
+      "The site contract is wired. The local fallback bundle validates the
+      interface, and the live Databricks score run is the next gated step to
+      replace placeholder chart artifacts with real generated charts."
+
+## What NOT to show on camera
+
+- The invite code, the invite-code input field mid-typing, or any URL with the
+  code as a query parameter.
+- Local git-ignored artifact paths or a file browser of `artifacts/happyco/`.
+- Databricks tokens, auth profiles, or `.env` content.
+- The placeholder chart PNGs presented as finished analytics.
+- Anything the claims sheet marks as a disallowed claim.
+
+## After recording
+
+- [ ] Watch the recording back once, specifically scanning for a leaked invite
+      code or secret in any frame.
+- [ ] If anything sensitive appears, re-record. Do not trim and ship.
+- [ ] Keep the recording link private until it is reviewed.


### PR DESCRIPTION
## PR-4 — HappyCo automation cadence + Loom prep (Tracks I, J)

Story `AB#396`, Feature #391, Epic #386. **Docs-only** — no runtime, pipeline, or routing code touched. Branched off `origin/main`.

The final build-phase PR. Authors the documentation that shows the HappyCo proof package runs on an operating cadence with receipts, and the materials to record the recruiter Loom.

### New — `docs/runbooks/happyco/`
- **`automation-cadence.md`** — the 5 nightly + 2 weekly Claude CoWork tasks, how they feed each other, and the baked-in safety gates.
- **`claude-cowork-nightly-tasks.md`** — all 7 task prompts as copy-pasteable blocks (Nightly QA, Control Room Refresh, Databricks Run/Receipt Check, Artifact Regeneration, Recruiter Draft Prep; Weekly Role-Fit Gap Analysis, Loom/Storyboard Refresh).
- **`loom-storyboard.md`** — the 5–7 minute, 7-beat recording script (`/happyco` → demo → weather-risk → Databricks → artifacts → ADO/automation → close).
- **`pre-recording-checklist.md`** — setup, tab order, what not to show.
- **`claims-and-caveats.md`** — the single source of truth for allowed vs not-allowed claims, with a table keeping the prior receipt-backed Databricks run and the current `local_fallback` sample bundle as distinct claims.
- **`post-merge-deploy-smoke.md`** — the post-merge/deploy smoke checklist.

### Updated
- `final-package-runbook.md` — package index, 6-PR table, routes, cadence.
- `docs/plans/.../happyco-property-ops-intelligence-kit.md` — 6-PR program status.

### Honesty
Every Databricks claim matches the verified state: `bundle validate -t dev` passes; `deploy`/`run` are pending an interactive `databricks auth login`; the current sample bundle is `local_fallback` with placeholder chart PNGs. The claims sheet explicitly forbids calling it a fresh live run. No real schedules were created — the task prompts are documented for later scheduling.

### Verification
`git diff --check` clean. Docs-only — `git status` shows only the 8 markdown files. No invite codes, no secrets.

### After this PR
The build phase is complete. Remaining work is review/merge, deploy + smoke, the live Databricks `auth login` + score run, and recording the Loom — the gated/human steps the plan flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
