### PR TITLE
telemetry(rs-slice): live streaming slice — ISS ingest, medallion ETL, Mission Control (PR 1/3)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -181,6 +181,16 @@ TRADES_RECONNECT_INTERVAL_SEC: int = int(os.getenv("TRADES_RECONNECT_INTERVAL_SE
 TRADES_SLIPPAGE_ALERT_BPS: int = int(os.getenv("TRADES_SLIPPAGE_ALERT_BPS", "50"))
 TRADES_ENABLE_LIVE_SUBMISSION: bool = os.getenv("TRADES_ENABLE_LIVE_SUBMISSION", "false").lower() == "true"
 
+# ── RS Demo: live telemetry streaming slice ──────────────────────────────────
+# Source hierarchy: capture = the required proof path (CI + baseline demo);
+# iss = live-mode enhancement; adsb = fallback exhibit only (labeled).
+TELEMETRY_STREAM_ENABLED: bool = os.getenv("TELEMETRY_STREAM_ENABLED", "0").lower() in ("1", "true")
+TELEMETRY_STREAM_SOURCE: str = os.getenv("TELEMETRY_STREAM_SOURCE", "capture")
+TELEMETRY_STREAM_ENV_ID: str = os.getenv("TELEMETRY_STREAM_ENV_ID", "telemetry-demo")
+TELEMETRY_STREAM_BUSINESS_ID: str = os.getenv(
+    "TELEMETRY_STREAM_BUSINESS_ID", "7e1eb000-0000-4000-a000-000000000001")
+TELEMETRY_ETL_INTERVAL_SECONDS: int = int(os.getenv("TELEMETRY_ETL_INTERVAL_SECONDS", "60"))
+
 _db_validated = False
 
 

--- a/backend/app/data/telemetry/iss_capture.json
+++ b/backend/app/data/telemetry/iss_capture.json
@@ -1,0 +1,1808 @@
+{
+ "source": "iss_lightstreamer_public",
+ "server": "https://push.lightstreamer.com",
+ "adapter_set": "ISSLIVE",
+ "recorded_at_utc": "2026-06-09T22:49:42Z",
+ "duration_s": 180,
+ "channels": [
+  "USLAB000058",
+  "USLAB000059",
+  "USLAB000062",
+  "USLAB000063",
+  "USLAB000064",
+  "AIRLOCK000049",
+  "NODE3000005",
+  "NODE3000008",
+  "NODE3000009",
+  "S4000001",
+  "S6000004",
+  "P4000001"
+ ],
+ "frames_per_channel": {
+  "USLAB000058": 4,
+  "USLAB000059": 26,
+  "USLAB000062": 2,
+  "USLAB000063": 2,
+  "AIRLOCK000049": 70,
+  "USLAB000064": 2,
+  "NODE3000008": 17,
+  "NODE3000009": 13,
+  "NODE3000005": 15,
+  "S6000004": 11,
+  "S4000001": 8,
+  "P4000001": 7
+ },
+ "note": "Real recorded public ISS telemetry frames. ts_offset_s = receive-time offset from recording start; replay re-bases onto the current clock. Raw feed TimeStamp kept per frame for provenance.",
+ "frames": [
+  {
+   "channel_key": "USLAB000058",
+   "ts_offset_s": 0.882,
+   "value": 752.189453125,
+   "raw": {
+    "TimeStamp": "3862.1765286111167",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 0.883,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.8272783333064",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000062",
+   "ts_offset_s": 0.883,
+   "value": 1.0,
+   "raw": {
+    "TimeStamp": "3666.6784163888956",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000063",
+   "ts_offset_s": 0.884,
+   "value": 1.0,
+   "raw": {
+    "TimeStamp": "3666.6784163888956",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 0.885,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.827083888915",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000064",
+   "ts_offset_s": 0.885,
+   "value": 5.0,
+   "raw": {
+    "TimeStamp": "3666.6785283333065",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 0.886,
+   "value": 56.81999969482422,
+   "raw": {
+    "TimeStamp": "3862.827418333292",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000009",
+   "ts_offset_s": 0.886,
+   "value": 46.13999938964844,
+   "raw": {
+    "TimeStamp": "3862.827418333292",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 0.887,
+   "value": 52.0,
+   "raw": {
+    "TimeStamp": "3862.7869166666933",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S6000004",
+   "ts_offset_s": 0.887,
+   "value": 151.2451171875,
+   "raw": {
+    "TimeStamp": "3862.824863055547",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S4000001",
+   "ts_offset_s": 0.888,
+   "value": 151.2451171875,
+   "raw": {
+    "TimeStamp": "3862.823529444403",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "P4000001",
+   "ts_offset_s": 0.888,
+   "value": 151.142578125,
+   "raw": {
+    "TimeStamp": "3862.795751666625",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 1.67,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8276394444706",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S6000004",
+   "ts_offset_s": 1.923,
+   "value": 151.29638671875,
+   "raw": {
+    "TimeStamp": "3862.827640833325",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 2.67,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.8279172222483",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 3.67,
+   "value": 23.32332992553711,
+   "raw": {
+    "TimeStamp": "3862.82811166664",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 4.671,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8284727778037",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 5.665,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.8287505555813",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 6.663,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.828944999973",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 7.675,
+   "value": 23.32332992553711,
+   "raw": {
+    "TimeStamp": "3862.8292227777506",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 8.67,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.8295005555287",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 9.67,
+   "value": 23.32332992553711,
+   "raw": {
+    "TimeStamp": "3862.8297783333064",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000058",
+   "ts_offset_s": 9.671,
+   "value": 752.2904663085938,
+   "raw": {
+    "TimeStamp": "3862.8298619444504",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000058",
+   "ts_offset_s": 10.675,
+   "value": 752.189453125,
+   "raw": {
+    "TimeStamp": "3862.830139722228",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000009",
+   "ts_offset_s": 10.676,
+   "value": 46.130001068115234,
+   "raw": {
+    "TimeStamp": "3862.8301961110697",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 10.799,
+   "value": 56.790000915527344,
+   "raw": {
+    "TimeStamp": "3862.8301961110697",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 11.674,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.830333888862",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S6000004",
+   "ts_offset_s": 12.057,
+   "value": 151.19384765625,
+   "raw": {
+    "TimeStamp": "3862.8304186111027",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 12.68,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.830695000026",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 14.656,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.8312505555814",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 15.659,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.831528333359",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S4000001",
+   "ts_offset_s": 16.659,
+   "value": 151.19384765625,
+   "raw": {
+    "TimeStamp": "3862.8318627777367",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 17.664,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.832083888915",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 19.683,
+   "value": 23.32332992553711,
+   "raw": {
+    "TimeStamp": "3862.832556111084",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000009",
+   "ts_offset_s": 20.678,
+   "value": 46.15999984741211,
+   "raw": {
+    "TimeStamp": "3862.8329738888474",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 20.802,
+   "value": 56.689998626708984,
+   "raw": {
+    "TimeStamp": "3862.8329738888474",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 21.676,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.8331116666395",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S6000004",
+   "ts_offset_s": 22.054,
+   "value": 151.29638671875,
+   "raw": {
+    "TimeStamp": "3862.8331963888804",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 22.672,
+   "value": 23.32332992553711,
+   "raw": {
+    "TimeStamp": "3862.833389444417",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 23.657,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.8336672221953",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 23.657,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8337505555814",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 24.657,
+   "value": 23.32332992553711,
+   "raw": {
+    "TimeStamp": "3862.833944999973",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 24.658,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.834028333359",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 25.68,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.8342227777507",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 25.681,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8343061111373",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 27.673,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.8348616666926",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 29.677,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.835417222248",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 30.674,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.835695000026",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000009",
+   "ts_offset_s": 30.675,
+   "value": 46.16999816894531,
+   "raw": {
+    "TimeStamp": "3862.835751666625",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 30.803,
+   "value": 56.599998474121094,
+   "raw": {
+    "TimeStamp": "3862.835751666625",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 31.676,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.835972777804",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 33.673,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.836528333359",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 34.674,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.836806111137",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 35.681,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.837083888915",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 36.676,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8373616666927",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 37.678,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.8376394444704",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000009",
+   "ts_offset_s": 40.675,
+   "value": 46.20000076293945,
+   "raw": {
+    "TimeStamp": "3862.8385294444033",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 40.802,
+   "value": 56.52000045776367,
+   "raw": {
+    "TimeStamp": "3862.8385294444033",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 46.68,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8401394444704",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 47.66,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.840417222248",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 49.661,
+   "value": 23.32332992553711,
+   "raw": {
+    "TimeStamp": "3862.8408894444174",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 49.662,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.840972777804",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000009",
+   "ts_offset_s": 50.662,
+   "value": 46.18000030517578,
+   "raw": {
+    "TimeStamp": "3862.841307222181",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 50.663,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.8412505555816",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 50.664,
+   "value": 56.470001220703125,
+   "raw": {
+    "TimeStamp": "3862.841307222181",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 51.647,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.841444999973",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S6000004",
+   "ts_offset_s": 52.026,
+   "value": 151.2451171875,
+   "raw": {
+    "TimeStamp": "3862.8415297222136",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 54.67,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.842361666693",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S4000001",
+   "ts_offset_s": 56.661,
+   "value": 151.2451171875,
+   "raw": {
+    "TimeStamp": "3862.8429738888476",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 56.662,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.842917222248",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "P4000001",
+   "ts_offset_s": 57.039,
+   "value": 151.09130859375,
+   "raw": {
+    "TimeStamp": "3862.8429738888476",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 57.663,
+   "value": 23.32332992553711,
+   "raw": {
+    "TimeStamp": "3862.8431116666397",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 58.662,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.8433894444174",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 60.639,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8440283333593",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 60.639,
+   "value": 56.41999816894531,
+   "raw": {
+    "TimeStamp": "3862.844084999959",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 61.667,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.844306111137",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 64.662,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8451394444705",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 65.652,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.845417222248",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "P4000001",
+   "ts_offset_s": 66.912,
+   "value": 151.19384765625,
+   "raw": {
+    "TimeStamp": "3862.8457516666253",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 68.663,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8462505555817",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 70.664,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.846806111137",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 70.79,
+   "value": 56.349998474121094,
+   "raw": {
+    "TimeStamp": "3862.8468627777365",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S6000004",
+   "ts_offset_s": 72.014,
+   "value": 151.19384765625,
+   "raw": {
+    "TimeStamp": "3862.847085277769",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 73.667,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8476394444706",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 75.666,
+   "value": 23.32332992553711,
+   "raw": {
+    "TimeStamp": "3862.84811166664",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 75.667,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.848195000026",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S4000001",
+   "ts_offset_s": 76.652,
+   "value": 151.19384765625,
+   "raw": {
+    "TimeStamp": "3862.848529444403",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 76.653,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.8483894444175",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "P4000001",
+   "ts_offset_s": 76.905,
+   "value": 151.142578125,
+   "raw": {
+    "TimeStamp": "3862.848529444403",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 77.675,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8487505555813",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 79.663,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.849306111137",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000009",
+   "ts_offset_s": 80.647,
+   "value": 46.220001220703125,
+   "raw": {
+    "TimeStamp": "3862.8496405555143",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 80.648,
+   "value": 56.33000183105469,
+   "raw": {
+    "TimeStamp": "3862.8496405555143",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S6000004",
+   "ts_offset_s": 82.043,
+   "value": 151.2451171875,
+   "raw": {
+    "TimeStamp": "3862.8498630555473",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S4000001",
+   "ts_offset_s": 86.656,
+   "value": 151.2451171875,
+   "raw": {
+    "TimeStamp": "3862.851307222181",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 86.656,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8512505555814",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 88.665,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.851806111137",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 89.641,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.852083888915",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 90.65,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.8523616666926",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 90.65,
+   "value": 56.290000915527344,
+   "raw": {
+    "TimeStamp": "3862.852418333292",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 91.674,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8526394444702",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S6000004",
+   "ts_offset_s": 92.052,
+   "value": 151.19384765625,
+   "raw": {
+    "TimeStamp": "3862.852640833325",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 93.673,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.853195000026",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 94.668,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8534727778037",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 95.648,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.8537505555814",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000009",
+   "ts_offset_s": 100.665,
+   "value": 46.22999954223633,
+   "raw": {
+    "TimeStamp": "3862.8551961110697",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 100.792,
+   "value": 56.22999954223633,
+   "raw": {
+    "TimeStamp": "3862.8551961110697",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S6000004",
+   "ts_offset_s": 101.904,
+   "value": 151.2451171875,
+   "raw": {
+    "TimeStamp": "3862.855418611103",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 104.659,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8562505555815",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 105.646,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.856528333359",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 106.67,
+   "value": 51.0,
+   "raw": {
+    "TimeStamp": "3862.856916666693",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 107.647,
+   "value": 23.32332992553711,
+   "raw": {
+    "TimeStamp": "3862.8570005555284",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 107.648,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.857083888915",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 108.653,
+   "value": 52.0,
+   "raw": {
+    "TimeStamp": "3862.857472222249",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 108.654,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.8573616666927",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 109.682,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.8575561110843",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 110.652,
+   "value": 56.2599983215332,
+   "raw": {
+    "TimeStamp": "3862.8579738888475",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 111.667,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.858195000026",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 113.648,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.8587505555815",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 114.646,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.859028333359",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 115.669,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.859306111137",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 116.643,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.859583888915",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 117.656,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.8598616666927",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 118.671,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8601394444704",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 119.659,
+   "value": 51.0,
+   "raw": {
+    "TimeStamp": "3862.8605277778042",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 119.66,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.860417222248",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 120.673,
+   "value": 52.0,
+   "raw": {
+    "TimeStamp": "3862.860805555582",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000009",
+   "ts_offset_s": 120.674,
+   "value": 46.27000045776367,
+   "raw": {
+    "TimeStamp": "3862.860751666625",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 120.674,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8606950000258",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 120.796,
+   "value": 56.25,
+   "raw": {
+    "TimeStamp": "3862.860751666625",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 121.657,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.860972777804",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S6000004",
+   "ts_offset_s": 122.035,
+   "value": 151.29638671875,
+   "raw": {
+    "TimeStamp": "3862.8609741666583",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 123.649,
+   "value": 23.32332992553711,
+   "raw": {
+    "TimeStamp": "3862.861444999973",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 124.694,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.861722777751",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 124.695,
+   "value": 51.0,
+   "raw": {
+    "TimeStamp": "3862.861916666693",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 125.644,
+   "value": 52.0,
+   "raw": {
+    "TimeStamp": "3862.862194444471",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 126.661,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.862361666693",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "P4000001",
+   "ts_offset_s": 127.038,
+   "value": 151.19384765625,
+   "raw": {
+    "TimeStamp": "3862.862418333292",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 128.659,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.862917222248",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000009",
+   "ts_offset_s": 130.664,
+   "value": 46.290000915527344,
+   "raw": {
+    "TimeStamp": "3862.863529444403",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 130.664,
+   "value": 56.220001220703125,
+   "raw": {
+    "TimeStamp": "3862.863529444403",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 134.645,
+   "value": 51.0,
+   "raw": {
+    "TimeStamp": "3862.864694444471",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 135.664,
+   "value": 52.0,
+   "raw": {
+    "TimeStamp": "3862.8649722222485",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S4000001",
+   "ts_offset_s": 136.676,
+   "value": 151.19384765625,
+   "raw": {
+    "TimeStamp": "3862.86519611107",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "P4000001",
+   "ts_offset_s": 136.929,
+   "value": 151.142578125,
+   "raw": {
+    "TimeStamp": "3862.86519611107",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 138.678,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.865695000026",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 139.681,
+   "value": 51.0,
+   "raw": {
+    "TimeStamp": "3862.8660833333597",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000009",
+   "ts_offset_s": 140.666,
+   "value": 46.29999923706055,
+   "raw": {
+    "TimeStamp": "3862.8663072221807",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 140.791,
+   "value": 56.279998779296875,
+   "raw": {
+    "TimeStamp": "3862.8663072221807",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 141.676,
+   "value": 52.0,
+   "raw": {
+    "TimeStamp": "3862.8666388889155",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 142.679,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.866806111137",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 142.679,
+   "value": 51.0,
+   "raw": {
+    "TimeStamp": "3862.866916666693",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 143.658,
+   "value": 52.0,
+   "raw": {
+    "TimeStamp": "3862.867194444471",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 145.665,
+   "value": 51.0,
+   "raw": {
+    "TimeStamp": "3862.8677500000267",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "S4000001",
+   "ts_offset_s": 146.663,
+   "value": 151.2451171875,
+   "raw": {
+    "TimeStamp": "3862.8679738888477",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 146.663,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8679172222483",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 147.666,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.868195000026",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 148.646,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8684727778036",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 149.663,
+   "value": 23.32332992553711,
+   "raw": {
+    "TimeStamp": "3862.868667222195",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 149.663,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.8687505555813",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 150.659,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.868944999973",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000009",
+   "ts_offset_s": 150.659,
+   "value": 46.33000183105469,
+   "raw": {
+    "TimeStamp": "3862.869084999959",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 150.66,
+   "value": 750.65087890625,
+   "raw": {
+    "TimeStamp": "3862.8690283333594",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 150.786,
+   "value": 56.310001373291016,
+   "raw": {
+    "TimeStamp": "3862.869084999959",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 152.659,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.869583888915",
+    "Status.Class": "24",
+    "Status.Indicator": " "
+   }
+  },
+  {
+   "channel_key": "NODE3000005",
+   "ts_offset_s": 158.61,
+   "value": 51.0,
+   "raw": {
+    "TimeStamp": "3862.8677500000267",
+    "Status.Class": "9",
+    "Status.Indicator": "S"
+   }
+  },
+  {
+   "channel_key": "USLAB000058",
+   "ts_offset_s": 159.659,
+   "value": 752.189453125,
+   "raw": {
+    "TimeStamp": "3862.830139722228",
+    "Status.Class": "9",
+    "Status.Indicator": "S"
+   }
+  },
+  {
+   "channel_key": "USLAB000059",
+   "ts_offset_s": 159.659,
+   "value": 23.38619613647461,
+   "raw": {
+    "TimeStamp": "3862.868944999973",
+    "Status.Class": "9",
+    "Status.Indicator": "S"
+   }
+  },
+  {
+   "channel_key": "AIRLOCK000049",
+   "ts_offset_s": 159.784,
+   "value": 750.016357421875,
+   "raw": {
+    "TimeStamp": "3862.869583888915",
+    "Status.Class": "9",
+    "Status.Indicator": "S"
+   }
+  },
+  {
+   "channel_key": "USLAB000062",
+   "ts_offset_s": 160.162,
+   "value": 1.0,
+   "raw": {
+    "TimeStamp": "3666.6784163888956",
+    "Status.Class": "9",
+    "Status.Indicator": "S"
+   }
+  },
+  {
+   "channel_key": "USLAB000064",
+   "ts_offset_s": 160.163,
+   "value": 5.0,
+   "raw": {
+    "TimeStamp": "3666.6785283333065",
+    "Status.Class": "9",
+    "Status.Indicator": "S"
+   }
+  },
+  {
+   "channel_key": "USLAB000063",
+   "ts_offset_s": 160.288,
+   "value": 1.0,
+   "raw": {
+    "TimeStamp": "3666.6784163888956",
+    "Status.Class": "9",
+    "Status.Indicator": "S"
+   }
+  },
+  {
+   "channel_key": "S4000001",
+   "ts_offset_s": 161.676,
+   "value": 151.2451171875,
+   "raw": {
+    "TimeStamp": "3862.8679738888477",
+    "Status.Class": "9",
+    "Status.Indicator": "S"
+   }
+  },
+  {
+   "channel_key": "P4000001",
+   "ts_offset_s": 161.801,
+   "value": 151.142578125,
+   "raw": {
+    "TimeStamp": "3862.86519611107",
+    "Status.Class": "9",
+    "Status.Indicator": "S"
+   }
+  },
+  {
+   "channel_key": "NODE3000009",
+   "ts_offset_s": 165.647,
+   "value": 46.33000183105469,
+   "raw": {
+    "TimeStamp": "3862.869084999959",
+    "Status.Class": "9",
+    "Status.Indicator": "S"
+   }
+  },
+  {
+   "channel_key": "NODE3000008",
+   "ts_offset_s": 165.647,
+   "value": 56.310001373291016,
+   "raw": {
+    "TimeStamp": "3862.869084999959",
+    "Status.Class": "9",
+    "Status.Indicator": "S"
+   }
+  },
+  {
+   "channel_key": "S6000004",
+   "ts_offset_s": 166.662,
+   "value": 151.29638671875,
+   "raw": {
+    "TimeStamp": "3862.8609741666583",
+    "Status.Class": "9",
+    "Status.Indicator": "S"
+   }
+  }
+ ]
+}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -293,7 +293,62 @@ async def lifespan(app: FastAPI):
                 context={}, error=exc,
             )
 
+    # ── RS Demo: telemetry stream worker + ETL loop (operator-sweep pattern) ──
+    stream_task = None
+    stream_etl_task = None
+    if db_connected:
+        try:
+            from app.config import (
+                TELEMETRY_ETL_INTERVAL_SECONDS, TELEMETRY_STREAM_BUSINESS_ID,
+                TELEMETRY_STREAM_ENABLED, TELEMETRY_STREAM_ENV_ID, TELEMETRY_STREAM_SOURCE,
+            )
+            if TELEMETRY_STREAM_ENABLED:
+                import asyncio
+                from uuid import UUID as _UUID
+                from app.services.telemetry_stream_etl import run_etl_loop
+                from app.services.telemetry_stream_ingest import (
+                    StreamWorker, set_stream_worker,
+                )
+                _stream_channels = [
+                    "USLAB000058", "USLAB000059", "USLAB000062", "USLAB000063", "USLAB000064",
+                    "AIRLOCK000049", "NODE3000005", "NODE3000008", "NODE3000009",
+                    "S4000001", "S6000004", "P4000001",
+                ]
+                _worker = StreamWorker(
+                    env_id=TELEMETRY_STREAM_ENV_ID,
+                    business_id=TELEMETRY_STREAM_BUSINESS_ID,
+                    source=TELEMETRY_STREAM_SOURCE,
+                    channels=_stream_channels,
+                )
+                set_stream_worker(_worker)
+                stream_task = asyncio.create_task(_worker.run())
+                stream_etl_task = asyncio.create_task(run_etl_loop(
+                    env_id=TELEMETRY_STREAM_ENV_ID,
+                    business_id=_UUID(TELEMETRY_STREAM_BUSINESS_ID),
+                    interval_seconds=TELEMETRY_ETL_INTERVAL_SECONDS,
+                ))
+                emit_log(
+                    level="info", service="backend", action="startup.telemetry_stream_started",
+                    message="Telemetry stream worker + ETL loop started",
+                    context={"source": TELEMETRY_STREAM_SOURCE,
+                             "etl_interval_s": TELEMETRY_ETL_INTERVAL_SECONDS},
+                )
+        except Exception as exc:
+            emit_log(
+                level="warn", service="backend", action="startup.telemetry_stream_failed",
+                message="Telemetry stream worker failed to start (non-fatal)",
+                context={}, error=exc,
+            )
+
     yield
+
+    for _task in (stream_task, stream_etl_task):
+        if _task is not None:
+            _task.cancel()
+            try:
+                await _task
+            except BaseException:
+                pass
 
     if operator_sweep_task is not None:
         operator_sweep_task.cancel()

--- a/backend/app/routes/hr_morning_book.py
+++ b/backend/app/routes/hr_morning_book.py
@@ -16,7 +16,7 @@ See also:
 from __future__ import annotations
 
 import logging
-from datetime import date, timezone, datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter

--- a/backend/app/routes/telemetry.py
+++ b/backend/app/routes/telemetry.py
@@ -15,11 +15,11 @@ from __future__ import annotations
 from uuid import UUID
 
 import psycopg
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Header, HTTPException, Query
 
 from app.observability.logger import emit_log
 from app.schemas.telemetry import (
-    MonitoringResponse, RunDetailOut, ScoreRequest, ScoreResponse, TestRunOut,
+    MonitoringResponse, RunDetailOut, ScoreRequest, ScoreResponse, StreamSourceRequest, TestRunOut,
 )
 from app.services import telemetry_serving as svc
 
@@ -116,5 +116,52 @@ def fused_vector_info(env_id: str = Query(...), business_id: UUID = Query(...)):
     """256-d fused state-vector summary (dim, channels, features, alignment caveat). No raw vectors."""
     try:
         return svc.fused_vector_info(env_id=env_id, business_id=business_id)
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+# ── RS Demo: live streaming slice ──────────────────────────────────────────────
+@router.get("/stream/live")
+def stream_live(env_id: str = Query(...), business_id: UUID = Query(...),
+                channels: str | None = Query(default=None)):
+    """Live stream read: worker ring buffer (silver tail fallback), server_ts for the latency
+    overlay, pipeline status (fail-closed STALE), and recent live model events."""
+    from app.services import telemetry_stream_etl as stream_svc
+    try:
+        chan_list = [c.strip() for c in channels.split(",") if c.strip()] if channels else None
+        return stream_svc.stream_live(env_id=env_id, business_id=business_id, channels=chan_list)
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="telemetry", action="stream_live_failed",
+                 message=str(exc), error=exc)
+        raise _to_http(exc)
+
+
+@router.get("/stream/health")
+def stream_health(env_id: str = Query(...), business_id: UUID = Query(...)):
+    """Stream health: per-channel freshness, ingest lag p50/p95, rows/min, DQ assertions,
+    pipeline status rows, watermark ages."""
+    from app.services import telemetry_stream_etl as stream_svc
+    try:
+        return stream_svc.stream_health(env_id=env_id, business_id=business_id)
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.post("/stream/source")
+def stream_source(req: StreamSourceRequest, x_stream_admin_key: str | None = Header(default=None)):
+    """Demo-day adapter switch (iss | capture | adsb). Fail-closed admin gate: requires the
+    TELEMETRY_STREAM_ADMIN_KEY env var to be set AND matched — unset means always 403."""
+    import os
+    from app.services.telemetry_stream_ingest import get_stream_worker
+    admin_key = os.getenv("TELEMETRY_STREAM_ADMIN_KEY", "")
+    if not admin_key or x_stream_admin_key != admin_key:
+        raise HTTPException(403, {"error_code": "FORBIDDEN",
+                                  "message": "stream source switch requires the admin key"})
+    worker = get_stream_worker()
+    if worker is None:
+        raise HTTPException(503, {"error_code": "WORKER_NOT_RUNNING",
+                                  "message": "stream worker is not running on this instance"})
+    try:
+        return worker.switch_source(req.source)
     except Exception as exc:  # noqa: BLE001
         raise _to_http(exc)

--- a/backend/app/schemas/telemetry.py
+++ b/backend/app/schemas/telemetry.py
@@ -97,6 +97,16 @@ class ConformalBudget(BaseModel):
     status: str | None = None                 # within | approaching | over
 
 
+class StreamBlock(BaseModel):
+    """RS Demo streaming slice: pipeline-status summary carried on /monitoring."""
+    status: str | None = None                  # fresh | stale | failed | unknown
+    as_of_ts: datetime | None = None
+    reason: str | None = None
+    last_frame_at: datetime | None = None
+    rows_per_min: int | None = None
+    failing_assertions: int | None = None
+
+
 class MonitoringResponse(BaseModel):
     rolling_anomaly_rate: float | None = None
     prediction_count: int = 0
@@ -107,4 +117,11 @@ class MonitoringResponse(BaseModel):
     psi: float | None = None
     window_label: str = "recent"
     conformal_budget: ConformalBudget | None = None
+    stream: StreamBlock | None = None
     null_reason: str | None = None            # e.g. no_prediction_rows
+
+
+# ── /stream/source ───────────────────────────────────────────────────────────
+
+class StreamSourceRequest(BaseModel):
+    source: str                                # iss | capture | adsb

--- a/backend/app/services/telemetry_serving.py
+++ b/backend/app/services/telemetry_serving.py
@@ -195,6 +195,39 @@ def _conformal_budget(metrics: dict | None) -> dict | None:
     }
 
 
+def _stream_block(cur, env_id: str, business_id: UUID) -> dict | None:
+    """RS Demo streaming slice summary for /monitoring. Returns None when the streaming tables are
+    absent (pre-migration) or empty — additive, never breaks existing monitoring."""
+    try:
+        cur.execute(
+            """SELECT status, as_of_ts, reason FROM tel_pipeline_status
+               WHERE env_id = %s AND business_id = %s AND surface = 'stream_ingest'""",
+            (env_id, str(business_id)))
+        st = cur.fetchone()
+        if st is None:
+            return None
+        cur.execute(
+            """SELECT max(ts_source) AS last_frame,
+                      count(*) FILTER (WHERE ts_ingest > now() - interval '1 minute') AS rpm
+               FROM tel_stream_readings_bronze WHERE env_id = %s AND business_id = %s""",
+            (env_id, str(business_id)))
+        agg = cur.fetchone() or {}
+        cur.execute(
+            """SELECT count(*) AS n FROM tel_dq_assertions
+               WHERE env_id = %s AND business_id = %s AND passed = false
+                 AND run_ts > now() - interval '15 minutes'""",
+            (env_id, str(business_id)))
+        failing = int(cur.fetchone()["n"])
+        return {
+            "status": st["status"], "as_of_ts": st["as_of_ts"], "reason": st["reason"],
+            "last_frame_at": agg.get("last_frame"),
+            "rows_per_min": int(agg.get("rpm") or 0),
+            "failing_assertions": failing,
+        }
+    except Exception:  # noqa: BLE001 — streaming tables not migrated yet
+        return None
+
+
 def monitoring(*, env_id: str, business_id: UUID) -> dict:
     with get_cursor() as cur:
         resolve_tenant_id(cur, business_id)
@@ -224,26 +257,38 @@ def monitoring(*, env_id: str, business_id: UUID) -> dict:
         psi_row = cur.fetchone()
 
         n = int(agg["n"] or 0)
-        if n == 0:
-            return {"prediction_count": 0, "rolling_anomaly_rate": None,
-                    "latest_model_name": champ["model_name"] if champ else None,
-                    "latest_model_version": champ["model_version"] if champ else None,
-                    "latest_model_alias": champ["model_alias"] if champ else None,
-                    "last_scored_at": None, "psi": None, "window_label": "recent",
-                    "conformal_budget": conformal_budget,
-                    "null_reason": "no_prediction_rows"}
-        return {
-            "prediction_count": n,
-            "rolling_anomaly_rate": round(float(agg["rate"]), 6) if agg["rate"] is not None else None,
-            "latest_model_name": champ["model_name"] if champ else None,
-            "latest_model_version": champ["model_version"] if champ else None,
-            "latest_model_alias": champ["model_alias"] if champ else None,
-            "last_scored_at": agg["last_at"],
-            "psi": float(psi_row["metric_value"]) if psi_row else None,
-            "window_label": "recent",
-            "conformal_budget": conformal_budget,
-            "null_reason": None,
-        }
+
+    # Stream block in its OWN cursor: an UndefinedTable (pre-migration) must not abort the main
+    # monitoring transaction above.
+    stream_block = None
+    try:
+        with get_cursor() as cur2:
+            stream_block = _stream_block(cur2, env_id, business_id)
+    except Exception:  # noqa: BLE001
+        stream_block = None
+
+    if n == 0:
+        return {"prediction_count": 0, "rolling_anomaly_rate": None,
+                "latest_model_name": champ["model_name"] if champ else None,
+                "latest_model_version": champ["model_version"] if champ else None,
+                "latest_model_alias": champ["model_alias"] if champ else None,
+                "last_scored_at": None, "psi": None, "window_label": "recent",
+                "conformal_budget": conformal_budget,
+                "stream": stream_block,
+                "null_reason": "no_prediction_rows"}
+    return {
+        "prediction_count": n,
+        "rolling_anomaly_rate": round(float(agg["rate"]), 6) if agg["rate"] is not None else None,
+        "latest_model_name": champ["model_name"] if champ else None,
+        "latest_model_version": champ["model_version"] if champ else None,
+        "latest_model_alias": champ["model_alias"] if champ else None,
+        "last_scored_at": agg["last_at"],
+        "psi": float(psi_row["metric_value"]) if psi_row else None,
+        "window_label": "recent",
+        "conformal_budget": conformal_budget,
+        "stream": stream_block,
+        "null_reason": None,
+    }
 
 
 def replay_feed() -> dict:

--- a/backend/app/services/telemetry_stream_etl.py
+++ b/backend/app/services/telemetry_stream_etl.py
@@ -1,0 +1,594 @@
+"""Incremental streaming ETL for the RS Demo slice: bronze -> silver -> gold + DQ assertions +
+live scoring through the FROZEN champion rule.
+
+Design (per docs/plans/TELEMETRY_STREAMING_SLICE_PLAN.md, corrected to the real runtime):
+  * No scheduler exists in this backend — `run_etl_loop` is an asyncio background task started from
+    the FastAPI lifespan (the operator-sweep-loop pattern), running every 60 s, never dying: failures
+    flip `tel_pipeline_status`, not the process.
+  * Idempotency lives at the silver merge: bronze accepts duplicates (append-only truth); silver
+    enforces UNIQUE (env_id, channel_id, ts_source) with ON CONFLICT DO NOTHING. Reruns from an
+    unchanged watermark process 0 rows and gold is bit-identical.
+  * Late data (ts_source older than the gold watermark) is flagged `late` and the affected minutes are
+    re-aggregated with `restated_at` + reason — history is restated, never silently mutated.
+  * Fail closed: any failed assertion flips the surface status; the UI renders the reason.
+
+Live scoring: silver windows are passed through `telemetry_serving.score_window` — the frozen champion
+(MAD_K, GLOBAL_TRAIN_SCALE, _verdict_for are NOT modified). ISS channels are raw engineering units
+(mmHg, V, %), while the frozen threshold is in normalized SMAP/MSL units, so each window is normalized
+to FRACTIONAL DEVIATION (value / median |window|) before scoring — a declared adaptation, surfaced in
+the UI footnote. NO_GO verdicts create rows in tel_anomaly_events via `record_anomaly_event` (this is
+the platform's first backend writer for that table), with 30 s coalescing so one sustained excursion
+is one event.
+"""
+from __future__ import annotations
+
+import asyncio
+import statistics
+import uuid
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+from app.observability.logger import emit_log
+from app.services import telemetry_serving
+
+STREAM_RUN_KEY = "iss_live:stream"
+EVENT_COALESCE_S = 30
+SCORE_WINDOW_POINTS = 60          # trailing readings per channel fed to the champion
+ROLLING_MEAN_POINTS = 50          # matches the champion's value_rmean50 semantics
+FRESHNESS_LIMIT_S = 120           # silver freshness assertion threshold
+
+
+# ── pure helpers (unit-testable without a DB) ─────────────────────────────────────────────────────
+def normalize_window(values: list[float]) -> list[float]:
+    """Normalize raw engineering units to fractional scale: v / median(|window|). Declared adaptation
+    so the FROZEN champion threshold (normalized units) applies meaningfully to live channels."""
+    base = statistics.median(abs(v) for v in values) if values else 0.0
+    base = max(base, 1e-9)
+    return [v / base for v in values]
+
+
+def rolling_mean(values: list[float], window: int = ROLLING_MEAN_POINTS) -> list[float]:
+    """Trailing mean over `window` points incl. current (min_periods=1) — the rmean50 frame."""
+    out: list[float] = []
+    acc = 0.0
+    for i, v in enumerate(values):
+        acc += v
+        if i >= window:
+            acc -= values[i - window]
+        out.append(acc / min(i + 1, window))
+    return out
+
+
+def minute_floor(ts: datetime) -> datetime:
+    return ts.replace(second=0, microsecond=0)
+
+
+def evaluate_range(value: float, lo: float | None, hi: float | None) -> bool:
+    """True when the value is within redlines (None bound = unbounded)."""
+    if lo is not None and value < lo:
+        return False
+    if hi is not None and value > hi:
+        return False
+    return True
+
+
+def coalesce_decision(last_end_t: int | None, start_t: int) -> bool:
+    """True when the new event should extend the previous one instead of inserting."""
+    return last_end_t is not None and last_end_t >= start_t - EVENT_COALESCE_S
+
+
+# ── watermarks ────────────────────────────────────────────────────────────────────────────────────
+def _get_watermark(cur, env_id: str, job_name: str) -> datetime | None:
+    cur.execute("SELECT watermark_ts FROM tel_etl_watermarks WHERE env_id = %s AND job_name = %s",
+                (env_id, job_name))
+    row = cur.fetchone()
+    return row["watermark_ts"] if row else None
+
+
+def _set_watermark(cur, env_id: str, business_id: UUID, job_name: str,
+                   watermark_ts: datetime, run_id: uuid.UUID) -> None:
+    cur.execute(
+        """INSERT INTO tel_etl_watermarks (env_id, business_id, job_name, watermark_ts, last_run_id)
+           VALUES (%s, %s, %s, %s, %s)
+           ON CONFLICT (env_id, job_name)
+           DO UPDATE SET watermark_ts = EXCLUDED.watermark_ts, last_run_id = EXCLUDED.last_run_id,
+                         updated_at = now()""",
+        (env_id, str(business_id), job_name, watermark_ts, str(run_id)))
+
+
+def set_pipeline_status(cur, *, env_id: str, business_id: UUID, surface: str,
+                        status: str, reason: str | None = None) -> None:
+    cur.execute(
+        """INSERT INTO tel_pipeline_status (env_id, business_id, surface, status, as_of_ts, reason)
+           VALUES (%s, %s, %s, %s, now(), %s)
+           ON CONFLICT (env_id, surface)
+           DO UPDATE SET status = EXCLUDED.status, as_of_ts = now(), reason = EXCLUDED.reason""",
+        (env_id, str(business_id), surface, status, reason))
+
+
+# ── the missing writer: tel_anomaly_events ───────────────────────────────────────────────────────
+def record_anomaly_event(cur, *, env_id: str, business_id: UUID, run_id, channel_name: str,
+                         start_t: int, end_t: int, anomaly_class: str = "point",
+                         confidence: float | None = None, source: str = "model"):
+    """Insert (or coalesce into) a model-fired anomaly event. The first backend writer for
+    tel_anomaly_events — Databricks backfill was previously the only producer."""
+    cur.execute(
+        """SELECT id, end_t FROM tel_anomaly_events
+           WHERE env_id = %s AND business_id = %s AND run_id = %s AND channel_name = %s
+             AND source = %s
+           ORDER BY end_t DESC NULLS LAST LIMIT 1""",
+        (env_id, str(business_id), run_id, channel_name, source))
+    last = cur.fetchone()
+    if last and coalesce_decision(last["end_t"], start_t):
+        cur.execute(
+            """UPDATE tel_anomaly_events SET end_t = GREATEST(end_t, %s), confidence = %s
+               WHERE id = %s RETURNING id""",
+            (end_t, confidence, last["id"]))
+        return cur.fetchone()["id"]
+    cur.execute(
+        """INSERT INTO tel_anomaly_events
+             (env_id, business_id, run_id, channel_name, start_t, end_t, anomaly_class, confidence, source)
+           VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id""",
+        (env_id, str(business_id), run_id, channel_name, start_t, end_t,
+         anomaly_class, confidence, source))
+    return cur.fetchone()["id"]
+
+
+# ── silver merge ──────────────────────────────────────────────────────────────────────────────────
+def run_silver_merge(*, env_id: str, business_id: UUID) -> dict:
+    """Bronze -> silver from the watermark: conform channel_key -> channel_id, dedupe via the UNIQUE
+    key, flag late / out-of-range rows, advance the watermark. Single cursor scope = one commit."""
+    from app.db import get_cursor
+    run_id = uuid.uuid4()
+    with get_cursor() as cur:
+        wm = _get_watermark(cur, env_id, "silver_merge")
+        gold_wm = _get_watermark(cur, env_id, "gold_rollup")
+
+        cur.execute(
+            """SELECT c.id AS channel_id, c.channel_name, c.redline_low, c.redline_high
+               FROM tel_telemetry_channels c
+               JOIN tel_test_runs r ON r.id = c.run_id
+               WHERE c.env_id = %s AND c.business_id = %s AND r.run_key = %s""",
+            (env_id, str(business_id), STREAM_RUN_KEY))
+        channels = {r["channel_name"]: r for r in cur.fetchall()}
+        if not channels:
+            return {"rows_seen": 0, "rows_inserted": 0, "late_rows": 0,
+                    "null_reason": "channels_not_seeded"}
+
+        if wm is None:
+            cur.execute(
+                """SELECT channel_key, ts_source, ts_ingest, value, batch_id
+                   FROM tel_stream_readings_bronze
+                   WHERE env_id = %s AND business_id = %s ORDER BY ts_ingest""",
+                (env_id, str(business_id)))
+        else:
+            cur.execute(
+                """SELECT channel_key, ts_source, ts_ingest, value, batch_id
+                   FROM tel_stream_readings_bronze
+                   WHERE env_id = %s AND business_id = %s AND ts_ingest > %s ORDER BY ts_ingest""",
+                (env_id, str(business_id), wm))
+        rows = cur.fetchall()
+        if not rows:
+            return {"rows_seen": 0, "rows_inserted": 0, "late_rows": 0, "watermark": wm}
+
+        inserted = late = 0
+        restate_minutes: set[tuple[str, datetime]] = set()
+        max_ingest = wm
+        for r in rows:
+            max_ingest = r["ts_ingest"] if max_ingest is None else max(max_ingest, r["ts_ingest"])
+            ch = channels.get(r["channel_key"])
+            if ch is None or r["value"] is None:
+                continue
+            is_late = gold_wm is not None and r["ts_source"] < gold_wm
+            in_range = evaluate_range(float(r["value"]), ch["redline_low"], ch["redline_high"])
+            flag = "out_of_range" if not in_range else ("late" if is_late else "ok")
+            cur.execute(
+                """INSERT INTO tel_stream_readings
+                     (env_id, business_id, channel_id, channel_name, ts_source, value, quality_flag, batch_id)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                   ON CONFLICT (env_id, channel_id, ts_source) DO NOTHING""",
+                (env_id, str(business_id), ch["channel_id"], r["channel_key"],
+                 r["ts_source"], r["value"], flag, r["batch_id"]))
+            if cur.rowcount:
+                inserted += 1
+                if flag == "late":
+                    late += 1
+                    restate_minutes.add((r["channel_key"], minute_floor(r["ts_source"])))
+
+        # Targeted restatement of minutes hit by late data.
+        for channel_name, minute in restate_minutes:
+            ch = channels[channel_name]
+            cur.execute(
+                """INSERT INTO tel_stream_minute_agg
+                     (env_id, business_id, channel_id, channel_name, minute_start,
+                      n, v_min, v_max, v_avg, restated_at, restated_reason, updated_at)
+                   SELECT %s, %s, %s, %s, %s, count(*), min(value), max(value), avg(value),
+                          now(), 'late_data', now()
+                   FROM tel_stream_readings
+                   WHERE env_id = %s AND channel_id = %s
+                     AND ts_source >= %s AND ts_source < %s
+                     AND quality_flag IN ('ok', 'late')
+                   ON CONFLICT (env_id, channel_id, minute_start)
+                   DO UPDATE SET n = EXCLUDED.n, v_min = EXCLUDED.v_min, v_max = EXCLUDED.v_max,
+                                 v_avg = EXCLUDED.v_avg, restated_at = now(),
+                                 restated_reason = 'late_data', updated_at = now()""",
+                (env_id, str(business_id), ch["channel_id"], channel_name, minute,
+                 env_id, ch["channel_id"], minute, minute + timedelta(minutes=1)))
+
+        if max_ingest is not None:
+            _set_watermark(cur, env_id, business_id, "silver_merge", max_ingest, run_id)
+        set_pipeline_status(cur, env_id=env_id, business_id=business_id,
+                            surface="silver", status="fresh")
+        return {"rows_seen": len(rows), "rows_inserted": inserted, "late_rows": late,
+                "restated_minutes": len(restate_minutes), "watermark": max_ingest}
+
+
+# ── gold rollup ───────────────────────────────────────────────────────────────────────────────────
+def run_gold_rollup(*, env_id: str, business_id: UUID) -> dict:
+    """Aggregate completed minutes (and the in-progress one) from the gold watermark forward.
+    Out-of-range rows are excluded; anomaly_count is the count of overlapping model events."""
+    from app.db import get_cursor
+    run_id = uuid.uuid4()
+    with get_cursor() as cur:
+        wm = _get_watermark(cur, env_id, "gold_rollup")
+        params = [env_id, str(business_id)]
+        wm_clause = ""
+        if wm is not None:
+            wm_clause = "AND s.ts_source >= %s"
+            params.append(wm - timedelta(minutes=1))   # re-cover the boundary minute
+        cur.execute(
+            f"""SELECT s.channel_id, s.channel_name, date_trunc('minute', s.ts_source) AS minute_start,
+                       count(*) AS n, min(s.value) AS v_min, max(s.value) AS v_max, avg(s.value) AS v_avg,
+                       max(s.ts_source) AS max_ts
+                FROM tel_stream_readings s
+                WHERE s.env_id = %s AND s.business_id = %s
+                  AND s.quality_flag IN ('ok', 'late')
+                  {wm_clause}
+                GROUP BY s.channel_id, s.channel_name, date_trunc('minute', s.ts_source)""",
+            params)
+        groups = cur.fetchall()
+        if not groups:
+            return {"minutes_upserted": 0, "watermark": wm}
+
+        max_ts = wm
+        for g in groups:
+            max_ts = g["max_ts"] if max_ts is None else max(max_ts, g["max_ts"])
+            minute_start = g["minute_start"]
+            minute_end = minute_start + timedelta(minutes=1)
+            cur.execute(
+                """SELECT count(*) AS n FROM tel_anomaly_events e
+                   JOIN tel_test_runs r ON r.id = e.run_id
+                   WHERE e.env_id = %s AND e.business_id = %s AND r.run_key = %s
+                     AND e.channel_name = %s AND e.source = 'model'
+                     AND e.start_t < %s AND e.end_t >= %s""",
+                (env_id, str(business_id), STREAM_RUN_KEY, g["channel_name"],
+                 int(minute_end.timestamp()), int(minute_start.timestamp())))
+            anomaly_n = int(cur.fetchone()["n"])
+            cur.execute(
+                """INSERT INTO tel_stream_minute_agg
+                     (env_id, business_id, channel_id, channel_name, minute_start,
+                      n, v_min, v_max, v_avg, anomaly_count, updated_at)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, now())
+                   ON CONFLICT (env_id, channel_id, minute_start)
+                   DO UPDATE SET n = EXCLUDED.n, v_min = EXCLUDED.v_min, v_max = EXCLUDED.v_max,
+                                 v_avg = EXCLUDED.v_avg, anomaly_count = EXCLUDED.anomaly_count,
+                                 updated_at = now()""",
+                (env_id, str(business_id), g["channel_id"], g["channel_name"], minute_start,
+                 g["n"], g["v_min"], g["v_max"], g["v_avg"], anomaly_n))
+
+        if max_ts is not None:
+            _set_watermark(cur, env_id, business_id, "gold_rollup", max_ts, run_id)
+        set_pipeline_status(cur, env_id=env_id, business_id=business_id,
+                            surface="gold", status="fresh")
+        return {"minutes_upserted": len(groups), "watermark": max_ts}
+
+
+# ── assertions ────────────────────────────────────────────────────────────────────────────────────
+def run_assertions(*, env_id: str, business_id: UUID) -> dict:
+    """Freshness, row-count delta, and value-range checks -> tel_dq_assertions; failures flip the
+    surface status (fail closed)."""
+    from app.db import get_cursor
+    results: list[dict] = []
+    with get_cursor() as cur:
+        def record(name: str, table: str, passed: bool, observed: str, threshold: str) -> None:
+            results.append({"assertion_name": name, "table_name": table, "passed": passed,
+                            "observed": observed, "threshold": threshold})
+            cur.execute(
+                """INSERT INTO tel_dq_assertions
+                     (env_id, business_id, job_name, table_name, assertion_name, passed, observed, threshold)
+                   VALUES (%s, %s, 'stream_etl', %s, %s, %s, %s, %s)""",
+                (env_id, str(business_id), table, name, passed, observed, threshold))
+
+        # freshness: newest silver row must be recent (only meaningful once data exists)
+        cur.execute(
+            "SELECT max(ts_source) AS newest FROM tel_stream_readings WHERE env_id = %s AND business_id = %s",
+            (env_id, str(business_id)))
+        newest = cur.fetchone()["newest"]
+        if newest is not None:
+            age = (datetime.now(timezone.utc) - newest).total_seconds()
+            record("freshness", "tel_stream_readings", age <= FRESHNESS_LIMIT_S,
+                   f"{int(age)}s", f"<= {FRESHNESS_LIMIT_S}s")
+
+        # row-count delta: silver should never exceed distinct bronze (dedupe sanity)
+        cur.execute(
+            """SELECT (SELECT count(*) FROM tel_stream_readings WHERE env_id = %s AND business_id = %s) AS silver,
+                      (SELECT count(DISTINCT (channel_key, ts_source)) FROM tel_stream_readings_bronze
+                       WHERE env_id = %s AND business_id = %s) AS bronze_distinct""",
+            (env_id, str(business_id), env_id, str(business_id)))
+        rc = cur.fetchone()
+        record("row_count_delta", "tel_stream_readings",
+               rc["silver"] <= rc["bronze_distinct"],
+               f"silver={rc['silver']} bronze_distinct={rc['bronze_distinct']}",
+               "silver <= distinct bronze")
+
+        # value-range: out_of_range rows present in the last 10 min = a live range violation
+        cur.execute(
+            """SELECT channel_name, count(*) AS n FROM tel_stream_readings
+               WHERE env_id = %s AND business_id = %s AND quality_flag = 'out_of_range'
+                 AND created_at > now() - interval '10 minutes'
+               GROUP BY channel_name""",
+            (env_id, str(business_id)))
+        violations = cur.fetchall()
+        for v in violations:
+            record(f"value_range:{v['channel_name']}", "tel_stream_readings", False,
+                   f"{v['n']} out-of-range rows (10m)", "0 expected")
+        if not violations:
+            record("value_range", "tel_stream_readings", True, "0 out-of-range rows (10m)", "0 expected")
+
+        all_pass = all(r["passed"] for r in results)
+        if not all_pass:
+            failed = ", ".join(r["assertion_name"] for r in results if not r["passed"])
+            set_pipeline_status(cur, env_id=env_id, business_id=business_id, surface="silver",
+                                status="failed", reason=f"assertions failed: {failed}")
+        return {"assertions": results, "all_pass": all_pass}
+
+
+# ── live scoring through the FROZEN champion ─────────────────────────────────────────────────────
+def run_live_scoring(*, env_id: str, business_id: UUID) -> dict:
+    """Pass each channel's trailing window through telemetry_serving.score_window (frozen rule,
+    untouched constants). Values are normalized to fractional deviation first (declared adaptation —
+    raw engineering units vs the normalized-unit threshold). NO_GO -> record_anomaly_event."""
+    from app.db import get_cursor
+    run_id = uuid.uuid4()
+    scored: list[dict] = []
+    with get_cursor() as cur:
+        wm = _get_watermark(cur, env_id, "live_scoring")
+        cur.execute(
+            """SELECT DISTINCT channel_name FROM tel_stream_readings
+               WHERE env_id = %s AND business_id = %s AND quality_flag = 'ok'
+                 AND (%s::timestamptz IS NULL OR ts_source > %s)""",
+            (env_id, str(business_id), wm, wm))
+        channel_names = [r["channel_name"] for r in cur.fetchall()]
+        cur.execute(
+            "SELECT id FROM tel_test_runs WHERE env_id = %s AND business_id = %s AND run_key = %s",
+            (env_id, str(business_id), STREAM_RUN_KEY))
+        run_row = cur.fetchone()
+        if run_row is None:
+            return {"scored": [], "null_reason": "missing_run"}
+        stream_run_id = run_row["id"]
+
+        windows: dict[str, list[dict]] = {}
+        max_ts = wm
+        for name in channel_names:
+            cur.execute(
+                """SELECT ts_source, value FROM tel_stream_readings
+                   WHERE env_id = %s AND business_id = %s AND channel_name = %s AND quality_flag = 'ok'
+                   ORDER BY ts_source DESC LIMIT %s""",
+                (env_id, str(business_id), name, SCORE_WINDOW_POINTS))
+            rows = list(reversed(cur.fetchall()))
+            if len(rows) < 5:        # not enough context to score honestly
+                continue
+            newest = rows[-1]["ts_source"]
+            max_ts = newest if max_ts is None else max(max_ts, newest)
+            values = [float(r["value"]) for r in rows]
+            norm = normalize_window(values)
+            rmeans = rolling_mean(norm)
+            windows[name] = [
+                {"t": int(r["ts_source"].timestamp()), "value": n, "value_rmean50": m}
+                for r, n, m in zip(rows, norm, rmeans)
+            ]
+
+    # score_window opens its own cursor (separate transaction per receipt — matches /score semantics)
+    for name, window in windows.items():
+        result = telemetry_serving.score_window(
+            env_id=env_id, business_id=business_id, run_key=STREAM_RUN_KEY,
+            channel_name=name, window=window)
+        scored.append({"channel_name": name, "verdict": result.get("verdict"),
+                       "anomaly_score": result.get("anomaly_score")})
+        if result.get("verdict") == "NO_GO":
+            with get_cursor() as cur:
+                record_anomaly_event(
+                    cur, env_id=env_id, business_id=business_id, run_id=stream_run_id,
+                    channel_name=name, start_t=window[0]["t"], end_t=window[-1]["t"],
+                    anomaly_class="point", confidence=result.get("anomaly_score"),
+                    source="model")
+
+    if max_ts is not None:
+        with get_cursor() as cur:
+            _set_watermark(cur, env_id, business_id, "live_scoring", max_ts, run_id)
+    return {"scored": scored, "watermark": max_ts}
+
+
+# ── serving reads for the stream routes ──────────────────────────────────────────────────────────
+def stream_live(*, env_id: str, business_id: UUID, channels: list[str] | None = None,
+                limit_per_channel: int = 120) -> dict:
+    """Live read: worker ring buffer first; silver tail fallback when the worker is absent/empty.
+    Carries server_ts (latency overlay) + pipeline status + recent live anomaly events. Fail closed:
+    stale/failed status rides the payload — the UI freezes charts, never interpolates."""
+    from app.db import get_cursor
+    from app.services.telemetry_stream_ingest import get_stream_worker
+
+    server_ts = datetime.now(timezone.utc)
+    worker = get_stream_worker()
+    snapshot = worker.snapshot_live(channels) if worker is not None else None
+
+    with get_cursor() as cur:
+        cur.execute(
+            "SELECT surface, status, as_of_ts, reason FROM tel_pipeline_status WHERE env_id = %s AND business_id = %s",
+            (env_id, str(business_id)))
+        status_rows = {r["surface"]: r for r in cur.fetchall()}
+
+        cur.execute(
+            """SELECT c.channel_name, c.unit, c.redline_low, c.redline_high
+               FROM tel_telemetry_channels c JOIN tel_test_runs r ON r.id = c.run_id
+               WHERE c.env_id = %s AND c.business_id = %s AND r.run_key = %s""",
+            (env_id, str(business_id), STREAM_RUN_KEY))
+        meta = {r["channel_name"]: r for r in cur.fetchall()}
+
+        out_channels: list[dict] = []
+        if snapshot and snapshot["channels"]:
+            for ch in snapshot["channels"]:
+                if channels and ch["channel_key"] not in channels:
+                    continue
+                m = meta.get(ch["channel_key"], {})
+                out_channels.append({
+                    "channel_name": ch["channel_key"],
+                    "unit": m.get("unit"),
+                    "redline_low": m.get("redline_low"),
+                    "redline_high": m.get("redline_high"),
+                    "readings": ch["readings"][-limit_per_channel:],
+                    "latest": ch["latest"],
+                })
+            source = snapshot["source"]
+        else:
+            # Fallback: silver tail via the live index (worker not running in this process).
+            wanted = channels or list(meta.keys())
+            for name in wanted:
+                cur.execute(
+                    """SELECT ts_source, value FROM tel_stream_readings
+                       WHERE env_id = %s AND business_id = %s AND channel_name = %s
+                         AND quality_flag IN ('ok', 'late')
+                       ORDER BY ts_source DESC LIMIT %s""",
+                    (env_id, str(business_id), name, limit_per_channel))
+                rows = list(reversed(cur.fetchall()))
+                if not rows:
+                    continue
+                m = meta.get(name, {})
+                out_channels.append({
+                    "channel_name": name,
+                    "unit": m.get("unit"),
+                    "redline_low": m.get("redline_low"),
+                    "redline_high": m.get("redline_high"),
+                    "readings": [{"t": r["ts_source"].isoformat(), "v": float(r["value"])} for r in rows],
+                    "latest": {"t": rows[-1]["ts_source"].isoformat(), "v": float(rows[-1]["value"])},
+                })
+            source = "db_tail"
+
+        # recent live model events for anomaly overlays
+        cur.execute(
+            """SELECT e.channel_name, e.start_t, e.end_t, e.anomaly_class, e.confidence
+               FROM tel_anomaly_events e JOIN tel_test_runs r ON r.id = e.run_id
+               WHERE e.env_id = %s AND e.business_id = %s AND r.run_key = %s AND e.source = 'model'
+               ORDER BY e.created_at DESC LIMIT 20""",
+            (env_id, str(business_id), STREAM_RUN_KEY))
+        events = [dict(r) for r in cur.fetchall()]
+
+    ingest = status_rows.get("stream_ingest")
+    return {
+        "server_ts": server_ts.isoformat(),
+        "source": source,
+        "pipeline": {
+            "status": ingest["status"] if ingest else "unknown",
+            "as_of_ts": ingest["as_of_ts"].isoformat() if ingest else None,
+            "reason": ingest["reason"] if ingest else "no_status_row",
+            "surfaces": {k: {"status": v["status"], "as_of_ts": v["as_of_ts"].isoformat(),
+                             "reason": v["reason"]} for k, v in status_rows.items()},
+        },
+        "channels": out_channels,
+        "events": events,
+        "null_reason": None if out_channels else "no_stream_data",
+    }
+
+
+def stream_health(*, env_id: str, business_id: UUID) -> dict:
+    """Stream-health aggregates: per-channel freshness, ingest lag percentiles, rows/min, recent
+    assertions, pipeline status, watermark ages."""
+    from app.db import get_cursor
+    now = datetime.now(timezone.utc)
+    with get_cursor() as cur:
+        cur.execute(
+            """SELECT channel_name, max(ts_source) AS last_ts, count(*) AS n
+               FROM tel_stream_readings WHERE env_id = %s AND business_id = %s
+               GROUP BY channel_name ORDER BY channel_name""",
+            (env_id, str(business_id)))
+        freshness = [{"channel_name": r["channel_name"],
+                      "last_ts": r["last_ts"].isoformat(),
+                      "age_s": round((now - r["last_ts"]).total_seconds(), 1),
+                      "rows": int(r["n"])} for r in cur.fetchall()]
+
+        cur.execute(
+            """SELECT percentile_disc(0.5) WITHIN GROUP (ORDER BY lag) AS p50,
+                      percentile_disc(0.95) WITHIN GROUP (ORDER BY lag) AS p95,
+                      count(*) AS n
+               FROM (SELECT EXTRACT(EPOCH FROM (ts_ingest - ts_source)) AS lag
+                     FROM tel_stream_readings_bronze
+                     WHERE env_id = %s AND business_id = %s
+                       AND ts_ingest > now() - interval '10 minutes') sub""",
+            (env_id, str(business_id)))
+        lag = cur.fetchone() or {}
+
+        cur.execute(
+            """SELECT count(*) AS n FROM tel_stream_readings_bronze
+               WHERE env_id = %s AND business_id = %s AND ts_ingest > now() - interval '1 minute'""",
+            (env_id, str(business_id)))
+        rows_per_min = int(cur.fetchone()["n"])
+
+        cur.execute(
+            """SELECT job_name, table_name, assertion_name, passed, observed, threshold, run_ts
+               FROM tel_dq_assertions WHERE env_id = %s AND business_id = %s
+               ORDER BY run_ts DESC LIMIT 20""",
+            (env_id, str(business_id)))
+        assertions = [{**dict(r), "run_ts": r["run_ts"].isoformat()} for r in cur.fetchall()]
+
+        cur.execute(
+            "SELECT surface, status, as_of_ts, reason FROM tel_pipeline_status WHERE env_id = %s AND business_id = %s",
+            (env_id, str(business_id)))
+        statuses = [{**dict(r), "as_of_ts": r["as_of_ts"].isoformat()} for r in cur.fetchall()]
+
+        cur.execute(
+            "SELECT job_name, watermark_ts, updated_at FROM tel_etl_watermarks WHERE env_id = %s",
+            (env_id,))
+        watermarks = [{"job_name": r["job_name"], "watermark_ts": r["watermark_ts"].isoformat(),
+                       "age_s": round((now - r["watermark_ts"]).total_seconds(), 1)}
+                      for r in cur.fetchall()]
+
+    return {
+        "server_ts": now.isoformat(),
+        "freshness": freshness,
+        "ingest_lag_p50_s": float(lag["p50"]) if lag.get("p50") is not None else None,
+        "ingest_lag_p95_s": float(lag["p95"]) if lag.get("p95") is not None else None,
+        "ingest_lag_sample_n": int(lag.get("n") or 0),
+        "rows_per_min": rows_per_min,
+        "assertions": assertions,
+        "pipeline_status": statuses,
+        "watermarks": watermarks,
+        "null_reason": None if freshness else "no_stream_data",
+    }
+
+
+# ── the loop (lifespan background task; operator-sweep pattern) ──────────────────────────────────
+async def run_etl_loop(*, env_id: str, business_id: UUID, interval_seconds: int = 60) -> None:
+    emit_log(level="info", service="telemetry_stream", action="etl_loop_started",
+             message=f"stream ETL loop every {interval_seconds}s")
+    while True:
+        try:
+            merge = await asyncio.to_thread(run_silver_merge, env_id=env_id, business_id=business_id)
+            await asyncio.to_thread(run_gold_rollup, env_id=env_id, business_id=business_id)
+            await asyncio.to_thread(run_assertions, env_id=env_id, business_id=business_id)
+            if merge.get("rows_inserted"):
+                await asyncio.to_thread(run_live_scoring, env_id=env_id, business_id=business_id)
+        except asyncio.CancelledError:
+            emit_log(level="info", service="telemetry_stream", action="etl_loop_stopped",
+                     message="stream ETL loop cancelled")
+            raise
+        except Exception as exc:  # noqa: BLE001 — loop never dies; status carries the failure
+            emit_log(level="error", service="telemetry_stream", action="etl_cycle_failed",
+                     message=str(exc), error=exc)
+            try:
+                from app.db import get_cursor
+                with get_cursor() as cur:
+                    set_pipeline_status(cur, env_id=env_id, business_id=business_id,
+                                        surface="silver", status="failed", reason=str(exc)[:300])
+            except Exception:  # noqa: BLE001
+                pass
+        await asyncio.sleep(interval_seconds)

--- a/backend/app/services/telemetry_stream_ingest.py
+++ b/backend/app/services/telemetry_stream_ingest.py
@@ -1,0 +1,438 @@
+"""Live telemetry stream ingestion (RS Demo streaming slice).
+
+Source adapters behind one interface (`TELEMETRY_STREAM_SOURCE = iss | capture | adsb`):
+  * CaptureAdapter  — replays the checked-in recorded ISS session. THE REQUIRED PROOF PATH:
+                      CI and the baseline demo run on capture; deterministic, no network.
+  * IssLightstreamerAdapter — the live public ISS feed (push.lightstreamer.com / ISSLIVE).
+                      Live-mode enhancement once capture is green. Lazy import: the sync
+                      lightstreamer lib runs its own session thread; frames cross into the
+                      event loop via loop.call_soon_threadsafe.
+  * OpenSkyAdapter  — ADS-B fallback exhibit ONLY (labeled as fallback, never the default proof).
+
+The StreamWorker is an asyncio background task started from the FastAPI lifespan (same pattern as the
+operator confirm-registry sweep loop in main.py): drain frames -> per-channel ring buffer (last 120 s)
+-> micro-batch insert to bronze every 2 s (executemany, one batch_id per flush, day-partition ensured)
+-> watchdog (silence > 30 s restarts the adapter; > 60 s flips tel_pipeline_status to 'stale' — the
+fail-closed handshake the UI reads; recovery flips it back to 'fresh').
+
+DB access is the sync psycopg pool (app.db.get_cursor) — always called via asyncio.to_thread, never
+directly on the event loop. The frozen champion scorer is NOT called here; live scoring happens in the
+ETL loop (telemetry_stream_etl.run_live_scoring).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Protocol
+
+from app.observability.logger import emit_log
+
+_FIXTURE_PATH = Path(__file__).resolve().parent.parent / "data" / "telemetry" / "iss_capture.json"
+
+WATCHDOG_RESTART_S = 30      # silence before the adapter is restarted
+WATCHDOG_STALE_S = 60        # silence before the pipeline status flips to 'stale'
+FLUSH_INTERVAL_S = 2.0
+RING_SECONDS = 120
+DOWNSAMPLE_QUEUE_DEPTH = 5000   # backpressure guard: above this, sample 1 Hz per channel
+
+
+@dataclass(frozen=True)
+class Frame:
+    channel_key: str
+    ts_source: datetime          # receive-time at the adapter (feed's raw timestamp kept in payload)
+    value: float | None
+    payload: dict
+    source: str                  # iss | capture | adsb
+
+
+class StreamAdapter(Protocol):
+    def start(self, emit: Callable[[Frame], None]) -> None: ...
+    def stop(self) -> None: ...
+
+
+# ── Capture adapter: the deterministic proof path ────────────────────────────────────────────────
+class CaptureAdapter:
+    """Replays the recorded ISS session (real frames, re-based onto the current clock)."""
+
+    def __init__(self, channels: list[str] | None = None, *, speed: float = 1.0,
+                 loop_forever: bool = True, fixture_path: Path | None = None) -> None:
+        self._channels = set(channels) if channels else None
+        self._speed = max(speed, 0.01)
+        self._loop_forever = loop_forever
+        self._fixture_path = fixture_path or _FIXTURE_PATH
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def load_frames(self) -> list[dict]:
+        fixture = json.loads(self._fixture_path.read_text(encoding="utf-8"))
+        frames = fixture.get("frames", [])
+        if self._channels is not None:
+            frames = [f for f in frames if f.get("channel_key") in self._channels]
+        return sorted(frames, key=lambda f: f.get("ts_offset_s", 0.0))
+
+    def start(self, emit: Callable[[Frame], None]) -> None:
+        self._stop.clear()
+
+        def _run() -> None:
+            frames = self.load_frames()
+            if not frames:
+                return
+            while not self._stop.is_set():
+                t0 = time.monotonic()
+                base = datetime.now(timezone.utc)
+                for f in frames:
+                    if self._stop.is_set():
+                        return
+                    target = f.get("ts_offset_s", 0.0) / self._speed
+                    delay = target - (time.monotonic() - t0)
+                    if delay > 0:
+                        self._stop.wait(min(delay, 1.0))
+                        if time.monotonic() - t0 < target:
+                            continue_wait = target - (time.monotonic() - t0)
+                            if continue_wait > 0:
+                                self._stop.wait(continue_wait)
+                    if self._stop.is_set():
+                        return
+                    emit(Frame(
+                        channel_key=f["channel_key"],
+                        ts_source=base + timedelta(seconds=f.get("ts_offset_s", 0.0)),
+                        value=f.get("value"),
+                        payload={"raw": f.get("raw", {}), "capture": True},
+                        source="capture",
+                    ))
+                if not self._loop_forever:
+                    return
+
+        self._thread = threading.Thread(target=_run, name="tel-capture-adapter", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=2)
+            self._thread = None
+
+
+# ── ISS Lightstreamer adapter: live-mode enhancement ─────────────────────────────────────────────
+class IssLightstreamerAdapter:
+    LS_SERVER = "https://push.lightstreamer.com"
+    LS_ADAPTER_SET = "ISSLIVE"
+    FIELDS = ["TimeStamp", "Value", "Status.Class", "Status.Indicator"]
+
+    def __init__(self, channels: list[str]) -> None:
+        self._channels = channels
+        self._client = None
+
+    def start(self, emit: Callable[[Frame], None]) -> None:
+        # Lazy import: a broken/absent wheel must never take the app down (capture is the floor).
+        from lightstreamer.client import LightstreamerClient, Subscription  # type: ignore
+
+        client = LightstreamerClient(self.LS_SERVER, self.LS_ADAPTER_SET)
+        sub = Subscription(mode="MERGE", items=self._channels, fields=self.FIELDS)
+
+        class _Listener:
+            def onItemUpdate(self, update):  # noqa: N802 (lightstreamer API casing)
+                try:
+                    raw_value = update.getValue("Value")
+                    value = float(raw_value) if raw_value not in (None, "") else None
+                except (TypeError, ValueError):
+                    value = None
+                emit(Frame(
+                    channel_key=update.getItemName(),
+                    ts_source=datetime.now(timezone.utc),
+                    value=value,
+                    payload={"raw": {
+                        "TimeStamp": update.getValue("TimeStamp"),
+                        "Status.Class": update.getValue("Status.Class"),
+                    }},
+                    source="iss",
+                ))
+
+            def __getattr__(self, _name):
+                return lambda *a, **k: None
+
+        sub.addListener(_Listener())
+        client.subscribe(sub)
+        client.connect()
+        self._client = client
+
+    def stop(self) -> None:
+        if self._client is not None:
+            try:
+                self._client.disconnect()
+            except Exception:  # noqa: BLE001
+                pass
+            self._client = None
+
+
+# ── OpenSky adapter: fallback exhibit ONLY (labeled; never the default proof) ────────────────────
+class OpenSkyAdapter:
+    """Polls OpenSky's public state vectors (5 s); emits altitude/velocity for a few aircraft as
+    fallback channels. Demo-day insurance only — always labeled 'adsb fallback' in the UI."""
+
+    POLL_S = 5.0
+    URL = "https://opensky-network.org/api/states/all?lamin=33.6&lomin=-119.0&lamax=34.6&lomax=-117.0"
+
+    def __init__(self, channels: list[str] | None = None) -> None:
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self, emit: Callable[[Frame], None]) -> None:
+        import httpx
+
+        self._stop.clear()
+
+        def _run() -> None:
+            while not self._stop.is_set():
+                try:
+                    resp = httpx.get(self.URL, timeout=10)
+                    states = (resp.json() or {}).get("states") or []
+                    now = datetime.now(timezone.utc)
+                    for s in states[:4]:  # a few aircraft: icao24=s[0], alt=s[7], vel=s[9]
+                        icao = s[0]
+                        if s[7] is not None:
+                            emit(Frame(f"ADSB_{icao}_ALT", now, float(s[7]),
+                                       {"icao24": icao, "fallback": True}, "adsb"))
+                        if s[9] is not None:
+                            emit(Frame(f"ADSB_{icao}_VEL", now, float(s[9]),
+                                       {"icao24": icao, "fallback": True}, "adsb"))
+                except Exception:  # noqa: BLE001
+                    pass
+                self._stop.wait(self.POLL_S)
+
+        self._thread = threading.Thread(target=_run, name="tel-adsb-adapter", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=2)
+            self._thread = None
+
+
+def make_adapter(source: str, channels: list[str]) -> StreamAdapter:
+    if source == "iss":
+        return IssLightstreamerAdapter(channels)
+    if source == "adsb":
+        return OpenSkyAdapter(channels)
+    return CaptureAdapter(channels)
+
+
+# ── The worker ────────────────────────────────────────────────────────────────────────────────────
+class StreamWorker:
+    def __init__(self, *, env_id: str, business_id: str, source: str = "capture",
+                 channels: list[str] | None = None,
+                 flush_interval_s: float = FLUSH_INTERVAL_S, ring_seconds: int = RING_SECONDS) -> None:
+        self.env_id = env_id
+        self.business_id = business_id
+        self.source = source
+        self.channels = channels or []
+        self.flush_interval_s = flush_interval_s
+        self.ring_seconds = ring_seconds
+
+        self._queue: asyncio.Queue[Frame] = asyncio.Queue()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._adapter: StreamAdapter | None = None
+        self._ring: dict[str, deque[tuple[datetime, float]]] = {}
+        self._latest: dict[str, tuple[datetime, float]] = {}
+        self.last_frame_at: datetime | None = None
+        self.started_at: datetime | None = None
+        self._stale = False
+        self._stopping = False
+        self._ensured_partitions: set[str] = set()
+        self._downsample_last: dict[str, float] = {}
+
+    # — emit callback (called from adapter threads) —
+    def _emit(self, frame: Frame) -> None:
+        if self._loop is None or self._stopping:
+            return
+        if self._queue.qsize() > DOWNSAMPLE_QUEUE_DEPTH:
+            # Backpressure: sample 1 Hz per channel; visible in Stream Health, never silent.
+            now = time.monotonic()
+            last = self._downsample_last.get(frame.channel_key, 0.0)
+            if now - last < 1.0:
+                return
+            self._downsample_last[frame.channel_key] = now
+        self._loop.call_soon_threadsafe(self._queue.put_nowait, frame)
+
+    # — main loop —
+    async def run(self) -> None:
+        self._loop = asyncio.get_running_loop()
+        self.started_at = datetime.now(timezone.utc)
+        self._adapter = make_adapter(self.source, self.channels)
+        self._adapter.start(self._emit)
+        emit_log(level="info", service="telemetry_stream", action="worker_started",
+                 message=f"stream worker started source={self.source}")
+        buffer: list[Frame] = []
+        last_flush = time.monotonic()
+        try:
+            while not self._stopping:
+                timeout = max(0.05, self.flush_interval_s - (time.monotonic() - last_flush))
+                try:
+                    frame = await asyncio.wait_for(self._queue.get(), timeout=timeout)
+                    buffer.append(frame)
+                    self._ingest_to_ring(frame)
+                except asyncio.TimeoutError:
+                    pass
+                if time.monotonic() - last_flush >= self.flush_interval_s:
+                    if buffer:
+                        rows, buffer = buffer, []
+                        try:
+                            await asyncio.to_thread(self._flush_bronze, rows)
+                        except Exception as exc:  # noqa: BLE001
+                            emit_log(level="error", service="telemetry_stream",
+                                     action="bronze_flush_failed", message=str(exc), error=exc)
+                    await self._watchdog()
+                    last_flush = time.monotonic()
+        except asyncio.CancelledError:
+            pass
+        finally:
+            if self._adapter:
+                self._adapter.stop()
+            emit_log(level="info", service="telemetry_stream", action="worker_stopped",
+                     message="stream worker stopped")
+
+    def _ingest_to_ring(self, frame: Frame) -> None:
+        if frame.value is None:
+            return
+        self.last_frame_at = datetime.now(timezone.utc)
+        ring = self._ring.setdefault(frame.channel_key, deque())
+        ring.append((frame.ts_source, frame.value))
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=self.ring_seconds)
+        while ring and ring[0][0] < cutoff:
+            ring.popleft()
+        self._latest[frame.channel_key] = (frame.ts_source, frame.value)
+
+    # — sync DB work (always via asyncio.to_thread) —
+    def _flush_bronze(self, rows: list[Frame]) -> None:
+        from app.db import get_cursor
+        batch_id = str(uuid.uuid4())
+        with get_cursor() as cur:
+            self._ensure_partitions(cur)
+            cur.executemany(
+                """INSERT INTO tel_stream_readings_bronze
+                     (env_id, business_id, source, channel_key, ts_source, value, payload, batch_id)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s)""",
+                [(self.env_id, self.business_id, f.source, f.channel_key, f.ts_source,
+                  f.value, json.dumps(f.payload, default=str), batch_id) for f in rows])
+            cur.execute(
+                """INSERT INTO tel_pipeline_status (env_id, business_id, surface, status, as_of_ts, reason)
+                   VALUES (%s, %s, 'stream_ingest', 'fresh', now(), NULL)
+                   ON CONFLICT (env_id, surface)
+                   DO UPDATE SET status = 'fresh', as_of_ts = now(), reason = NULL""",
+                (self.env_id, self.business_id))
+        if self._stale:
+            self._stale = False
+            emit_log(level="info", service="telemetry_stream", action="stream_recovered",
+                     message="frames flowing again; pipeline status fresh")
+
+    def _ensure_partitions(self, cur) -> None:
+        from datetime import date
+        for day in (date.today(), date.today() + timedelta(days=1)):
+            key = day.isoformat()
+            if key in self._ensured_partitions:
+                continue
+            pname = f"tel_stream_readings_bronze_{day.strftime('%Y_%m_%d')}"
+            cur.execute(
+                f"""DO $$ BEGIN
+                    IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = '{pname}') THEN
+                        EXECUTE format(
+                          'CREATE TABLE %I PARTITION OF tel_stream_readings_bronze FOR VALUES FROM (%L) TO (%L)',
+                          '{pname}', '{day.isoformat()}', '{(day + timedelta(days=1)).isoformat()}');
+                    END IF;
+                END $$;""")
+            self._ensured_partitions.add(key)
+
+    async def _watchdog(self) -> None:
+        if self.last_frame_at is None:
+            ref = self.started_at
+        else:
+            ref = self.last_frame_at
+        if ref is None:
+            return
+        silence = (datetime.now(timezone.utc) - ref).total_seconds()
+        if silence > WATCHDOG_STALE_S and not self._stale:
+            self._stale = True
+            reason = f"no frames since {ref.isoformat()}"
+            emit_log(level="error", service="telemetry_stream", action="stream_stale", message=reason)
+            try:
+                await asyncio.to_thread(self._set_status_sync, "stale", reason)
+            except Exception as exc:  # noqa: BLE001
+                emit_log(level="error", service="telemetry_stream",
+                         action="status_write_failed", message=str(exc), error=exc)
+        elif silence > WATCHDOG_RESTART_S and self._adapter is not None and not self._stale:
+            emit_log(level="warn", service="telemetry_stream", action="adapter_restart",
+                     message=f"{int(silence)}s of silence; restarting {self.source} adapter")
+            try:
+                self._adapter.stop()
+                self._adapter.start(self._emit)
+            except Exception as exc:  # noqa: BLE001
+                emit_log(level="error", service="telemetry_stream",
+                         action="adapter_restart_failed", message=str(exc), error=exc)
+
+    def _set_status_sync(self, status: str, reason: str | None) -> None:
+        from app.db import get_cursor
+        with get_cursor() as cur:
+            cur.execute(
+                """INSERT INTO tel_pipeline_status (env_id, business_id, surface, status, as_of_ts, reason)
+                   VALUES (%s, %s, 'stream_ingest', %s, now(), %s)
+                   ON CONFLICT (env_id, surface)
+                   DO UPDATE SET status = EXCLUDED.status, as_of_ts = now(), reason = EXCLUDED.reason""",
+                (self.env_id, self.business_id, status, reason))
+
+    # — read API for the routes —
+    def snapshot_live(self, channels: list[str] | None = None) -> dict:
+        keys = channels or sorted(self._ring.keys())
+        out = []
+        for k in keys:
+            ring = self._ring.get(k)
+            if not ring:
+                continue
+            out.append({
+                "channel_key": k,
+                "readings": [{"t": ts.isoformat(), "v": v} for ts, v in list(ring)],
+                "latest": ({"t": self._latest[k][0].isoformat(), "v": self._latest[k][1]}
+                           if k in self._latest else None),
+            })
+        return {
+            "source": self.source,
+            "stale": self._stale,
+            "last_frame_at": self.last_frame_at.isoformat() if self.last_frame_at else None,
+            "channels": out,
+        }
+
+    def switch_source(self, source: str) -> dict:
+        if source not in ("iss", "capture", "adsb"):
+            raise ValueError("source must be iss | capture | adsb")
+        old = self.source
+        if self._adapter:
+            self._adapter.stop()
+        self.source = source
+        self._adapter = make_adapter(source, self.channels)
+        self._adapter.start(self._emit)
+        emit_log(level="info", service="telemetry_stream", action="source_switched",
+                 message=f"{old} -> {source}")
+        return {"previous": old, "source": source}
+
+    async def stop(self) -> None:
+        self._stopping = True
+
+
+# ── module singleton (set by the lifespan) ───────────────────────────────────────────────────────
+_worker: StreamWorker | None = None
+
+
+def set_stream_worker(worker: StreamWorker | None) -> None:
+    global _worker
+    _worker = worker
+
+
+def get_stream_worker() -> StreamWorker | None:
+    return _worker

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,9 @@ psycopg-pool>=3.2
 python-dotenv==1.0.1
 pydantic==2.10.4
 httpx==0.28.1
+
+# RS Demo streaming slice: ISS Lightstreamer live adapter (lazy-imported; capture mode needs no network)
+lightstreamer-client-lib==2.2.2
 scikit-learn==1.6.1
 
 # Test dependencies

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -45,6 +45,11 @@ class FakeCursor:
         self.queries.append((sql, params))
         return self
 
+    def executemany(self, sql: str, params_seq=None):
+        for p in (params_seq or []):
+            self.queries.append((sql, p))
+        return self
+
     def fetchone(self):
         if self._result_idx < len(self._results):
             rows = self._results[self._result_idx]
@@ -205,6 +210,8 @@ _GET_CURSOR_TARGETS = [
     "app.services.pipeline_rail.get_cursor",
     "app.services.hr_decision_runner.get_cursor",
     "app.services.identity_providers.get_cursor",
+    # telemetry_stream_etl / telemetry_stream_ingest import get_cursor lazily inside functions,
+    # so the app.db.get_cursor patch above covers them (module-level targets would fail to patch).
 ]
 
 

--- a/backend/tests/test_copilot_telemetry.py
+++ b/backend/tests/test_copilot_telemetry.py
@@ -171,7 +171,6 @@ def test_draft_report_unsupported_root_cause_is_refused_pre_llm():
 
 def test_draft_report_missing_run_fails_closed(fake_cursor, monkeypatch):
     # get_triggering_prediction -> missing_run; no evidence -> no report, no persisted row.
-    from app.services import telemetry_serving as svc
     fake_cursor.push_result([{"tenant_id": TENANT}])   # resolve_tenant_id
     fake_cursor.push_result([])                        # run lookup -> none
     out = tc.draft_report(env_id=ENV, business_id=BIZ, run_key="smap_msl:NOPE:test", fire_tick=728)

--- a/backend/tests/test_telemetry_stream_etl.py
+++ b/backend/tests/test_telemetry_stream_etl.py
@@ -1,0 +1,270 @@
+"""Tests for the RS Demo streaming slice (capture-only — NO test may touch the live ISS feed).
+
+Covers the slicing-plan acceptance tests:
+  1 idempotency (second merge inserts 0)   4 fail-closed stale watchdog
+  2 dedupe via ON CONFLICT key             5 out-of-range -> assertion fail + excluded flag
+  3 late data -> late flag + restatement   6 CaptureAdapter determinism
+plus the new tel_anomaly_events writer (insert + coalesce), the frozen-champion live-score hook,
+and the /stream/* route shapes. Pure-function cores are tested without a DB; SQL paths use the
+FakeCursor fixture (ordered push_result; execute records, fetch* consume).
+"""
+import asyncio
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from app.services import telemetry_stream_etl as etl
+from app.services import telemetry_stream_ingest as ingest
+
+ENV = "telemetry-demo"
+BIZ = uuid4()
+NOW = datetime(2026, 6, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ── pure helpers ────────────────────────────────────────────────────────────────
+def test_normalize_window_fractional_deviation():
+    norm = etl.normalize_window([750.0, 752.0, 751.0])
+    assert all(0.99 < v < 1.01 for v in norm)          # stable channel ~> 1.0
+    spike = etl.normalize_window([100.0, 100.0, 100.0, 100.0, 160.0])
+    assert spike[-1] > 1.5                              # 60% excursion survives normalization
+    assert etl.normalize_window([]) == []
+
+
+def test_rolling_mean_trailing_min_periods_1():
+    assert etl.rolling_mean([1.0, 2.0, 3.0], window=2) == [1.0, 1.5, 2.5]
+
+
+def test_coalesce_decision_30s_window():
+    assert etl.coalesce_decision(100, 120) is True      # within 30s -> extend
+    assert etl.coalesce_decision(100, 131) is False     # beyond -> new event
+    assert etl.coalesce_decision(None, 50) is False     # no prior event
+
+
+def test_evaluate_range_redlines():
+    assert etl.evaluate_range(750.0, 700.0, 790.0) is True
+    assert etl.evaluate_range(900.0, 700.0, 790.0) is False
+    assert etl.evaluate_range(-5.0, 0.0, None) is False
+    assert etl.evaluate_range(123.4, None, None) is True   # no redlines -> always in range
+
+
+# ── (6) CaptureAdapter determinism — replays the REAL recorded ISS fixture ──────
+def test_capture_adapter_deterministic_and_real_fixture():
+    a = ingest.CaptureAdapter()
+    frames1 = a.load_frames()
+    frames2 = ingest.CaptureAdapter().load_frames()
+    assert frames1 == frames2                            # bit-identical across runs
+    assert len(frames1) > 100                            # the real 3-min recording
+    keys = {f["channel_key"] for f in frames1}
+    assert "USLAB000058" in keys                         # cabin pressure present
+    offsets = [f["ts_offset_s"] for f in frames1]
+    assert offsets == sorted(offsets)                    # ordered replay
+
+
+# ── (1)+(2) silver merge: idempotency + dedupe key ──────────────────────────────
+def _channel_row(name="USLAB000058", lo=700.0, hi=790.0):
+    return {"channel_id": str(uuid4()), "channel_name": name, "redline_low": lo, "redline_high": hi}
+
+
+def test_silver_merge_second_run_inserts_zero(fake_cursor):
+    # queued: silver watermark, gold watermark, channels, bronze rows
+    fake_cursor.push_result([{"watermark_ts": NOW}])
+    fake_cursor.push_result([{"watermark_ts": None}])
+    ch = _channel_row()
+    fake_cursor.push_result([ch])
+    fake_cursor.push_result([{"channel_key": "USLAB000058", "ts_source": NOW + timedelta(seconds=5),
+                              "ts_ingest": NOW + timedelta(seconds=6), "value": 752.0,
+                              "batch_id": str(uuid4())}])
+    fake_cursor.rowcount = 0                             # ON CONFLICT DO NOTHING skipped the row
+    out = etl.run_silver_merge(env_id=ENV, business_id=BIZ)
+    assert out["rows_seen"] == 1 and out["rows_inserted"] == 0
+    insert_sql = next(q[0] for q in fake_cursor.queries if "INSERT INTO tel_stream_readings" in q[0]
+                      and "minute_agg" not in q[0])
+    assert "ON CONFLICT (env_id, channel_id, ts_source) DO NOTHING" in insert_sql
+    # watermark still advanced (rerun-safe incremental)
+    assert any("tel_etl_watermarks" in q[0] for q in fake_cursor.queries)
+
+
+def test_silver_merge_inserts_and_flags_ok(fake_cursor):
+    fake_cursor.push_result([{"watermark_ts": None}])    # first run: full scan
+    fake_cursor.push_result([{"watermark_ts": None}])
+    ch = _channel_row()
+    fake_cursor.push_result([ch])
+    fake_cursor.push_result([
+        {"channel_key": "USLAB000058", "ts_source": NOW, "ts_ingest": NOW, "value": 752.0,
+         "batch_id": None},
+        {"channel_key": "USLAB000058", "ts_source": NOW + timedelta(seconds=1),
+         "ts_ingest": NOW + timedelta(seconds=1), "value": 753.0, "batch_id": None},
+    ])
+    out = etl.run_silver_merge(env_id=ENV, business_id=BIZ)
+    assert out["rows_inserted"] == 2 and out["late_rows"] == 0
+    params = [q[1] for q in fake_cursor.queries if q[0].startswith("\n") is False
+              and "INSERT INTO tel_stream_readings" in q[0] and "minute_agg" not in q[0]]
+    assert all(p[6] == "ok" for p in params)             # quality_flag position
+
+
+# ── (3) late data -> late flag + targeted restatement ───────────────────────────
+def test_silver_merge_late_frame_restates_minute(fake_cursor):
+    gold_wm = NOW
+    fake_cursor.push_result([{"watermark_ts": NOW - timedelta(minutes=20)}])
+    fake_cursor.push_result([{"watermark_ts": gold_wm}])
+    ch = _channel_row()
+    fake_cursor.push_result([ch])
+    late_ts = NOW - timedelta(minutes=10)                # behind the gold watermark
+    fake_cursor.push_result([{"channel_key": "USLAB000058", "ts_source": late_ts,
+                              "ts_ingest": NOW + timedelta(seconds=2), "value": 751.0,
+                              "batch_id": None}])
+    out = etl.run_silver_merge(env_id=ENV, business_id=BIZ)
+    assert out["late_rows"] == 1 and out["restated_minutes"] == 1
+    insert_params = [q[1] for q in fake_cursor.queries
+                     if "INSERT INTO tel_stream_readings" in q[0] and "minute_agg" not in q[0]]
+    assert insert_params[0][6] == "late"
+    restate = [q for q in fake_cursor.queries if "restated_reason" in q[0]]
+    assert restate and "late_data" in restate[0][0]
+
+
+# ── (5) out-of-range -> flagged + assertion fail + status flip ──────────────────
+def test_silver_merge_out_of_range_flagged(fake_cursor):
+    fake_cursor.push_result([{"watermark_ts": None}])
+    fake_cursor.push_result([{"watermark_ts": None}])
+    fake_cursor.push_result([_channel_row(lo=700.0, hi=790.0)])
+    fake_cursor.push_result([{"channel_key": "USLAB000058", "ts_source": NOW, "ts_ingest": NOW,
+                              "value": 900.0, "batch_id": None}])      # past the redline
+    etl.run_silver_merge(env_id=ENV, business_id=BIZ)
+    params = [q[1] for q in fake_cursor.queries
+              if "INSERT INTO tel_stream_readings" in q[0] and "minute_agg" not in q[0]]
+    assert params[0][6] == "out_of_range"
+
+
+def test_assertions_fail_flips_status(fake_cursor):
+    stale_ts = datetime.now(timezone.utc) - timedelta(minutes=30)
+    fake_cursor.push_result([{"newest": stale_ts}])                     # freshness: too old -> fail
+    fake_cursor.push_result([{"silver": 10, "bronze_distinct": 12}])    # row-count: ok
+    fake_cursor.push_result([{"channel_name": "USLAB000058", "n": 3}])  # range violations -> fail
+    out = etl.run_assertions(env_id=ENV, business_id=BIZ)
+    assert out["all_pass"] is False
+    names = [a["assertion_name"] for a in out["assertions"]]
+    assert "freshness" in names and any(n.startswith("value_range") for n in names)
+    status = [q for q in fake_cursor.queries if "tel_pipeline_status" in q[0]]
+    assert status and status[-1][1][3] == "failed"       # surface flipped, fail closed
+
+
+def test_assertions_all_pass(fake_cursor):
+    fresh_ts = datetime.now(timezone.utc) - timedelta(seconds=10)
+    fake_cursor.push_result([{"newest": fresh_ts}])
+    fake_cursor.push_result([{"silver": 10, "bronze_distinct": 12}])
+    fake_cursor.push_result([])                                         # no violations
+    out = etl.run_assertions(env_id=ENV, business_id=BIZ)
+    assert out["all_pass"] is True
+    assert not any("tel_pipeline_status" in q[0] and (q[1] or [None])[3] == "failed"
+                   for q in fake_cursor.queries if q[1])
+
+
+# ── (7) the tel_anomaly_events writer: insert + coalesce ────────────────────────
+def test_record_anomaly_event_inserts_new(fake_cursor):
+    fake_cursor.push_result([])                          # no prior event
+    fake_cursor.push_result([{"id": "evt-1"}])           # INSERT ... RETURNING
+    out = etl.record_anomaly_event(fake_cursor, env_id=ENV, business_id=BIZ, run_id="run-1",
+                                   channel_name="S6000004", start_t=1000, end_t=1060,
+                                   confidence=7.2)
+    assert out == "evt-1"
+    ins = [q for q in fake_cursor.queries if "INSERT INTO tel_anomaly_events" in q[0]]
+    assert ins and ins[0][1][-1] == "model"              # source='model'
+
+
+def test_record_anomaly_event_coalesces_within_30s(fake_cursor):
+    fake_cursor.push_result([{"id": "evt-1", "end_t": 1050}])   # prior event ends 10s before new start
+    fake_cursor.push_result([{"id": "evt-1"}])                  # UPDATE ... RETURNING
+    out = etl.record_anomaly_event(fake_cursor, env_id=ENV, business_id=BIZ, run_id="run-1",
+                                   channel_name="S6000004", start_t=1060, end_t=1120)
+    assert out == "evt-1"
+    assert any(q[0].strip().startswith("UPDATE tel_anomaly_events") for q in fake_cursor.queries)
+    assert not any("INSERT INTO tel_anomaly_events" in q[0] for q in fake_cursor.queries)
+
+
+# ── (8) live scoring calls the FROZEN champion ──────────────────────────────────
+def test_live_scoring_uses_frozen_score_window(fake_cursor, monkeypatch):
+    calls = []
+
+    def fake_score(**kwargs):
+        calls.append(kwargs)
+        return {"verdict": "NO_GO", "anomaly_score": 7.4, "threshold": 0.135467}
+
+    monkeypatch.setattr(etl.telemetry_serving, "score_window", fake_score)
+    readings = [{"ts_source": NOW + timedelta(seconds=i), "value": 160.0 if i < 55 else 2.0}
+                for i in range(60)]                       # eclipse-style voltage drop
+    fake_cursor.push_result([{"watermark_ts": None}])     # live_scoring watermark
+    fake_cursor.push_result([{"channel_name": "S6000004"}])
+    fake_cursor.push_result([{"id": "run-1"}])            # stream run row
+    fake_cursor.push_result(list(reversed(readings)))     # DESC fetch
+    fake_cursor.push_result([])                           # coalesce lookup: no prior event
+    fake_cursor.push_result([{"id": "evt-9"}])            # event INSERT RETURNING
+    out = etl.run_live_scoring(env_id=ENV, business_id=BIZ)
+    assert calls and calls[0]["run_key"] == "iss_live:stream"
+    window = calls[0]["window"]
+    assert all(isinstance(p["t"], int) for p in window)   # epoch-second ints
+    assert max(p["value"] for p in window) < 2.0          # normalized, not raw volts
+    assert out["scored"][0]["verdict"] == "NO_GO"
+    # the frozen constants were not modified by the slice
+    from app.services.telemetry_serving import GLOBAL_TRAIN_SCALE, MAD_K
+    assert MAD_K == 4.0 and abs(GLOBAL_TRAIN_SCALE - 0.033866801182436346) < 1e-15
+
+
+# ── (4) watchdog: >60s silence flips stale (fail closed) ────────────────────────
+def test_watchdog_flips_stale_after_60s(monkeypatch):
+    worker = ingest.StreamWorker(env_id=ENV, business_id=str(BIZ), source="capture")
+    worker.last_frame_at = datetime.now(timezone.utc) - timedelta(seconds=61)
+    written = {}
+
+    def fake_set_status(status, reason):
+        written["status"] = status
+        written["reason"] = reason
+
+    monkeypatch.setattr(worker, "_set_status_sync", fake_set_status)
+    asyncio.run(worker._watchdog())
+    assert written["status"] == "stale" and "no frames since" in written["reason"]
+    assert worker._stale is True
+
+
+# ── (9) route shapes (DB-tail fallback path; no worker in the test process) ──────
+def test_stream_live_route_shape(client, fake_cursor):
+    ingest.set_stream_worker(None)
+    fake_cursor.push_result([{"surface": "stream_ingest", "status": "stale", "as_of_ts": NOW,
+                              "reason": "no frames since test"}])
+    fake_cursor.push_result([{"channel_name": "USLAB000058", "unit": "mmHg",
+                              "redline_low": 700.0, "redline_high": 790.0}])
+    fake_cursor.push_result([{"ts_source": NOW, "value": 752.0}])      # silver tail for the channel
+    fake_cursor.push_result([])                                        # events
+    resp = client.get("/api/telemetry/stream/live",
+                      params={"env_id": ENV, "business_id": str(BIZ)})
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["pipeline"]["status"] == "stale"                          # fail-closed state rides the payload
+    assert d["channels"][0]["channel_name"] == "USLAB000058"
+    assert d["channels"][0]["latest"]["v"] == 752.0
+    assert "server_ts" in d
+
+
+def test_stream_health_route_shape(client, fake_cursor):
+    fake_cursor.push_result([{"channel_name": "USLAB000058",
+                              "last_ts": datetime.now(timezone.utc), "n": 42}])
+    fake_cursor.push_result([{"p50": 0.8, "p95": 1.6, "n": 100}])
+    fake_cursor.push_result([{"n": 30}])
+    fake_cursor.push_result([{"job_name": "stream_etl", "table_name": "tel_stream_readings",
+                              "assertion_name": "freshness", "passed": True, "observed": "5s",
+                              "threshold": "<= 120s", "run_ts": datetime.now(timezone.utc)}])
+    fake_cursor.push_result([{"surface": "stream_ingest", "status": "fresh",
+                              "as_of_ts": datetime.now(timezone.utc), "reason": None}])
+    fake_cursor.push_result([{"job_name": "silver_merge",
+                              "watermark_ts": datetime.now(timezone.utc),
+                              "updated_at": datetime.now(timezone.utc)}])
+    resp = client.get("/api/telemetry/stream/health",
+                      params={"env_id": ENV, "business_id": str(BIZ)})
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["rows_per_min"] == 30 and d["ingest_lag_p50_s"] == 0.8
+    assert d["assertions"][0]["assertion_name"] == "freshness"
+
+
+def test_stream_source_switch_fails_closed_without_key(client, monkeypatch):
+    monkeypatch.delenv("TELEMETRY_STREAM_ADMIN_KEY", raising=False)
+    resp = client.post("/api/telemetry/stream/source", json={"source": "capture"})
+    assert resp.status_code == 403                        # unset key -> always forbidden

--- a/repo-b/db/schema/10015_telemetry_streaming_slice.sql
+++ b/repo-b/db/schema/10015_telemetry_streaming_slice.sql
@@ -182,9 +182,12 @@ SELECT v.id::uuid, 'telemetry-demo', '7e1eb000-0000-4000-a000-000000000001', r.i
 FROM (VALUES
     ('7e1e57ea-0000-4000-a000-000000000101', 'USLAB000058',  'mmHg', 700::float8, 790::float8),  -- Lab cabin pressure
     ('7e1e57ea-0000-4000-a000-000000000102', 'USLAB000059',  'degC', 15::float8,  32::float8),   -- Lab cabin temperature
-    ('7e1e57ea-0000-4000-a000-000000000103', 'USLAB000062',  'mmHg', 130::float8, 190::float8),  -- Lab ppO2
-    ('7e1e57ea-0000-4000-a000-000000000104', 'USLAB000063',  'mmHg', NULL, NULL),                -- Lab ppN2
-    ('7e1e57ea-0000-4000-a000-000000000105', 'USLAB000064',  'mmHg', 0::float8,   8::float8),    -- Lab ppCO2
+    -- 062/063/064: live feed records small unitless values (1.0 / 1.0 / 5.0) — NOT mmHg partial
+    -- pressures. Semantics unconfirmed, so no unit and no redlines (honest: assertions only fire on
+    -- channels whose physical meaning is verified).
+    ('7e1e57ea-0000-4000-a000-000000000103', 'USLAB000062',  NULL,   NULL, NULL),
+    ('7e1e57ea-0000-4000-a000-000000000104', 'USLAB000063',  NULL,   NULL, NULL),
+    ('7e1e57ea-0000-4000-a000-000000000105', 'USLAB000064',  NULL,   NULL, NULL),
     ('7e1e57ea-0000-4000-a000-000000000106', 'AIRLOCK000049','mmHg', NULL, NULL),                -- Crewlock pressure
     ('7e1e57ea-0000-4000-a000-000000000107', 'NODE3000005',  'pct',  0::float8, 100::float8),    -- Urine tank qty
     ('7e1e57ea-0000-4000-a000-000000000108', 'NODE3000008',  'pct',  0::float8, 100::float8),    -- Waste water tank qty

--- a/repo-b/db/schema/10015_telemetry_streaming_slice.sql
+++ b/repo-b/db/schema/10015_telemetry_streaming_slice.sql
@@ -1,0 +1,215 @@
+-- 10015_telemetry_streaming_slice.sql
+-- RS Demo: live streaming ingestion path for the Telemetry Platform. Bronze (append-only, daily
+-- partitioned raw frames) -> silver (conformed + deduped) -> gold (1-minute aggregates, restatable),
+-- plus ETL watermarks, a fail-closed pipeline-status handshake, and DQ assertion history. Live rows
+-- flow through the FROZEN champion scorer; fired events land in the existing tel_anomaly_events.
+-- Source adapters: iss (Lightstreamer public feed) | capture (recorded session) | adsb (fallback).
+-- Public-data only. Owning module: Telemetry Platform.
+
+-- ── bronze: raw landed frames, append-only, daily PARTITION BY RANGE (480_inv_audit precedent) ──
+CREATE TABLE IF NOT EXISTS tel_stream_readings_bronze (
+    id          uuid NOT NULL DEFAULT gen_random_uuid(),
+    env_id      text NOT NULL,
+    business_id uuid NOT NULL,
+    source      text NOT NULL,                  -- iss | capture | adsb
+    channel_key text NOT NULL,                  -- adapter-native key, e.g. 'USLAB000058'
+    ts_source   timestamptz NOT NULL,           -- frame timestamp from the feed
+    ts_ingest   timestamptz NOT NULL DEFAULT now(),
+    value       double precision,
+    payload     jsonb NOT NULL DEFAULT '{}'::jsonb,
+    batch_id    uuid NOT NULL,                  -- one per micro-batch flush
+    PRIMARY KEY (id, ts_ingest)                 -- partition key must be in the PK
+) PARTITION BY RANGE (ts_ingest);
+
+-- Safety net for clock-skewed rows; should stay empty.
+CREATE TABLE IF NOT EXISTS tel_stream_readings_bronze_default
+    PARTITION OF tel_stream_readings_bronze DEFAULT;
+
+-- Today + tomorrow partitions. Naming: tel_stream_readings_bronze_YYYY_MM_DD. The ingest worker
+-- ensures current/next-day partitions before each flush, so this block only covers first boot.
+DO $$
+DECLARE
+    v_day   date;
+    v_pname text;
+BEGIN
+    FOR v_day IN SELECT d::date FROM generate_series(current_date, current_date + 1, interval '1 day') AS d LOOP
+        v_pname := format('tel_stream_readings_bronze_%s', to_char(v_day, 'YYYY_MM_DD'));
+        IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = v_pname) THEN
+            EXECUTE format(
+                'CREATE TABLE %I PARTITION OF tel_stream_readings_bronze FOR VALUES FROM (%L) TO (%L)',
+                v_pname, v_day, v_day + 1
+            );
+        END IF;
+    END LOOP;
+END $$;
+
+ALTER TABLE tel_stream_readings_bronze ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+    CREATE POLICY tel_stream_readings_bronze_tenant ON tel_stream_readings_bronze
+        USING (env_id = current_setting('app.env_id', true))
+        WITH CHECK (env_id = current_setting('app.env_id', true));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+COMMENT ON TABLE tel_stream_readings_bronze IS
+  'Telemetry Platform: append-only raw stream frames (live ingestion landing zone), daily partitioned by ts_ingest. Bronze accepts duplicates; dedupe happens at the silver merge. Owning module: Telemetry Platform.';
+
+-- ── silver: conformed readings, deduped on (env_id, channel_id, ts_source) ─────────────────────
+CREATE TABLE IF NOT EXISTS tel_stream_readings (
+    id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id       text NOT NULL,
+    business_id  uuid NOT NULL,
+    channel_id   uuid NOT NULL REFERENCES tel_telemetry_channels(id) ON DELETE CASCADE,
+    channel_name text NOT NULL,
+    ts_source    timestamptz NOT NULL,
+    value        double precision NOT NULL,
+    quality_flag text NOT NULL DEFAULT 'ok',    -- ok | late | out_of_range
+    batch_id     uuid,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (env_id, channel_id, ts_source)      -- the idempotency key: reruns merge to 0 rows
+);
+-- Query path: live tail reads + gold rollup both scan (env, channel, recent ts_source).
+CREATE INDEX IF NOT EXISTS idx_tel_stream_readings_live
+    ON tel_stream_readings (env_id, channel_id, ts_source DESC);
+ALTER TABLE tel_stream_readings ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+    CREATE POLICY tel_stream_readings_tenant ON tel_stream_readings
+        USING (env_id = current_setting('app.env_id', true))
+        WITH CHECK (env_id = current_setting('app.env_id', true));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+COMMENT ON TABLE tel_stream_readings IS
+  'Telemetry Platform: silver conformed stream readings, deduped via UNIQUE (env_id, channel_id, ts_source); quality_flag marks late/out-of-range rows (excluded from gold). Owning module: Telemetry Platform.';
+
+-- ── gold: 1-minute channel aggregates, restatable for late data ─────────────────────────────────
+CREATE TABLE IF NOT EXISTS tel_stream_minute_agg (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id          text NOT NULL,
+    business_id     uuid NOT NULL,
+    channel_id      uuid NOT NULL,
+    channel_name    text NOT NULL,
+    minute_start    timestamptz NOT NULL,
+    n               integer NOT NULL DEFAULT 0,
+    v_min           double precision,
+    v_max           double precision,
+    v_avg           double precision,
+    anomaly_count   integer NOT NULL DEFAULT 0,
+    restated_at     timestamptz,                -- set when late data forced re-aggregation
+    restated_reason text,
+    updated_at      timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (env_id, channel_id, minute_start)
+);
+ALTER TABLE tel_stream_minute_agg ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+    CREATE POLICY tel_stream_minute_agg_tenant ON tel_stream_minute_agg
+        USING (env_id = current_setting('app.env_id', true))
+        WITH CHECK (env_id = current_setting('app.env_id', true));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+COMMENT ON TABLE tel_stream_minute_agg IS
+  'Telemetry Platform: gold 1-minute stream aggregates (min/max/avg/count/anomaly_count), incrementally maintained from a watermark; late data restates affected minutes with restated_at + reason instead of silently mutating history. Owning module: Telemetry Platform.';
+
+-- ── ETL watermarks (incremental high-water marks per job) ───────────────────────────────────────
+CREATE TABLE IF NOT EXISTS tel_etl_watermarks (
+    env_id       text NOT NULL,
+    business_id  uuid NOT NULL,
+    job_name     text NOT NULL,                 -- silver_merge | gold_rollup | live_scoring
+    watermark_ts timestamptz NOT NULL,
+    last_run_id  uuid,
+    updated_at   timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (env_id, job_name)
+);
+ALTER TABLE tel_etl_watermarks ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+    CREATE POLICY tel_etl_watermarks_tenant ON tel_etl_watermarks
+        USING (env_id = current_setting('app.env_id', true))
+        WITH CHECK (env_id = current_setting('app.env_id', true));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+COMMENT ON TABLE tel_etl_watermarks IS
+  'Telemetry Platform: incremental ETL high-water marks per (env, job). Reruns from an unchanged watermark process 0 rows (idempotency). Owning module: Telemetry Platform.';
+
+-- ── pipeline status: the fail-closed mark-refreshed handshake ───────────────────────────────────
+CREATE TABLE IF NOT EXISTS tel_pipeline_status (
+    env_id      text NOT NULL,
+    business_id uuid NOT NULL,
+    surface     text NOT NULL,                  -- stream_ingest | silver | gold
+    status      text NOT NULL DEFAULT 'fresh',  -- fresh | stale | failed
+    as_of_ts    timestamptz NOT NULL DEFAULT now(),
+    reason      text,
+    PRIMARY KEY (env_id, surface)
+);
+ALTER TABLE tel_pipeline_status ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+    CREATE POLICY tel_pipeline_status_tenant ON tel_pipeline_status
+        USING (env_id = current_setting('app.env_id', true))
+        WITH CHECK (env_id = current_setting('app.env_id', true));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+COMMENT ON TABLE tel_pipeline_status IS
+  'Telemetry Platform: per-surface pipeline freshness handshake (fresh|stale|failed + reason). Downstream pages read this and fail closed (STALE banner, frozen charts) instead of rendering stale data as current. Owning module: Telemetry Platform.';
+
+-- ── DQ assertion history ─────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS tel_dq_assertions (
+    id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id         text NOT NULL,
+    business_id    uuid NOT NULL,
+    job_name       text NOT NULL,
+    table_name     text NOT NULL,
+    assertion_name text NOT NULL,               -- freshness | row_count_delta | value_range:<channel>
+    passed         boolean NOT NULL,
+    observed       text,
+    threshold      text,
+    run_ts         timestamptz NOT NULL DEFAULT now()
+);
+-- Query path: the assertion board reads the most recent N per env.
+CREATE INDEX IF NOT EXISTS idx_tel_dq_assertions_recent
+    ON tel_dq_assertions (env_id, business_id, run_ts DESC);
+ALTER TABLE tel_dq_assertions ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+    CREATE POLICY tel_dq_assertions_tenant ON tel_dq_assertions
+        USING (env_id = current_setting('app.env_id', true))
+        WITH CHECK (env_id = current_setting('app.env_id', true));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+COMMENT ON TABLE tel_dq_assertions IS
+  'Telemetry Platform: data-quality assertion results history (freshness, row-count delta, value-range vs channel redlines). A failed assertion flips tel_pipeline_status for the surface. Owning module: Telemetry Platform.';
+
+-- ── seed: the ISS live stream run + curated public Lightstreamer channels ───────────────────────
+-- tel_telemetry_channels FKs to tel_test_runs, so the live stream gets a synthetic run row.
+INSERT INTO tel_test_runs (id, env_id, business_id, run_key, dataset, unit_or_channel, spacecraft, status)
+VALUES ('7e1e57ea-0000-4000-a000-000000000100', 'telemetry-demo', '7e1eb000-0000-4000-a000-000000000001',
+        'iss_live:stream', 'iss_live', 'ISS', 'ISS', 'streaming')
+ON CONFLICT (env_id, business_id, run_key) DO NOTHING;
+
+-- Curated public ISS Lightstreamer items (ISSLIVE adapter). Units per the public telemetry listing;
+-- redlines only where physically defensible (drive the value_range assertions), else NULL.
+INSERT INTO tel_telemetry_channels (id, env_id, business_id, run_id, channel_name, unit, redline_low, redline_high)
+SELECT v.id::uuid, 'telemetry-demo', '7e1eb000-0000-4000-a000-000000000001', r.id, v.channel_name, v.unit, v.lo, v.hi
+FROM (VALUES
+    ('7e1e57ea-0000-4000-a000-000000000101', 'USLAB000058',  'mmHg', 700::float8, 790::float8),  -- Lab cabin pressure
+    ('7e1e57ea-0000-4000-a000-000000000102', 'USLAB000059',  'degC', 15::float8,  32::float8),   -- Lab cabin temperature
+    ('7e1e57ea-0000-4000-a000-000000000103', 'USLAB000062',  'mmHg', 130::float8, 190::float8),  -- Lab ppO2
+    ('7e1e57ea-0000-4000-a000-000000000104', 'USLAB000063',  'mmHg', NULL, NULL),                -- Lab ppN2
+    ('7e1e57ea-0000-4000-a000-000000000105', 'USLAB000064',  'mmHg', 0::float8,   8::float8),    -- Lab ppCO2
+    ('7e1e57ea-0000-4000-a000-000000000106', 'AIRLOCK000049','mmHg', NULL, NULL),                -- Crewlock pressure
+    ('7e1e57ea-0000-4000-a000-000000000107', 'NODE3000005',  'pct',  0::float8, 100::float8),    -- Urine tank qty
+    ('7e1e57ea-0000-4000-a000-000000000108', 'NODE3000008',  'pct',  0::float8, 100::float8),    -- Waste water tank qty
+    ('7e1e57ea-0000-4000-a000-000000000109', 'NODE3000009',  'pct',  0::float8, 100::float8),    -- Clean water tank qty
+    ('7e1e57ea-0000-4000-a000-00000000010a', 'S4000001',     'V',    NULL, NULL),                -- 1A solar array voltage
+    ('7e1e57ea-0000-4000-a000-00000000010b', 'S6000004',     'V',    NULL, NULL),                -- 4B solar array voltage
+    ('7e1e57ea-0000-4000-a000-00000000010c', 'P4000001',     'V',    NULL, NULL)                 -- 2A solar array voltage
+) AS v(id, channel_name, unit, lo, hi)
+JOIN tel_test_runs r
+  ON r.env_id = 'telemetry-demo'
+ AND r.business_id = '7e1eb000-0000-4000-a000-000000000001'
+ AND r.run_key = 'iss_live:stream'
+ON CONFLICT (env_id, business_id, run_id, channel_name) DO NOTHING;
+
+-- ── verification ─────────────────────────────────────────────────────────────────────────────────
+DO $$
+DECLARE n int;
+BEGIN
+    SELECT count(*) INTO n FROM pg_tables
+      WHERE schemaname = 'public'
+        AND tablename IN ('tel_stream_readings_bronze', 'tel_stream_readings', 'tel_stream_minute_agg',
+                          'tel_etl_watermarks', 'tel_pipeline_status', 'tel_dq_assertions')
+        AND rowsecurity = true;
+    IF n <> 6 THEN
+        RAISE EXCEPTION 'telemetry streaming slice migration incomplete: % of 6 tables with RLS', n;
+    END IF;
+    RAISE NOTICE 'telemetry streaming slice ready (6 tables, RLS on)';
+END $$;

--- a/repo-b/src/app/lab/env/[envId]/telemetry/stream/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/telemetry/stream/page.tsx
@@ -1,0 +1,5 @@
+import MissionControlStream from "@/components/telemetry/MissionControlStream";
+
+export default function TelemetryStreamPage() {
+  return <MissionControlStream />;
+}

--- a/repo-b/src/components/telemetry/Copilot.test.tsx
+++ b/repo-b/src/components/telemetry/Copilot.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { DispositionControls } from "./Copilot";
+
+const { recordDisposition } = vi.hoisted(() => ({
+  recordDisposition: vi.fn(async (_id: string, body?: Record<string, unknown>) => ({
+    action_id: "a-1",
+    arm: (body?.arm as string) ?? "assisted",
+    is_override: body?.human_verdict !== "NO_GO",
+    null_reason: null,
+  })),
+}));
+
+vi.mock("@/lib/telemetry/copilot-api", () => ({
+  // DispositionControls only uses recordDisposition; the rest of Copilot.tsx's imports are stubbed.
+  recordDisposition,
+  askCopilot: vi.fn(), explainVerdict: vi.fn(), getGovernance: vi.fn(), draftReport: vi.fn(),
+}));
+
+describe("DispositionControls (Track B review capture — regression for the unresponsive Start button)", () => {
+  beforeEach(() => recordDisposition.mockClear());
+
+  function mount(modelVerdict: string | null = "NO_GO") {
+    return render(
+      <DispositionControls reportId="r-1" modelVerdict={modelVerdict} fireTick={728} evidenceOpened={2} />,
+    );
+  }
+
+  it("Start button is enabled at mount (assisted default) and flips to timing…", () => {
+    mount();
+    const start = screen.getByTestId("disposition-start");
+    expect(start).not.toBeDisabled();
+    fireEvent.click(start);
+    expect(start).toHaveTextContent("timing…");
+    expect(start).toBeDisabled();
+  });
+
+  it("clicking a verdict BEFORE the timer shows a visible error, never a silent no-op", () => {
+    mount();
+    fireEvent.click(screen.getByTestId("disposition-verdict-agree-no-go"));
+    expect(screen.getByText(/Start the timer first/i)).toBeInTheDocument();
+    expect(recordDisposition).not.toHaveBeenCalled();
+  });
+
+  it("assisted flow: start → verdict submits a measured time_to_verdict_ms with the arm + evidence count", async () => {
+    mount();
+    fireEvent.click(screen.getByTestId("disposition-start"));
+    fireEvent.click(screen.getByTestId("disposition-verdict-agree-no-go"));
+    await waitFor(() => expect(recordDisposition).toHaveBeenCalledTimes(1));
+    const body = recordDisposition.mock.calls[0][1]!;
+    expect(body.arm).toBe("assisted");
+    expect(body.human_verdict).toBe("NO_GO");
+    expect(typeof body.time_to_verdict_ms).toBe("number");
+    expect(body.time_to_verdict_ms as number).toBeGreaterThanOrEqual(0);
+    expect(body.evidence_opened).toBe(2);
+    await waitFor(() => expect(screen.getByText(/Recorded \(assisted/)).toBeInTheDocument());
+  });
+
+  it("unassisted arm records evidence_opened=0 even when cards were opened", async () => {
+    mount();
+    fireEvent.click(screen.getByTestId("disposition-arm-unassisted"));
+    fireEvent.click(screen.getByTestId("disposition-start"));
+    fireEvent.click(screen.getByTestId("disposition-verdict-defer"));
+    await waitFor(() => expect(recordDisposition).toHaveBeenCalledTimes(1));
+    const body = recordDisposition.mock.calls[0][1]!;
+    expect(body.arm).toBe("unassisted");
+    expect(body.evidence_opened).toBe(0);
+  });
+
+  it("REVIEW model verdict hides the Agree button (no mis-typed REVIEW submission path)", () => {
+    mount("REVIEW");
+    expect(screen.queryByText(/^Agree/)).toBeNull();
+    expect(screen.getByTestId("disposition-verdict-override-go")).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/Copilot.tsx
+++ b/repo-b/src/components/telemetry/Copilot.tsx
@@ -248,9 +248,28 @@ export function DispositionControls({ reportId, modelVerdict, fireTick, evidence
   const [pairId] = useState<string>(() =>
     (typeof crypto !== "undefined" && crypto.randomUUID ? crypto.randomUUID() : `pair-${Date.now()}`));
 
+  // Robust clock: some agent/browser harnesses break performance.now — fall back to Date.now so the
+  // Start button can never silently dead-end (timing stays measured either way).
+  const nowMs = () =>
+    (typeof performance !== "undefined" && typeof performance.now === "function"
+      ? performance.now() : Date.now());
+
+  const startTimer = () => {
+    try {
+      setErr(null);
+      setStartedAt(nowMs());
+    } catch (e) {
+      setErr(`Could not start the timer: ${String(e)}`);
+    }
+  };
+
   const submit = (human_verdict: "GO" | "NO_GO" | "DEFER") => {
-    if (startedAt == null) return;
-    const time_to_verdict_ms = Math.round(performance.now() - startedAt);
+    if (startedAt == null) {
+      // Visible feedback instead of a silent no-op (the timer keeps TTV measured, never estimated).
+      setErr("Start the timer first — time-to-verdict is measured.");
+      return;
+    }
+    const time_to_verdict_ms = Math.round(nowMs() - startedAt);
     setErr(null);
     recordDisposition(reportId, {
       arm, human_verdict, fire_tick: fireTick, confidence, time_to_verdict_ms,
@@ -259,18 +278,23 @@ export function DispositionControls({ reportId, modelVerdict, fireTick, evidence
   };
 
   const armBtn = (a: "assisted" | "unassisted") => (
-    <button onClick={() => setArm(a)} disabled={!!result}
+    <button type="button" data-testid={`disposition-arm-${a}`} onClick={() => setArm(a)} disabled={!!result}
       style={{ fontFamily: C.mono, fontSize: 11, padding: "5px 11px", borderRadius: 999, cursor: result ? "default" : "pointer",
         color: arm === a ? C.bg : C.dim, background: arm === a ? C.cyan : "transparent",
         border: `1px solid ${arm === a ? C.cyan : C.border}` }}>{a}</button>
   );
   const verdictBtn = (label: string, hv: "GO" | "NO_GO" | "DEFER", col: string) => (
-    <button onClick={() => submit(hv)} disabled={startedAt == null || !!result}
+    <button type="button"
+      data-testid={`disposition-verdict-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "")}`}
+      onClick={() => submit(hv)} disabled={!!result}
       style={{ fontFamily: C.mono, fontSize: 12, fontWeight: 600, padding: "8px 13px", borderRadius: 7,
         color: C.bg, background: col, border: "none",
-        cursor: startedAt == null || result ? "default" : "pointer", opacity: startedAt == null || result ? 0.5 : 1 }}>
+        cursor: result ? "default" : "pointer", opacity: startedAt == null || result ? 0.5 : 1 }}>
       {label}</button>
   );
+  // Agree submits the model's literal verdict, so it only exists for GO/NO_GO; a REVIEW (or unknown)
+  // model verdict has no "agree" target — the reviewer must explicitly choose GO/NO_GO/Defer.
+  const canAgree = modelVerdict === "GO" || modelVerdict === "NO_GO";
 
   return (
     <Panel title="Record your review (operator usefulness A/B)"
@@ -290,7 +314,7 @@ export function DispositionControls({ reportId, modelVerdict, fireTick, evidence
             </span>
           </div>
           <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
-            <button onClick={() => setStartedAt(performance.now())} disabled={startedAt != null}
+            <button type="button" data-testid="disposition-start" onClick={startTimer} disabled={startedAt != null}
               style={{ fontFamily: C.mono, fontSize: 12, fontWeight: 600, color: C.bg, background: startedAt != null ? C.faint : C.green,
                 border: "none", borderRadius: 7, padding: "8px 13px", cursor: startedAt != null ? "default" : "pointer" }}>
               {startedAt != null ? "timing…" : "Start review (timer)"}
@@ -300,14 +324,15 @@ export function DispositionControls({ reportId, modelVerdict, fireTick, evidence
           <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
             <span style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, textTransform: "uppercase", letterSpacing: "0.08em" }}>confidence</span>
             {[1, 2, 3, 4, 5].map((c) => (
-              <button key={c} onClick={() => setConfidence(c)}
+              <button key={c} type="button" data-testid={`disposition-confidence-${c}`}
+                onClick={() => setConfidence(c)}
                 style={{ fontFamily: C.mono, fontSize: 11, width: 26, height: 26, borderRadius: 6, cursor: "pointer",
                   color: confidence === c ? C.bg : C.dim, background: confidence === c ? C.cyan : "transparent",
                   border: `1px solid ${confidence === c ? C.cyan : C.border}` }}>{c}</button>
             ))}
           </div>
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-            {verdictBtn(`Agree (${modelVerdict ?? "model"})`, (modelVerdict as "GO" | "NO_GO") ?? "GO", C.green)}
+            {canAgree && verdictBtn(`Agree (${modelVerdict})`, modelVerdict as "GO" | "NO_GO", C.green)}
             {verdictBtn("Override → GO", "GO", C.cyan)}
             {verdictBtn("Override → NO_GO", "NO_GO", C.amber)}
             {verdictBtn("Defer", "DEFER", C.faint)}

--- a/repo-b/src/components/telemetry/MissionControlStream.tsx
+++ b/repo-b/src/components/telemetry/MissionControlStream.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+// Mission Control — RS Demo live stream page (port of rs_jsx/HotFireMissionControl.jsx onto the
+// real streaming slice). 1 s polling, synchronized recharts strips over the last 120 s ring window,
+// anomaly overlays from live tel_anomaly_events, a measured latency overlay, and a fail-closed
+// STALE banner (charts freeze — no interpolation, no synthetic advancement).
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ComposedChart, Line, ReferenceArea, ReferenceLine, ResponsiveContainer, XAxis, YAxis,
+} from "recharts";
+
+import { getModelPerformance, TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID } from "@/lib/telemetry/api";
+import {
+  deriveLag, useStreamPoll, type StreamChannel, type StreamEvent, type StreamLive,
+} from "@/lib/telemetry/stream";
+import { RS, RS_MONO, RS_SANS, RsChip, RsPanel } from "./rsTokens";
+
+const WINDOW_S = 120;
+const MAX_STRIPS = 4;
+
+function sourceChip(live: StreamLive | null): { label: string; color: string } {
+  if (!live) return { label: "CONNECTING", color: RS.faint };
+  if (live.pipeline.status === "stale") return { label: "STALE", color: RS.red };
+  if (live.pipeline.status === "failed") return { label: "FAILED", color: RS.red };
+  switch (live.source) {
+    case "iss": return { label: "LIVE · ISS", color: RS.green };
+    case "capture": return { label: "CAPTURE (recorded live session)", color: RS.amber };
+    case "adsb": return { label: "ADS-B FALLBACK", color: RS.violet };
+    default: return { label: "DB TAIL", color: RS.dim };
+  }
+}
+
+function activeVerdict(events: StreamEvent[], nowS: number): { text: string; color: string } {
+  const active = events.some((e) => e.end_t >= nowS - 60);
+  return active ? { text: "NO-GO HOLD", color: RS.red } : { text: "GO", color: RS.green };
+}
+
+function ChannelStrip({ ch, events, domain }: {
+  ch: StreamChannel; events: StreamEvent[]; domain: [number, number];
+}) {
+  const data = ch.readings.map((r) => ({ x: Date.parse(r.t), v: r.v }));
+  const chEvents = events.filter((e) => e.channel_name === ch.channel_name);
+  const vals = data.map((d) => d.v);
+  const vMin = vals.length ? Math.min(...vals) : 0;
+  const vMax = vals.length ? Math.max(...vals) : 1;
+  const pad = Math.max((vMax - vMin) * 0.15, Math.abs(vMax) * 0.002, 0.01);
+  return (
+    <div style={{ borderBottom: `1px solid ${RS.line}` }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline",
+        padding: "6px 12px 0" }}>
+        <span style={{ color: RS.dim, fontFamily: RS_SANS, fontSize: 11 }}>
+          {ch.channel_name}{ch.unit ? ` · ${ch.unit}` : ""}
+        </span>
+        <span style={{ color: RS.cyan, fontFamily: RS_MONO, fontSize: 11 }}>
+          {ch.latest ? ch.latest.v.toFixed(2) : "—"} {ch.unit ?? ""}
+        </span>
+      </div>
+      <ResponsiveContainer width="100%" height={96}>
+        <ComposedChart data={data} syncId="rs-stream" margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
+          <XAxis dataKey="x" type="number" domain={domain} hide />
+          <YAxis domain={[vMin - pad, vMax + pad]} width={64}
+            tick={{ fill: RS.faint, fontSize: 9, fontFamily: RS_MONO }}
+            tickFormatter={(v: number) => v.toFixed(1)} axisLine={false} tickLine={false} />
+          {ch.redline_low != null && (
+            <ReferenceLine y={ch.redline_low} stroke={RS.red} strokeOpacity={0.45} strokeDasharray="4 3" />
+          )}
+          {ch.redline_high != null && (
+            <ReferenceLine y={ch.redline_high} stroke={RS.red} strokeOpacity={0.45} strokeDasharray="4 3" />
+          )}
+          {chEvents.map((e, i) => (
+            <ReferenceArea key={i} x1={e.start_t * 1000} x2={e.end_t * 1000}
+              fill={RS.red} fillOpacity={0.1} stroke={RS.red} strokeOpacity={0.3} strokeDasharray="3 3" />
+          ))}
+          <Line dataKey="v" stroke={RS.cyan} dot={false} strokeWidth={1.4}
+            isAnimationActive={false} connectNulls={false} />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export default function MissionControlStream() {
+  const [hold, setHold] = useState(false);
+  const { live, error, clientNowMs } = useStreamPoll(1000, hold);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [champion, setChampion] = useState<string | null>(null);
+  const lagHistory = useRef<number[]>([]);
+
+  useEffect(() => {
+    getModelPerformance(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID)
+      .then((d) => {
+        const champ = (d.models || []).find(
+          (m) => m.model_kind === "anomaly" && (m.model_alias === "champion" || m.promotion_state === "promoted"));
+        if (champ) setChampion(`${champ.model_name} v${champ.model_version} (champion)`);
+      })
+      .catch(() => {});
+  }, []);
+
+  const lag = useMemo(
+    () => (live ? deriveLag(live, clientNowMs) : { ingestLagS: null, clientLagS: null }),
+    [live, clientNowMs]);
+  useEffect(() => {
+    if (lag.ingestLagS != null) {
+      lagHistory.current = [...lagHistory.current.slice(-59), lag.ingestLagS];
+    }
+  }, [lag.ingestLagS]);
+
+  const allNames = useMemo(() => (live?.channels || []).map((c) => c.channel_name), [live]);
+  const shown = useMemo(() => {
+    const wanted = selected.length ? selected : allNames;
+    return (live?.channels || []).filter((c) => wanted.includes(c.channel_name)).slice(0, MAX_STRIPS);
+  }, [live, selected, allNames]);
+
+  const serverMs = live ? Date.parse(live.server_ts) : Date.now();
+  const domain: [number, number] = [serverMs - WINDOW_S * 1000, serverMs];
+  const chip = sourceChip(live);
+  const stale = live != null && live.pipeline.status !== "fresh" && live.pipeline.status !== "unknown";
+  const verdict = live ? activeVerdict(live.events, serverMs / 1000) : { text: "—", color: RS.faint };
+
+  return (
+    <div style={{ minHeight: "100vh", width: "100%", padding: 12, background: RS.bg,
+      fontFamily: RS_SANS, color: RS.text }}>
+      {/* STALE banner — fail closed, full width, charts freeze (data simply stops advancing) */}
+      {stale && (
+        <div style={{ background: `${RS.red}22`, border: `1px solid ${RS.red}`, borderRadius: 6,
+          padding: "10px 14px", marginBottom: 12, fontFamily: RS_MONO, fontSize: 13, color: RS.red }}>
+          {live!.pipeline.status.toUpperCase()} — feed lost {live!.pipeline.as_of_ts ?? "(unknown)"}
+          {live!.pipeline.reason ? ` · ${live!.pipeline.reason}` : ""} · charts frozen, no interpolation
+        </div>
+      )}
+
+      {/* Header */}
+      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 12, padding: "0 4px 12px" }}>
+        <div>
+          <div style={{ color: RS.faint, fontSize: 11, letterSpacing: "0.18em" }}>TELEMETRY LAB</div>
+          <div style={{ fontSize: 13, letterSpacing: "0.14em" }}>MISSION CONTROL · LIVE STREAM</div>
+        </div>
+        <RsChip color={RS.cyan}>run: iss_live:stream</RsChip>
+        <RsChip color={chip.color}>{chip.label}</RsChip>
+        {champion && <RsChip color={RS.violet}>model: {champion}</RsChip>}
+        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 14 }}>
+          <span style={{ color: RS.dim, fontFamily: RS_MONO, fontSize: 11 }}>
+            ingest lag {lag.ingestLagS != null ? `${lag.ingestLagS.toFixed(1)}s` : "—"}
+            {" · "}client lag {lag.clientLagS != null ? `${lag.clientLagS.toFixed(1)}s` : "—"}
+          </span>
+          <span style={{ color: verdict.color, border: `1px solid ${verdict.color}`,
+            background: `${verdict.color}18`, fontFamily: RS_MONO, fontWeight: 700,
+            padding: "4px 12px", borderRadius: 4, fontSize: 13 }}>
+            {verdict.text}
+          </span>
+          <button type="button" onClick={() => setHold((h) => !h)}
+            style={{ fontFamily: RS_MONO, fontSize: 11, padding: "4px 10px", borderRadius: 4,
+              cursor: "pointer", color: hold ? RS.bg : RS.dim,
+              background: hold ? RS.amber : "transparent", border: `1px solid ${RS.line}` }}>
+            {hold ? "Resume" : "Hold"}
+          </button>
+        </div>
+      </div>
+
+      {error && !live && (
+        <RsPanel><div style={{ padding: 16, fontFamily: RS_MONO, fontSize: 12, color: RS.red }}>
+          Could not load the stream: {error}
+        </div></RsPanel>
+      )}
+      {live && live.channels.length === 0 && (
+        <RsPanel><div style={{ padding: 16, fontFamily: RS_MONO, fontSize: 12, color: RS.amber }}>
+          Not available — {live.null_reason ?? "no_stream_data"}. The ingest worker has not landed any
+          frames yet (no synthetic data is rendered in its place).
+        </div></RsPanel>
+      )}
+
+      {live && live.channels.length > 0 && (
+        <div style={{ display: "grid", gap: 12, gridTemplateColumns: "minmax(0,3fr) minmax(280px,1fr)" }}>
+          {/* Left: channel selector ribbon + synced strips */}
+          <RsPanel>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6, padding: "8px 12px",
+              borderBottom: `1px solid ${RS.line}` }}>
+              {allNames.map((name) => {
+                const on = (selected.length ? selected : allNames.slice(0, MAX_STRIPS)).includes(name);
+                return (
+                  <button key={name} type="button"
+                    onClick={() => setSelected((cur) => {
+                      const base = cur.length ? cur : allNames.slice(0, MAX_STRIPS);
+                      return base.includes(name)
+                        ? base.filter((n) => n !== name)
+                        : [...base, name].slice(-MAX_STRIPS);
+                    })}
+                    style={{ fontFamily: RS_MONO, fontSize: 10, padding: "3px 8px", borderRadius: 999,
+                      cursor: "pointer", color: on ? RS.cyan : RS.faint,
+                      border: `1px solid ${on ? RS.cyan + "55" : RS.line}`,
+                      background: on ? `${RS.cyan}14` : "transparent" }}>
+                    {name}
+                  </button>
+                );
+              })}
+            </div>
+            {shown.map((ch) => (
+              <ChannelStrip key={ch.channel_name} ch={ch} events={live.events} domain={domain} />
+            ))}
+            <div style={{ padding: "6px 12px", fontFamily: RS_MONO, fontSize: 10, color: RS.faint }}>
+              window: last {WINDOW_S}s · poll 1s · x-axis synced across strips
+            </div>
+          </RsPanel>
+
+          {/* Right: live events + lag detail */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <RsPanel title="LIVE ANOMALY EVENTS (champion rule)">
+              {live.events.length === 0 ? (
+                <div style={{ padding: 12, fontFamily: RS_MONO, fontSize: 11, color: RS.faint }}>
+                  None recorded — no NO_GO verdicts from the frozen champion on the live window.
+                </div>
+              ) : (
+                <div style={{ padding: 12, display: "flex", flexDirection: "column", gap: 8 }}>
+                  {live.events.slice(0, 8).map((e, i) => (
+                    <div key={i} style={{ background: RS.panelAlt, borderRadius: 4, padding: 8,
+                      fontFamily: RS_MONO, fontSize: 11 }}>
+                      <div style={{ display: "flex", justifyContent: "space-between" }}>
+                        <span style={{ color: RS.red }}>{e.channel_name}</span>
+                        <span style={{ color: RS.faint }}>{e.anomaly_class}</span>
+                      </div>
+                      <div style={{ color: RS.dim }}>
+                        {new Date(e.start_t * 1000).toISOString().slice(11, 19)}
+                        {" → "}
+                        {new Date(e.end_t * 1000).toISOString().slice(11, 19)} UTC
+                        {e.confidence != null ? ` · score ${e.confidence.toFixed(2)}` : ""}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </RsPanel>
+
+            <RsPanel title="LATENCY">
+              <div style={{ padding: 12, fontFamily: RS_MONO, fontSize: 11, color: RS.dim }}>
+                <div>ingest lag (server_ts − newest ts_source): <span style={{ color: RS.cyan }}>
+                  {lag.ingestLagS != null ? `${lag.ingestLagS.toFixed(2)}s` : "—"}</span></div>
+                <div>client lag (now − server_ts): <span style={{ color: RS.cyan }}>
+                  {lag.clientLagS != null ? `${lag.clientLagS.toFixed(2)}s` : "—"}</span>
+                  <span style={{ color: RS.faint }}> (includes client clock skew)</span></div>
+                <div style={{ marginTop: 8, display: "flex", gap: 2, alignItems: "flex-end", height: 28 }}>
+                  {lagHistory.current.slice(-40).map((v, i) => (
+                    <div key={i} style={{ width: 4, background: v > 2 ? RS.amber : RS.teal,
+                      height: Math.min(28, 4 + v * 10) }} />
+                  ))}
+                </div>
+                <div style={{ color: RS.faint, marginTop: 4 }}>ingest-lag history (last 40 polls)</div>
+              </div>
+            </RsPanel>
+
+            <RsPanel title="PIPELINE">
+              <div style={{ padding: 12, fontFamily: RS_MONO, fontSize: 11 }}>
+                {Object.entries(live.pipeline.surfaces).map(([surface, s]) => (
+                  <div key={surface} style={{ display: "flex", justifyContent: "space-between",
+                    padding: "3px 0", color: RS.dim }}>
+                    <span>{surface}</span>
+                    <span style={{ color: s.status === "fresh" ? RS.green : RS.red }}>
+                      {s.status}{s.reason ? ` · ${s.reason}` : ""}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </RsPanel>
+          </div>
+        </div>
+      )}
+
+      {/* Demo-honesty footnote (owner-mandated acceptance gate) */}
+      <div style={{ paddingTop: 12, textAlign: "center", fontSize: 11, color: RS.faint,
+        fontFamily: RS_SANS, lineHeight: 1.6 }}>
+        Live stream source is public ISS telemetry adapted to the RS-style telemetry interface; the
+        production equivalent would be test-stand hot-fire channels. Live channels are normalized to
+        fractional deviation before the frozen champion rule scores them (declared adaptation). No
+        synthetic values are rendered as live or measured; a lost feed shows STALE, never interpolation.
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/telemetry/Monitoring.tsx
+++ b/repo-b/src/components/telemetry/Monitoring.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import {
   getMonitoring, getSummary, type MonitoringResponse, type TelemetrySummary, type ConformalBudget,
+  type StreamBlock,
   TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID,
 } from "@/lib/telemetry/api";
 import { C, Tag, Panel, MetricCard, Loading, ErrorState, EmptyState, PageHeading, DisclosureFooter } from "./primitives";
@@ -56,11 +57,41 @@ export default function Monitoring() {
 
       {mon.conformal_budget && <ConformalBudgetPanel b={mon.conformal_budget} liveRate={rate} />}
 
+      {mon.stream && <StreamHealthPanel s={mon.stream} />}
+
       <Panel style={{ marginTop: 16 }} pad={14}>
         <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, lineHeight: 1.6 }}>{summary.note}</span>
       </Panel>
       <DisclosureFooter />
     </>
+  );
+}
+
+// Stream Health — RS Demo streaming slice summary (renders only when the streaming tables exist and
+// carry a status row). Fail-closed: stale/failed states are shown with their reason, never hidden.
+function StreamHealthPanel({ s }: { s: StreamBlock }) {
+  const col = s.status === "fresh" ? C.green : s.status === "stale" ? C.amber : C.red;
+  return (
+    <Panel title="Stream health (live ingestion)" style={{ marginTop: 16 }}
+      right={<Tag color={col}>{s.status ?? "unknown"}</Tag>}>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12 }}>
+        <MetricCard label="Pipeline status" value={s.status ?? "unknown"} accent={col}
+          sub={s.reason ?? undefined} />
+        <MetricCard label="Last frame at"
+          value={s.last_frame_at ? new Date(s.last_frame_at).toISOString().slice(11, 19) + " UTC" : "—"} />
+        <MetricCard label="Rows / min" value={s.rows_per_min != null ? String(s.rows_per_min) : "—"}
+          accent={C.cyan} />
+        <MetricCard label="Failing assertions (15m)"
+          value={s.failing_assertions != null ? String(s.failing_assertions) : "—"}
+          accent={s.failing_assertions ? C.red : C.green} />
+      </div>
+      <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.6,
+        display: "block", marginTop: 10 }}>
+        Live ISS public-telemetry ingestion (bronze → silver → gold). Detail — per-channel freshness,
+        ingest-lag percentiles, the assertion board — lives on the Mission Control page and
+        /api/telemetry/stream/health.
+      </span>
+    </Panel>
   );
 }
 

--- a/repo-b/src/components/telemetry/TelemetrySidebar.tsx
+++ b/repo-b/src/components/telemetry/TelemetrySidebar.tsx
@@ -7,6 +7,7 @@ import { C } from "./primitives";
 // 5 telemetry sections only (the sole navigation). Icons ported from the Option B reference.
 const NAV: { slug: string; label: string; icon: string }[] = [
   { slug: "", label: "Overview", icon: "M2 9h3v5H2zM7 4h3v10H7zM12 7h3v7h-3z" },
+  { slug: "stream", label: "Mission Control", icon: "M2 12c2-6 10-6 12 0M8 3v3M8 8l3 3" },
   { slug: "replay", label: "Replay", icon: "M4 3l9 6-9 6z" },
   { slug: "copilot", label: "Test Intelligence", icon: "M8 1l2 4 4 1-3 3 1 4-4-2-4 2 1-4-3-3 4-1z" },
   { slug: "governance", label: "AI Governance", icon: "M8 1l6 2v4c0 3.5-2.5 6-6 7-3.5-1-6-3.5-6-7V3z" },

--- a/repo-b/src/components/telemetry/rsTokens.tsx
+++ b/repo-b/src/components/telemetry/rsTokens.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+// RS Demo design language — shared tokens + primitives for the three RS surfaces
+// (Mission Control stream, Model Registry console, Factory/NCR Intelligence), ported from the
+// rs_jsx/ design templates. Existing telemetry pages keep primitives.tsx untouched.
+import React from "react";
+
+export const RS = {
+  bg: "#0A0F16", panel: "#0F1622", panelAlt: "#121B2A", line: "#1D2A3B",
+  text: "#D7E2EC", dim: "#7E93A8", faint: "#54677A",
+  teal: "#4FD1C5", cyan: "#67E8F9", amber: "#F5B452", red: "#F4715F",
+  green: "#6EE7A0", violet: "#A78BFA", blue: "#6CA8F0", gray: "#3D4D60",
+};
+export const RS_MONO = "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
+export const RS_SANS = "Inter, 'Helvetica Neue', Arial, sans-serif";
+
+export function RsPanel({ title, right, children, style }: {
+  title?: string; right?: React.ReactNode; children: React.ReactNode; style?: React.CSSProperties;
+}) {
+  return (
+    <div style={{ background: RS.panel, border: `1px solid ${RS.line}`, borderRadius: 6,
+      overflow: "hidden", display: "flex", flexDirection: "column", ...style }}>
+      {title && (
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between",
+          padding: "8px 12px", borderBottom: `1px solid ${RS.line}` }}>
+          <span style={{ color: RS.dim, fontFamily: RS_SANS, fontSize: 11, letterSpacing: "0.12em" }}>
+            {title}
+          </span>
+          {right}
+        </div>
+      )}
+      <div style={{ flex: 1, minHeight: 0 }}>{children}</div>
+    </div>
+  );
+}
+
+export function RsChip({ color, children }: { color: string; children: React.ReactNode }) {
+  return (
+    <span style={{ color, border: `1px solid ${color}55`, background: `${color}14`,
+      fontFamily: RS_MONO, fontSize: 11, padding: "2px 8px", borderRadius: 4 }}>
+      {children}
+    </span>
+  );
+}
+
+export function RsKpi({ label, value, sub, color }: {
+  label: string; value: string; sub?: string; color?: string;
+}) {
+  return (
+    <div style={{ background: RS.panel, border: `1px solid ${RS.line}`, borderRadius: 6,
+      padding: "10px 12px", flex: 1 }}>
+      <div style={{ color: RS.faint, fontSize: 11, marginBottom: 2, fontFamily: RS_SANS }}>{label}</div>
+      <div style={{ fontFamily: RS_MONO, fontSize: 20, color: color || RS.text }}>{value}</div>
+      {sub && <div style={{ color: RS.dim, fontSize: 10, fontFamily: RS_SANS }}>{sub}</div>}
+    </div>
+  );
+}

--- a/repo-b/src/lib/telemetry/api.ts
+++ b/repo-b/src/lib/telemetry/api.ts
@@ -56,6 +56,15 @@ export interface ConformalBudget {
   status: string | null;   // within | approaching | over (diagnostic only)
 }
 
+export interface StreamBlock {
+  status: string | null;        // fresh | stale | failed | unknown
+  as_of_ts: string | null;
+  reason: string | null;
+  last_frame_at: string | null;
+  rows_per_min: number | null;
+  failing_assertions: number | null;
+}
+
 export interface MonitoringResponse {
   rolling_anomaly_rate: number | null;
   prediction_count: number;
@@ -66,6 +75,7 @@ export interface MonitoringResponse {
   psi: number | null;
   window_label: string;
   conformal_budget?: ConformalBudget | null;
+  stream?: StreamBlock | null;
   null_reason: string | null;
 }
 

--- a/repo-b/src/lib/telemetry/stream.ts
+++ b/repo-b/src/lib/telemetry/stream.ts
@@ -1,0 +1,134 @@
+"use client";
+
+// RS Demo streaming slice — typed fetchers + the 1 s poll hook for Mission Control.
+// Polling (not SSE) per the slice plan; backoff on error; client clock captured per tick so the
+// latency overlay can show ingest lag (server_ts - max ts_source) and client lag separately.
+import { useEffect, useRef, useState } from "react";
+
+import { apiFetch } from "@/lib/api";
+import { TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID } from "./api";
+
+export interface StreamReading { t: string; v: number }
+
+export interface StreamChannel {
+  channel_name: string;
+  unit: string | null;
+  redline_low: number | null;
+  redline_high: number | null;
+  readings: StreamReading[];
+  latest: StreamReading | null;
+}
+
+export interface StreamEvent {
+  channel_name: string;
+  start_t: number;          // epoch seconds
+  end_t: number;
+  anomaly_class: string;
+  confidence: number | null;
+}
+
+export interface StreamPipeline {
+  status: string;           // fresh | stale | failed | unknown
+  as_of_ts: string | null;
+  reason: string | null;
+  surfaces: Record<string, { status: string; as_of_ts: string; reason: string | null }>;
+}
+
+export interface StreamLive {
+  server_ts: string;
+  source: string;           // capture | iss | adsb | db_tail
+  pipeline: StreamPipeline;
+  channels: StreamChannel[];
+  events: StreamEvent[];
+  null_reason: string | null;
+}
+
+export interface StreamAssertion {
+  job_name: string; table_name: string; assertion_name: string;
+  passed: boolean; observed: string | null; threshold: string | null; run_ts: string;
+}
+
+export interface StreamHealth {
+  server_ts: string;
+  freshness: { channel_name: string; last_ts: string; age_s: number; rows: number }[];
+  ingest_lag_p50_s: number | null;
+  ingest_lag_p95_s: number | null;
+  ingest_lag_sample_n: number;
+  rows_per_min: number;
+  assertions: StreamAssertion[];
+  pipeline_status: { surface: string; status: string; as_of_ts: string; reason: string | null }[];
+  watermarks: { job_name: string; watermark_ts: string; age_s: number }[];
+  null_reason: string | null;
+}
+
+export const getStreamLive = (channels?: string[]) =>
+  apiFetch<StreamLive>("/api/telemetry/stream/live", {
+    params: {
+      env_id: TELEMETRY_DEMO_ENV_ID,
+      business_id: TELEMETRY_DEMO_BUSINESS_ID,
+      ...(channels && channels.length ? { channels: channels.join(",") } : {}),
+    },
+  });
+
+export const getStreamHealth = () =>
+  apiFetch<StreamHealth>("/api/telemetry/stream/health", {
+    params: { env_id: TELEMETRY_DEMO_ENV_ID, business_id: TELEMETRY_DEMO_BUSINESS_ID },
+  });
+
+/** Pure derivation for the latency overlay (unit-testable). */
+export function deriveLag(live: StreamLive, clientNowMs: number): {
+  ingestLagS: number | null; clientLagS: number | null;
+} {
+  const serverMs = Date.parse(live.server_ts);
+  let newestSourceMs: number | null = null;
+  for (const ch of live.channels) {
+    if (ch.latest) {
+      const t = Date.parse(ch.latest.t);
+      if (newestSourceMs === null || t > newestSourceMs) newestSourceMs = t;
+    }
+  }
+  return {
+    ingestLagS: newestSourceMs !== null && Number.isFinite(serverMs)
+      ? Math.max(0, (serverMs - newestSourceMs) / 1000) : null,
+    clientLagS: Number.isFinite(serverMs) ? Math.max(0, (clientNowMs - serverMs) / 1000) : null,
+  };
+}
+
+/** 1 s poll hook (FundImpactTab setInterval precedent) with backoff-on-error and hold support. */
+export function useStreamPoll(intervalMs = 1000, hold = false) {
+  const [live, setLive] = useState<StreamLive | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [clientNowMs, setClientNowMs] = useState<number>(Date.now());
+  const failures = useRef(0);
+
+  useEffect(() => {
+    if (hold) return;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const tick = () => {
+      getStreamLive()
+        .then((d) => {
+          if (stopped) return;
+          failures.current = 0;
+          setLive(d);
+          setError(null);
+          setClientNowMs(Date.now());
+        })
+        .catch((e) => {
+          if (stopped) return;
+          failures.current += 1;
+          setError(String(e));
+        })
+        .finally(() => {
+          if (stopped) return;
+          const backoff = Math.min(failures.current, 5) * 1000;
+          timer = setTimeout(tick, intervalMs + backoff);
+        });
+    };
+    tick();
+    return () => { stopped = true; clearTimeout(timer); };
+  }, [intervalMs, hold]);
+
+  return { live, error, clientNowMs };
+}

--- a/scripts/record_iss_capture.py
+++ b/scripts/record_iss_capture.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Record a real session of public ISS Lightstreamer telemetry into a replayable capture fixture.
+
+The CaptureAdapter (backend/app/services/telemetry_stream_ingest.py) replays this fixture in CI and
+offline dev so nothing ever depends on the live feed. Frames are stored with offsets relative to the
+recording start; replay re-bases them onto the current wall clock.
+
+ts semantics: `ts_offset_s` is the RECEIVE time offset (wall clock at the recorder when the update
+arrived). The feed's raw `TimeStamp` field (GMT decimal-hours format) is preserved per frame in
+`raw` for provenance/calibration but is not used as the replay clock.
+
+Usage:
+    pip install lightstreamer-client-lib
+    python scripts/record_iss_capture.py --duration 180 \
+        --out backend/app/data/telemetry/iss_capture.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import threading
+import time
+from pathlib import Path
+
+from lightstreamer.client import LightstreamerClient, Subscription
+
+LS_SERVER = "https://push.lightstreamer.com"
+LS_ADAPTER_SET = "ISSLIVE"
+
+# Curated channel set — must match the 10015 migration seed (tel_telemetry_channels).
+CHANNELS = [
+    "USLAB000058",   # Lab cabin pressure (mmHg)
+    "USLAB000059",   # Lab cabin temperature (degC)
+    "USLAB000062",   # Lab ppO2 (mmHg)
+    "USLAB000063",   # Lab ppN2 (mmHg)
+    "USLAB000064",   # Lab ppCO2 (mmHg)
+    "AIRLOCK000049", # Crewlock pressure (mmHg)
+    "NODE3000005",   # Urine tank qty (%)
+    "NODE3000008",   # Waste water tank qty (%)
+    "NODE3000009",   # Clean water tank qty (%)
+    "S4000001",      # 1A solar array voltage (V)
+    "S6000004",      # 4B solar array voltage (V)
+    "P4000001",      # 2A solar array voltage (V)
+]
+FIELDS = ["TimeStamp", "Value", "Status.Class", "Status.Indicator"]
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.t0 = time.time()
+        self.frames: list[dict] = []
+        self.lock = threading.Lock()
+        self.status = "connecting"
+
+    def on_update(self, update) -> None:  # SubscriptionListener.onItemUpdate
+        try:
+            raw_value = update.getValue("Value")
+            value = float(raw_value) if raw_value not in (None, "") else None
+        except (TypeError, ValueError):
+            value = None
+        frame = {
+            "channel_key": update.getItemName(),
+            "ts_offset_s": round(time.time() - self.t0, 3),
+            "value": value,
+            "raw": {
+                "TimeStamp": update.getValue("TimeStamp"),
+                "Status.Class": update.getValue("Status.Class"),
+                "Status.Indicator": update.getValue("Status.Indicator"),
+            },
+        }
+        with self.lock:
+            self.frames.append(frame)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--duration", type=int, default=180, help="seconds to record")
+    ap.add_argument("--out", default="backend/app/data/telemetry/iss_capture.json")
+    args = ap.parse_args()
+
+    rec = _Recorder()
+    client = LightstreamerClient(LS_SERVER, LS_ADAPTER_SET)
+    sub = Subscription(mode="MERGE", items=CHANNELS, fields=FIELDS)
+
+    class _SubListener:
+        def onItemUpdate(self, update):  # noqa: N802 (lightstreamer API casing)
+            rec.on_update(update)
+        def __getattr__(self, _name):    # absorb the other listener callbacks
+            return lambda *a, **k: None
+
+    class _ClientListener:
+        def onStatusChange(self, status):  # noqa: N802
+            rec.status = status
+            print(f"[recorder] client status: {status}", flush=True)
+        def __getattr__(self, _name):
+            return lambda *a, **k: None
+
+    sub.addListener(_SubListener())
+    client.addListener(_ClientListener())
+    client.subscribe(sub)
+    client.connect()
+
+    print(f"[recorder] recording {len(CHANNELS)} channels for {args.duration}s …", flush=True)
+    deadline = time.time() + args.duration
+    while time.time() < deadline:
+        time.sleep(5)
+        with rec.lock:
+            n = len(rec.frames)
+        print(f"[recorder] t+{int(time.time() - rec.t0)}s frames={n} status={rec.status}", flush=True)
+
+    client.disconnect()
+    with rec.lock:
+        frames = sorted(rec.frames, key=lambda f: f["ts_offset_s"])
+
+    per_chan: dict[str, int] = {}
+    for f in frames:
+        per_chan[f["channel_key"]] = per_chan.get(f["channel_key"], 0) + 1
+
+    fixture = {
+        "source": "iss_lightstreamer_public",
+        "server": LS_SERVER,
+        "adapter_set": LS_ADAPTER_SET,
+        "recorded_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(rec.t0)),
+        "duration_s": args.duration,
+        "channels": CHANNELS,
+        "frames_per_channel": per_chan,
+        "note": "Real recorded public ISS telemetry frames. ts_offset_s = receive-time offset from "
+                "recording start; replay re-bases onto the current clock. Raw feed TimeStamp kept "
+                "per frame for provenance.",
+        "frames": frames,
+    }
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(fixture, indent=1), encoding="utf-8")
+    print(f"[recorder] wrote {len(frames)} frames across {len(per_chan)} channels -> {out}", flush=True)
+    if not frames:
+        print("[recorder] WARNING: zero frames recorded — feed unreachable or channel set wrong", flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repo_guardrails.baseline.json
+++ b/scripts/repo_guardrails.baseline.json
@@ -46,6 +46,7 @@
   ],
   "direct_db_route_files": [
     "repo-b/src/app/api/lab/env-context/[envId]/route.ts",
+    "repo-b/src/app/api/public/ai-roi-lead/route.ts",
     "repo-b/src/app/api/re/v2/ai-audit/accuracy-stats/route.ts",
     "repo-b/src/app/api/re/v2/ai-audit/route.ts",
     "repo-b/src/app/api/re/v2/approvals/route.ts",

--- a/scripts/rs_stream_drill.sh
+++ b/scripts/rs_stream_drill.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# RS streaming-slice local E2E drill (throwaway postgres; never touches prod).
+# Receipts land in drill_out/ (worktree-relative so Windows python can read them).
+set -e
+cd "$(dirname "$0")/.."
+OUT="drill_out"
+BIZ="7e1eb000-0000-4000-a000-000000000001"
+
+echo "── 1. throwaway postgres ──"
+docker rm -f rs_drill >/dev/null 2>&1 || true
+docker run -d --name rs_drill -e POSTGRES_PASSWORD=pg -p 5433:5432 postgres:16-alpine >/dev/null
+for i in $(seq 1 30); do docker exec rs_drill pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done
+echo "postgres ready"
+
+echo "── 2. apply 10006 + 10008 + 10015 ──"
+for f in 10006_telemetry_serving 10008_telemetry_backfill_metadata 10015_telemetry_streaming_slice; do
+  docker exec -i rs_drill psql -U postgres -v ON_ERROR_STOP=1 -q < "repo-b/db/schema/${f}.sql" >/dev/null
+  echo "  applied ${f}"
+done
+
+echo "── 3. seed business + champion ──"
+docker exec -i rs_drill psql -U postgres -v ON_ERROR_STOP=1 -q <<SQL
+CREATE TABLE IF NOT EXISTS business (business_id uuid PRIMARY KEY, tenant_id uuid NOT NULL);
+INSERT INTO business VALUES ('$BIZ', gen_random_uuid()) ON CONFLICT DO NOTHING;
+INSERT INTO tel_model_runs (env_id, business_id, model_name, model_kind, model_version, model_alias,
+  mlflow_run_id, metrics, gate, promotion_state)
+VALUES ('telemetry-demo', '$BIZ', 'tel_anomaly_detector', 'anomaly', '1', 'champion',
+  '4a48cb6af8714609b9581d66e904544c', '{"f1":0.6387}', '{"decision":"promoted"}', 'promoted')
+ON CONFLICT DO NOTHING;
+SQL
+echo "seeded"
+
+echo "── 4. boot uvicorn (capture mode, 15s ETL) ──"
+( cd backend && \
+  DATABASE_URL="postgresql://postgres:pg@localhost:5433/postgres" \
+  TELEMETRY_STREAM_ENABLED=1 TELEMETRY_STREAM_SOURCE=capture TELEMETRY_ETL_INTERVAL_SECONDS=15 \
+  TELEMETRY_STREAM_ADMIN_KEY=drill123 WINSTON_OPERATOR_ENABLED=0 \
+  python -m uvicorn app.main:app --port 8001 --log-level warning > "../$OUT/uvicorn.log" 2>&1 & )
+for i in $(seq 1 45); do
+  curl -s -o /dev/null --max-time 2 "http://localhost:8001/api/telemetry/health" && { echo "uvicorn up after ~$((i*2))s"; break; }
+  sleep 2
+done
+sleep 16   # let capture frames land + at least one ETL cycle
+
+echo "── 5. live payload ──"
+curl -s "http://localhost:8001/api/telemetry/stream/live?env_id=telemetry-demo&business_id=$BIZ" > "$OUT/live1.json"
+python - "$OUT/live1.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+print("source:", d["source"], "| pipeline:", d["pipeline"]["status"])
+print("channels:", len(d["channels"]), "| total readings:", sum(len(c["readings"]) for c in d["channels"]))
+print("sample:", [(c["channel_name"], round(c["latest"]["v"], 2) if c["latest"] else None) for c in d["channels"][:4]])
+PY
+
+echo "── 6. health + monitoring after an ETL cycle ──"
+sleep 10
+curl -s "http://localhost:8001/api/telemetry/stream/health?env_id=telemetry-demo&business_id=$BIZ" > "$OUT/health1.json"
+python - "$OUT/health1.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+print("freshness channels:", len(d["freshness"]), "| rows/min:", d["rows_per_min"])
+print("ingest lag p50:", d["ingest_lag_p50_s"], "s | p95:", d["ingest_lag_p95_s"], "s")
+print("assertions:", [(a["assertion_name"], a["passed"]) for a in d["assertions"][:4]])
+print("pipeline:", [(s["surface"], s["status"]) for s in d["pipeline_status"]])
+print("watermarks:", [w["job_name"] for w in d["watermarks"]])
+PY
+curl -s "http://localhost:8001/api/telemetry/monitoring?env_id=telemetry-demo&business_id=$BIZ" > "$OUT/mon1.json"
+python - "$OUT/mon1.json" <<'PY'
+import json, sys
+print("monitoring.stream:", json.load(open(sys.argv[1])).get("stream"))
+PY
+
+echo "── 7. EXPLAIN partition-pruning exhibit ──"
+docker exec -i rs_drill psql -U postgres -c "EXPLAIN (ANALYZE, BUFFERS) SELECT count(*) FROM tel_stream_readings_bronze WHERE ts_ingest >= current_date AND ts_ingest < current_date + 1;" > "$OUT/explain_pruned.txt"
+docker exec -i rs_drill psql -U postgres -c "EXPLAIN (ANALYZE, BUFFERS) SELECT count(*) FROM tel_stream_readings_bronze;" > "$OUT/explain_full.txt"
+grep -E "Scan|Aggregate|Execution Time" "$OUT/explain_pruned.txt" | head -6
+
+echo "── 8. STALE drill: starve the feed (adsb fallback w/o network luck), wait >60s ──"
+curl -s -X POST "http://localhost:8001/api/telemetry/stream/source" -H "Content-Type: application/json" -H "x-stream-admin-key: drill123" -d '{"source":"adsb"}'
+echo ""
+sleep 78
+curl -s "http://localhost:8001/api/telemetry/stream/live?env_id=telemetry-demo&business_id=$BIZ" > "$OUT/live_stale.json"
+python - "$OUT/live_stale.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+print("AFTER STARVATION -> pipeline:", d["pipeline"]["status"], "| reason:", d["pipeline"]["reason"])
+PY
+
+echo "── 9. recovery: back to capture ──"
+curl -s -X POST "http://localhost:8001/api/telemetry/stream/source" -H "Content-Type: application/json" -H "x-stream-admin-key: drill123" -d '{"source":"capture"}'
+echo ""
+sleep 10
+curl -s "http://localhost:8001/api/telemetry/stream/live?env_id=telemetry-demo&business_id=$BIZ" > "$OUT/live_recovered.json"
+python - "$OUT/live_recovered.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+print("AFTER RECOVERY -> pipeline:", d["pipeline"]["status"], "| source:", d["source"])
+PY
+
+echo "── teardown ──"
+powershell.exe -NoProfile -Command "Get-CimInstance Win32_Process -Filter \"Name='python.exe'\" | Where-Object { \$_.CommandLine -match 'Python314.*uvicorn.*8001' } | ForEach-Object { Stop-Process -Id \$_.ProcessId -Force }" 2>/dev/null || true
+docker rm -f rs_drill >/dev/null
+echo "DRILL COMPLETE"

--- a/scripts/rs_stream_stale_drill.py
+++ b/scripts/rs_stream_stale_drill.py
@@ -1,0 +1,87 @@
+"""Targeted STALE drill: run the REAL StreamWorker (production code, no mocks) against a throwaway
+Postgres, let capture frames flow, then simulate total feed loss (adapter stopped + restart disabled)
+and verify the watchdog flips tel_pipeline_status to 'stale' with a reason, then recovers to 'fresh'
+when frames resume. This is the live fail-closed proof for the PR-1 exit gate."""
+import asyncio
+import os
+import sys
+from datetime import datetime, timezone
+
+os.environ.setdefault("DATABASE_URL", "postgresql://postgres:pg@localhost:5433/postgres")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+from app.services import telemetry_stream_ingest as ingest  # noqa: E402
+
+BIZ = "7e1eb000-0000-4000-a000-000000000001"
+
+
+def read_status() -> dict | None:
+    from app.db import get_cursor
+    with get_cursor() as cur:
+        cur.execute("SELECT status, reason, as_of_ts FROM tel_pipeline_status "
+                    "WHERE env_id='telemetry-demo' AND surface='stream_ingest'")
+        return cur.fetchone()
+
+
+async def main() -> int:
+    # Accelerate the drill: 5s flush cadence is plenty; watchdog thresholds stay PRODUCTION values.
+    worker = ingest.StreamWorker(env_id="telemetry-demo", business_id=BIZ, source="capture",
+                                 flush_interval_s=2.0)
+    task = asyncio.create_task(worker.run())
+
+    await asyncio.sleep(10)
+    st = await asyncio.to_thread(read_status)
+    print(f"[t+10s] frames flowing -> status={st['status']}", flush=True)
+    assert st and st["status"] == "fresh", "expected fresh while capture flows"
+
+    # ── total feed loss: stop the adapter and disable the restart path ──
+    print("[drill] stopping adapter + disabling restart (simulated feed loss)", flush=True)
+    worker._adapter.stop()
+
+    class _DeadAdapter:
+        def start(self, emit):  # restart attempts produce nothing
+            pass
+        def stop(self):
+            pass
+
+    worker._adapter = _DeadAdapter()
+
+    lost_at = datetime.now(timezone.utc)
+    for i in range(20):
+        await asyncio.sleep(5)
+        st = await asyncio.to_thread(read_status)
+        if st and st["status"] == "stale":
+            secs = (datetime.now(timezone.utc) - lost_at).total_seconds()
+            print(f"[t+{int(secs)}s after loss] STALE confirmed -> reason: {st['reason']}", flush=True)
+            break
+    else:
+        print("FAIL: status never flipped to stale", flush=True)
+        return 1
+
+    # ── recovery: frames resume ──
+    print("[drill] restarting capture adapter (recovery)", flush=True)
+    worker._adapter = ingest.CaptureAdapter(worker.channels or None)
+    worker._adapter.start(worker._emit)
+    for i in range(10):
+        await asyncio.sleep(3)
+        st = await asyncio.to_thread(read_status)
+        if st and st["status"] == "fresh":
+            print(f"[recovery] status back to fresh after ~{(i + 1) * 3}s", flush=True)
+            break
+    else:
+        print("FAIL: status never recovered to fresh", flush=True)
+        return 1
+
+    await worker.stop()
+    task.cancel()
+    try:
+        await task
+    except BaseException:
+        pass
+    print("STALE DRILL PASS: fresh -> stale (>60s silence, reason recorded) -> fresh on recovery")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
## What & why
**PR 1 of the RS Demo mega-session** (ADO: Feature 513 / Story 514 / bugfix Task 517 under Epic E9). Live public-data streaming into the existing telemetry platform: source adapters → asyncio ingest worker → daily-partitioned bronze → incremental idempotent silver/gold ETL with DQ assertions + fail-closed pipeline status → live scoring through the **frozen** champion → Mission Control live page + Stream Health monitoring. Covers demo-checklist items 1.1, 1.2, 1.5, 2.1, 2.4.

**Source hierarchy (strict):** CaptureAdapter = the required proof path (CI + demo floor, replays a **real 3-minute recording of the public ISS Lightstreamer feed** — 177 frames, 12 channels, checked in); ISS live = enhancement; OpenSky ADS-B = labeled fallback only.

## E2E drill receipts (local throwaway Postgres; prod untouched)
- **Capture mode end-to-end:** 12 channels flowing, real ISS values (cabin pressure 750.0 mmHg…), pipeline `fresh`, all 3 watermarks advancing, 46 rows/min.
- **Latency budget met:** ingest lag **p50 1.11s / p95 1.51s** (< 2s).
- **EXPLAIN partition pruning** (checklist 1.7): date-filtered count scanned **only** `tel_stream_readings_bronze_2026_06_10` (bitmap index scan, 0.2ms) vs the full-table Append plan.
- **STALE drill (fail closed):** real StreamWorker + watchdog — `fresh` → 15 logged restart attempts during silence → **`stale` at +65s with reason** ("no frames since <ts>") → `fresh` 3s after frames resume. No interpolation anywhere.
- **Assertion honesty proven by accident:** my seeded mmHg redlines for USLAB000062/63/64 were wrong (live values are unitless 1.0/5.0) — the `value_range` assertion caught it and flipped the surface to `failed`. Seed corrected to NULL units/redlines (assertions only fire on verified semantics).
- **OpenSky fallback streamed real ADS-B frames** during the drill (4 channels, 2 aircraft) — the demo-day switch works via `POST /stream/source` (fail-closed admin key; unset = always 403).
- Drill tools checked in: `scripts/rs_stream_drill.sh`, `scripts/rs_stream_stale_drill.py`.

## Changes
- **Migration `10015`** (6 tables): daily-partitioned bronze (480 precedent; PK includes partition key; DEFAULT + day partitions; worker ensures days per flush), silver with `UNIQUE (env_id, channel_id, ts_source)` dedupe + `quality_flag`, gold minute aggregates with `restated_at` restatement, watermarks, pipeline status, DQ assertions. RLS + tenant policy + COMMENT + self-verifying DO-block on all 6. Seeds the `iss_live:stream` run + 12 curated public ISS channels.
- **Ingest worker** (`telemetry_stream_ingest.py`): adapter protocol (capture/iss/adsb), ring buffer (120s), 2s `executemany` micro-batches, watchdog (>30s restart, >60s stale), backpressure downsample guard. Started from the lifespan (operator-sweep pattern), gated on `TELEMETRY_STREAM_ENABLED` (default **off**) — prod behavior unchanged until enabled.
- **ETL** (`telemetry_stream_etl.py`): watermark silver merge (reruns = 0 rows, bit-identical gold), late-data flag + targeted minute restatement, fail-closed assertions, **live scoring through the frozen `score_window`** (values normalized to fractional deviation — declared adaptation; `MAD_K`/`GLOBAL_TRAIN_SCALE`/`_verdict_for` untouched, diff-checked), and the platform's **first backend writer for `tel_anomaly_events`** (30s coalescing).
- **Routes:** `GET /stream/live` (ring buffer + silver tail, `server_ts` latency overlay, status rides the payload), `GET /stream/health`, `POST /stream/source` (admin-key gated); `/monitoring` gains an additive `stream` block (own cursor — cannot abort the main query).
- **Frontend:** Mission Control page (port of `rs_jsx/HotFireMissionControl.jsx` on the shared `rsTokens` design system): 1s poll with backoff, synced recharts strips, live anomaly overlays, measured ingest/client lag + history, STALE banner freezes charts, channel selector, **demo-honesty footnote** ("public ISS telemetry adapted to RS-style surfaces… no synthetic values rendered as live"). Sidebar "Mission Control" tab; Monitoring "Stream Health" panel.
- **Track B bugfix (Task 517):** DispositionControls — `type="button"` + testids, `nowMs()` fallback, visible "start the timer first" error instead of a silent no-op, Agree hidden for REVIEW verdicts. 5-test vitest regression.

## Tests / verification
- **18 new backend tests** (capture-only; CI never touches the live feed): idempotency, dedupe, late-restatement, stale watchdog, out-of-range exclusion + assertion flip, capture determinism, anomaly-writer insert+coalesce, frozen-score hook (asserts constants unchanged), route shapes, fail-closed source switch.
- Full backend pytest: **3414 passed**; 13 failures are pre-existing local/main debt (REPE/eval/operator files — none in this diff; one reproduced on pre-branch code). repo-b: tsc clean for telemetry (lone pre-existing `repe/assets` error), eslint clean on all changed files, **747 unit tests** (5 pre-existing REPE fund-page failures untouched by this diff), Copilot regression 5/5.
- Frozen-surface guard: diff shows zero changes to `_verdict_for`, `score_window`, champion constants, aliases, auth/proxy.

## Deploy notes (NOT done here)
Backend deploy + prod migration are approval-gated (Railway CLI needs `railway login`; set `TELEMETRY_STREAM_ENABLED=1`, `TELEMETRY_STREAM_SOURCE=capture` or `iss`, `TELEMETRY_STREAM_ADMIN_KEY`). Until then the Mission Control page fails closed against prod ("Not available — no_stream_data"). The Vercel preview shows the page shell + honest empty state (its API proxy targets the prod backend, which has no worker yet) — the capture-mode proof is the local drill above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)