### PR TITLE
fix(hha): standalone route + /bos proxy (demo-ready)

### DIFF
--- a/repo-b/src/components/lab/LabEnvironmentShell.tsx
+++ b/repo-b/src/components/lab/LabEnvironmentShell.tsx
@@ -164,7 +164,7 @@ export default function LabEnvironmentShell({ envId, children }: Props) {
     };
   }, [mobileSidebarOpen]);
 
-  const isDomainRoute = new RegExp(`^/lab/env/${envId}/(re|pds|credit|legal|medical|consulting|operator|opportunity-engine|ecc|demo|documents|definitions|resume|markets|trading|ncf|supply-chain|investment-engine|altered-mind|telemetry)(/|$)`).test(pathname);
+  const isDomainRoute = new RegExp(`^/lab/env/${envId}/(re|pds|credit|legal|medical|consulting|operator|opportunity-engine|ecc|demo|documents|definitions|resume|markets|trading|ncf|supply-chain|investment-engine|altered-mind|telemetry|healthcare-subscription)(/|$)`).test(pathname);
   const homeHref = `/lab/env/${envId}`;
   if (isDomainRoute) {
     return <div className="min-h-screen bg-bm-bg">{children}</div>;

--- a/repo-b/src/lib/healthcare-subscription/client.ts
+++ b/repo-b/src/lib/healthcare-subscription/client.ts
@@ -47,7 +47,11 @@ export interface HhaHealth {
   phi: boolean;
 }
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "";
+// Browser calls route through the same-origin `/bos` proxy
+// (`repo-b/src/app/bos/[...path]/route.ts`), which forwards to the FastAPI backend
+// via BOS_API_ORIGIN — the canonical prod pattern (see `src/lib/bos-api.ts`).
+// `NEXT_PUBLIC_API_BASE` can override it for direct local dev against :8000.
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "/bos";
 
 async function getJson<T>(path: string): Promise<T | null> {
   try {


### PR DESCRIPTION
Follow-up to #130/#133. Fixes two defects in the HHA-1 Exec Overview caught by **logged-in visual verification** on novendor.ai:

1. **Not standalone** — the route was wrapped in `LabEnvironmentShell` (breadcrumb, WORKSPACE SWITCH, OPERATIONS FUNCTIONS sidebar). Fix: add `healthcare-subscription` to the `isDomainRoute` allowlist (the same full-bleed mechanism telemetry uses). `OverviewClient` carries its own chrome, so no wrapping layout needed.
2. **KPI data 404 in prod** — client used empty `NEXT_PUBLIC_API_BASE` → same-origin `/api/hha/v1/overview` (404). Fix: default to the same-origin `/bos` proxy (canonical prod pattern per `bos-api.ts`; `novendor.ai/bos/api/hha/v1/health` → 200). `NEXT_PUBLIC_API_BASE` still overrides for local dev.

Two-line runtime change. No backend / schema / telemetry / copilot changes. After merge + auto-deploy, the logged-in screenshot will be re-captured (expect standalone + 18 KPIs) and the visual gate flipped to PASS on #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)