### PR TITLE
Telemetry environment: mobile refactor + navigation cohesion

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -3201,3 +3201,26 @@ nothing throws. Bonus diagnosis lesson re-confirmed: the same browser-agent revi
 WebGL error on a page with zero three.js imports (Factory ML) while simultaneously describing it
 rendering fully — agent-mode artifacts ride along with real findings; verify each against the code
 before fixing.
+
+### Making an inline-style surface responsive: literal Tailwind for layout, palette for paint (2026-06-12)
+
+The telemetry console styles everything with inline `CSSProperties` from a palette object, which
+means zero media queries — every grid was desktop-only. The retrofit that worked: a handful of
+layout primitives in `primitives.tsx` (`StatGrid`, `SplitGrid`, `ScrollTable`, `ResponsiveSwap`,
+`RowCard`) that carry **literal** Tailwind responsive classes (`grid grid-cols-2 lg:grid-cols-4`,
+`lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]`) while color/typography stay inline. Rules learned:
+
+- Class strings must be literal, keyed off a fixed variant union — Tailwind's content scanner never
+  sees classes composed from props, so `lg:grid-cols-${n}` silently generates nothing.
+- An inline `style={{ display: "flex" }}` beats `lg:hidden` (inline > any class), so an element that
+  must hide per-breakpoint needs its display in classes too: `className="flex lg:hidden"`. This bit
+  the mobile header and bottom nav on first pass — desktop showed both plus the rail.
+- `ResponsiveSwap` (CSS-only `sm:hidden` / `hidden sm:block`) is the zero-hydration-risk way to swap
+  a dense grid-table for a card list; reserve `useIsMobile()` for true behavior changes (e.g. not
+  mounting the Stargate three.js canvas under 640px — and gate it behind a `mounted` flag, because
+  the hook's SSR default is desktop and would otherwise mount the canvas for one frame on phones).
+- Navigation cohesion came free once `TELEMETRY_NAV` became a single config consumed by the desktop
+  rail, the mobile drawer, and the bottom tab bar (4 primaries + "More" opens the drawer). 12 flat
+  items in a bottom bar don't fit; group the drawer instead.
+- When re-verifying after a rebuild, confirm the new server actually bound the port — an EADDRINUSE
+  leftover from the previous `next start` will happily serve the stale build and "disprove" the fix.

--- a/repo-b/package-lock.json
+++ b/repo-b/package-lock.json
@@ -8989,6 +8989,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/repo-b/src/components/telemetry/Copilot.tsx
+++ b/repo-b/src/components/telemetry/Copilot.tsx
@@ -339,7 +339,7 @@ export function DispositionControls({ reportId, modelVerdict, fireTick, evidence
             {[1, 2, 3, 4, 5].map((c) => (
               <button key={c} type="button" data-testid={`disposition-confidence-${c}`}
                 onClick={() => setConfidence(c)}
-                style={{ fontFamily: C.mono, fontSize: 11, width: 26, height: 26, borderRadius: 6, cursor: "pointer",
+                style={{ fontFamily: C.mono, fontSize: 11, width: 40, height: 40, borderRadius: 6, cursor: "pointer",
                   color: confidence === c ? C.bg : C.dim, background: confidence === c ? C.cyan : "transparent",
                   border: `1px solid ${confidence === c ? C.cyan : C.border}` }}>{c}</button>
             ))}

--- a/repo-b/src/components/telemetry/FactoryNcrIntelligence.tsx
+++ b/repo-b/src/components/telemetry/FactoryNcrIntelligence.tsx
@@ -12,6 +12,7 @@ import {
   XAxis, YAxis, ReferenceLine, Cell,
 } from "recharts";
 
+import { SplitGrid, StatGrid } from "./primitives";
 import { RS, RS_MONO, RS_SANS, RsPanel, RsChip, RsKpi } from "./rsTokens";
 import {
   getNcr, TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID,
@@ -185,7 +186,7 @@ export default function FactoryNcrIntelligence() {
       </div>
 
       {/* KPI tiles — all real derivations; absent values say so */}
-      <div style={{ display: "flex", gap: 12, paddingBottom: 12 }}>
+      <StatGrid cols={4} style={{ paddingBottom: 12 }}>
         <RsKpi label="Open NCRs" value={k?.open_now != null ? String(k.open_now) : "not available"}
           sub={k?.open_weeks_ago != null ? `vs ${k.open_weeks_ago} eight weeks ago` : "no 8-week history"} />
         <RsKpi label="Median time to close"
@@ -199,9 +200,9 @@ export default function FactoryNcrIntelligence() {
             ? `${k.rising_labels[0]} +${k.rising_labels.length - 1} more`
             : (k?.rising_labels?.[0] ?? "none rising")}
           color={k && k.clusters_rising > 0 ? RS.red : RS.green} />
-      </div>
+      </StatGrid>
 
-      <div style={{ display: "grid", gap: 12, gridTemplateColumns: "minmax(0,2fr) minmax(300px,1fr)" }}>
+      <SplitGrid variant="two-one">
         {/* embedding map — REAL model coordinates */}
         <RsPanel title="NCR EMBEDDING MAP · UMAP PROJECTION · HDBSCAN CLUSTERS"
           right={<span style={{ color: RS.faint, fontFamily: RS_MONO, fontSize: 11 }}>
@@ -337,10 +338,10 @@ export default function FactoryNcrIntelligence() {
             </div>
           )}
         </RsPanel>
-      </div>
+      </SplitGrid>
 
       {/* bottom analytics row */}
-      <div style={{ display: "grid", gap: 12, marginTop: 12, gridTemplateColumns: "1fr 1fr" }}>
+      <SplitGrid variant="halves" style={{ marginTop: 12 }}>
         <RsPanel title="PARETO BY DISCOVERED CLUSTER · CORPUS WINDOW">
           <ResponsiveContainer width="100%" height={190}>
             <ComposedChart data={data.pareto} margin={{ top: 10, right: 8, bottom: 0, left: 0 }}>
@@ -417,7 +418,7 @@ export default function FactoryNcrIntelligence() {
             the empirical 90% quantile of walk-forward residuals.
           </div>
         </RsPanel>
-      </div>
+      </SplitGrid>
 
       <div style={{ padding: "12px 0 4px", textAlign: "center", fontSize: 11, color: RS.faint }}>
         Synthetic NCR corpus (deterministic, SEED=20260609) — no program or supplier data. The

--- a/repo-b/src/components/telemetry/GovernanceDashboard.tsx
+++ b/repo-b/src/components/telemetry/GovernanceDashboard.tsx
@@ -5,7 +5,10 @@ import {
   getGovernance, getEvals, getUsefulness,
   type GovernanceSummary, type EvalResults, type UsefulnessSummary, type ArmMeasures,
 } from "@/lib/telemetry/copilot-api";
-import { C, Tag, Panel, MetricCard, Loading, ErrorState, PageHeading, DisclosureFooter } from "./primitives";
+import {
+  C, Tag, Panel, MetricCard, Loading, ErrorState, PageHeading, DisclosureFooter,
+  StatGrid, SplitGrid, ScrollTable, ResponsiveSwap, RowCard,
+} from "./primitives";
 
 const pct = (x: number | null | undefined) => (x == null ? null : `${Math.round(x * 100)}%`);
 const ms = (x: number | null | undefined) => (x == null ? null : `${x}ms`);
@@ -73,7 +76,7 @@ export default function GovernanceDashboard() {
       </Panel>
 
       {/* metric strip */}
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12, marginTop: 16 }}>
+      <StatGrid cols={4} style={{ marginTop: 16 }}>
         <GovMetric label="Grounded answer rate" value={pct(g.grounded_rate)} accent={C.green}
           sub={`${g.total_interactions} logged interactions`} />
         <GovMetric label="Refusal rate" value={pct(g.refusal_rate)} accent={C.amber}
@@ -88,13 +91,13 @@ export default function GovernanceDashboard() {
           sub={`${tool.success || 0} ok · ${toolErr} error · ${tool.skipped || 0} skipped`} />
         <GovMetric label="Active model" value={g.active_model || null}
           sub={`prompt ${g.active_prompt_version}`} />
-      </div>
+      </StatGrid>
 
       {/* operator usefulness (within-reviewer A/B) */}
       <UsefulnessPanel u={u} />
 
       {/* evals + production smoke */}
-      <div style={{ display: "grid", gridTemplateColumns: "1.3fr 1fr", gap: 16, marginTop: 16 }}>
+      <SplitGrid variant="main-side" style={{ marginTop: 16 }}>
         <Panel title="Eval suite"
           right={e?.summary ? <Tag color={e.summary.passed === e.summary.total ? C.green : C.red}>{e.summary.passed}/{e.summary.total} pass</Tag> : <Tag color={C.faint}>not available</Tag>}>
           {!e || !e.available ? (
@@ -142,32 +145,51 @@ export default function GovernanceDashboard() {
             </>
           )}
         </Panel>
-      </div>
+      </SplitGrid>
 
       {/* recent interactions */}
       <Panel title="Recent interactions" right={<Tag color={C.cyan}>{g.recent_interactions.length} shown</Tag>} style={{ marginTop: 16 }}>
-        <div style={{ display: "grid", gridTemplateColumns: "1.1fr 0.8fr 0.9fr 0.5fr 1.6fr", gap: 8, fontFamily: C.mono,
-          fontSize: 10, color: C.faint, letterSpacing: "0.06em", textTransform: "uppercase", paddingBottom: 6 }}>
-          <span>When</span><span>Intent</span><span>Source</span><span>ms</span><span>Question</span>
-        </div>
-        <div style={{ borderTop: `1px solid ${C.border}` }}>
-          {g.recent_interactions.map((r, i) => (
-            <div key={i} style={{ display: "grid", gridTemplateColumns: "1.1fr 0.8fr 0.9fr 0.5fr 1.6fr", gap: 8,
-              fontFamily: C.mono, fontSize: 11, color: C.text, padding: "6px 0", borderBottom: `1px solid ${C.border}` }}>
-              <span style={{ color: C.dim }}>{r.created_at ? r.created_at.replace("T", " ").slice(0, 19) : "—"}</span>
-              <span style={{ color: r.is_refusal ? C.amber : C.dim }}>{r.is_refusal ? "refusal" : (r.intent || "—")}</span>
-              <span style={{ color: r.answer_source === "live_llm" ? C.green : r.answer_source === "refusal" ? C.amber : C.cyan }}>
-                {r.answer_source}{r.fallback_reason ? `:${r.fallback_reason}` : ""}
-              </span>
-              <span style={{ color: C.faint }}>{r.elapsed_ms ?? "—"}</span>
-              <span style={{ color: C.dim, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{r.question || "—"}</span>
+        <ResponsiveSwap
+          mobile={
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              {g.recent_interactions.map((r, i) => (
+                <RowCard key={i}
+                  title={<span style={{ fontWeight: 400, color: C.dim }}>{r.question || "—"}</span>}
+                  tags={<Tag color={r.is_refusal ? C.amber : C.dim}>{r.is_refusal ? "refusal" : (r.intent || "—")}</Tag>}
+                  fields={[
+                    { label: "When", value: r.created_at ? r.created_at.replace("T", " ").slice(0, 19) : "—" },
+                    { label: "ms", value: r.elapsed_ms ?? "—" },
+                    { label: "Source", value: `${r.answer_source}${r.fallback_reason ? `:${r.fallback_reason}` : ""}` },
+                  ]} />
+              ))}
             </div>
-          ))}
-        </div>
+          }
+          desktop={
+            <>
+              <div style={{ display: "grid", gridTemplateColumns: "1.1fr 0.8fr 0.9fr 0.5fr 1.6fr", gap: 8, fontFamily: C.mono,
+                fontSize: 10, color: C.faint, letterSpacing: "0.06em", textTransform: "uppercase", paddingBottom: 6 }}>
+                <span>When</span><span>Intent</span><span>Source</span><span>ms</span><span>Question</span>
+              </div>
+              <div style={{ borderTop: `1px solid ${C.border}` }}>
+                {g.recent_interactions.map((r, i) => (
+                  <div key={i} style={{ display: "grid", gridTemplateColumns: "1.1fr 0.8fr 0.9fr 0.5fr 1.6fr", gap: 8,
+                    fontFamily: C.mono, fontSize: 11, color: C.text, padding: "6px 0", borderBottom: `1px solid ${C.border}` }}>
+                    <span style={{ color: C.dim }}>{r.created_at ? r.created_at.replace("T", " ").slice(0, 19) : "—"}</span>
+                    <span style={{ color: r.is_refusal ? C.amber : C.dim }}>{r.is_refusal ? "refusal" : (r.intent || "—")}</span>
+                    <span style={{ color: r.answer_source === "live_llm" ? C.green : r.answer_source === "refusal" ? C.amber : C.cyan }}>
+                      {r.answer_source}{r.fallback_reason ? `:${r.fallback_reason}` : ""}
+                    </span>
+                    <span style={{ color: C.faint }}>{r.elapsed_ms ?? "—"}</span>
+                    <span style={{ color: C.dim, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{r.question || "—"}</span>
+                  </div>
+                ))}
+              </div>
+            </>
+          } />
       </Panel>
 
       {/* refusal + blocked examples */}
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, marginTop: 16 }}>
+      <SplitGrid variant="halves" style={{ marginTop: 16 }}>
         <Panel title="Recent refusals (out-of-scope)">
           {g.recent_refusals.length === 0 ? (
             <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint }}>None recorded.</span>
@@ -188,7 +210,7 @@ export default function GovernanceDashboard() {
             </div>
           ))}
         </Panel>
-      </div>
+      </SplitGrid>
 
       <DisclosureFooter />
     </>
@@ -231,22 +253,24 @@ function UsefulnessPanel({ u }: { u: UsefulnessSummary | null }) {
         Until then they read “not measured”, never a placeholder zero. Deterministic anchors below are live now.
       </div>
       {/* six measures × two arms, N in the header */}
-      <div style={{ display: "grid", gridTemplateColumns: "1.6fr 1fr 1fr", gap: 8, fontFamily: C.mono,
-        fontSize: 10, color: C.faint, letterSpacing: "0.06em", textTransform: "uppercase", paddingBottom: 6 }}>
-        <span>Measure</span>
-        <span>assisted (N={asg?.n ?? 0})</span>
-        <span>unassisted (N={una?.n ?? 0})</span>
-      </div>
-      <div style={{ borderTop: `1px solid ${C.border}` }}>
-        {ROWS.map((row) => (
-          <div key={row.label} style={{ display: "grid", gridTemplateColumns: "1.6fr 1fr 1fr", gap: 8,
-            fontFamily: C.mono, fontSize: 11.5, color: C.text, padding: "7px 0", borderBottom: `1px solid ${C.border}` }}>
-            <span style={{ color: C.dim }}>{row.label}</span>
-            <Cell v={armCell(asg, row.fld, row.kind)} />
-            <Cell v={armCell(una, row.fld, row.kind)} />
-          </div>
-        ))}
-      </div>
+      <ScrollTable minWidth={560}>
+        <div style={{ display: "grid", gridTemplateColumns: "1.6fr 1fr 1fr", gap: 8, fontFamily: C.mono,
+          fontSize: 10, color: C.faint, letterSpacing: "0.06em", textTransform: "uppercase", paddingBottom: 6 }}>
+          <span>Measure</span>
+          <span>assisted (N={asg?.n ?? 0})</span>
+          <span>unassisted (N={una?.n ?? 0})</span>
+        </div>
+        <div style={{ borderTop: `1px solid ${C.border}` }}>
+          {ROWS.map((row) => (
+            <div key={row.label} style={{ display: "grid", gridTemplateColumns: "1.6fr 1fr 1fr", gap: 8,
+              fontFamily: C.mono, fontSize: 11.5, color: C.text, padding: "7px 0", borderBottom: `1px solid ${C.border}` }}>
+              <span style={{ color: C.dim }}>{row.label}</span>
+              <Cell v={armCell(asg, row.fld, row.kind)} />
+              <Cell v={armCell(una, row.fld, row.kind)} />
+            </div>
+          ))}
+        </div>
+      </ScrollTable>
       {/* deterministic anchors — real now, not self-reported */}
       <div style={{ display: "flex", flexWrap: "wrap", gap: 16, marginTop: 12, paddingTop: 10, borderTop: `1px solid ${C.border}` }}>
         <Anchor k="Unsupported claims blocked" v={u ? String(u.anchors.postvalidator_block_count) : "—"} col={C.red} />

--- a/repo-b/src/components/telemetry/MissionControlStream.tsx
+++ b/repo-b/src/components/telemetry/MissionControlStream.tsx
@@ -14,6 +14,7 @@ import {
   deriveLag, STREAM_REASON_HINT, useStreamPoll,
   type StreamChannel, type StreamEvent, type StreamLive,
 } from "@/lib/telemetry/stream";
+import { SplitGrid } from "./primitives";
 import { RS, RS_MONO, RS_SANS, RsChip, RsPanel } from "./rsTokens";
 
 const WINDOW_S = 120;
@@ -187,7 +188,7 @@ export default function MissionControlStream() {
       )}
 
       {live && live.channels.length > 0 && (
-        <div style={{ display: "grid", gap: 12, gridTemplateColumns: "minmax(0,3fr) minmax(280px,1fr)" }}>
+        <SplitGrid variant="wide-main-side">
           {/* Left: channel selector ribbon + synced strips */}
           <RsPanel>
             <div style={{ display: "flex", flexWrap: "wrap", gap: 6, padding: "8px 12px",
@@ -278,7 +279,7 @@ export default function MissionControlStream() {
               </div>
             </RsPanel>
           </div>
-        </div>
+        </SplitGrid>
       )}
 
       {/* Demo-honesty footnote (owner-mandated acceptance gate) */}

--- a/repo-b/src/components/telemetry/ModelPerformance.tsx
+++ b/repo-b/src/components/telemetry/ModelPerformance.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import {
   getModelPerformance, type ModelRun, TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID,
 } from "@/lib/telemetry/api";
-import { C, Tag, Panel, Loading, ErrorState, PageHeading, DisclosureFooter } from "./primitives";
+import { C, Tag, Panel, Loading, ErrorState, PageHeading, DisclosureFooter, ScrollTable } from "./primitives";
 
 function metric(m: ModelRun, k: string): string {
   const v = (m.metrics || {})[k];
@@ -22,22 +22,24 @@ function Table({ title, cols, rows }: { title: string; cols: string[]; rows: Mod
   const grid = "1.4fr 0.8fr 0.8fr 0.9fr 0.9fr";
   return (
     <Panel title={title}>
-      <div style={{ display: "grid", gridTemplateColumns: grid, gap: 8, fontFamily: C.mono, fontSize: 10,
-        color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase", paddingBottom: 8 }}>
-        {cols.map((c) => <span key={c}>{c}</span>)}
-      </div>
-      <div style={{ borderTop: `1px solid ${C.border}` }}>
-        {rows.map((m) => (
-          <div key={`${m.model_name}-${m.model_version}`} style={{ display: "grid", gridTemplateColumns: grid, gap: 8,
-            alignItems: "center", fontFamily: C.mono, fontSize: 12, color: C.text, padding: "9px 0", borderBottom: `1px solid ${C.border}` }}>
-            <span>{m.model_name}</span>
-            <span style={{ fontWeight: 600 }}>{isRul ? metric(m, "rmse") : metric(m, "precision")}</span>
-            <span style={{ color: C.dim }}>{isRul ? metric(m, "phm") : metric(m, "recall")}</span>
-            <span style={{ color: isRul ? C.dim : C.text, fontWeight: isRul ? 400 : 600 }}>{isRul ? "" : metric(m, "f1")}</span>
-            <span><StatusTag m={m} /></span>
-          </div>
-        ))}
-      </div>
+      <ScrollTable minWidth={560}>
+        <div style={{ display: "grid", gridTemplateColumns: grid, gap: 8, fontFamily: C.mono, fontSize: 10,
+          color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase", paddingBottom: 8 }}>
+          {cols.map((c) => <span key={c}>{c}</span>)}
+        </div>
+        <div style={{ borderTop: `1px solid ${C.border}` }}>
+          {rows.map((m) => (
+            <div key={`${m.model_name}-${m.model_version}`} style={{ display: "grid", gridTemplateColumns: grid, gap: 8,
+              alignItems: "center", fontFamily: C.mono, fontSize: 12, color: C.text, padding: "9px 0", borderBottom: `1px solid ${C.border}` }}>
+              <span>{m.model_name}</span>
+              <span style={{ fontWeight: 600 }}>{isRul ? metric(m, "rmse") : metric(m, "precision")}</span>
+              <span style={{ color: C.dim }}>{isRul ? metric(m, "phm") : metric(m, "recall")}</span>
+              <span style={{ color: isRul ? C.dim : C.text, fontWeight: isRul ? 400 : 600 }}>{isRul ? "" : metric(m, "f1")}</span>
+              <span><StatusTag m={m} /></span>
+            </div>
+          ))}
+        </div>
+      </ScrollTable>
     </Panel>
   );
 }

--- a/repo-b/src/components/telemetry/Monitoring.tsx
+++ b/repo-b/src/components/telemetry/Monitoring.tsx
@@ -6,7 +6,10 @@ import {
   type StreamBlock,
   TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID,
 } from "@/lib/telemetry/api";
-import { C, Tag, Panel, MetricCard, Loading, ErrorState, EmptyState, PageHeading, DisclosureFooter } from "./primitives";
+import {
+  C, Tag, Panel, MetricCard, Loading, ErrorState, EmptyState, PageHeading, DisclosureFooter,
+  StatGrid, SplitGrid,
+} from "./primitives";
 
 export default function Monitoring() {
   const [mon, setMon] = useState<MonitoringResponse | null>(null);
@@ -31,14 +34,14 @@ export default function Monitoring() {
   return (
     <>
       {heading}
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12 }}>
+      <StatGrid cols={4}>
         <MetricCard label="Predictions logged" value={String(summary.kpi.predictions)} />
         <MetricCard label="Rolling no-go rate" value={rate != null ? `${(rate * 100).toFixed(1)}%` : "—"} accent={C.amber} />
         <MetricCard label="Drift monitors" value={String(driftMonitors)} sub={mon.psi != null ? `worst PSI ${mon.psi.toFixed(2)}` : "PSI computed"} />
         <MetricCard label="Serving model" value={mon.latest_model_version ? `v${mon.latest_model_version}` : "—"} sub={mon.latest_model_name ?? undefined} accent={C.cyan} />
-      </div>
+      </StatGrid>
 
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, marginTop: 16 }}>
+      <SplitGrid variant="halves" style={{ marginTop: 16 }}>
         <Panel title="Drift status (PSI per monitored channel)">
           {driftMonitors > 0 ? (
             <DriftBands summary={summary} />
@@ -53,7 +56,7 @@ export default function Monitoring() {
           <Row label="Window" value={mon.window_label} />
           <Row label="PSI bands" value="stable <0.1 · watch 0.1-0.25 · drift >0.25" />
         </Panel>
-      </div>
+      </SplitGrid>
 
       {mon.conformal_budget && <ConformalBudgetPanel b={mon.conformal_budget} liveRate={rate} />}
 
@@ -74,7 +77,7 @@ function StreamHealthPanel({ s }: { s: StreamBlock }) {
   return (
     <Panel title="Stream health (live ingestion)" style={{ marginTop: 16 }}
       right={<Tag color={col}>{s.status ?? "unknown"}</Tag>}>
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12 }}>
+      <StatGrid cols={4}>
         <MetricCard label="Pipeline status" value={s.status ?? "unknown"} accent={col}
           sub={s.reason ?? undefined} />
         <MetricCard label="Last frame at"
@@ -84,7 +87,7 @@ function StreamHealthPanel({ s }: { s: StreamBlock }) {
         <MetricCard label="Failing assertions (15m)"
           value={s.failing_assertions != null ? String(s.failing_assertions) : "—"}
           accent={s.failing_assertions ? C.red : C.green} />
-      </div>
+      </StatGrid>
       <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.6,
         display: "block", marginTop: 10 }}>
         Live ISS public-telemetry ingestion (bronze → silver → gold). Detail — per-channel freshness,
@@ -103,12 +106,12 @@ function ConformalBudgetPanel({ b, liveRate }: { b: ConformalBudget; liveRate: n
   return (
     <Panel title="Conformal false-alarm budget (diagnostic)" style={{ marginTop: 16 }}
       right={b.status ? <Tag color={color}>{b.status} budget</Tag> : undefined}>
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12 }}>
+      <StatGrid cols={4}>
         <MetricCard label="Target false-alarm budget (α)" value={pct(b.alpha)} />
         <MetricCard label="Measured calibration FA rate" value={pct(b.measured_false_alarm_rate)} accent={color} />
         <MetricCard label="Calibration coverage" value={pct(b.calib_coverage)} accent={C.green} />
         <MetricCard label="Live rolling no-go rate" value={pct(liveRate)} accent={C.amber} />
-      </div>
+      </StatGrid>
       <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.6, display: "block", marginTop: 10 }}>
         Measured on a blocked (contiguous) nominal-train calibration slice against the frozen detector
         (K={b.frozen_k ?? "—"}); to hold false alarms at α you would set K≈{b.threshold_quantile ?? "—"}. This is a

--- a/repo-b/src/components/telemetry/RegistryConsole.tsx
+++ b/repo-b/src/components/telemetry/RegistryConsole.tsx
@@ -208,8 +208,7 @@ export default function RegistryConsole() {
       )}
 
       {data && data.models.length > 0 && (
-        <div style={{ display: "grid", gap: 12,
-          gridTemplateColumns: "230px minmax(0,2fr) minmax(0,1.4fr)" }}>
+        <div className="grid gap-3 grid-cols-1 lg:grid-cols-[230px_minmax(0,2fr)_minmax(0,1.4fr)]">
           {/* Model list */}
           <RsPanel title="REGISTERED MODELS">
             {kinds.map((k) => {

--- a/repo-b/src/components/telemetry/ReplayConsole.tsx
+++ b/repo-b/src/components/telemetry/ReplayConsole.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { getReplayFeed, type ReplayFeed, type ReplayTick } from "@/lib/telemetry/api";
-import { C, Tag, Panel, Loading, ErrorState, PageHeading, DisclosureFooter } from "./primitives";
+import { C, Panel, Loading, ErrorState, PageHeading, DisclosureFooter, SplitGrid } from "./primitives";
 import { CopilotExplanationPanel } from "./Copilot";
 
 const W = 900, H = 280, PAD = 28;
@@ -75,7 +75,7 @@ export default function ReplayConsole() {
         </span>
       </div>
 
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 320px", gap: 16 }}>
+      <SplitGrid variant="main-side">
         <Panel title="Telemetry trace" pad={12}>
           <svg viewBox={`0 0 ${W} ${H}`} style={{ width: "100%", display: "block" }} role="img" aria-label="Telemetry trace with detected anomaly">
             {fireX >= 0 && cursorX >= fireX && (
@@ -134,7 +134,7 @@ export default function ReplayConsole() {
             ) : <span style={{ fontFamily: C.mono, fontSize: 12, color: C.dim }}>No contributing channels yet.</span>}
           </Panel>
         </div>
-      </div>
+      </SplitGrid>
 
       {explain && firedSoFar && (
         <div style={{ marginTop: 16 }}>

--- a/repo-b/src/components/telemetry/RunsExplorer.tsx
+++ b/repo-b/src/components/telemetry/RunsExplorer.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { getRuns, type TestRun, TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID } from "@/lib/telemetry/api";
-import { C, Tag, Panel, Loading, ErrorState, PageHeading, DisclosureFooter } from "./primitives";
+import { C, Tag, Panel, Loading, ErrorState, PageHeading, DisclosureFooter, ResponsiveSwap, RowCard } from "./primitives";
 
 export default function RunsExplorer() {
   const [runs, setRuns] = useState<TestRun[] | null>(null);
@@ -22,22 +22,39 @@ export default function RunsExplorer() {
     <>
       {heading}
       <Panel title="Ingested test runs" right={<Tag color={C.cyan}>{runs.length} runs</Tag>}>
-        <div style={{ display: "grid", gridTemplateColumns: grid, gap: 8, fontFamily: C.mono, fontSize: 10,
-          color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase", paddingBottom: 8 }}>
-          <span>Run</span><span>Dataset</span><span>Unit / craft</span><span>Rows</span><span>Status</span>
-        </div>
-        <div style={{ borderTop: `1px solid ${C.border}`, maxHeight: 560, overflowY: "auto" }}>
-          {runs.map((r) => (
-            <div key={r.id} style={{ display: "grid", gridTemplateColumns: grid, gap: 8, alignItems: "center",
-              fontFamily: C.mono, fontSize: 12, color: C.text, padding: "8px 0", borderBottom: `1px solid ${C.border}` }}>
-              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{r.run_key}</span>
-              <span style={{ color: C.dim }}>{r.dataset}</span>
-              <span style={{ color: C.dim }}>{r.unit_or_channel}{r.spacecraft ? ` · ${r.spacecraft}` : ""}</span>
-              <span>{r.row_count.toLocaleString()}</span>
-              <span><Tag color={C.green}>{r.status}</Tag></span>
+        <ResponsiveSwap
+          mobile={
+            <div style={{ maxHeight: 560, overflowY: "auto", display: "flex", flexDirection: "column", gap: 8 }}>
+              {runs.map((r) => (
+                <RowCard key={r.id} title={r.run_key}
+                  tags={<><Tag color={C.dim}>{r.dataset}</Tag><Tag color={C.green}>{r.status}</Tag></>}
+                  fields={[
+                    { label: "Unit / craft", value: `${r.unit_or_channel}${r.spacecraft ? ` · ${r.spacecraft}` : ""}` },
+                    { label: "Rows", value: r.row_count.toLocaleString() },
+                  ]} />
+              ))}
             </div>
-          ))}
-        </div>
+          }
+          desktop={
+            <>
+              <div style={{ display: "grid", gridTemplateColumns: grid, gap: 8, fontFamily: C.mono, fontSize: 10,
+                color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase", paddingBottom: 8 }}>
+                <span>Run</span><span>Dataset</span><span>Unit / craft</span><span>Rows</span><span>Status</span>
+              </div>
+              <div style={{ borderTop: `1px solid ${C.border}`, maxHeight: 560, overflowY: "auto" }}>
+                {runs.map((r) => (
+                  <div key={r.id} style={{ display: "grid", gridTemplateColumns: grid, gap: 8, alignItems: "center",
+                    fontFamily: C.mono, fontSize: 12, color: C.text, padding: "8px 0", borderBottom: `1px solid ${C.border}` }}>
+                    <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{r.run_key}</span>
+                    <span style={{ color: C.dim }}>{r.dataset}</span>
+                    <span style={{ color: C.dim }}>{r.unit_or_channel}{r.spacecraft ? ` · ${r.spacecraft}` : ""}</span>
+                    <span>{r.row_count.toLocaleString()}</span>
+                    <span><Tag color={C.green}>{r.status}</Tag></span>
+                  </div>
+                ))}
+              </div>
+            </>
+          } />
         <div style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, marginTop: 12 }}>
           Runs served from the Supabase serving layer (tel_test_runs). Row counts are the real ingested
           window counts from Databricks Gold.

--- a/repo-b/src/components/telemetry/TelemetryBottomNav.tsx
+++ b/repo-b/src/components/telemetry/TelemetryBottomNav.tsx
@@ -27,9 +27,9 @@ export default function TelemetryBottomNav({ envId, onMore }: { envId: string; o
   const labelStyle: React.CSSProperties = { fontFamily: C.mono, fontSize: 9, letterSpacing: "0.06em" };
 
   return (
-    <nav aria-label="Telemetry sections" className="lg:hidden pb-safe"
-      style={{ position: "fixed", bottom: 0, left: 0, right: 0, zIndex: 40,
-        background: C.rail, borderTop: `1px solid ${C.border}`, display: "flex" }}>
+    // Display stays in classes (flex lg:hidden) — an inline display would override lg:hidden.
+    <nav aria-label="Telemetry sections" className="flex lg:hidden pb-safe fixed bottom-0 inset-x-0 z-40"
+      style={{ background: C.rail, borderTop: `1px solid ${C.border}` }}>
       {tabs.map((t) => {
         const active = tabActive(t.slug);
         const shortLabel = t.slug === "stream" ? "Stream" : t.slug === "copilot" ? "Copilot" : t.label;

--- a/repo-b/src/components/telemetry/TelemetryBottomNav.tsx
+++ b/repo-b/src/components/telemetry/TelemetryBottomNav.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { C } from "./primitives";
+import { TELEMETRY_NAV, isTelemetryItemActive, telemetryHref } from "./telemetryNav";
+
+// Mobile bottom tab bar: the four mobilePrimary sections plus a "More" button
+// that opens the full drawer. Structure follows MobileBottomNav (fixed bottom,
+// pb-safe, active indicator bar) but styled on the telemetry palette — the
+// shared component is bound to bm-* tokens and a lucide icon union.
+export default function TelemetryBottomNav({ envId, onMore }: { envId: string; onMore: () => void }) {
+  const pathname = usePathname() || "";
+  const tabs = TELEMETRY_NAV.filter((n) => n.mobilePrimary);
+  const tabActive = (slug: string) => isTelemetryItemActive(pathname, envId, slug);
+  const moreActive = !tabs.some((t) => tabActive(t.slug));
+
+  const itemStyle = (active: boolean): React.CSSProperties => ({
+    position: "relative", display: "flex", flexDirection: "column", alignItems: "center",
+    justifyContent: "center", gap: 4, flex: 1, minHeight: 56, textDecoration: "none",
+    color: active ? C.cyan : C.dim, background: "transparent", border: "none", cursor: "pointer",
+  });
+  const indicator = (
+    <span aria-hidden style={{ position: "absolute", top: 0, left: "25%", right: "25%", height: 2,
+      borderRadius: 2, background: C.cyan }} />
+  );
+  const labelStyle: React.CSSProperties = { fontFamily: C.mono, fontSize: 9, letterSpacing: "0.06em" };
+
+  return (
+    <nav aria-label="Telemetry sections" className="lg:hidden pb-safe"
+      style={{ position: "fixed", bottom: 0, left: 0, right: 0, zIndex: 40,
+        background: C.rail, borderTop: `1px solid ${C.border}`, display: "flex" }}>
+      {tabs.map((t) => {
+        const active = tabActive(t.slug);
+        const shortLabel = t.slug === "stream" ? "Stream" : t.slug === "copilot" ? "Copilot" : t.label;
+        return (
+          <Link key={t.slug || "overview"} href={telemetryHref(envId, t.slug)}
+            aria-current={active ? "page" : undefined} style={itemStyle(active)}>
+            {active && indicator}
+            <svg width="20" height="20" viewBox="0 0 16 16">
+              <path d={t.icon} stroke={active ? C.cyan : C.faint} strokeWidth={active ? 1.5 : 1.3} fill="none" strokeLinejoin="round" />
+            </svg>
+            <span style={labelStyle}>{shortLabel}</span>
+          </Link>
+        );
+      })}
+      <button type="button" onClick={onMore} aria-label="All sections" style={itemStyle(moreActive)}>
+        {moreActive && indicator}
+        <svg width="20" height="20" viewBox="0 0 16 16">
+          <path d="M3 8h.01M8 8h.01M13 8h.01" stroke={moreActive ? C.cyan : C.faint} strokeWidth="2.4" strokeLinecap="round" fill="none" />
+        </svg>
+        <span style={labelStyle}>More</span>
+      </button>
+    </nav>
+  );
+}

--- a/repo-b/src/components/telemetry/TelemetryOverview.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.tsx
@@ -7,7 +7,10 @@ import {
   type ModelRun, type TelemetrySummary, type TestRun, type FusedVectorInfo,
   TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID,
 } from "@/lib/telemetry/api";
-import { C, Tag, Panel, MetricCard, Loading, ErrorState, PageHeading, DisclosureFooter } from "./primitives";
+import {
+  C, Tag, Panel, MetricCard, Loading, ErrorState, PageHeading, DisclosureFooter,
+  StatGrid, SplitGrid, ResponsiveSwap, RowCard,
+} from "./primitives";
 
 function ModelCard({ m }: { m: ModelRun }) {
   const champ = m.promotion_state === "promoted";
@@ -106,7 +109,7 @@ export default function TelemetryOverview({ envId }: { envId: string }) {
         } />
 
       {/* metric strip */}
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12 }}>
+      <StatGrid cols={4}>
         <MetricCard label="Promoted models" value={String(k.promoted_models)} sub={`of ${inv.model_runs} evaluated`} />
         <MetricCard label="Anomaly F1" value={k.anomaly_f1 != null ? Number(k.anomaly_f1).toFixed(4) : "—"}
           sub={challengerF1 != null ? `champion vs ${Number(challengerF1).toFixed(4)} challenger` : undefined} accent={C.cyan} />
@@ -114,12 +117,12 @@ export default function TelemetryOverview({ envId }: { envId: string }) {
           sub={challengerRmse != null ? `champion vs ${Number(challengerRmse).toFixed(2)} challenger` : undefined} accent={C.green} />
         <MetricCard label="Predictions" value={num(k.predictions)}
           sub={noGoPct != null ? `${noGoPct}% no-go · ${k.test_runs} runs` : undefined} accent={C.amber} />
-      </div>
+      </StatGrid>
 
       {/* model registry + (replay preview + drift) */}
-      <div style={{ display: "grid", gridTemplateColumns: "1.5fr 1fr", gap: 16, marginTop: 16 }}>
+      <SplitGrid variant="main-side" style={{ marginTop: 16 }}>
         <Panel title="Model registry" right={<Tag color={C.green}>{k.promoted_models} promoted · {models.length - k.promoted_models} challengers</Tag>}>
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             {models.map((m) => <ModelCard key={`${m.model_name}-${m.model_version}`} m={m} />)}
           </div>
           <div style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, marginTop: 14 }}>
@@ -135,7 +138,7 @@ export default function TelemetryOverview({ envId }: { envId: string }) {
             <p style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, lineHeight: 1.5 }}>{summary.note}</p>
           </Panel>
         </div>
-      </div>
+      </SplitGrid>
 
       {/* Fused state vector (Phase 7A) — only when built + verified; shows the ACTUAL dim */}
       {fused?.available && (
@@ -161,23 +164,39 @@ export default function TelemetryOverview({ envId }: { envId: string }) {
       )}
 
       {/* test runs + serving inventory */}
-      <div style={{ display: "grid", gridTemplateColumns: "1.5fr 1fr", gap: 16, marginTop: 16 }}>
+      <SplitGrid variant="main-side" style={{ marginTop: 16 }}>
         <Panel title="Ingested test runs" right={<Tag color={C.cyan}>{inv.test_runs} runs</Tag>}>
-          <div style={{ display: "grid", gridTemplateColumns: "1.6fr 1fr 1fr 0.7fr", gap: 8, fontFamily: C.mono,
-            fontSize: 10, color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase", paddingBottom: 8 }}>
-            <span>Run</span><span>Dataset</span><span>Unit / craft</span><span>Rows</span>
-          </div>
-          <div style={{ borderTop: `1px solid ${C.border}` }}>
-            {runs.slice(0, 8).map((r) => (
-              <div key={r.id} style={{ display: "grid", gridTemplateColumns: "1.6fr 1fr 1fr 0.7fr", gap: 8,
-                fontFamily: C.mono, fontSize: 12, color: C.text, padding: "7px 0", borderBottom: `1px solid ${C.border}` }}>
-                <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{r.run_key}</span>
-                <span style={{ color: C.dim }}>{r.dataset}</span>
-                <span style={{ color: C.dim }}>{r.unit_or_channel}{r.spacecraft ? ` · ${r.spacecraft}` : ""}</span>
-                <span>{r.row_count.toLocaleString()}</span>
+          <ResponsiveSwap
+            mobile={
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                {runs.slice(0, 8).map((r) => (
+                  <RowCard key={r.id} title={r.run_key} tags={<Tag color={C.dim}>{r.dataset}</Tag>}
+                    fields={[
+                      { label: "Unit / craft", value: `${r.unit_or_channel}${r.spacecraft ? ` · ${r.spacecraft}` : ""}` },
+                      { label: "Rows", value: r.row_count.toLocaleString() },
+                    ]} />
+                ))}
               </div>
-            ))}
-          </div>
+            }
+            desktop={
+              <>
+                <div style={{ display: "grid", gridTemplateColumns: "1.6fr 1fr 1fr 0.7fr", gap: 8, fontFamily: C.mono,
+                  fontSize: 10, color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase", paddingBottom: 8 }}>
+                  <span>Run</span><span>Dataset</span><span>Unit / craft</span><span>Rows</span>
+                </div>
+                <div style={{ borderTop: `1px solid ${C.border}` }}>
+                  {runs.slice(0, 8).map((r) => (
+                    <div key={r.id} style={{ display: "grid", gridTemplateColumns: "1.6fr 1fr 1fr 0.7fr", gap: 8,
+                      fontFamily: C.mono, fontSize: 12, color: C.text, padding: "7px 0", borderBottom: `1px solid ${C.border}` }}>
+                      <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{r.run_key}</span>
+                      <span style={{ color: C.dim }}>{r.dataset}</span>
+                      <span style={{ color: C.dim }}>{r.unit_or_channel}{r.spacecraft ? ` · ${r.spacecraft}` : ""}</span>
+                      <span>{r.row_count.toLocaleString()}</span>
+                    </div>
+                  ))}
+                </div>
+              </>
+            } />
           <div style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, marginTop: 12 }}>
             SMAP/MSL anomaly channels (go/no-go) + C-MAPSS RUL units. {inv.test_runs} runs total.
           </div>
@@ -197,7 +216,7 @@ export default function TelemetryOverview({ envId }: { envId: string }) {
             Drift monitors: {k.drift_monitors} · last score {k.last_scored_at ? new Date(k.last_scored_at).toISOString().slice(0, 10) : "—"}
           </div>
         </Panel>
-      </div>
+      </SplitGrid>
 
       <DisclosureFooter />
     </>

--- a/repo-b/src/components/telemetry/TelemetryShell.tsx
+++ b/repo-b/src/components/telemetry/TelemetryShell.tsx
@@ -3,31 +3,47 @@
 import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import TelemetrySidebar from "./TelemetrySidebar";
+import TelemetryBottomNav from "./TelemetryBottomNav";
 import { C } from "./primitives";
+import { telemetrySectionLabel } from "./telemetryNav";
 
-// Option B "Lab Workbench" shell: a single 224px rail (TEL ANOMALY / WORKBENCH identity, the five
-// telemetry sections, serving + auth status pinned at the bottom) and a full-bleed main column.
+// Option B "Lab Workbench" shell. Desktop: a single 224px rail (TEL ANOMALY / WORKBENCH
+// identity, grouped sections, serving + auth status pinned at the bottom) and a full-bleed
+// main column. Mobile: sticky top header (identity + current section + hamburger), a
+// slide-over drawer reusing the rail, and a bottom tab bar with the four primary sections.
 // No executive chrome (the lab shell yields full-bleed for /telemetry).
 export default function TelemetryShell({ envId, children }: { envId: string; children: React.ReactNode }) {
   const pathname = usePathname();
   const [drawerOpen, setDrawerOpen] = useState(false);
   useEffect(() => { setDrawerOpen(false); }, [pathname]);
 
+  // Lock body scroll while the drawer is open (same pattern as ConsultingWorkspaceShell).
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = prev; };
+  }, [drawerOpen]);
+
+  const Brand = (
+    <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+      <div style={{ width: 24, height: 24, borderRadius: 6, border: `1px solid ${C.cyan}55`,
+        background: "rgba(63,177,232,0.1)", display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+        <svg width="13" height="13" viewBox="0 0 14 14">
+          <path d="M1 10l3-4 2.5 2L9 4l4 6" stroke={C.cyan} strokeWidth="1.4" fill="none" strokeLinejoin="round" />
+        </svg>
+      </div>
+      <div>
+        <div style={{ fontFamily: C.mono, fontSize: 11, fontWeight: 600, letterSpacing: "0.04em", color: C.text }}>TEL ANOMALY</div>
+        <div style={{ fontFamily: C.mono, fontSize: 9, color: C.faint, letterSpacing: "0.1em" }}>WORKBENCH</div>
+      </div>
+    </div>
+  );
+
   const Rail = (
     <aside style={{ width: 224, flexShrink: 0, background: C.rail, borderRight: `1px solid ${C.border}`,
-      display: "flex", flexDirection: "column", padding: "20px 14px", minHeight: "100vh" }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "0 6px 18px" }}>
-        <div style={{ width: 24, height: 24, borderRadius: 6, border: `1px solid ${C.cyan}55`,
-          background: "rgba(63,177,232,0.1)", display: "flex", alignItems: "center", justifyContent: "center" }}>
-          <svg width="13" height="13" viewBox="0 0 14 14">
-            <path d="M1 10l3-4 2.5 2L9 4l4 6" stroke={C.cyan} strokeWidth="1.4" fill="none" strokeLinejoin="round" />
-          </svg>
-        </div>
-        <div>
-          <div style={{ fontFamily: C.mono, fontSize: 11, fontWeight: 600, letterSpacing: "0.04em", color: C.text }}>TEL ANOMALY</div>
-          <div style={{ fontFamily: C.mono, fontSize: 9, color: C.faint, letterSpacing: "0.1em" }}>WORKBENCH</div>
-        </div>
-      </div>
+      display: "flex", flexDirection: "column", padding: "20px 14px", minHeight: "100%" }}>
+      <div style={{ padding: "0 6px 18px" }}>{Brand}</div>
       <TelemetrySidebar envId={envId} onNavigate={() => setDrawerOpen(false)} />
       <div style={{ marginTop: "auto", paddingTop: 18, borderTop: `1px solid ${C.border}` }}>
         <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
@@ -43,21 +59,41 @@ export default function TelemetryShell({ envId, children }: { envId: string; chi
     <div style={{ display: "flex", background: C.bg, minHeight: "100vh", fontFamily: C.sans, color: C.text }}>
       <div className="hidden lg:flex">{Rail}</div>
 
-      {/* mobile menu button */}
-      <button type="button" onClick={() => setDrawerOpen(true)}
-        className="lg:hidden"
-        style={{ position: "fixed", top: 12, left: 12, zIndex: 30, fontFamily: C.mono, fontSize: 12,
-          color: C.dim, background: C.panel, border: `1px solid ${C.border}`, borderRadius: 7, padding: "6px 10px" }}>
-        Menu
-      </button>
+      <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}>
+        {/* mobile top header */}
+        <header className="lg:hidden sticky top-0 z-30"
+          style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10,
+            padding: "8px 8px 8px 16px", background: C.rail, borderBottom: `1px solid ${C.border}` }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 12, minWidth: 0 }}>
+            {Brand}
+            <span style={{ fontFamily: C.mono, fontSize: 10, color: C.dim, letterSpacing: "0.08em",
+              textTransform: "uppercase", borderLeft: `1px solid ${C.border}`, paddingLeft: 12,
+              whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+              {telemetrySectionLabel(pathname || "", envId)}
+            </span>
+          </div>
+          <button type="button" onClick={() => setDrawerOpen(true)} aria-label="Open navigation"
+            style={{ width: 44, height: 44, display: "flex", alignItems: "center", justifyContent: "center",
+              background: "transparent", border: "none", cursor: "pointer", flexShrink: 0 }}>
+            <svg width="18" height="18" viewBox="0 0 16 16">
+              <path d="M2 4h12M2 8h12M2 12h12" stroke={C.dim} strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
+        </header>
 
-      <main style={{ flex: 1, minWidth: 0, padding: "24px 28px 40px" }}>{children}</main>
+        <main className="px-4 pt-5 pb-24 lg:px-7 lg:pt-6 lg:pb-10" style={{ flex: 1, minWidth: 0 }}>{children}</main>
+      </div>
+
+      <TelemetryBottomNav envId={envId} onMore={() => setDrawerOpen(true)} />
 
       {drawerOpen && (
-        <div className="lg:hidden" style={{ position: "fixed", inset: 0, zIndex: 40 }}>
+        <div className="lg:hidden" style={{ position: "fixed", inset: 0, zIndex: 50 }}>
           <button type="button" aria-label="Close" onClick={() => setDrawerOpen(false)}
             style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.6)", border: "none" }} />
-          <div style={{ position: "absolute", left: 0, top: 0 }}>{Rail}</div>
+          <div className="max-w-[88vw]"
+            style={{ position: "absolute", left: 0, top: 0, height: "100%", overflowY: "auto", overflowX: "hidden", display: "flex" }}>
+            {Rail}
+          </div>
         </div>
       )}
     </div>

--- a/repo-b/src/components/telemetry/TelemetryShell.tsx
+++ b/repo-b/src/components/telemetry/TelemetryShell.tsx
@@ -60,10 +60,9 @@ export default function TelemetryShell({ envId, children }: { envId: string; chi
       <div className="hidden lg:flex">{Rail}</div>
 
       <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}>
-        {/* mobile top header */}
-        <header className="lg:hidden sticky top-0 z-30"
-          style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10,
-            padding: "8px 8px 8px 16px", background: C.rail, borderBottom: `1px solid ${C.border}` }}>
+        {/* mobile top header — display lives in classes so lg:hidden can win */}
+        <header className="flex lg:hidden sticky top-0 z-30 items-center justify-between gap-2.5"
+          style={{ padding: "8px 8px 8px 16px", background: C.rail, borderBottom: `1px solid ${C.border}` }}>
           <div style={{ display: "flex", alignItems: "center", gap: 12, minWidth: 0 }}>
             {Brand}
             <span style={{ fontFamily: C.mono, fontSize: 10, color: C.dim, letterSpacing: "0.08em",

--- a/repo-b/src/components/telemetry/TelemetrySidebar.tsx
+++ b/repo-b/src/components/telemetry/TelemetrySidebar.tsx
@@ -3,45 +3,39 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { C } from "./primitives";
+import { TELEMETRY_NAV, TELEMETRY_NAV_GROUPS, isTelemetryItemActive, telemetryHref } from "./telemetryNav";
 
-// 5 telemetry sections only (the sole navigation). Icons ported from the Option B reference.
-const NAV: { slug: string; label: string; icon: string }[] = [
-  { slug: "", label: "Overview", icon: "M2 9h3v5H2zM7 4h3v10H7zM12 7h3v7h-3z" },
-  { slug: "stream", label: "Mission Control", icon: "M2 12c2-6 10-6 12 0M8 3v3M8 8l3 3" },
-  { slug: "replay", label: "Replay", icon: "M4 3l9 6-9 6z" },
-  { slug: "copilot", label: "Test Intelligence", icon: "M8 1l2 4 4 1-3 3 1 4-4-2-4 2 1-4-3-3 4-1z" },
-  { slug: "governance", label: "AI Governance", icon: "M8 1l6 2v4c0 3.5-2.5 6-6 7-3.5-1-6-3.5-6-7V3z" },
-  { slug: "runs", label: "Test Runs", icon: "M2 4h13v2H2zM2 8h13v2H2zM2 12h9v2H2z" },
-  { slug: "model-performance", label: "Model Performance", icon: "M2 13l4-5 3 2 5-7" },
-  { slug: "registry", label: "Model Registry", icon: "M3 2h10v3H3zM3 7h10v3H3zM3 12h6v2H3z" },
-  { slug: "factory", label: "Factory · NCR", icon: "M2 13V7l4 3V7l4 3V4h4v9z" },
-  { slug: "monitoring", label: "Monitoring", icon: "M2 9h3l2-5 3 10 2-5h3" },
-  { slug: "stargate", label: "Stargate Live", icon: "M8 1l6 3.5v7L8 15l-6-3.5v-7zM8 8l6-3.5M8 8L2 4.5M8 8v7" },
-  { slug: "factory-ml", label: "Factory ML", icon: "M2 14V7l3-2 3 2 3-5 3 2v10zM5 14v-4M8 14V8M11 14V6" },
-];
-
+// Grouped navigation rail. Rendered in the desktop rail and inside the mobile
+// drawer (TelemetryShell), so item height stays >=40px for touch.
 export default function TelemetrySidebar({ envId, onNavigate }: { envId: string; onNavigate?: () => void }) {
   const pathname = usePathname() || "";
-  const base = `/lab/env/${envId}/telemetry`;
   return (
     <nav style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      {NAV.map((n) => {
-        const href = n.slug ? `${base}/${n.slug}` : base;
-        const active = n.slug ? pathname.startsWith(href) : pathname === base;
-        return (
-          <Link key={n.slug || "overview"} href={href} onClick={onNavigate}
-            style={{ display: "flex", alignItems: "center", gap: 10, textDecoration: "none",
-              padding: "9px 10px", borderRadius: 7,
-              color: active ? C.text : C.dim,
-              background: active ? "rgba(63,177,232,0.10)" : "transparent",
-              boxShadow: active ? `inset 2px 0 0 ${C.cyan}` : "none" }}>
-            <svg width="15" height="15" viewBox="0 0 16 16" style={{ flexShrink: 0 }}>
-              <path d={n.icon} stroke={active ? C.cyan : C.faint} strokeWidth="1.3" fill="none" strokeLinejoin="round" />
-            </svg>
-            <span style={{ fontFamily: C.mono, fontSize: 12 }}>{n.label}</span>
-          </Link>
-        );
-      })}
+      {TELEMETRY_NAV_GROUPS.map((group, gi) => (
+        <div key={group} style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <div style={{ fontFamily: C.mono, fontSize: 9, letterSpacing: "0.16em", color: C.faint,
+            textTransform: "uppercase", padding: gi === 0 ? "2px 10px 4px" : "14px 10px 4px" }}>
+            {group}
+          </div>
+          {TELEMETRY_NAV.filter((n) => n.group === group).map((n) => {
+            const active = isTelemetryItemActive(pathname, envId, n.slug);
+            return (
+              <Link key={n.slug || "overview"} href={telemetryHref(envId, n.slug)} onClick={onNavigate}
+                aria-current={active ? "page" : undefined}
+                style={{ display: "flex", alignItems: "center", gap: 10, textDecoration: "none",
+                  minHeight: 40, padding: "9px 10px", borderRadius: 7,
+                  color: active ? C.text : C.dim,
+                  background: active ? "rgba(63,177,232,0.10)" : "transparent",
+                  boxShadow: active ? `inset 2px 0 0 ${C.cyan}` : "none" }}>
+                <svg width="15" height="15" viewBox="0 0 16 16" style={{ flexShrink: 0 }}>
+                  <path d={n.icon} stroke={active ? C.cyan : C.faint} strokeWidth="1.3" fill="none" strokeLinejoin="round" />
+                </svg>
+                <span style={{ fontFamily: C.mono, fontSize: 12 }}>{n.label}</span>
+              </Link>
+            );
+          })}
+        </div>
+      ))}
     </nav>
   );
 }

--- a/repo-b/src/components/telemetry/factory-ml/NcrPanel.tsx
+++ b/repo-b/src/components/telemetry/factory-ml/NcrPanel.tsx
@@ -6,7 +6,7 @@
 
 import { useState } from "react";
 import { Bar, BarChart, Line, LineChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
-import { C, Panel, Tag } from "../primitives";
+import { C, Panel, SplitGrid, Tag } from "../primitives";
 import type { NcrExport } from "@/lib/lab/factoryMlData";
 
 export default function NcrPanel({ data }: { data: NcrExport }) {
@@ -15,7 +15,7 @@ export default function NcrPanel({ data }: { data: NcrExport }) {
   const active = clusters.find((c) => c.defect_code === selected) ?? clusters[0];
 
   return (
-    <div style={{ display: "grid", gridTemplateColumns: "minmax(320px, 5fr) minmax(360px, 7fr)", gap: 14 }}>
+    <SplitGrid variant="five-seven">
       <Panel title="Defect pareto" pad={12}>
         <ResponsiveContainer width="100%" height={Math.max(200, clusters.length * 30)}>
           <BarChart data={clusters} layout="vertical" margin={{ left: 24, right: 12 }}>
@@ -66,6 +66,6 @@ export default function NcrPanel({ data }: { data: NcrExport }) {
           </div>
         </Panel>
       )}
-    </div>
+    </SplitGrid>
   );
 }

--- a/repo-b/src/components/telemetry/primitives.tsx
+++ b/repo-b/src/components/telemetry/primitives.tsx
@@ -118,11 +118,13 @@ export function StatGrid({ cols = 4, style, children }: {
   return <div className={STAT_GRID_COLS[cols]} style={style}>{children}</div>;
 }
 
-export type SplitVariant = "main-side" | "wide-main-side" | "halves" | "thirds";
+export type SplitVariant = "main-side" | "two-one" | "wide-main-side" | "five-seven" | "halves" | "thirds";
 
 const SPLIT_GRID_COLS: Record<SplitVariant, string> = {
   "main-side": "grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]",
+  "two-one": "grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]",
   "wide-main-side": "grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,3fr)_minmax(0,1fr)]",
+  "five-seven": "grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,5fr)_minmax(0,7fr)]",
   halves: "grid grid-cols-1 gap-4 lg:grid-cols-2",
   thirds: "grid grid-cols-1 gap-4 sm:grid-cols-3",
 };

--- a/repo-b/src/components/telemetry/primitives.tsx
+++ b/repo-b/src/components/telemetry/primitives.tsx
@@ -98,6 +98,98 @@ export function PageHeading({ eyebrow, title, blurb, right }: {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Responsive layout primitives. Layout lives in literal Tailwind classes
+// (never composed from props — the content scanner only sees literal strings);
+// color/typography stay on the inline palette above. Content reflows at `sm`
+// and `lg`; the shell's rail/drawer split is also at `lg`.
+// ---------------------------------------------------------------------------
+
+const STAT_GRID_COLS: Record<3 | 4 | 5, string> = {
+  3: "grid grid-cols-2 gap-3 lg:grid-cols-3",
+  4: "grid grid-cols-2 gap-3 lg:grid-cols-4",
+  5: "grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5",
+};
+
+// Metric-card strip: 2-up on phones, full width count on desktop.
+export function StatGrid({ cols = 4, style, children }: {
+  cols?: 3 | 4 | 5; style?: CSSProperties; children: ReactNode;
+}) {
+  return <div className={STAT_GRID_COLS[cols]} style={style}>{children}</div>;
+}
+
+export type SplitVariant = "main-side" | "wide-main-side" | "halves" | "thirds";
+
+const SPLIT_GRID_COLS: Record<SplitVariant, string> = {
+  "main-side": "grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]",
+  "wide-main-side": "grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,3fr)_minmax(0,1fr)]",
+  halves: "grid grid-cols-1 gap-4 lg:grid-cols-2",
+  thirds: "grid grid-cols-1 gap-4 sm:grid-cols-3",
+};
+
+// Two-panel (or three-panel) splits that stack vertically on phones.
+export function SplitGrid({ variant, style, children }: {
+  variant: SplitVariant; style?: CSSProperties; children: ReactNode;
+}) {
+  return <div className={SPLIT_GRID_COLS[variant]} style={style}>{children}</div>;
+}
+
+// Horizontal-scroll wrapper for numeric matrices that have no sane card form.
+export function ScrollTable({ minWidth = 640, children }: { minWidth?: number; children: ReactNode }) {
+  return (
+    <div className="overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
+      <div style={{ minWidth }}>{children}</div>
+    </div>
+  );
+}
+
+// CSS-only mobile/desktop swap (no useIsMobile — zero hydration risk). Both
+// branches render; keep row counts small where this wraps tables.
+export function ResponsiveSwap({ mobile, desktop }: { mobile: ReactNode; desktop: ReactNode }) {
+  return (
+    <>
+      <div className="sm:hidden">{mobile}</div>
+      <div className="hidden sm:block">{desktop}</div>
+    </>
+  );
+}
+
+// Uniform mobile representation of a table row: title line, optional tags,
+// then label/value pairs in a 2-col mono grid.
+export function RowCard({ title, tags, fields, onClick, active }: {
+  title: ReactNode;
+  tags?: ReactNode;
+  fields: { label: string; value: ReactNode }[];
+  onClick?: () => void;
+  active?: boolean;
+}) {
+  const body = (
+    <>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+        <span style={{ fontFamily: C.mono, fontSize: 12, color: C.text, fontWeight: 600 }}>{title}</span>
+        {tags && <span style={{ display: "flex", gap: 6, alignItems: "center" }}>{tags}</span>}
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px 14px", marginTop: 10 }}>
+        {fields.map((f) => (
+          <div key={f.label}>
+            <div style={{ fontFamily: C.mono, fontSize: 9, letterSpacing: "0.1em", color: C.faint, textTransform: "uppercase" }}>{f.label}</div>
+            <div style={{ fontFamily: C.mono, fontSize: 12, color: C.dim, marginTop: 3 }}>{f.value}</div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+  const style: CSSProperties = {
+    background: active ? C.panelHi : C.panel,
+    border: `1px solid ${active ? C.borderHi : C.border}`,
+    borderRadius: 9, padding: 12, textAlign: "left", width: "100%",
+  };
+  if (onClick) {
+    return <button type="button" onClick={onClick} style={{ ...style, cursor: "pointer", display: "block" }}>{body}</button>;
+  }
+  return <div style={style}>{body}</div>;
+}
+
 // Public-data + backfill disclosure (the UI never overclaims).
 export function DisclosureFooter() {
   return (

--- a/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
+++ b/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
@@ -6,11 +6,12 @@
 // the DLQ feed. Full-bleed inside TelemetryShell like every telemetry page.
 
 import dynamic from "next/dynamic";
-import { useMemo, useState } from "react";
-import { C, MetricCard, PageHeading, Panel, Tag } from "../primitives";
+import { useEffect, useMemo, useState } from "react";
+import { C, MetricCard, PageHeading, Panel, RowCard, SplitGrid, Tag } from "../primitives";
 import DlqPanel from "./DlqPanel";
 import TempVibrationChart from "./TempVibrationChart";
 import { useStargateStream } from "@/lib/lab/stargateStream";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 const PrinterHead3D = dynamic(() => import("./PrinterHead3D"), {
   ssr: false,
@@ -29,6 +30,13 @@ function aggBadge(source?: string): { label: string; color: string } {
 export default function StargateConsole() {
   const stream = useStargateStream();
   const [selected, setSelected] = useState<string | null>(null);
+  // The three.js canvas only mounts on desktop, and only after hydration —
+  // useIsMobile defaults to desktop on the server, so an unguarded render
+  // would mount the canvas for one frame on phones.
+  const isMobile = useIsMobile();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+  const show3D = mounted && !isMobile;
 
   // version is the render clock: buffers are refs, so reading them is keyed on it.
   const { telemetry, agg, anomalies, dlq, printers } = useMemo(() => {
@@ -84,7 +92,7 @@ export default function StargateConsole() {
       </div>
 
       {printers.length > 1 && (
-        <div style={{ display: "flex", gap: 8, marginBottom: 14 }}>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginBottom: 14 }}>
           {printers.map((id) => (
             <button key={id} type="button" onClick={() => setSelected(id)}
               style={{ fontFamily: C.mono, fontSize: 11, padding: "6px 12px", borderRadius: 7, cursor: "pointer",
@@ -97,19 +105,37 @@ export default function StargateConsole() {
         </div>
       )}
 
-      <div style={{ display: "grid", gridTemplateColumns: "minmax(360px, 5fr) minmax(420px, 7fr)", gap: 14, marginBottom: 14 }}>
+      <SplitGrid variant="five-seven" style={{ marginBottom: 14 }}>
         <Panel title={`Toolhead — ${printer ?? "no printer"}`} pad={10}>
-          <PrinterHead3D points={printerPoints} />
-          <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 8 }}>
-            Melt-pool sphere tracks live x/y/z; color tracks temperature (white-hot nominal, dark red below 1400°C).
-          </div>
+          {show3D ? (
+            <>
+              <PrinterHead3D points={printerPoints} />
+              <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 8 }}>
+                Melt-pool sphere tracks live x/y/z; color tracks temperature (white-hot nominal, dark red below 1400°C).
+              </div>
+            </>
+          ) : (
+            <>
+              <RowCard title={printer ?? "no printer"}
+                tags={latest ? <Tag color={latest.melt_pool_temp_c < 1400 ? C.red : C.green}>{latest.melt_pool_temp_c.toFixed(0)}°C</Tag> : undefined}
+                fields={[
+                  { label: "x / y / z", value: latest ? `${latest.x.toFixed(0)} · ${latest.y.toFixed(0)} · ${latest.z.toFixed(1)}` : "—" },
+                  { label: "Layer", value: latest ? String(latest.layer) : "—" },
+                  { label: "Deposition", value: latest ? `${latest.deposition_rate_kg_hr.toFixed(1)} kg/hr` : "—" },
+                  { label: "Vibration", value: latest ? `${latest.arm_vibration_g.toFixed(3)}g` : "—" },
+                ]} />
+              <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 8 }}>
+                Live toolhead state. The 3D view renders on larger screens.
+              </div>
+            </>
+          )}
         </Panel>
         <Panel title="Melt pool vs arm vibration — 60s window" pad={10}>
           <TempVibrationChart points={printerPoints} agg={printerAgg} anomalies={printerAnomalies} />
         </Panel>
-      </div>
+      </SplitGrid>
 
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}>
+      <SplitGrid variant="halves">
         <Panel title="Anomaly ticker" pad={0}
           right={<Tag color={printerAnomalies.length ? C.red : C.green}>{printerAnomalies.length} on {printer ?? "—"}</Tag>}>
           {printerAnomalies.length === 0 ? (
@@ -132,7 +158,7 @@ export default function StargateConsole() {
           )}
         </Panel>
         <DlqPanel rows={dlq} count={stream.dlqCount} />
-      </div>
+      </SplitGrid>
     </div>
   );
 }

--- a/repo-b/src/components/telemetry/telemetryNav.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.ts
@@ -1,0 +1,50 @@
+// Single source of truth for telemetry navigation. The desktop rail (TelemetrySidebar),
+// the mobile drawer (same component), and the mobile bottom bar (TelemetryBottomNav) all
+// consume this list, so adding a section means adding one entry here.
+// Icon strings are 16x16 SVG path data, ported from the Option B reference.
+
+export type TelemetryNavGroup = "Operations" | "ML & Models" | "Factory" | "AI & Governance";
+
+export type TelemetryNavItem = {
+  slug: string;
+  label: string;
+  icon: string;
+  group: TelemetryNavGroup;
+  /** Shown as a tab in the mobile bottom bar (max 4 + "More"). */
+  mobilePrimary?: boolean;
+};
+
+export const TELEMETRY_NAV: TelemetryNavItem[] = [
+  { slug: "", label: "Overview", icon: "M2 9h3v5H2zM7 4h3v10H7zM12 7h3v7h-3z", group: "Operations", mobilePrimary: true },
+  { slug: "stream", label: "Mission Control", icon: "M2 12c2-6 10-6 12 0M8 3v3M8 8l3 3", group: "Operations", mobilePrimary: true },
+  { slug: "replay", label: "Replay", icon: "M4 3l9 6-9 6z", group: "Operations" },
+  { slug: "stargate", label: "Stargate Live", icon: "M8 1l6 3.5v7L8 15l-6-3.5v-7zM8 8l6-3.5M8 8L2 4.5M8 8v7", group: "Operations" },
+  { slug: "monitoring", label: "Monitoring", icon: "M2 9h3l2-5 3 10 2-5h3", group: "Operations" },
+  { slug: "runs", label: "Test Runs", icon: "M2 4h13v2H2zM2 8h13v2H2zM2 12h9v2H2z", group: "ML & Models", mobilePrimary: true },
+  { slug: "model-performance", label: "Model Performance", icon: "M2 13l4-5 3 2 5-7", group: "ML & Models" },
+  { slug: "registry", label: "Model Registry", icon: "M3 2h10v3H3zM3 7h10v3H3zM3 12h6v2H3z", group: "ML & Models" },
+  { slug: "factory", label: "Factory · NCR", icon: "M2 13V7l4 3V7l4 3V4h4v9z", group: "Factory" },
+  { slug: "factory-ml", label: "Factory ML", icon: "M2 14V7l3-2 3 2 3-5 3 2v10zM5 14v-4M8 14V8M11 14V6", group: "Factory" },
+  { slug: "copilot", label: "Test Intelligence", icon: "M8 1l2 4 4 1-3 3 1 4-4-2-4 2 1-4-3-3 4-1z", group: "AI & Governance", mobilePrimary: true },
+  { slug: "governance", label: "AI Governance", icon: "M8 1l6 2v4c0 3.5-2.5 6-6 7-3.5-1-6-3.5-6-7V3z", group: "AI & Governance" },
+];
+
+export const TELEMETRY_NAV_GROUPS: TelemetryNavGroup[] = ["Operations", "ML & Models", "Factory", "AI & Governance"];
+
+export function telemetryHref(envId: string, slug: string): string {
+  const base = `/lab/env/${envId}/telemetry`;
+  return slug ? `${base}/${slug}` : base;
+}
+
+export function isTelemetryItemActive(pathname: string, envId: string, slug: string): boolean {
+  const base = `/lab/env/${envId}/telemetry`;
+  if (!slug) return pathname === base;
+  const href = `${base}/${slug}`;
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+/** Label of the section owning the current pathname (for the mobile header). */
+export function telemetrySectionLabel(pathname: string, envId: string): string {
+  const match = TELEMETRY_NAV.find((n) => n.slug && isTelemetryItemActive(pathname, envId, n.slug));
+  return match?.label ?? "Overview";
+}


### PR DESCRIPTION
## What

The telemetry environment was a desktop UI compressed onto a phone: 34 hard-coded `gridTemplateColumns`, fixed `minmax(280–420px)` chart panels, dense 5-column grid-tables, and a floating "Menu" button as the only mobile navigation. This refactor makes all 12 telemetry pages reflow on phones and gives desktop and mobile one coherent navigation system, without touching the aerospace-ops visual language (palette `C`, mono data styling, fail-closed states).

## How

**Layout primitives** (`primitives.tsx`): `StatGrid`, `SplitGrid`, `ScrollTable`, `ResponsiveSwap`, `RowCard` — literal Tailwind responsive classes for layout, inline palette styles for paint. The 12 pages converge on these instead of bespoke grids.

**Navigation** (`telemetryNav.ts`): one config feeds three surfaces —
- Desktop rail: same 224px rail, now grouped (Operations / ML & Models / Factory / AI & Governance), ≥40px rows.
- Mobile header: sticky, with the brand, current section label, and a 44px hamburger (replaces the floating button).
- Mobile bottom tab bar: Overview, Stream, Test Runs, Copilot + "More" (opens the drawer). The drawer locks body scroll and closes on route change.

**Pages**: metric strips go 2-up on phones; split panels stack; narrative tables (overview runs, runs explorer, governance interactions) swap to row cards under 640px; numeric matrices (model performance, A/B measures) scroll horizontally; the Stargate three.js toolhead is replaced by a live state card on phones (the canvas never mounts); Copilot confidence buttons grow to 40px tap targets.

## Verification

- `typecheck`, `build`, and all 26 telemetry unit tests pass.
- Playwright screenshots at 375×812, 768×1024, and 1280×800 against the production build: mobile shows header + bottom tabs + grouped drawer, desktop shows the rail only and is visually unchanged.
- Generated CSS confirmed to contain the arbitrary-value grid classes and `pb-safe`.

Reusable lesson appended to `docs/tips.md` (inline-style surfaces + literal Tailwind layout variants; inline `display` defeats `lg:hidden`).

https://claude.ai/code/session_0151cMtiT3QDLYhr3HwHUTuT

---
_Generated by [Claude Code](https://claude.ai/code/session_0151cMtiT3QDLYhr3HwHUTuT)_