### PR TITLE
feat(stargate): Confluent Cloud lane - provisioning, Flink, schema evolution, DLQ (PR 4)

### DIFF
--- a/backend/app/events/protobuf_codec.py
+++ b/backend/app/events/protobuf_codec.py
@@ -61,13 +61,22 @@ def build_schema_registry_client():
 
 
 def build_protobuf_serializer(message_type, schema_registry_client=None):
-    """ProtobufSerializer for a generated message class, registering the schema
-    on first use. ``use.deprecated.format=False`` is the current wire format —
-    both Redpanda SR and Confluent Cloud accept it."""
+    """ProtobufSerializer for a generated message class.
+
+    ``CONFLUENT_SR_AUTO_REGISTER`` (default true) controls schema
+    registration: true suits local Redpanda where the producer may register on
+    first use; the cloud lane sets it false so producers only LOOK UP the
+    governed subject (DeveloperRead) — registration stays a provisioning act,
+    not a data-plane side effect. ``use.deprecated.format=False`` is the
+    current wire format on both Redpanda SR and Confluent Cloud."""
     from confluent_kafka.schema_registry.protobuf import ProtobufSerializer
 
+    auto_register = _env("CONFLUENT_SR_AUTO_REGISTER", "true").lower() != "false"
+    conf = {"use.deprecated.format": False, "auto.register.schemas": auto_register}
+    if not auto_register:
+        conf["use.latest.version"] = True
     client = schema_registry_client or build_schema_registry_client()
-    return ProtobufSerializer(message_type, client, {"use.deprecated.format": False})
+    return ProtobufSerializer(message_type, client, conf)
 
 
 def build_protobuf_deserializer(message_type):

--- a/backend/tests/test_stargate_codec.py
+++ b/backend/tests/test_stargate_codec.py
@@ -70,6 +70,71 @@ class TestTumblingAggregator:
         assert rows2[0]["n"] == 1
 
 
+class TestFlinkSqlLock:
+    """The Flink anomaly route and signal_mapping.is_anomalous are two
+    spellings of one predicate. Parse the checked-in SQL and fail if the
+    constants ever drift apart (PR 4)."""
+
+    FLINK_SQL = (
+        Path(__file__).resolve().parents[2]
+        / "infra" / "confluent" / "stargate" / "flink" / "02_anomaly_route.sql"
+    )
+
+    def test_sql_constants_match_python_predicate(self):
+        import re
+
+        sql = self.FLINK_SQL.read_text(encoding="utf-8")
+        temp = re.search(r"melt_pool_temp_c\s*<\s*([0-9.]+)", sql)
+        vib = re.search(r"arm_vibration_g\s*>\s*([0-9.]+)", sql)
+        assert temp and vib, "anomaly predicate not found in 02_anomaly_route.sql"
+        assert float(temp.group(1)) == sm.TEMP_THRESHOLD_C
+        assert float(vib.group(1)) == sm.VIBRATION_THRESHOLD_G
+
+    def test_sql_requires_both_conditions(self):
+        sql = self.FLINK_SQL.read_text(encoding="utf-8").upper()
+        where = sql.split("WHERE", 1)[1]
+        assert "AND" in where, "predicate must require temp AND vibration together"
+
+
+class TestSchemaEvolution:
+    """BACKWARD compatibility in practice: a v1 reader must skip the v2 field.
+    v2 wire bytes are built by hand (field 11, fixed64) because two descriptors
+    with the same message name cannot coexist in one process (PR 4)."""
+
+    def test_v1_reader_skips_v2_laser_power_field(self):
+        pytest.importorskip("google.protobuf")
+        import struct
+
+        from proto_gen.stargate_telemetry_pb2 import StargateTelemetry
+
+        v1 = StargateTelemetry(printer_id="stargate-v4-01", ts_us=42, melt_pool_temp_c=1502.0)
+        # append laser_power_w = 950.0 as field 11, wire type 1 (fixed64):
+        # tag byte = (11 << 3) | 1 = 0x59
+        v2_wire = v1.SerializeToString() + bytes([0x59]) + struct.pack("<d", 950.0)
+
+        decoded = StargateTelemetry()
+        decoded.ParseFromString(v2_wire)
+        assert decoded.printer_id == "stargate-v4-01"
+        assert decoded.ts_us == 42
+        assert decoded.melt_pool_temp_c == pytest.approx(1502.0)
+        # the unknown field is preserved, not lost — round-tripping keeps it
+        assert b"\x59" in decoded.SerializeToString()
+
+
+class TestRegistryFramedJson:
+    """Bridge cloud mode reads Flink's json-registry rows: magic byte + schema
+    id + JSON. Both framed and plain forms must decode (PR 4)."""
+
+    def test_framed_and_plain_json_decode(self):
+        import bridge
+
+        row = {"printer_id": "p1", "avg_temp_c": 1500.5, "n": 3}
+        plain = __import__("json").dumps(row).encode()
+        framed = b"\x00\x00\x00\x00\x07" + plain
+        assert bridge.loads_registry_json(plain) == row
+        assert bridge.loads_registry_json(framed) == row
+
+
 class TestProtobufWire:
     """Round-trips through the generated bindings and the SR framing. Skipped
     where the optional clients are not installed (backend CI)."""

--- a/docs/plans/RS_STARGATE_FACTORY_ML_SESSION_PLAN.md
+++ b/docs/plans/RS_STARGATE_FACTORY_ML_SESSION_PLAN.md
@@ -75,16 +75,14 @@ Decisions worth recording:
 
 Evidence (checkpoint A): recorded below when the PR opens.
 
-## PR 4 — Confluent Cloud + Schema Registry + Flink + DLQ (built; cloud verification pending login)
+## PR 4 — Confluent Cloud + Schema Registry + Flink + DLQ (cloud-verified; see Checkpoint B2)
 
-Status: every artifact is built, tested, and exercised locally. The live-cloud
-verification beat is blocked on one interactive step that cannot be scripted:
-`confluent login --save`. The repo-root `confluent)_kafka_api.json` key is
-cluster-scoped (confirmed: 401 against the management API), no bootstrap or SR
-URL is recorded anywhere on this machine, and the CLI (winget, v4.60) has no
-saved context. After login, `infra\confluent\stargate\provision.ps1` does the
-rest — discovery, topics, SR subjects, service account, ACLs, Flink pool — and
-prints the env exports.
+Status: built, tested locally, and verified live against Confluent Cloud on
+2026-06-11 after one interactive `confluent login --save` (the repo-root
+`confluent)_kafka_api.json` key is cluster-scoped and could not drive
+management commands). Provisioning, Flink statements, the schema-evolution
+beat, the anomaly route, and the DLQ beat all ran for real — evidence in
+Checkpoint B2 below, lessons folded into `infra/confluent/stargate/README.md`.
 
 Toe-stepping note: the Phase 3B event-backbone session (clone at
 C:\Projects\cons_rs_demo, branch feat/cloud-broker-event-transport) has
@@ -165,6 +163,38 @@ Handoff into PR 5:
   bridge `/stargate/dlq` count went **0 → 5**, each entry carrying its real
   deserialization reason (`Invalid magic byte`, `Unexpected EOF while reading
   index`, …). Nothing crashed; ingestion continued.
-- Cloud verification: **pending `confluent login --save`** (see PR 4 status
-  note above). The provision script, Flink statements, v2 schema registration
-  command, and consume checks are ready to run verbatim once authenticated.
+- Cloud verification: completed 2026-06-11 — see Checkpoint B2.
+
+### Checkpoint B2 — PR 4 cloud verification (2026-06-11)
+
+- Authenticated via `confluent login --save` (env `env-vwkk2z`, cluster
+  `lkc-gqpvvyv` gcp/us-east1, SR `lsrc-pgnzz12`).
+- `provision.ps1` completed end to end: topics (`telemetry` 6 partitions,
+  `dlq` 7d retention — agg5s/anomalies are Flink-owned, see runbook), v1
+  Protobuf schema registered with BACKWARD compatibility, service account
+  `sa-5w51vmn` with prefix-scoped Kafka ACLs + SR DeveloperRead RBAC, cluster
+  and SR keys written to the gitignored lane `.env`, Flink pool `lfcp-22wznzq`.
+- **Schema evolution live**: v2 (`laser_power_w`) registered as version 2 on
+  the same subject — the BACKWARD gate passed (IDs 100002 → 100003).
+- **Flink**: 4 statements submitted (2 CREATE TABLE COMPLETED, 2 INSERT
+  RUNNING). Producer pushed **89,200 Protobuf messages at ~993/s** with
+  auto-register off (SR lookup only — registration stays a provisioning act);
+  managed Flink produced 5s windows (n=1250 = 250/s x 5s, avg_temp ≈ 1499°C)
+  and routed **anomaly rows from the pre-failure jobs**
+  (e.g. JOB-00-0005-PRE_FAILURE, 1353°C / 0.110g), captured both in the
+  bridge (200-row ring full) and via CLI consume.
+- **DLQ beat, cloud**: `bad_producer.py --mode cloud` took `/stargate/dlq`
+  **0 → 10** — each corrupted payload appears as its decode failure AND
+  consumed back off the DLQ topic (full route proven).
+- **Poison-record finding**: the corrupted payloads fail-stopped both Flink
+  INSERT statements at the bad offsets (no skip-on-error knob in this Flink
+  version) while the bridge degraded gracefully — the contrast is now a demo
+  beat. Recovery proven: resubmit with
+  `sql.tables.scan.startup.mode=latest-offset`; statements returned to
+  RUNNING and produced 23 more windows from a fresh burst (68 → 91).
+- Fixes folded back into the lane: provision script (SR id field, .env key
+  handling, idempotent re-runs, RBAC grant, Flink-owned topics, PS 5.1
+  stderr handling), `CONFLUENT_SR_AUTO_REGISTER` toggle in the codec,
+  `CAST(layer AS INT)` in the anomaly route (proto uint32 infers BIGINT).
+- Cleanup: both INSERT statements stopped, bridge stopped, pool idle
+  (no running statements = no CFU burn).

--- a/docs/plans/RS_STARGATE_FACTORY_ML_SESSION_PLAN.md
+++ b/docs/plans/RS_STARGATE_FACTORY_ML_SESSION_PLAN.md
@@ -75,9 +75,26 @@ Decisions worth recording:
 
 Evidence (checkpoint A): recorded below when the PR opens.
 
-## PR 4 — Confluent Cloud + Schema Registry + Flink + DLQ (queued)
+## PR 4 — Confluent Cloud + Schema Registry + Flink + DLQ (built; cloud verification pending login)
 
-Handoff into PR 4:
+Status: every artifact is built, tested, and exercised locally. The live-cloud
+verification beat is blocked on one interactive step that cannot be scripted:
+`confluent login --save`. The repo-root `confluent)_kafka_api.json` key is
+cluster-scoped (confirmed: 401 against the management API), no bootstrap or SR
+URL is recorded anywhere on this machine, and the CLI (winget, v4.60) has no
+saved context. After login, `infra\confluent\stargate\provision.ps1` does the
+rest — discovery, topics, SR subjects, service account, ACLs, Flink pool — and
+prints the env exports.
+
+Toe-stepping note: the Phase 3B event-backbone session (clone at
+C:\Projects\cons_rs_demo, branch feat/cloud-broker-event-transport) has
+uncommitted work modifying backend/app/events/config.py + transport.py and
+creating infra/confluent/README.md with an EVENTS_* env contract and
+winston.* topics. This lane was kept disjoint on purpose: stargate.* topics,
+CONFLUENT_* env, all files under infra/confluent/stargate/ and
+infra/confluent/proto/ — no shared filenames, no shared cluster resources.
+
+Original handoff list (all delivered except the cloud run):
 
 - `infra/confluent/provision.ps1`: discovery (`confluent environment list`,
   cluster + SR describe), topics (`stargate.printer.telemetry.v1` 6 partitions,
@@ -136,3 +153,18 @@ Handoff into PR 5:
 - Local E2E (Redpanda compose): producer pushed **9,940 Protobuf messages at ~397/s** through Schema Registry; bridge consumed 9,480 (group joined at `latest`), telemetry ring full at 2,000, **64 tumbling windows** with nominal values (avg_temp ≈ 1501°C, max_vib ≈ 0.035g); SSE emitted a snapshot frame then 100ms deltas (curl capture).
 - Capture determinism: two cold starts in capture mode produced **identical state** — sha `0477A8A8ACF69F3E` both runs; 600-tail telemetry, 48 windows, **148 anomalous samples** from the pre-failure segments, **3 DLQ entries** from the planted bad lines.
 - Frontend: `npm run lint` exit 0; `npm run build` exit 0 with the stargate route compiled. Fix recorded: `src/types/r3f.d.ts` bridges fiber v8's element map into @types/react v19's JSX namespace.
+
+### Checkpoint B — PR 4 (2026-06-11)
+
+- Tests: **27 passed** in the lane venv — adds the Flink-SQL constants lock
+  (parses 02_anomaly_route.sql, asserts equality with `signal_mapping`), the
+  schema-evolution proof (v1 reader skips hand-built v2 field 11 and preserves
+  it on re-serialize), and the json-registry frame decoder.
+- DLQ beat, live against local Redpanda: `bad_producer.py` sent 5 corrupted
+  payloads (raw JSON, bad magic byte, truncated frame, log-line text, empty);
+  bridge `/stargate/dlq` count went **0 → 5**, each entry carrying its real
+  deserialization reason (`Invalid magic byte`, `Unexpected EOF while reading
+  index`, …). Nothing crashed; ingestion continued.
+- Cloud verification: **pending `confluent login --save`** (see PR 4 status
+  note above). The provision script, Flink statements, v2 schema registration
+  command, and consume checks are ready to run verbatim once authenticated.

--- a/docs/reference/ENV_KEYS.md
+++ b/docs/reference/ENV_KEYS.md
@@ -11,4 +11,19 @@
 | `ADMIN_INVITE_CODE` | `SWvxEtVPMK_YanlB` | Legacy invite code — fallback if email auth fails |
 | `ENV_INVITE_CODE` | *(check Vercel env vars)* | Grants access to environments as env_user |
 
-Last updated: 2026-03-29
+## Stargate streaming lane (Confluent Cloud — PR 4)
+
+| Variable | Value | Notes |
+|---|---|---|
+| `CONFLUENT_BOOTSTRAP_SERVERS` | *(printed by infra/confluent/stargate/provision.ps1)* | Cluster bootstrap; `localhost:9092` for local Redpanda |
+| `CONFLUENT_API_KEY` / `CONFLUENT_API_SECRET` | *(minted by provision.ps1 for sa-stargate-demo)* | Cluster key; the repo-root `confluent)_kafka_api.json` key is cluster-scoped and unlabeled — prefer the minted one |
+| `CONFLUENT_SR_URL` | *(printed by provision.ps1)* | Schema Registry; `http://localhost:8081` for local Redpanda SR |
+| `CONFLUENT_SR_API_KEY` / `CONFLUENT_SR_API_SECRET` | *(minted by provision.ps1)* | SR credentials, cloud only |
+| `STARGATE_MODE` | `cloud` \| `local` \| `capture` | Bridge + producer mode; capture needs no broker |
+| `NEXT_PUBLIC_STARGATE_BRIDGE_URL` | `http://localhost:8100` | Dashboard → bridge SSE endpoint |
+
+The Winston event backbone uses a separate `EVENTS_*` contract (see the Phase
+3B lane's `infra/confluent/README.md`) — same cluster, different consumers, do
+not merge the two.
+
+Last updated: 2026-06-11

--- a/infra/confluent/proto/stargate_telemetry_v2.proto
+++ b/infra/confluent/proto/stargate_telemetry_v2.proto
@@ -1,0 +1,28 @@
+// Stargate telemetry v2 — the schema-evolution demo beat.
+//
+// Adds laser_power_w with a NEW tag (11). Registered on the SAME subject
+// (stargate.printer.telemetry.v1-value) where BACKWARD compatibility makes the
+// registry prove, live, that v1 consumers keep working: unknown field 11 is
+// skipped by every v1 reader. Never reuse or renumber existing tags.
+//
+// No Python bindings are generated for v2 on purpose: two descriptors with the
+// same message name cannot coexist in one process, and the evolution test
+// builds the v2 wire bytes by hand (tag 0x59 + fixed64) instead.
+
+syntax = "proto3";
+
+package stargate.v1;
+
+message StargateTelemetry {
+  string printer_id = 1;
+  int64 ts_us = 2;
+  uint32 layer = 3;
+  string print_job_id = 4;
+  double x = 5;
+  double y = 6;
+  double z = 7;
+  double melt_pool_temp_c = 8;
+  double deposition_rate_kg_hr = 9;
+  double arm_vibration_g = 10;
+  optional double laser_power_w = 11;  // v2: melt-pool energy input
+}

--- a/infra/confluent/stargate/README.md
+++ b/infra/confluent/stargate/README.md
@@ -1,0 +1,78 @@
+# Stargate lane — Confluent Cloud runbook
+
+Cloud provisioning for the Stargate streaming demo (PR 4 of the RS demo
+campaign). Distinct from the Winston event-backbone Phase 3B work in
+`infra/confluent/README.md`: that lane connects `backend/app/events/` to
+`winston.*` topics with the `EVENTS_*` env contract; this lane owns the
+`stargate.*` topics, Schema Registry subjects, and managed Flink, with the
+`CONFLUENT_*` env contract read by `backend/app/events/protobuf_codec.py`.
+Same cluster, two non-overlapping resource sets.
+
+## One-time prerequisite (interactive, cannot be scripted)
+
+```powershell
+confluent login --save
+```
+
+The repo-root `confluent)_kafka_api.json` key is cluster-scoped; management
+commands (topics, SR, service accounts, Flink pools) need an authenticated CLI
+session. Everything after login is scripted and idempotent.
+
+## Provision
+
+```powershell
+cd infra\confluent\stargate
+.\provision.ps1              # discovery + topics + SR + service account + Flink pool
+.\provision.ps1 -SkipFlink   # skip the compute pool (no CFU cost)
+```
+
+The script prints the `CONFLUENT_*` env exports for the producer and bridge at
+the end. Secrets are shown once and never written to disk; put them in
+`scripts/streaming/stargate/.env` (gitignored) or the shell.
+
+## Flink statements
+
+```powershell
+confluent flink statement create agg5s --compute-pool <pool-id> --sql-file .\flink\01_agg_5s.sql
+confluent flink statement create anomaly-route --compute-pool <pool-id> --sql-file .\flink\02_anomaly_route.sql
+confluent flink statement list
+```
+
+`01` produces 5-second tumbling aggregates; `02` routes rows matching
+`melt_pool_temp_c < 1400 AND arm_vibration_g > 0.08` to the anomalies topic.
+The predicate is locked to `signal_mapping.py` by
+`backend/tests/test_stargate_codec.py::TestFlinkSqlLock`.
+
+## The schema-evolution beat (live, during the demo)
+
+```powershell
+confluent schema-registry schema create --subject stargate.printer.telemetry.v1-value `
+  --type protobuf --schema ..\proto\stargate_telemetry_v2.proto
+```
+
+The subject has BACKWARD compatibility; registering v2 (adds optional
+`laser_power_w`) passes the check on stage while the v1 producer keeps running.
+
+## Verification
+
+```powershell
+confluent kafka topic list
+confluent schema-registry schema list --subject-prefix stargate
+confluent flink statement list
+# anomalies routed live while producer.py runs a pre-failure job:
+confluent kafka topic consume stargate.printer.anomalies.v1 --from-beginning
+# DLQ beat:
+python ..\..\..\scripts\streaming\stargate\bad_producer.py --mode cloud
+```
+
+## Cost hygiene
+
+Pause or delete the Flink pool when the demo is done:
+
+```powershell
+confluent flink compute-pool list
+confluent flink compute-pool delete <pool-id>
+```
+
+A Basic cluster bills by throughput/storage and the stargate topics are tiny;
+the compute pool is the only line item that grows while idle.

--- a/infra/confluent/stargate/README.md
+++ b/infra/confluent/stargate/README.md
@@ -32,16 +32,36 @@ the end. Secrets are shown once and never written to disk; put them in
 
 ## Flink statements
 
+Statements are single-SQL: submit each CREATE TABLE and each INSERT
+separately (the checked-in `flink/*.sql` files pair them for readability).
+This CLI version (v4.x) takes `--database <kafka-cluster-id>` and
+`--environment <env-id>` — there is no `--catalog` flag.
+
 ```powershell
-confluent flink statement create agg5s --compute-pool <pool-id> --sql-file .\flink\01_agg_5s.sql
-confluent flink statement create anomaly-route --compute-pool <pool-id> --sql-file .\flink\02_anomaly_route.sql
-confluent flink statement list
+confluent flink statement create agg5s --sql "<INSERT from 01_agg_5s.sql>" `
+  --compute-pool <pool-id> --database <lkc-id> --environment <env-id> `
+  --cloud gcp --region us-east1 `
+  --property "sql.tables.scan.startup.mode=latest-offset" --wait
+confluent flink statement list --cloud gcp --region us-east1 --environment <env-id>
 ```
 
 `01` produces 5-second tumbling aggregates; `02` routes rows matching
 `melt_pool_temp_c < 1400 AND arm_vibration_g > 0.08` to the anomalies topic.
 The predicate is locked to `signal_mapping.py` by
 `backend/tests/test_stargate_codec.py::TestFlinkSqlLock`.
+
+Two lessons from the live verification (2026-06-11):
+
+- **Flink owns its sink topics.** Do not pre-create `agg5s`/`anomalies`
+  topics; the CREATE TABLE statements bind topic + json-registry schema
+  together, and a pre-existing topic leaves Flink an inferred binary table it
+  cannot insert into. The provision script only creates `telemetry` and `dlq`.
+- **Poison records fail-stop managed Flink.** The DLQ beat's corrupted
+  payloads killed both INSERT statements at the bad offsets (deserialization
+  error; this Flink version has no skip-on-error knob). The bridge degraded
+  gracefully — that contrast IS the demo point. Ordering: run the DLQ beat
+  after the Flink beats, then resubmit the statements with
+  `startup.mode=latest-offset` to skip past the poison.
 
 ## The schema-evolution beat (live, during the demo)
 

--- a/infra/confluent/stargate/flink/01_agg_5s.sql
+++ b/infra/confluent/stargate/flink/01_agg_5s.sql
@@ -1,0 +1,35 @@
+-- Managed Flink: 5-second tumbling aggregates per printer.
+-- Run in a Confluent Cloud Flink workspace/compute pool scoped to the cluster
+-- that holds the stargate topics. Statement 1 of 2 (see 02_anomaly_route.sql).
+--
+-- The source table is the topic table Confluent infers from the Protobuf
+-- subject; $rowtime is the Kafka record timestamp. The sink is declared with
+-- json-registry so the bridge's cloud mode reads plain JSON after the
+-- registry frame (it tolerates the 5-byte prefix).
+--
+-- The bridge's local mode emulates exactly this window in
+-- scripts/streaming/stargate/signal_mapping.py::TumblingAggregator.
+
+CREATE TABLE IF NOT EXISTS `stargate.printer.telemetry.agg5s.v1` (
+  printer_id STRING,
+  window_start_ms BIGINT,
+  window_end_ms BIGINT,
+  avg_temp_c DOUBLE,
+  max_vibration_g DOUBLE,
+  n BIGINT
+) WITH (
+  'value.format' = 'json-registry'
+);
+
+INSERT INTO `stargate.printer.telemetry.agg5s.v1`
+SELECT
+  printer_id,
+  1000 * UNIX_TIMESTAMP(CAST(window_start AS STRING)) AS window_start_ms,
+  1000 * UNIX_TIMESTAMP(CAST(window_end AS STRING)) AS window_end_ms,
+  AVG(melt_pool_temp_c) AS avg_temp_c,
+  MAX(arm_vibration_g) AS max_vibration_g,
+  COUNT(*) AS n
+FROM TABLE(
+  TUMBLE(TABLE `stargate.printer.telemetry.v1`, DESCRIPTOR($rowtime), INTERVAL '5' SECOND)
+)
+GROUP BY printer_id, window_start, window_end;

--- a/infra/confluent/stargate/flink/02_anomaly_route.sql
+++ b/infra/confluent/stargate/flink/02_anomaly_route.sql
@@ -19,7 +19,7 @@ INSERT INTO `stargate.printer.anomalies.v1`
 SELECT
   printer_id,
   ts_us,
-  layer,
+  CAST(layer AS INT) AS layer,  -- proto uint32 infers as BIGINT; sink is INT
   print_job_id,
   melt_pool_temp_c,
   arm_vibration_g

--- a/infra/confluent/stargate/flink/02_anomaly_route.sql
+++ b/infra/confluent/stargate/flink/02_anomaly_route.sql
@@ -1,0 +1,27 @@
+-- Managed Flink: route structural-flaw signatures to their own topic.
+-- Statement 2 of 2. The predicate is the canonical anomaly definition; it must
+-- stay equal to scripts/streaming/stargate/signal_mapping.py (is_anomalous).
+-- backend/tests/test_stargate_codec.py parses this file and fails if the
+-- constants drift.
+
+CREATE TABLE IF NOT EXISTS `stargate.printer.anomalies.v1` (
+  printer_id STRING,
+  ts_us BIGINT,
+  layer INT,
+  print_job_id STRING,
+  melt_pool_temp_c DOUBLE,
+  arm_vibration_g DOUBLE
+) WITH (
+  'value.format' = 'json-registry'
+);
+
+INSERT INTO `stargate.printer.anomalies.v1`
+SELECT
+  printer_id,
+  ts_us,
+  layer,
+  print_job_id,
+  melt_pool_temp_c,
+  arm_vibration_g
+FROM `stargate.printer.telemetry.v1`
+WHERE melt_pool_temp_c < 1400.0 AND arm_vibration_g > 0.08;

--- a/infra/confluent/stargate/provision.ps1
+++ b/infra/confluent/stargate/provision.ps1
@@ -1,0 +1,148 @@
+# Stargate lane — Confluent Cloud provisioning. Idempotent; safe to re-run.
+#
+# Prereq: `confluent login --save` once (interactive). The repo-root
+# confluent)_kafka_api.json key is CLUSTER-scoped — it cannot drive these
+# management commands, which is why login is required here and only here.
+#
+#   .\provision.ps1                # discover + provision everything
+#   .\provision.ps1 -SkipFlink     # topics/SR only (no compute pool cost)
+#
+# Creates, in the first environment/cluster found (override with -EnvId/-ClusterId):
+#   topics    stargate.printer.telemetry.v1 (6 partitions)
+#             stargate.printer.telemetry.agg5s.v1, stargate.printer.anomalies.v1,
+#             stargate.printer.dlq.v1 (7-day retention)
+#   SR        v1 + v2 Protobuf schemas on stargate.printer.telemetry.v1-value,
+#             compatibility BACKWARD
+#   account   service account sa-stargate-demo + cluster API key + ACLs scoped
+#             to the stargate.* prefix and the stargate-bridge consumer group
+#   flink     compute pool stargate-demo-pool (5 CFU) — submit the statements in
+#             .\flink\ afterward, and PAUSE the pool when the demo is done.
+#
+# Prints the env exports for the producer/bridge at the end. Never writes
+# secrets to disk.
+
+param(
+    [string]$EnvId = "",
+    [string]$ClusterId = "",
+    [switch]$SkipFlink
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-ConfluentCli {
+    $cmd = Get-Command confluent -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    $winget = "$env:LOCALAPPDATA\Microsoft\WinGet\Packages\ConfluentInc.Confluent-CLI_Microsoft.Winget.Source_8wekyb3d8bbwe\confluent\confluent.exe"
+    if (Test-Path $winget) { return $winget }
+    throw "confluent CLI not found - install with: winget install ConfluentInc.Confluent-CLI"
+}
+
+$cli = Resolve-ConfluentCli
+Write-Host "confluent CLI: $cli"
+
+# -- auth gate ----------------------------------------------------------------
+$whoami = & $cli organization list -o json 2>$null | ConvertFrom-Json
+if (-not $whoami) {
+    Write-Host ""
+    Write-Host "BLOCKED: not logged in to Confluent Cloud." -ForegroundColor Red
+    Write-Host "Run once:  & `"$cli`" login --save"
+    Write-Host "then re-run this script."
+    exit 1
+}
+
+# -- discovery ----------------------------------------------------------------
+if (-not $EnvId) {
+    $envs = & $cli environment list -o json | ConvertFrom-Json
+    $EnvId = $envs[0].id
+}
+& $cli environment use $EnvId | Out-Null
+Write-Host "environment: $EnvId"
+
+if (-not $ClusterId) {
+    $clusters = & $cli kafka cluster list -o json | ConvertFrom-Json
+    if (-not $clusters) { throw "no Kafka cluster in $EnvId - create one in the console first" }
+    $ClusterId = $clusters[0].id
+}
+& $cli kafka cluster use $ClusterId | Out-Null
+$cluster = & $cli kafka cluster describe $ClusterId -o json | ConvertFrom-Json
+$bootstrap = $cluster.endpoint -replace "^SASL_SSL://", ""
+Write-Host "cluster: $ClusterId  bootstrap: $bootstrap"
+
+$sr = & $cli schema-registry cluster describe -o json | ConvertFrom-Json
+$srUrl = $sr.endpoint_url
+Write-Host "schema registry: $srUrl"
+
+# -- topics (idempotent) --------------------------------------------------------
+$existing = (& $cli kafka topic list -o json | ConvertFrom-Json) | ForEach-Object { $_.name }
+$topics = @(
+    @{ name = "stargate.printer.telemetry.v1"; partitions = 6; config = @() },
+    @{ name = "stargate.printer.telemetry.agg5s.v1"; partitions = 1; config = @() },
+    @{ name = "stargate.printer.anomalies.v1"; partitions = 1; config = @() },
+    @{ name = "stargate.printer.dlq.v1"; partitions = 1; config = @("retention.ms=604800000") }
+)
+foreach ($t in $topics) {
+    if ($existing -contains $t.name) { Write-Host "topic exists: $($t.name)"; continue }
+    $cfgArgs = @(); foreach ($c in $t.config) { $cfgArgs += @("--config", $c) }
+    & $cli kafka topic create $t.name --partitions $t.partitions @cfgArgs | Out-Null
+    Write-Host "topic created: $($t.name) ($($t.partitions) partitions)"
+}
+
+# -- schema registry: register v1 + v2, BACKWARD --------------------------------
+$subject = "stargate.printer.telemetry.v1-value"
+$protoDir = Join-Path $PSScriptRoot "..\proto"
+& $cli schema-registry schema create --subject $subject --type protobuf `
+    --schema (Join-Path $protoDir "stargate_telemetry.proto") | Out-Null
+Write-Host "schema registered: $subject (v1)"
+& $cli schema-registry subject update $subject --compatibility BACKWARD | Out-Null
+Write-Host "compatibility: BACKWARD"
+# v2 registration is the live demo beat - the BACKWARD check passing on stage.
+# Run it during the demo, or here if you want it pre-registered:
+#   & $cli schema-registry schema create --subject $subject --type protobuf `
+#       --schema (Join-Path $protoDir "stargate_telemetry_v2.proto")
+
+# -- service account + key + ACLs ------------------------------------------------
+$accounts = & $cli iam service-account list -o json | ConvertFrom-Json
+$sa = $accounts | Where-Object { $_.name -eq "sa-stargate-demo" }
+if (-not $sa) {
+    $sa = & $cli iam service-account create "sa-stargate-demo" `
+        --description "Stargate streaming demo lane (PR 4)" -o json | ConvertFrom-Json
+    Write-Host "service account created: $($sa.id)"
+} else { Write-Host "service account exists: $($sa.id)" }
+
+foreach ($op in @("WRITE", "READ", "DESCRIBE")) {
+    & $cli kafka acl create --allow --service-account $sa.id --operations $op `
+        --topic "stargate." --prefix | Out-Null
+}
+& $cli kafka acl create --allow --service-account $sa.id --operations READ `
+    --consumer-group "stargate-bridge" --prefix | Out-Null
+Write-Host "ACLs: stargate.* topics + stargate-bridge* groups for $($sa.id)"
+
+$key = & $cli api-key create --service-account $sa.id --resource $ClusterId -o json | ConvertFrom-Json
+$srKey = & $cli api-key create --service-account $sa.id --resource $sr.cluster_id -o json | ConvertFrom-Json
+Write-Host "cluster + SR API keys minted for $($sa.id) (secrets shown once below)"
+
+# -- flink compute pool -----------------------------------------------------------
+if (-not $SkipFlink) {
+    $pools = & $cli flink compute-pool list -o json 2>$null | ConvertFrom-Json
+    $pool = $pools | Where-Object { $_.name -eq "stargate-demo-pool" }
+    if (-not $pool) {
+        $pool = & $cli flink compute-pool create "stargate-demo-pool" `
+            --cloud $cluster.cloud --region $cluster.region --max-cfu 5 -o json | ConvertFrom-Json
+        Write-Host "flink pool created: $($pool.id) ($($cluster.cloud)/$($cluster.region), max 5 CFU)"
+    } else { Write-Host "flink pool exists: $($pool.id)" }
+    Write-Host "submit statements with:"
+    Write-Host "  & `"$cli`" flink statement create agg5s --compute-pool $($pool.id) --sql-file .\flink\01_agg_5s.sql"
+    Write-Host "  & `"$cli`" flink statement create anomaly-route --compute-pool $($pool.id) --sql-file .\flink\02_anomaly_route.sql"
+    Write-Host "PAUSE THE POOL after the demo: confluent flink compute-pool update $($pool.id) --max-cfu 0 (or delete it)"
+}
+
+# -- env exports ------------------------------------------------------------------
+Write-Host ""
+Write-Host "Producer/bridge env (copy into scripts/streaming/stargate/.env or the shell):"
+Write-Host "  `$env:CONFLUENT_BOOTSTRAP_SERVERS = `"$bootstrap`""
+Write-Host "  `$env:CONFLUENT_API_KEY = `"$($key.api_key)`""
+Write-Host "  `$env:CONFLUENT_API_SECRET = `"<shown once above>`""
+Write-Host "  `$env:CONFLUENT_SR_URL = `"$srUrl`""
+Write-Host "  `$env:CONFLUENT_SR_API_KEY = `"$($srKey.api_key)`""
+Write-Host "  `$env:CONFLUENT_SR_API_SECRET = `"<shown once above>`""
+Write-Host "  `$env:STARGATE_MODE = `"cloud`""

--- a/infra/confluent/stargate/provision.ps1
+++ b/infra/confluent/stargate/provision.ps1
@@ -27,7 +27,14 @@ param(
     [switch]$SkipFlink
 )
 
-$ErrorActionPreference = "Stop"
+# NOT "Stop": the confluent CLI writes informational lines to stderr ("Set
+# Kafka cluster ... as the active cluster"), which PowerShell 5.1 would turn
+# fatal. Failures are caught by explicit exit-code checks instead.
+$ErrorActionPreference = "Continue"
+
+function Assert-Ok([string]$what) {
+    if ($LASTEXITCODE -ne 0) { Write-Host "FAILED: $what (exit $LASTEXITCODE)" -ForegroundColor Red; exit 1 }
+}
 
 function Resolve-ConfluentCli {
     $cmd = Get-Command confluent -ErrorAction SilentlyContinue
@@ -55,7 +62,7 @@ if (-not $EnvId) {
     $envs = & $cli environment list -o json | ConvertFrom-Json
     $EnvId = $envs[0].id
 }
-& $cli environment use $EnvId | Out-Null
+& $cli environment use $EnvId 2>$null | Out-Null
 Write-Host "environment: $EnvId"
 
 if (-not $ClusterId) {
@@ -63,27 +70,30 @@ if (-not $ClusterId) {
     if (-not $clusters) { throw "no Kafka cluster in $EnvId - create one in the console first" }
     $ClusterId = $clusters[0].id
 }
-& $cli kafka cluster use $ClusterId | Out-Null
+& $cli kafka cluster use $ClusterId 2>$null | Out-Null
 $cluster = & $cli kafka cluster describe $ClusterId -o json | ConvertFrom-Json
 $bootstrap = $cluster.endpoint -replace "^SASL_SSL://", ""
 Write-Host "cluster: $ClusterId  bootstrap: $bootstrap"
 
 $sr = & $cli schema-registry cluster describe -o json | ConvertFrom-Json
 $srUrl = $sr.endpoint_url
-Write-Host "schema registry: $srUrl"
+$srId = $sr.cluster        # field is named 'cluster' (lsrc-...), not cluster_id
+Write-Host "schema registry: $srId $srUrl"
 
 # -- topics (idempotent) --------------------------------------------------------
 $existing = (& $cli kafka topic list -o json | ConvertFrom-Json) | ForEach-Object { $_.name }
+# agg5s + anomalies are NOT created here: Flink's CREATE TABLE statements own
+# them (table = topic + json-registry schema, bound together). Pre-creating
+# them leaves Flink an inferred binary table it cannot insert into.
 $topics = @(
     @{ name = "stargate.printer.telemetry.v1"; partitions = 6; config = @() },
-    @{ name = "stargate.printer.telemetry.agg5s.v1"; partitions = 1; config = @() },
-    @{ name = "stargate.printer.anomalies.v1"; partitions = 1; config = @() },
     @{ name = "stargate.printer.dlq.v1"; partitions = 1; config = @("retention.ms=604800000") }
 )
 foreach ($t in $topics) {
     if ($existing -contains $t.name) { Write-Host "topic exists: $($t.name)"; continue }
     $cfgArgs = @(); foreach ($c in $t.config) { $cfgArgs += @("--config", $c) }
     & $cli kafka topic create $t.name --partitions $t.partitions @cfgArgs | Out-Null
+    Assert-Ok "create topic $($t.name)"
     Write-Host "topic created: $($t.name) ($($t.partitions) partitions)"
 }
 
@@ -92,6 +102,7 @@ $subject = "stargate.printer.telemetry.v1-value"
 $protoDir = Join-Path $PSScriptRoot "..\proto"
 & $cli schema-registry schema create --subject $subject --type protobuf `
     --schema (Join-Path $protoDir "stargate_telemetry.proto") | Out-Null
+Assert-Ok "register v1 schema on $subject"
 Write-Host "schema registered: $subject (v1)"
 & $cli schema-registry subject update $subject --compatibility BACKWARD | Out-Null
 Write-Host "compatibility: BACKWARD"
@@ -117,9 +128,34 @@ foreach ($op in @("WRITE", "READ", "DESCRIBE")) {
     --consumer-group "stargate-bridge" --prefix | Out-Null
 Write-Host "ACLs: stargate.* topics + stargate-bridge* groups for $($sa.id)"
 
-$key = & $cli api-key create --service-account $sa.id --resource $ClusterId -o json | ConvertFrom-Json
-$srKey = & $cli api-key create --service-account $sa.id --resource $sr.cluster_id -o json | ConvertFrom-Json
-Write-Host "cluster + SR API keys minted for $($sa.id) (secrets shown once below)"
+# Schema Registry permissions are RBAC, not Kafka ACLs. Producers only READ
+# the subject (auto-register is off in the cloud env; registration is a
+# provisioning act, done above).
+& $cli iam rbac role-binding create --principal "User:$($sa.id)" --role DeveloperRead `
+    --resource "Subject:$subject" --environment $EnvId --schema-registry-cluster $srId 2>$null | Out-Null
+Write-Host "RBAC: DeveloperRead on $subject for $($sa.id)"
+
+# Keys land in the gitignored lane .env (never the console, never git). If the
+# .env already carries a key pair, reuse it — secrets are unretrievable after
+# minting, so re-running must not orphan working keys.
+$envFile = Join-Path $PSScriptRoot "..\..\..\scripts\streaming\stargate\.env"
+$haveKeys = (Test-Path $envFile) -and (Select-String -Path $envFile -Pattern "^CONFLUENT_API_KEY=" -Quiet)
+if ($haveKeys) {
+    Write-Host "API keys already in scripts/streaming/stargate/.env - reusing (delete the file to re-mint)"
+} else {
+    $key = & $cli api-key create --service-account $sa.id --resource $ClusterId -o json | ConvertFrom-Json
+    $srKey = & $cli api-key create --service-account $sa.id --resource $srId -o json | ConvertFrom-Json
+    @(
+        "CONFLUENT_BOOTSTRAP_SERVERS=$bootstrap"
+        "CONFLUENT_API_KEY=$($key.api_key)"
+        "CONFLUENT_API_SECRET=$($key.api_secret)"
+        "CONFLUENT_SR_URL=$srUrl"
+        "CONFLUENT_SR_API_KEY=$($srKey.api_key)"
+        "CONFLUENT_SR_API_SECRET=$($srKey.api_secret)"
+        "STARGATE_MODE=cloud"
+    ) | Set-Content -Path $envFile -Encoding ascii
+    Write-Host "cluster + SR API keys minted for $($sa.id) -> scripts/streaming/stargate/.env (gitignored)"
+}
 
 # -- flink compute pool -----------------------------------------------------------
 if (-not $SkipFlink) {
@@ -136,13 +172,8 @@ if (-not $SkipFlink) {
     Write-Host "PAUSE THE POOL after the demo: confluent flink compute-pool update $($pool.id) --max-cfu 0 (or delete it)"
 }
 
-# -- env exports ------------------------------------------------------------------
+# -- done ---------------------------------------------------------------------------
 Write-Host ""
-Write-Host "Producer/bridge env (copy into scripts/streaming/stargate/.env or the shell):"
-Write-Host "  `$env:CONFLUENT_BOOTSTRAP_SERVERS = `"$bootstrap`""
-Write-Host "  `$env:CONFLUENT_API_KEY = `"$($key.api_key)`""
-Write-Host "  `$env:CONFLUENT_API_SECRET = `"<shown once above>`""
-Write-Host "  `$env:CONFLUENT_SR_URL = `"$srUrl`""
-Write-Host "  `$env:CONFLUENT_SR_API_KEY = `"$($srKey.api_key)`""
-Write-Host "  `$env:CONFLUENT_SR_API_SECRET = `"<shown once above>`""
-Write-Host "  `$env:STARGATE_MODE = `"cloud`""
+Write-Host "Producer/bridge env contract written to scripts/streaming/stargate/.env."
+Write-Host "Load it in a shell with:"
+Write-Host "  Get-Content scripts/streaming/stargate/.env | ForEach-Object { `$n, `$v = `$_ -split '=', 2; Set-Item env:`$n `$v }"

--- a/scripts/streaming/stargate/bad_producer.py
+++ b/scripts/streaming/stargate/bad_producer.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""DLQ demo: publish deliberately corrupted payloads to the telemetry topic.
+
+The bridge's deserializer rejects each one, surfaces it in the DLQ buffer with
+a reason, and best-effort routes the raw bytes to stargate.printer.dlq.v1 —
+the "break it on purpose" beat: bad data is visible and routed, never dropped
+and never fatal.
+
+    python bad_producer.py --mode local            # Redpanda
+    python bad_producer.py --mode cloud --count 5  # Confluent Cloud
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+
+import common  # noqa: F401  (sys.path bootstrap)
+from common import StargateTopics
+
+CORRUPT_PAYLOADS = [
+    # raw JSON where Protobuf + SR framing is expected
+    json.dumps({"printer_id": "stargate-v4-66", "melt_pool_temp_c": "not-a-number"}).encode(),
+    # valid magic byte, garbage after it
+    b"\x00\x00\x00\x00\x07\xff\xfe\xfd\xfc\xfb",
+    # truncated mid-message
+    b"\x00\x00\x00",
+    # plain text, the classic "sensor firmware printed a log line into the data plane"
+    b"ERROR: sensor SG-TEMP-04 watchdog reset 0xDEADBEEF",
+    # empty value
+    b"",
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=["local", "cloud"], default="local")
+    parser.add_argument("--count", type=int, default=len(CORRUPT_PAYLOADS))
+    args = parser.parse_args()
+
+    if args.mode == "local":
+        os.environ.setdefault("CONFLUENT_BOOTSTRAP_SERVERS", "localhost:9092")
+
+    from confluent_kafka import Producer
+
+    from app.events.protobuf_codec import build_confluent_conf
+
+    producer = Producer(build_confluent_conf())
+    sent = 0
+    for i in range(args.count):
+        payload = CORRUPT_PAYLOADS[i % len(CORRUPT_PAYLOADS)]
+        producer.produce(StargateTopics.TELEMETRY, key=b"bad-producer", value=payload)
+        sent += 1
+        time.sleep(0.3)  # spaced out so the DLQ panel visibly counts up
+    producer.flush(10)
+    print(f"sent {sent} corrupted payloads to {StargateTopics.TELEMETRY} ({args.mode})")
+    print("watch /stargate/dlq and the dashboard DLQ panel count up")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/streaming/stargate/bridge.py
+++ b/scripts/streaming/stargate/bridge.py
@@ -249,6 +249,17 @@ async def replay_capture_forever(state: BridgeState, lines: list[str]) -> None:
 
 # -- broker modes --------------------------------------------------------------
 
+def loads_registry_json(raw: bytes) -> dict:
+    """JSON rows from managed Flink sinks arrive json-registry framed (magic
+    byte + 4-byte schema id before the JSON). Accept both framed and plain."""
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        if len(raw) > 5 and raw[0] == 0:
+            return json.loads(raw[5:])
+        raise
+
+
 def consume_forever(state: BridgeState) -> None:
     """Daemon thread: consume the Stargate topics. Telemetry decode failures are
     routed to the DLQ topic (best-effort) AND surfaced in the DLQ buffer."""
@@ -306,13 +317,13 @@ def consume_forever(state: BridgeState) -> None:
                 state.ingest_dlq(topic, "routed to DLQ topic", raw)
             elif topic == StargateTopics.AGG_5S:
                 try:
-                    state.rings["agg"].append(json.loads(raw))
-                except json.JSONDecodeError:
+                    state.rings["agg"].append(loads_registry_json(raw))
+                except (json.JSONDecodeError, UnicodeDecodeError):
                     state.ingest_dlq(topic, "agg row not JSON", raw)
             elif topic == StargateTopics.ANOMALIES:
                 try:
-                    state.rings["anomalies"].append(json.loads(raw))
-                except json.JSONDecodeError:
+                    state.rings["anomalies"].append(loads_registry_json(raw))
+                except (json.JSONDecodeError, UnicodeDecodeError):
                     state.ingest_dlq(topic, "anomaly row not JSON", raw)
     finally:
         state.consumer_alive = False


### PR DESCRIPTION
PR 4 of the RS demo campaign. **Merge after PR 3 (#149)** - stacked on `feat/rs-stargate-slice`.

ADO: Epic #497 > Feature #530 > Story #533.

## What this is

The cloud half of the Stargate lane, fully built and locally exercised:

- `infra/confluent/stargate/provision.ps1` - idempotent: env/cluster/SR discovery, the 4 `stargate.*` topics, Protobuf subject registration with BACKWARD compatibility, `sa-stargate-demo` service account + prefix-scoped ACLs, Flink compute pool. Prints the `CONFLUENT_*` env exports; never writes secrets.
- `infra/confluent/stargate/flink/` - the two managed-Flink statements: 5s tumbling aggregates and the anomaly route (`temp < 1400 AND vib > 0.08`) to its own topic, json-registry sinks the bridge already decodes.
- `infra/confluent/proto/stargate_telemetry_v2.proto` - the live schema-evolution beat (optional `laser_power_w`, registered against the BACKWARD subject during the demo).
- `scripts/streaming/stargate/bad_producer.py` - five corruption shapes for the break-it-on-purpose beat.
- Tests (+4, now 27): Flink-SQL constants parsed from `02_anomaly_route.sql` and locked to `signal_mapping`; v1-reader-skips-v2-field evolution proof (hand-built wire bytes); json-registry frame decoding.

## Evidence (checkpoint B, details in docs/plans/RS_STARGATE_FACTORY_ML_SESSION_PLAN.md)

- 27 tests passed in the lane venv
- DLQ beat live against local Redpanda: `/stargate/dlq` count **0 -> 5**, each entry carrying its real deserialization reason; ingestion never crashed

## Pending: cloud verification

One interactive step cannot be scripted: `confluent login --save`. The stored repo-root key is **cluster-scoped** (401 on the management API) and no bootstrap/SR URL exists anywhere on this machine, so topics/SR/Flink provisioning needs an authenticated CLI session once. After login, the runbook in `infra/confluent/stargate/README.md` runs verbatim: provision -> submit both Flink statements -> `producer.py --mode cloud` -> consume the anomalies topic -> `bad_producer.py --mode cloud` -> pause the pool. Evidence will be appended to the session plan doc and this PR when that runs.

## Toe-stepping note

The Phase 3B event-backbone session (branch `feat/cloud-broker-event-transport`, uncommitted) owns `infra/confluent/README.md`, the `EVENTS_*` env contract, and `winston.*` topics. This lane is disjoint by construction: `stargate.*` topics, `CONFLUENT_*` env, everything under `infra/confluent/stargate/` and `infra/confluent/proto/`. No shared files, no shared cluster resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)