### PR TITLE
docs(telemetry): wire real screenshots + manual-capture checklist into reviewer pack

### DIFF
--- a/telemetry-platform/PROOF.md
+++ b/telemetry-platform/PROOF.md
@@ -362,9 +362,11 @@ frontend `GovernanceDashboard.tsx`, `…/telemetry/governance/page.tsx`, `Teleme
 `copilot-api.ts`.
 
 **Known gaps:** production-smoke is **not yet machine-automated** — the dashboard shows the last
-*manually recorded* cold smoke (timestamp/source), as designed. An authenticated production screenshot
-of the rendered dashboard is not capturable from the build session (same limitation since Phase 5); the
-data-level proof above + the route stand in.
+*manually recorded* cold smoke (timestamp/source), as designed. Authenticated screenshots of the
+rendered Explain-verdict / Draft-report / Governance pages are not capturable headlessly from the
+build session (same limitation since Phase 5) — the real replay-NO-GO and model-performance shots are
+wired into the reviewer pack, and a 2-minute manual-capture checklist for the remaining three is in
+`REVIEWER_DEMO.md` §7; the data-level proof above + the live routes stand in.
 
 ---
 

--- a/telemetry-platform/REVIEWER_DEMO.md
+++ b/telemetry-platform/REVIEWER_DEMO.md
@@ -106,5 +106,26 @@ curl -s -X POST $B/copilot/draft-report   -H 'content-type: application/json' \
 - **Branch history:** this shipped via PR #118 from the legacy-named branch `feat/hr-morning-book-v1`
   (a naming holdover) — it is **merged to `main`**; the branch name is not meaningful.
 
+## 7. Screenshots
+
+Captured (real, in repo — `telemetry-platform/docs/screenshots/`):
+
+- **Replay after GO→NO-GO at t=728** — ![replay NO-GO](docs/screenshots/p6_replay_flip.png)
+- **Model performance** (champion vs challenger, exact metrics) — ![model performance](docs/screenshots/p6_model_performance.png)
+
+To capture (authenticated, ~2 min in a logged-in browser — these pages are auth-gated, so they
+can't be captured headlessly from the build session). Save each into
+`telemetry-platform/docs/screenshots/` with the exact filename, then embed it here with
+`![…](docs/screenshots/<name>.png)`:
+
+| # | Page / state to show | Route (after login) | Save as |
+|---|---|---|---|
+| 1 | **Explain verdict** — the grounded answer + evidence cards + tool/evidence trail, after clicking "Explain this verdict →" on the NO-GO replay | `/lab/env/dc82d39d-…/telemetry/replay` → Replay → wait for NO-GO → Explain this verdict | `copilot_explain_verdict.png` |
+| 2 | **Draft test report** — the `DraftReportCard` with the amber `REQUIRES HUMAN REVIEW` banner + provenance + report body | `/lab/env/dc82d39d-…/telemetry/copilot` → ask "Why NO-GO?" → Draft test report → | `copilot_draft_report.png` |
+| 3 | **AI Governance dashboard** — "What this proves" strip + metric strip + eval table + recent interactions | `/lab/env/dc82d39d-…/telemetry/governance` | `governance.png` |
+
+(Full env id in §2. The replay-NO-GO and model-performance shots above already cover 2 of the 5 the
+reviewer pack calls for; the three here complete it.)
+
 See `telemetry-platform/docs/portfolio-proof.md` for the 2-minute written summary, and
 `telemetry-platform/PROOF.md` for the full per-phase evidence log.

--- a/telemetry-platform/docs/portfolio-proof.md
+++ b/telemetry-platform/docs/portfolio-proof.md
@@ -37,8 +37,14 @@ Databricks NASA ingest (Bronze/Silver/Gold medallion)
   (`tel_copilot_reports`) labeled `ASSISTANT-GENERATED DRAFT — REQUIRES HUMAN REVIEW`, re-fetchable by
   receipt.
 - **It's measured.** A governance panel reports grounded rate, refusal rate, latency, answer-source
-  mix, and the active prompt hash — all from real logged interactions.
+  mix, post-validator block count, and the active prompt hash — all from real logged interactions.
   ![overview](screenshots/p6_overview.png)
+- **The models are gated.** Champion-vs-challenger metrics with the declared promotion gate.
+  ![model performance](screenshots/p6_model_performance.png)
+
+> Screenshot gallery (replay-NO-GO + model-performance embedded above) and a 2-minute capture
+> checklist for the authenticated Explain-verdict / Draft-report / Governance pages are in
+> [`../REVIEWER_DEMO.md`](../REVIEWER_DEMO.md) §7.
 
 ## Applied-AI controls (the safety story)
 


### PR DESCRIPTION
Docs-only polish pass (no runtime change, no behavior change). Closes the screenshot gap as far as is possible from the build session.

- Embeds the **two real existing screenshots** into `REVIEWER_DEMO.md` §7 + `portfolio-proof.md`: replay after **GO→NO-GO at t=728** (`p6_replay_flip.png`) and **model performance** (`p6_model_performance.png`).
- Adds a precise **2-minute manual-capture checklist** (exact route + state + target filename) for the three **authenticated** pages that can't be captured headlessly: Explain-verdict, Draft-report, Governance. Drop the PNGs into `telemetry-platform/docs/screenshots/` with the listed names and they slot into the gallery.
- `PROOF.md` known-gaps updated to reflect this.

No new screenshot binaries are committed — I won't fabricate captures; the 2 real ones are wired, the 3 authenticated ones await a logged-in browser (yours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)