### PR TITLE
telemetry(rs-registry): Model Registry & Promotion Control console — display-only (PR 2/3)

### DIFF
--- a/backend/app/routes/telemetry.py
+++ b/backend/app/routes/telemetry.py
@@ -120,6 +120,19 @@ def fused_vector_info(env_id: str = Query(...), business_id: UUID = Query(...)):
         raise _to_http(exc)
 
 
+# ── RS Demo: Model Registry console (DISPLAY-ONLY — no mutation routes exist) ──
+@router.get("/registry")
+def registry(env_id: str = Query(...), business_id: UUID = Query(...)):
+    """Registry console read: all tel_model_runs rows (full metrics/gate jsonb incl. the Track A
+    honest_gate), real PSI drift history, derived lifecycle timeline. Promotion is an alias update via
+    the governed Databricks flow — this API has no POST/PUT/DELETE on purpose."""
+    from app.services import telemetry_registry as registry_svc
+    try:
+        return registry_svc.registry_console(env_id=env_id, business_id=business_id)
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
 # ── RS Demo: live streaming slice ──────────────────────────────────────────────
 @router.get("/stream/live")
 def stream_live(env_id: str = Query(...), business_id: UUID = Query(...),

--- a/backend/app/services/telemetry_registry.py
+++ b/backend/app/services/telemetry_registry.py
@@ -1,0 +1,73 @@
+"""Model Registry & Promotion Control console (RS Demo PR 2) — DISPLAY-ONLY serving read.
+
+One payload for the registry page: every tel_model_runs row (champion + challengers, full metrics/gate
+jsonb including the Track A honest_gate / affiliation / conformal keys), real PSI drift history from
+tel_drift_metrics, and a lifecycle timeline derived from the rows themselves (created_at +
+promotion_state + gate.decision). There are NO mutation routes — promotion is an alias update performed
+through the governed Databricks flow (notebooks/promote_models.py), never from this console. Display-only
+is enforced by API absence, not just disabled buttons.
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.db import get_cursor
+from app.services.reporting_common import resolve_tenant_id
+
+
+def _lifecycle_events(models: list[dict]) -> list[dict]:
+    """Derive the registry timeline from real rows — never invented entries."""
+    events: list[dict] = []
+    for m in models:
+        ts = m.get("created_at")
+        gate = m.get("gate") or {}
+        name_v = f"{m['model_name']} v{m.get('model_version') or '?'}"
+        if m.get("promotion_state") == "promoted":
+            over = gate.get("selected_over")
+            text = f"{name_v} promoted to champion" + (f" · selected over {over}" if over else "")
+        else:
+            decision = gate.get("decision") or m.get("promotion_state") or "evaluated"
+            text = f"{name_v} registered · {decision}"
+        events.append({"ts": ts, "text": text, "model_kind": m.get("model_kind")})
+    events.sort(key=lambda e: (e["ts"] is None, e["ts"]))
+    return events
+
+
+def registry_console(*, env_id: str, business_id: UUID) -> dict:
+    with get_cursor() as cur:
+        resolve_tenant_id(cur, business_id)
+        cur.execute(
+            """SELECT model_name, model_kind, model_version, model_alias, mlflow_run_id,
+                      experiment_id, metrics, gate, promotion_state, created_at
+               FROM tel_model_runs
+               WHERE env_id = %s AND business_id = %s
+               ORDER BY model_kind, created_at""",
+            (env_id, str(business_id)))
+        models = [dict(r) for r in cur.fetchall()]
+
+        cur.execute(
+            """SELECT model_name, metric_value, window_label, computed_at
+               FROM tel_drift_metrics
+               WHERE env_id = %s AND business_id = %s AND metric_name = 'psi'
+               ORDER BY model_name, computed_at""",
+            (env_id, str(business_id)))
+        drift_rows = cur.fetchall()
+
+    drift: dict[str, list[dict]] = {}
+    for r in drift_rows:
+        drift.setdefault(r["model_name"], []).append({
+            "psi": float(r["metric_value"]) if r["metric_value"] is not None else None,
+            "window_label": r["window_label"],
+            "computed_at": r["computed_at"],
+        })
+
+    if not models:
+        return {"models": [], "drift": {}, "lifecycle": [],
+                "null_reason": "model_not_promoted"}
+
+    return {
+        "models": models,
+        "drift": drift,
+        "lifecycle": _lifecycle_events(models),
+        "null_reason": None,
+    }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -89,6 +89,7 @@ _GET_CURSOR_TARGETS = [
     "app.services.reports.get_cursor",
     "app.services.crm.get_cursor",
     "app.services.telemetry_serving.get_cursor",
+    "app.services.telemetry_registry.get_cursor",
     "app.services.copilot_logger.get_cursor",
     "app.services.underwriting.get_cursor",
     "app.services.real_estate.get_cursor",

--- a/backend/tests/test_telemetry_registry.py
+++ b/backend/tests/test_telemetry_registry.py
@@ -1,0 +1,86 @@
+"""Tests for the Model Registry console serving read (RS Demo PR 2) — display-only by construction."""
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from app.services import telemetry_registry as reg
+
+ENV = "telemetry-demo"
+BIZ = uuid4()
+TENANT = uuid4()
+T0 = datetime(2026, 5, 21, tzinfo=timezone.utc)
+T1 = datetime(2026, 6, 3, tzinfo=timezone.utc)
+
+CHAMPION = {
+    "model_name": "tel_anomaly_detector", "model_kind": "anomaly", "model_version": "1",
+    "model_alias": "champion", "mlflow_run_id": "4a48cb6af8714609b9581d66e904544c",
+    "experiment_id": "374", "promotion_state": "promoted", "created_at": T0,
+    "metrics": {
+        "f1": 0.6387, "precision": 0.5460, "recall": 0.7691,
+        "f1_pointwise": 0.312953, "event_recall": 0.769231, "alarm_precision": 0.3279,
+        "affiliation_f1": 0.474634, "vus_status": "pending: import failed",
+        "conformal_alpha": 0.05, "conformal_measured_false_alarm_rate": 0.067307,
+        "honest_gate": {
+            "thresholds": {"f1_pointwise": 0.10, "event_recall": 0.50,
+                           "alarm_precision": 0.20, "affiliation_f1": 0.25},
+            "values": {"f1_pointwise": 0.312953, "event_recall": 0.769231,
+                       "alarm_precision": 0.3279, "affiliation_f1": 0.474634},
+            "checks": {"f1_pointwise": True, "event_recall": True,
+                       "alarm_precision": True, "affiliation_f1": True},
+            "passed": True,
+        },
+    },
+    "gate": {"metric": "f1", "threshold": 0.30, "decision": "promoted",
+             "selected_over": "pca_recon(f1=0.4196)"},
+}
+CHALLENGER = {
+    "model_name": "tel_anomaly_pca", "model_kind": "anomaly", "model_version": "1",
+    "model_alias": None, "mlflow_run_id": "8e99b41142c14948b37aadade59e5aad",
+    "experiment_id": "374", "promotion_state": "evaluated", "created_at": T1,
+    "metrics": {"f1": 0.4196, "precision": 0.8726, "recall": 0.2762},
+    "gate": {"metric": "f1", "threshold": 0.30, "decision": "not_selected"},
+}
+
+
+def test_registry_payload_shape(fake_cursor):
+    fake_cursor.push_result([{"tenant_id": TENANT}])
+    fake_cursor.push_result([CHAMPION, CHALLENGER])
+    fake_cursor.push_result([
+        {"model_name": "D-4", "metric_value": 0.06, "window_label": "w1", "computed_at": T0},
+        {"model_name": "D-4", "metric_value": 0.11, "window_label": "w2", "computed_at": T1},
+        {"model_name": "T-1", "metric_value": 0.18, "window_label": "w2", "computed_at": T1},
+    ])
+    out = reg.registry_console(env_id=ENV, business_id=BIZ)
+    assert out["null_reason"] is None
+    assert len(out["models"]) == 2
+    champ = next(m for m in out["models"] if m["model_alias"] == "champion")
+    assert champ["metrics"]["honest_gate"]["passed"] is True       # Track A gate rides through intact
+    assert list(out["drift"].keys()) == ["D-4", "T-1"]
+    assert [d["psi"] for d in out["drift"]["D-4"]] == [0.06, 0.11]  # real history, ordered
+
+
+def test_registry_lifecycle_derivation(fake_cursor):
+    fake_cursor.push_result([{"tenant_id": TENANT}])
+    fake_cursor.push_result([CHAMPION, CHALLENGER])
+    fake_cursor.push_result([])
+    out = reg.registry_console(env_id=ENV, business_id=BIZ)
+    texts = [e["text"] for e in out["lifecycle"]]
+    assert any("promoted to champion" in t and "selected over pca_recon" in t for t in texts)
+    assert any("tel_anomaly_pca v1 registered · not_selected" in t for t in texts)
+    # chronological order
+    assert out["lifecycle"][0]["ts"] <= out["lifecycle"][-1]["ts"]
+
+
+def test_registry_fail_closed_when_empty(fake_cursor):
+    fake_cursor.push_result([{"tenant_id": TENANT}])
+    fake_cursor.push_result([])
+    fake_cursor.push_result([])
+    out = reg.registry_console(env_id=ENV, business_id=BIZ)
+    assert out["null_reason"] == "model_not_promoted" and out["models"] == []
+
+
+def test_registry_has_no_mutation_routes(client):
+    """Display-only is enforced by API absence: no POST/PUT/DELETE under /registry."""
+    assert client.post("/api/telemetry/registry", json={}).status_code in (404, 405)
+    assert client.post("/api/telemetry/registry/promote", json={}).status_code in (404, 405)
+    assert client.put("/api/telemetry/registry", json={}).status_code in (404, 405)
+    assert client.delete("/api/telemetry/registry").status_code in (404, 405)

--- a/repo-b/src/app/lab/env/[envId]/telemetry/registry/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/telemetry/registry/page.tsx
@@ -1,0 +1,5 @@
+import RegistryConsole from "@/components/telemetry/RegistryConsole";
+
+export default function TelemetryRegistryPage() {
+  return <RegistryConsole />;
+}

--- a/repo-b/src/components/telemetry/RegistryConsole.test.tsx
+++ b/repo-b/src/components/telemetry/RegistryConsole.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import RegistryConsole, { mapGateRows } from "./RegistryConsole";
+import type { RegistryModel, RegistryResponse } from "@/lib/telemetry/api";
+
+const { getRegistry } = vi.hoisted(() => ({ getRegistry: vi.fn() }));
+
+vi.mock("@/lib/telemetry/api", () => ({
+  getRegistry,
+  TELEMETRY_DEMO_ENV_ID: "telemetry-demo",
+  TELEMETRY_DEMO_BUSINESS_ID: "7e1eb000-0000-4000-a000-000000000001",
+}));
+
+const champion: RegistryModel = {
+  model_name: "tel_anomaly_detector", model_kind: "anomaly", model_version: "1",
+  model_alias: "champion", mlflow_run_id: "4a48cb6a", experiment_id: "374",
+  promotion_state: "promoted", created_at: "2026-05-21T00:00:00Z",
+  metrics: {
+    f1: 0.6387, f1_pointwise: 0.312953, event_recall: 0.769231,
+    alarm_precision: 0.3279, affiliation_f1: 0.474634,
+    vus_status: "pending: import failed",
+    honest_gate: {
+      thresholds: { f1_pointwise: 0.10, affiliation_f1: 0.25 },
+      values: { f1_pointwise: 0.312953, affiliation_f1: 0.474634 },
+      checks: { f1_pointwise: true, affiliation_f1: false },   // one failing check for the test
+    },
+  },
+  gate: { metric: "f1", threshold: 0.30, decision: "promoted", selected_over: "pca" },
+};
+
+describe("mapGateRows (real Track A honest_gate jsonb → checklist)", () => {
+  it("maps thresholds/values/checks and appends the legacy gate as reference", () => {
+    const rows = mapGateRows(champion);
+    expect(rows).toHaveLength(3);
+    const f1pw = rows.find((r) => r.rule.startsWith("f1_pointwise"))!;
+    expect(f1pw.rule).toBe("f1_pointwise >= 0.1");
+    expect(f1pw.observed).toBe("0.312953");
+    expect(f1pw.pass).toBe(true);
+    const aff = rows.find((r) => r.rule.startsWith("affiliation_f1"))!;
+    expect(aff.pass).toBe(false);                              // the failing check surfaces
+    const legacy = rows.find((r) => r.rule.includes("legacy"))!;
+    expect(legacy.rule).toContain("reference only");
+    expect(legacy.pass).toBe(true);
+  });
+
+  it("returns only the legacy row when no honest_gate exists (older rows render honestly)", () => {
+    const rows = mapGateRows({ ...champion, metrics: { f1: 0.42 } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].rule).toContain("legacy");
+  });
+});
+
+describe("RegistryConsole rendering", () => {
+  it("renders honestly with no data — explicit not-available, no fake charts", async () => {
+    getRegistry.mockResolvedValueOnce({
+      models: [], drift: {}, lifecycle: [], null_reason: "model_not_promoted",
+    } satisfies RegistryResponse);
+    render(<RegistryConsole />);
+    await waitFor(() =>
+      expect(screen.getByText(/Not available — model_not_promoted/)).toBeInTheDocument());
+  });
+
+  it("renders the champion with disabled promote/rollback (display-only)", async () => {
+    getRegistry.mockResolvedValueOnce({
+      models: [champion], drift: {}, lifecycle: [
+        { ts: "2026-05-21T00:00:00Z", text: "tel_anomaly_detector v1 promoted to champion", model_kind: "anomaly" },
+      ], null_reason: null,
+    } satisfies RegistryResponse);
+    render(<RegistryConsole />);
+    await waitFor(() => expect(screen.getByText(/CHAMPION v1/)).toBeInTheDocument());
+    const promote = screen.getByRole("button", { name: /Promote — requires reviewer approval/ });
+    expect(promote).toBeDisabled();
+    expect(screen.getByText(/no challenger registered/)).toBeInTheDocument();
+    expect(screen.getByText(/pending: import failed/)).toBeInTheDocument();   // honest VUS status
+  });
+});

--- a/repo-b/src/components/telemetry/RegistryConsole.tsx
+++ b/repo-b/src/components/telemetry/RegistryConsole.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+// Model Registry & Promotion Control console (RS Demo PR 2) — port of rs_jsx/ModelRegistryConsole.jsx
+// onto REAL tel_model_runs data (incl. the Track A honest_gate / affiliation / conformal keys) and
+// REAL PSI drift history. DISPLAY-ONLY: the API has no mutation routes; the promote/rollback buttons
+// are permanently disabled — promotion is an alias update through the governed Databricks flow.
+import { useEffect, useMemo, useState } from "react";
+import { Area, AreaChart, ReferenceLine, ResponsiveContainer, XAxis, YAxis } from "recharts";
+
+import {
+  getRegistry, type RegistryModel, type RegistryResponse,
+  TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID,
+} from "@/lib/telemetry/api";
+import { RS, RS_MONO, RS_SANS, RsChip, RsPanel } from "./rsTokens";
+
+const PSI_WARN = 0.15;
+
+export interface GateRow { rule: string; observed: string; pass: boolean }
+
+/** Pure mapper: the REAL Track A honest_gate jsonb (+ the legacy declared gate) → checklist rows. */
+export function mapGateRows(model: RegistryModel): GateRow[] {
+  const rows: GateRow[] = [];
+  const m = (model.metrics ?? {}) as Record<string, unknown>;
+  const hg = m.honest_gate as {
+    thresholds?: Record<string, number>; values?: Record<string, number>;
+    checks?: Record<string, boolean>;
+  } | undefined;
+  if (hg?.thresholds) {
+    for (const [key, thr] of Object.entries(hg.thresholds)) {
+      const val = hg.values?.[key];
+      rows.push({
+        rule: `${key} >= ${thr}`,
+        observed: val != null ? String(val) : "not recorded",
+        pass: hg.checks?.[key] === true,
+      });
+    }
+  }
+  const gate = (model.gate ?? {}) as Record<string, unknown>;
+  if (gate.metric != null && gate.threshold != null) {
+    rows.push({
+      rule: `legacy ${String(gate.metric)} >= ${String(gate.threshold)} (reference only)`,
+      observed: `decision: ${String(gate.decision ?? "—")}`,
+      pass: gate.decision === "promoted",
+    });
+  }
+  return rows;
+}
+
+// Metric display sets per model_kind: [key, label, higherIsBetter]
+const METRIC_SETS: Record<string, [string, string, boolean][]> = {
+  anomaly: [
+    ["affiliation_f1", "Affiliation F1 (range-aware)", true],
+    ["f1_pointwise", "F1 (point-wise — honest)", true],
+    ["event_recall", "Event recall", true],
+    ["alarm_precision", "Alarm precision", true],
+    ["vus_pr", "VUS-PR", true],
+    ["f1", "F1 (point-adjusted — inflated legacy)", true],
+  ],
+  rul: [
+    ["rmse", "RMSE (cycles)", false],
+    ["phm", "NASA PHM08 score", false],
+    ["conformal_calib_coverage", "Conformal coverage", true],
+  ],
+};
+
+function num(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function MetricBars({ label, higherBetter, champ, chall }: {
+  label: string; higherBetter: boolean; champ: number | null; chall: number | null;
+}) {
+  if (champ == null && chall == null) return null;
+  const max = Math.max(Math.abs(champ ?? 0), Math.abs(chall ?? 0)) || 1;
+  const challBetter = champ != null && chall != null
+    ? (higherBetter ? chall >= champ : chall <= champ) : null;
+  return (
+    <div style={{ padding: "8px 12px", borderBottom: `1px solid ${RS.line}` }}>
+      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 6 }}>
+        <span style={{ fontSize: 11, color: RS.text, fontFamily: RS_SANS }}>
+          {label}
+          <span style={{ color: RS.faint, fontSize: 10, marginLeft: 8 }}>
+            {higherBetter ? "higher is better" : "lower is better"}
+          </span>
+        </span>
+        {challBetter != null && (
+          <span style={{ fontFamily: RS_MONO, fontSize: 11, color: challBetter ? RS.green : RS.red }}>
+            {challBetter ? "challenger ahead" : "champion ahead"}
+          </span>
+        )}
+      </div>
+      {[{ lbl: "champion", v: champ, color: RS.teal },
+        { lbl: "challenger", v: chall, color: RS.violet }].map((row) => (
+        <div key={row.lbl} style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
+          <span style={{ width: 76, fontFamily: RS_MONO, fontSize: 10, color: RS.faint }}>{row.lbl}</span>
+          <div style={{ flex: 1, height: 8, borderRadius: 4, background: RS.panelAlt }}>
+            {row.v != null && (
+              <div style={{ height: 8, borderRadius: 4, width: `${(Math.abs(row.v) / max) * 100}%`,
+                background: row.color }} />
+            )}
+          </div>
+          <span style={{ width: 70, textAlign: "right", fontFamily: RS_MONO, fontSize: 11,
+            color: row.v != null ? RS.text : RS.faint }}>
+            {row.v != null ? row.v.toFixed(4) : "n/a"}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DriftCard({ channel, series }: {
+  channel: string; series: { psi: number | null; computed_at: string }[];
+}) {
+  const pts = series.filter((s) => s.psi != null)
+    .map((s, i) => ({ i, psi: s.psi as number }));
+  const latest = pts.length ? pts[pts.length - 1].psi : null;
+  const warn = latest != null && latest >= PSI_WARN;
+  return (
+    <div style={{ background: RS.panelAlt, borderRadius: 4, padding: 8 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", fontFamily: RS_MONO,
+        fontSize: 10, marginBottom: 4 }}>
+        <span style={{ color: RS.dim }}>{channel}</span>
+        <span style={{ color: warn ? RS.amber : RS.green }}>
+          PSI {latest != null ? latest.toFixed(2) : "—"}{warn ? " · watch" : ""}
+        </span>
+      </div>
+      {pts.length >= 2 ? (
+        <ResponsiveContainer width="100%" height={40}>
+          <AreaChart data={pts} margin={{ top: 2, right: 0, bottom: 0, left: 0 }}>
+            <XAxis dataKey="i" hide />
+            <YAxis domain={[0, Math.max(0.25, ...pts.map((p) => p.psi))]} hide />
+            <ReferenceLine y={PSI_WARN} stroke={RS.amber} strokeOpacity={0.5} strokeDasharray="3 3" />
+            <Area dataKey="psi" stroke={warn ? RS.amber : RS.teal}
+              fill={warn ? RS.amber : RS.teal} fillOpacity={0.15} strokeWidth={1.2}
+              isAnimationActive={false} />
+          </AreaChart>
+        </ResponsiveContainer>
+      ) : (
+        <div style={{ fontFamily: RS_MONO, fontSize: 10, color: RS.faint }}>
+          single observation — history accrues as drift jobs run (no fabricated curve)
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function RegistryConsole() {
+  const [data, setData] = useState<RegistryResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [kind, setKind] = useState<string>("anomaly");
+
+  useEffect(() => {
+    getRegistry(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID)
+      .then(setData).catch((e) => setError(String(e)));
+  }, []);
+
+  const byKind = useMemo(() => {
+    const out: Record<string, RegistryModel[]> = {};
+    for (const m of data?.models ?? []) (out[m.model_kind] ??= []).push(m);
+    return out;
+  }, [data]);
+
+  const kinds = Object.keys(byKind);
+  const models = byKind[kind] ?? [];
+  const champion = models.filter((m) => m.promotion_state === "promoted").at(-1) ?? null;
+  const challenger = models.filter((m) => m.promotion_state !== "promoted").at(-1) ?? null;
+  const gateRows = champion ? mapGateRows(champion) : [];
+  const gatePass = gateRows.length > 0 && gateRows.every((g) => g.pass);
+  const vusStatus = champion ? (champion.metrics as Record<string, unknown>).vus_status : null;
+
+  return (
+    <div style={{ minHeight: "100vh", width: "100%", padding: 12, background: RS.bg,
+      fontFamily: RS_SANS, color: RS.text }}>
+      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 12, padding: "0 4px 12px" }}>
+        <div>
+          <div style={{ color: RS.faint, fontSize: 11, letterSpacing: "0.18em" }}>TELEMETRY LAB</div>
+          <div style={{ fontSize: 13, letterSpacing: "0.14em" }}>MODEL REGISTRY · PROMOTION CONTROL</div>
+        </div>
+        <RsChip color={RS.cyan}>registry: unity_catalog · novendor_1.telemetry</RsChip>
+        <RsChip color={RS.teal}>aliases: champion / challenger</RsChip>
+        <div style={{ marginLeft: "auto", fontFamily: RS_MONO, fontSize: 11, color: RS.faint }}>
+          promotion = alias update · fail closed · display-only console
+        </div>
+      </div>
+
+      {error && (
+        <RsPanel><div style={{ padding: 16, fontFamily: RS_MONO, fontSize: 12, color: RS.red }}>
+          Could not load the registry: {error}
+        </div></RsPanel>
+      )}
+      {data && data.models.length === 0 && (
+        <RsPanel><div style={{ padding: 16, fontFamily: RS_MONO, fontSize: 12, color: RS.amber }}>
+          Not available — {data.null_reason ?? "no model rows"}. Nothing is rendered in its place.
+        </div></RsPanel>
+      )}
+
+      {data && data.models.length > 0 && (
+        <div style={{ display: "grid", gap: 12,
+          gridTemplateColumns: "230px minmax(0,2fr) minmax(0,1.4fr)" }}>
+          {/* Model list */}
+          <RsPanel title="REGISTERED MODELS">
+            {kinds.map((k) => {
+              const champ = byKind[k].find((m) => m.promotion_state === "promoted");
+              const active = k === kind;
+              return (
+                <button key={k} type="button" onClick={() => setKind(k)}
+                  style={{ width: "100%", textAlign: "left", display: "block", padding: 12,
+                    background: active ? RS.panelAlt : "transparent", cursor: "pointer",
+                    border: "none", borderBottom: `1px solid ${RS.line}`,
+                    borderLeft: `2px solid ${active ? RS.violet : "transparent"}` }}>
+                  <div style={{ fontFamily: RS_MONO, fontSize: 11,
+                    color: active ? RS.text : RS.dim, marginBottom: 4 }}>
+                    {champ?.model_name ?? byKind[k][0].model_name}
+                  </div>
+                  <div style={{ display: "flex", gap: 6 }}>
+                    <RsChip color={RS.teal}>{k}</RsChip>
+                    {champ && <RsChip color={RS.green}>v{champ.model_version} champion</RsChip>}
+                  </div>
+                </button>
+              );
+            })}
+            <div style={{ padding: 12, fontSize: 10.5, color: RS.faint, lineHeight: 1.6 }}>
+              Anomaly quality is reported range-aware (affiliation F1) beside the honest point-wise
+              metrics; the point-adjusted legacy F1 is shown last and labeled inflated.
+              {typeof vusStatus === "string" && vusStatus.startsWith("pending") && (
+                <> VUS-PR/ROC: <span style={{ color: RS.amber }}>{vusStatus}</span> — shown only when a
+                vetted library computes them.</>
+              )}
+            </div>
+          </RsPanel>
+
+          {/* Champion vs challenger + drift */}
+          <RsPanel title={champion
+            ? `CHAMPION v${champion.model_version}${challenger ? ` VS CHALLENGER (${challenger.model_name})` : ""}`
+            : "NO PROMOTED CHAMPION"}>
+            {champion && (
+              <div style={{ padding: "8px 12px", borderBottom: `1px solid ${RS.line}`,
+                display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8,
+                fontFamily: RS_MONO, fontSize: 10, color: RS.faint }}>
+                <div>
+                  <div style={{ color: RS.teal }}>champion: {champion.model_name} v{champion.model_version}</div>
+                  <div>mlflow {champion.mlflow_run_id}</div>
+                </div>
+                <div>
+                  {challenger ? (
+                    <>
+                      <div style={{ color: RS.violet }}>challenger: {challenger.model_name} v{challenger.model_version}</div>
+                      <div>mlflow {challenger.mlflow_run_id}</div>
+                    </>
+                  ) : (
+                    <div style={{ color: RS.faint }}>no challenger registered for this kind</div>
+                  )}
+                </div>
+              </div>
+            )}
+            {(METRIC_SETS[kind] ?? []).map(([key, label, higher]) => (
+              <MetricBars key={key} label={label} higherBetter={higher}
+                champ={num((champion?.metrics as Record<string, unknown> | undefined)?.[key])}
+                chall={num((challenger?.metrics as Record<string, unknown> | undefined)?.[key])} />
+            ))}
+            <div style={{ padding: "8px 12px" }}>
+              <div style={{ fontSize: 10, color: RS.faint, letterSpacing: "0.1em", marginBottom: 8 }}>
+                SERVING DRIFT · REAL PSI HISTORY PER CHANNEL
+              </div>
+              {Object.keys(data.drift).length === 0 ? (
+                <div style={{ fontFamily: RS_MONO, fontSize: 11, color: RS.faint }}>
+                  No PSI history recorded for this scope.
+                </div>
+              ) : (
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+                  {Object.entries(data.drift).map(([channel, series]) => (
+                    <DriftCard key={channel} channel={channel} series={series} />
+                  ))}
+                </div>
+              )}
+            </div>
+          </RsPanel>
+
+          {/* Gates + decision + lifecycle */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <RsPanel title={`PROMOTION GATES · ${gateRows.filter((g) => g.pass).length}/${gateRows.length} PASS`}>
+              {gateRows.length === 0 ? (
+                <div style={{ padding: 12, fontFamily: RS_MONO, fontSize: 11, color: RS.faint }}>
+                  No declared gate recorded for this model.
+                </div>
+              ) : gateRows.map((g) => (
+                <div key={g.rule} style={{ display: "flex", gap: 8, padding: "8px 12px",
+                  borderBottom: `1px solid ${RS.line}` }}>
+                  <span style={{ color: g.pass ? RS.green : RS.red, fontFamily: RS_MONO, fontSize: 11 }}>
+                    {g.pass ? "✓" : "✕"}
+                  </span>
+                  <div>
+                    <div style={{ fontFamily: RS_MONO, fontSize: 11, color: RS.text }}>{g.rule}</div>
+                    <div style={{ fontSize: 10, color: RS.faint }}>{g.observed}</div>
+                  </div>
+                </div>
+              ))}
+              <div style={{ padding: 12 }}>
+                {gateRows.length > 0 && (
+                  <div style={{ borderRadius: 4, padding: 10, fontSize: 11, lineHeight: 1.5,
+                    border: `1px solid ${(gatePass ? RS.green : RS.amber)}55`,
+                    background: `${gatePass ? RS.green : RS.amber}10` }}>
+                    <span style={{ fontWeight: 700, fontFamily: RS_MONO, marginRight: 8,
+                      color: gatePass ? RS.green : RS.amber }}>
+                      {gatePass ? "GATES PASS" : "GATES INCOMPLETE"}
+                    </span>
+                    The declared honest gate was fixed before recompute (fail-closed). Promotion
+                    requires reviewer approval; the alias update is the only mutation.
+                  </div>
+                )}
+                <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+                  <button type="button" disabled
+                    style={{ flex: 1, fontFamily: RS_MONO, fontSize: 11, padding: "8px 0",
+                      borderRadius: 4, color: RS.faint, background: RS.panelAlt,
+                      border: `1px solid ${RS.line}`, cursor: "not-allowed" }}>
+                    Promote — requires reviewer approval
+                  </button>
+                  <button type="button" disabled
+                    style={{ flex: 1, fontFamily: RS_MONO, fontSize: 11, padding: "8px 0",
+                      borderRadius: 4, color: RS.faint, background: "transparent",
+                      border: `1px solid ${RS.line}`, cursor: "not-allowed" }}>
+                    Roll back — requires reviewer approval
+                  </button>
+                </div>
+                <div style={{ fontSize: 10, color: RS.faint, marginTop: 8, lineHeight: 1.5 }}>
+                  This console never mutates aliases. Promotion is performed through the governed
+                  Databricks flow (notebooks/promote_models.py) and the API exposes no write routes.
+                </div>
+              </div>
+            </RsPanel>
+
+            <RsPanel title="LIFECYCLE EVENTS (derived from registry rows)">
+              <div style={{ padding: 12 }}>
+                {data.lifecycle.filter((e) => e.model_kind === kind).map((e, i, arr) => (
+                  <div key={i} style={{ display: "flex", gap: 10, paddingBottom: 10 }}>
+                    <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+                      <span style={{ width: 7, height: 7, borderRadius: 999, marginTop: 3,
+                        background: i === arr.length - 1 ? RS.cyan : RS.faint }} />
+                      {i < arr.length - 1 && <span style={{ flex: 1, width: 1, background: RS.line, marginTop: 3 }} />}
+                    </div>
+                    <div style={{ fontSize: 11 }}>
+                      <span style={{ fontFamily: RS_MONO, color: RS.faint }}>
+                        {e.ts ? e.ts.slice(0, 10) : "—"}
+                      </span>
+                      <span style={{ marginLeft: 8, color: RS.dim }}>{e.text}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </RsPanel>
+          </div>
+        </div>
+      )}
+
+      <div style={{ paddingTop: 12, textAlign: "center", fontSize: 11, color: RS.faint, lineHeight: 1.6 }}>
+        All numbers are read live from tel_model_runs / tel_drift_metrics — the same registry rows the
+        serving API uses. Nothing on this page is hardcoded; absent data renders as not available.
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/telemetry/TelemetrySidebar.tsx
+++ b/repo-b/src/components/telemetry/TelemetrySidebar.tsx
@@ -13,6 +13,7 @@ const NAV: { slug: string; label: string; icon: string }[] = [
   { slug: "governance", label: "AI Governance", icon: "M8 1l6 2v4c0 3.5-2.5 6-6 7-3.5-1-6-3.5-6-7V3z" },
   { slug: "runs", label: "Test Runs", icon: "M2 4h13v2H2zM2 8h13v2H2zM2 12h9v2H2z" },
   { slug: "model-performance", label: "Model Performance", icon: "M2 13l4-5 3 2 5-7" },
+  { slug: "registry", label: "Model Registry", icon: "M3 2h10v3H3zM3 7h10v3H3zM3 12h6v2H3z" },
   { slug: "monitoring", label: "Monitoring", icon: "M2 9h3l2-5 3 10 2-5h3" },
 ];
 

--- a/repo-b/src/lib/telemetry/api.ts
+++ b/repo-b/src/lib/telemetry/api.ts
@@ -79,6 +79,32 @@ export interface MonitoringResponse {
   null_reason: string | null;
 }
 
+// ── RS Demo: Model Registry console (display-only) ─────────────────────────────
+export interface RegistryModel {
+  model_name: string;
+  model_kind: string;
+  model_version: string | null;
+  model_alias: string | null;
+  mlflow_run_id: string | null;
+  experiment_id: string | null;
+  metrics: Record<string, unknown>;
+  gate: Record<string, unknown>;
+  promotion_state: string;
+  created_at: string | null;
+}
+
+export interface RegistryResponse {
+  models: RegistryModel[];
+  drift: Record<string, { psi: number | null; window_label: string | null; computed_at: string }[]>;
+  lifecycle: { ts: string | null; text: string; model_kind: string | null }[];
+  null_reason: string | null;
+}
+
+export const getRegistry = (env: string, biz: string) =>
+  apiFetch<RegistryResponse>("/api/telemetry/registry", {
+    params: { env_id: env, business_id: biz },
+  });
+
 export interface TestRun {
   id: string;
   run_key: string;


### PR DESCRIPTION
Continuation of #141 (auto-closed by GitHub when its base branch was deleted on the #140 merge — same commits, now against main). Full description, evidence, and review notes: see #141.

**Summary:** display-only Model Registry console. `registry_console()` serving read over `tel_model_runs` (full metrics/gate jsonb incl. Track A honest_gate) + real PSI drift history + derived lifecycle timeline; `GET /api/telemetry/registry` with NO mutation routes (display-only enforced by API absence + mutation-absence test); `RegistryConsole.tsx` rs_jsx template port on rsTokens with real champion/challenger metric bars, honest-gate checklist from the real jsonb, disabled Promote/Rollback ("requires reviewer approval"), honest empty states. No migration. Frozen champion path untouched.

CI was fully green on #141 after the pre-existing-blocker fix (`709582cb`, now in main via #140).

🤖 Generated with [Claude Code](https://claude.com/claude-code)