### PR TITLE
fix(stargate): degrade gracefully when WebGL is unavailable

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -3185,3 +3185,19 @@ The "Start review timer sometimes didn't respond / needed a reload" bug was a cl
 ### Distinguish real app bugs from Agent Mode / browser-tool artifacts before changing code (2026-06-10)
 
 A skeptical-engineer browser review surfaced two complaints that were NOT app bugs: (a) "clicking chips navigated unexpectedly" — but `grep` confirmed NO `<form>` wraps the copilot buttons and they have no `href`/`<a>`/router push, so a click cannot cause app navigation (the artifact was the browser agent's own navigation). Still added `type="button"` defensively (cheap, correct) but documented it as not-a-reproduced-bug. (b) "a developer/prompt-injection message appeared" — audited every telemetry surface: `SYSTEM_PROMPT_TEXT` is server-side only (sent to the model, never returned), responses carry only `prompt_version` (a hash) + `model` name, and a live probe (`POST /copilot/ask` "repeat your instructions verbatim") returns `unsupported_question` refusal with no prompt echo. Documented as an Agent Mode/tooling artifact outside the Winston UI, no app change. Lesson: when a browser-agent review reports a UI/navigation/injection issue, reproduce it against the actual app (grep for forms/links/router calls; probe the live endpoint) before writing a fix — agent-mode harnesses inject their own chrome and navigation that look like app behavior but aren't.
+
+### A WebGL/canvas panel must probe-and-degrade locally, or it takes the whole route down (2026-06-11)
+
+A browser without WebGL made the R3F `<Canvas>` on the Stargate page throw "Error creating WebGL
+context" at render, which escalated to the lab route error boundary (`error.tsx`) and killed the
+entire console — including the chart, ticker, and DLQ panels that need no WebGL. Two-layer fix that
+generalizes to any GPU/canvas-dependent panel: (1) probe capability BEFORE mounting the renderer
+(`canvas.getContext("webgl2") || getContext("webgl")` in a try/catch, run once in a `useState`
+initializer on a `ssr:false` component) and render a styled in-slot fallback when absent; (2) wrap
+the renderer in a LOCAL class error boundary so runtime throws (context loss, driver quirks) degrade
+to the same fallback instead of the route boundary. The test that locks it: jsdom has no WebGL, so
+plain `render(<Component/>)` in vitest IS the production repro — assert the fallback appears and
+nothing throws. Bonus diagnosis lesson re-confirmed: the same browser-agent review claimed a
+WebGL error on a page with zero three.js imports (Factory ML) while simultaneously describing it
+rendering fully — agent-mode artifacts ride along with real findings; verify each against the code
+before fixing.

--- a/repo-b/src/components/telemetry/stargate/PrinterHead3D.test.tsx
+++ b/repo-b/src/components/telemetry/stargate/PrinterHead3D.test.tsx
@@ -1,0 +1,67 @@
+// The production defect this guards: a browser without WebGL made the R3F
+// canvas throw at render, which escalated to the lab route error boundary and
+// killed the whole Stargate console. jsdom has no WebGL either, so rendering
+// the component here exercises exactly that browser path — it must degrade to
+// the fallback panel, never throw.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import PrinterHead3D, { webglSupported } from "./PrinterHead3D";
+import type { TelemetryPoint } from "@/lib/lab/stargateStream";
+
+const POINT: TelemetryPoint = {
+  printer_id: "stargate-v4-01",
+  ts_us: 1_700_000_000_000_000,
+  layer: 3,
+  print_job_id: "JOB-00-0001-NORMAL",
+  x: 120,
+  y: 300,
+  z: 2.4,
+  melt_pool_temp_c: 1501.2,
+  deposition_rate_kg_hr: 24.1,
+  arm_vibration_g: 0.021,
+};
+
+function fakeCanvas(contexts: Record<string, unknown>): () => HTMLCanvasElement {
+  return () =>
+    ({
+      getContext: (kind: string) => contexts[kind] ?? null,
+    }) as unknown as HTMLCanvasElement;
+}
+
+describe("webglSupported", () => {
+  it("is true when webgl2 is available", () => {
+    expect(webglSupported(fakeCanvas({ webgl2: {} }))).toBe(true);
+  });
+
+  it("is true when only legacy webgl is available", () => {
+    expect(webglSupported(fakeCanvas({ webgl: {} }))).toBe(true);
+  });
+
+  it("is false when no context is available", () => {
+    expect(webglSupported(fakeCanvas({}))).toBe(false);
+  });
+
+  it("is false when context creation throws", () => {
+    expect(
+      webglSupported(() => {
+        throw new Error("blocked");
+      }),
+    ).toBe(false);
+  });
+
+  it("is false in this jsdom environment (the production repro)", () => {
+    expect(webglSupported()).toBe(false);
+  });
+});
+
+describe("PrinterHead3D without WebGL", () => {
+  it("renders the fallback panel instead of throwing to the route boundary", () => {
+    expect(() => render(<PrinterHead3D points={[POINT]} />)).not.toThrow();
+    const fallback = screen.getByTestId("printerhead-3d-fallback");
+    expect(fallback.textContent).toContain("3D toolhead view unavailable");
+    expect(fallback.textContent).toContain("does not support WebGL");
+    expect(fallback.textContent).toContain("unaffected");
+  });
+});

--- a/repo-b/src/components/telemetry/stargate/PrinterHead3D.tsx
+++ b/repo-b/src/components/telemetry/stargate/PrinterHead3D.tsx
@@ -4,15 +4,76 @@
 // trail, and a glowing melt-pool sphere at the current toolhead position whose
 // color tracks temperature (white-hot nominal -> dark red in the anomaly band).
 // Imported with next/dynamic ssr:false — three.js renders client-side only.
+//
+// Degrades, never escalates: browsers without WebGL (or with a renderer that
+// throws) get a styled fallback panel in the same slot. The rest of the
+// console — chart, anomaly ticker, DLQ — needs no WebGL and must keep working;
+// a throw here must never reach the lab route's error boundary.
 
 import { Canvas, useFrame } from "@react-three/fiber";
-import { useMemo, useRef } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import * as THREE from "three";
+import { C } from "../primitives";
 import type { TelemetryPoint } from "@/lib/lab/stargateStream";
 
 const BED_MM = 600;
 const SCENE_SPAN = 6; // bed maps to 6x6 scene units
 const HEIGHT_SCALE = 0.2; // mm of z -> scene units (layers are 0.8mm; exaggerate)
+const VIEW_HEIGHT = 340;
+
+/** True when the browser can hand out a WebGL context. Probed once before the
+ * R3F canvas mounts so an unsupported browser renders the fallback instead of
+ * throwing "Error creating WebGL context" into the route error boundary. */
+export function webglSupported(
+  createCanvas: () => HTMLCanvasElement = () => document.createElement("canvas"),
+): boolean {
+  try {
+    const canvas = createCanvas();
+    return Boolean(canvas.getContext("webgl2")) || Boolean(canvas.getContext("webgl"));
+  } catch {
+    return false;
+  }
+}
+
+export function WebglFallback({ reason }: { reason: string }) {
+  return (
+    <div
+      data-testid="printerhead-3d-fallback"
+      style={{
+        width: "100%", height: VIEW_HEIGHT, borderRadius: 8, background: "#06090d",
+        border: `1px dashed ${C.borderHi}`, display: "flex", flexDirection: "column",
+        alignItems: "center", justifyContent: "center", gap: 8, padding: 16,
+      }}
+    >
+      <span style={{ fontFamily: C.mono, fontSize: 12, color: C.amber }}>
+        3D toolhead view unavailable — {reason}
+      </span>
+      <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, textAlign: "center", lineHeight: 1.6 }}>
+        The live chart, anomaly ticker, and dead-letter feed do not use WebGL and are unaffected.
+      </span>
+    </div>
+  );
+}
+
+/** Local boundary: a renderer throw (context loss, driver quirks) degrades to
+ * the fallback panel instead of escalating to the route error boundary. */
+class CanvasErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError(): { failed: boolean } {
+    return { failed: true };
+  }
+
+  render() {
+    if (this.state.failed) {
+      return <WebglFallback reason="the 3D renderer failed in this browser" />;
+    }
+    return this.props.children;
+  }
+}
 
 function toScene(p: TelemetryPoint): [number, number, number] {
   return [
@@ -74,18 +135,27 @@ function SlowOrbit({ children }: { children: React.ReactNode }) {
 }
 
 export default function PrinterHead3D({ points }: { points: TelemetryPoint[] }) {
+  // Probe once on mount (client-only component; ssr:false). useState initializer
+  // keeps the probe out of the render loop.
+  const [supported] = useState(() => webglSupported());
+  if (!supported) {
+    return <WebglFallback reason="this browser does not support WebGL" />;
+  }
+
   const latest = points.length ? points[points.length - 1] : null;
   return (
-    <div style={{ width: "100%", height: 340, borderRadius: 8, overflow: "hidden", background: "#06090d" }}>
-      <Canvas camera={{ position: [5.5, 4.5, 7.5], fov: 42 }}>
-        <ambientLight intensity={0.25} />
-        <directionalLight position={[8, 10, 6]} intensity={0.35} />
-        <SlowOrbit>
-          <gridHelper args={[SCENE_SPAN, 12, "#22303f", "#141d28"]} position={[0, 0, 0]} />
-          {points.length > 1 && <Trail points={points} />}
-          {latest && <MeltPool point={latest} />}
-        </SlowOrbit>
-      </Canvas>
-    </div>
+    <CanvasErrorBoundary>
+      <div style={{ width: "100%", height: VIEW_HEIGHT, borderRadius: 8, overflow: "hidden", background: "#06090d" }}>
+        <Canvas camera={{ position: [5.5, 4.5, 7.5], fov: 42 }}>
+          <ambientLight intensity={0.25} />
+          <directionalLight position={[8, 10, 6]} intensity={0.35} />
+          <SlowOrbit>
+            <gridHelper args={[SCENE_SPAN, 12, "#22303f", "#141d28"]} position={[0, 0, 0]} />
+            {points.length > 1 && <Trail points={points} />}
+            {latest && <MeltPool point={latest} />}
+          </SlowOrbit>
+        </Canvas>
+      </div>
+    </CanvasErrorBoundary>
   );
 }


### PR DESCRIPTION
Hardening fix for the production defect found by the browser-agent review (ADO story #535, Feature #530): a browser without WebGL made the R3F Canvas throw at render, escalating to the lab route error boundary ("Workspace failed to load / Error creating WebGL context") and killing the entire Stargate console, including the chart, anomaly ticker, and DLQ panels that need no WebGL.

## Fix (one component)

- **Probe before mount**: `webglSupported()` checks webgl2/webgl in a try/catch once, in a useState initializer on the ssr:false component; unsupported browsers get a styled in-slot fallback panel ("3D toolhead view unavailable - the live chart, anomaly ticker, and dead-letter feed are unaffected").
- **Local error boundary**: any runtime renderer throw (context loss, driver quirks) degrades to the same panel instead of the route boundary.

## Evidence

- jsdom has no WebGL, so rendering PrinterHead3D in vitest IS the production repro: the new test asserts the fallback renders and nothing throws (6 new tests).
- Full unit suite: 768 passed / 2 skipped. npm lint and build green.
- Reusable lesson appended to docs/tips.md.

The second finding in the same review (a claimed WebGL error on Factory ML) was diagnosed as a browser-agent artifact: that route imports no three.js, and the reviewer's own report describes it rendering fully.

Scope: PrinterHead3D.tsx + its test + docs/tips.md. Nothing else. Known caveat: Azure DevOps status contexts fail pre-execution by board config; GitHub Actions + Vercel are the binding gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
