### PR TITLE
feat(telemetry): Spaceflight Bottleneck Map context module

### DIFF
--- a/repo-b/src/components/telemetry/TelemetryOverview.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.tsx
@@ -11,6 +11,7 @@ import {
   C, Tag, Panel, MetricCard, Loading, ErrorState, PageHeading, DisclosureFooter,
   StatGrid, SplitGrid, ResponsiveSwap, RowCard,
 } from "./primitives";
+import BottleneckMap from "./context/BottleneckMap/BottleneckMap";
 
 function ModelCard({ m }: { m: ModelRun }) {
   const champ = m.promotion_state === "promoted";
@@ -82,11 +83,35 @@ export default function TelemetryOverview({ envId }: { envId: string }) {
       .catch((e) => setError(String(e)));
   }, []);
 
+  // The page heading and the context module are static; only the operational sections below
+  // depend on the serving API, so the narrative on-ramp renders even while loading or erroring.
+  const heading = (
+    <PageHeading eyebrow="Overview"
+      title="Turning engine-test telemetry into automated go/no-go"
+      blurb="Public NASA telemetry ingested in Databricks, trained and gated in MLflow, served behind FastAPI, every score persisted to a prediction log, monitored for drift. The headline is run-to-failure prognostics (C-MAPSS RUL today; N-CMAPSS and IMS planned); SMAP/MSL anomaly detection is a legacy baseline. Every value below is read from the serving API."
+      right={
+        <Link href={`/lab/env/${envId}/telemetry/replay`}
+          style={{ fontFamily: C.mono, fontSize: 13, fontWeight: 600, color: C.bg, background: C.cyan,
+            border: "none", borderRadius: 8, padding: "10px 18px", textDecoration: "none" }}>
+          Run the replay →
+        </Link>
+      } />
+  );
+  const contextSection = (
+    <section aria-label="Context: why launch became a data problem" style={{ margin: "0 0 24px" }}>
+      <div style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.13em", color: C.faint,
+        textTransform: "uppercase", marginBottom: 12 }}>
+        Context: why launch became a data problem
+      </div>
+      <BottleneckMap />
+    </section>
+  );
+
   if (error) return (
-    <><PageHeading eyebrow="Overview" title="Telemetry anomaly workbench" /><ErrorState message={error} /></>
+    <>{heading}{contextSection}<ErrorState message={error} /></>
   );
   if (!summary || !models || !runs) return (
-    <><PageHeading eyebrow="Overview" title="Telemetry anomaly workbench" /><Loading label="Loading console…" /></>
+    <>{heading}{contextSection}<Loading label="Loading console…" /></>
   );
 
   const k = summary.kpi;
@@ -97,16 +122,8 @@ export default function TelemetryOverview({ envId }: { envId: string }) {
 
   return (
     <>
-      <PageHeading eyebrow="Overview"
-        title="Turning engine-test telemetry into automated go/no-go"
-        blurb="Public NASA telemetry ingested in Databricks, trained and gated in MLflow, served behind FastAPI, every score persisted to a prediction log, monitored for drift. The headline is run-to-failure prognostics (C-MAPSS RUL today; N-CMAPSS and IMS planned); SMAP/MSL anomaly detection is a legacy baseline. Every value below is read from the serving API."
-        right={
-          <Link href={`/lab/env/${envId}/telemetry/replay`}
-            style={{ fontFamily: C.mono, fontSize: 13, fontWeight: 600, color: C.bg, background: C.cyan,
-              border: "none", borderRadius: 8, padding: "10px 18px", textDecoration: "none" }}>
-            Run the replay →
-          </Link>
-        } />
+      {heading}
+      {contextSection}
 
       {/* metric strip */}
       <StatGrid cols={4}>

--- a/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.module.css
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.module.css
@@ -1,0 +1,34 @@
+/* Motion + focus styles for the Bottleneck Map context module. Keyframe names are scoped by the
+   CSS module; the reduced-motion guards below are preserved verbatim from the prototype. */
+
+@keyframes lem-pulse {
+  0%   { stroke-opacity: 0.7; transform: scale(1); }
+  70%  { stroke-opacity: 0;   transform: scale(1.5); }
+  100% { stroke-opacity: 0;   transform: scale(1.5); }
+}
+
+.pulse {
+  animation: lem-pulse 1.6s ease-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+@keyframes lem-fade-slide {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.fade {
+  animation: lem-fade-slide 500ms ease both;
+}
+
+/* currentColor keeps the focus ring on each control's own accent without duplicating token hex. */
+.control:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pulse { animation: none; }
+  .fade { animation: none; }
+}

--- a/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.test.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import BottleneckMap from "./BottleneckMap";
+import { EVENTS, EVENTS_CHRONO, FULL_WINDOW, YEAR_SERIES, shareAt } from "./data";
+
+describe("static narrative data", () => {
+  it("covers 1957-2026 with one row per year and a 16-event chronology", () => {
+    expect(YEAR_SERIES).toHaveLength(2026 - 1957 + 1);
+    expect(YEAR_SERIES[0].year).toBe(FULL_WINDOW[0]);
+    expect(YEAR_SERIES[YEAR_SERIES.length - 1].year).toBe(FULL_WINDOW[1]);
+    expect(EVENTS_CHRONO).toHaveLength(16);
+    const years = EVENTS_CHRONO.map((e) => e.year);
+    expect(years).toEqual([...years].sort((a, b) => a - b));
+  });
+
+  it("interpolates commercial share between anchors and clamps outside them", () => {
+    expect(shareAt(1950)).toBe(0);
+    expect(shareAt(2030)).toBe(70);
+    expect(shareAt(2022)).toBe(55);
+    const mid = shareAt(2010.5);
+    expect(mid).toBeGreaterThan(25);
+    expect(mid).toBeLessThan(35);
+  });
+
+  it("keeps the Relativity figures labeled company-stated", () => {
+    const terranR = EVENTS.find((e) => e.id === "terranR")!;
+    expect(JSON.stringify(terranR.metrics)).toContain("company-stated");
+  });
+});
+
+describe("BottleneckMap rendering", () => {
+  it("renders the full-range KPI strip and the verbatim methodology footer", () => {
+    render(<BottleneckMap />);
+    expect(screen.getByText("1957 - 2026")).toBeInTheDocument();
+    expect(screen.getByText("full range")).toBeInTheDocument();
+    expect(screen.getByText(/makes no\s+domain-expertise claims/)).toBeInTheDocument();
+  });
+
+  it("pins the Terran 1 record by default with the bottleneck relay cells", () => {
+    render(<BottleneckMap />);
+    expect(screen.getByText("Terran 1: Good Luck, Have Fun")).toBeInTheDocument();
+    expect(screen.getByText("Additive manufacturing at rocket primary-structure scale")).toBeInTheDocument();
+    expect(screen.getByText("Scaling printed production to a reusable medium-heavy vehicle")).toBeInTheDocument();
+  });
+
+  it("enters presenter mode from the button, steps with the on-screen controls, exits on Escape", () => {
+    render(<BottleneckMap />);
+    fireEvent.click(screen.getByRole("button", { name: "Enter presenter mode" }));
+    expect(screen.getByText(/1 \/ 16/)).toBeInTheDocument();
+    expect(screen.getByText(EVENTS_CHRONO[0].caption)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Next step" }));
+    expect(screen.getByText(/2 \/ 16/)).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByText(/2 \/ 16/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Enter presenter mode" })).toBeInTheDocument();
+  });
+
+  it("enters presenter mode on P but not while focus is in a form field", () => {
+    const { container } = render(
+      <div>
+        <input aria-label="host field" />
+        <BottleneckMap />
+      </div>,
+    );
+    const input = container.querySelector("input")!;
+    input.focus();
+    fireEvent.keyDown(input, { key: "p" });
+    expect(screen.queryByText(/1 \/ 16/)).not.toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "p" });
+    expect(screen.getByText(/1 \/ 16/)).toBeInTheDocument();
+  });
+
+  it("re-derives the legend chips when the color dimension toggles", () => {
+    render(<BottleneckMap />);
+    expect(screen.getByText("Mission achievement")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Funding model" }));
+    expect(screen.queryByText("Mission achievement")).not.toBeInTheDocument();
+    expect(screen.getByText("Fixed-price commercial")).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+// The Spaceflight Bottleneck Map: narrative on-ramp for the telemetry environment. Every era of
+// spaceflight solved the previous bottleneck and exposed a new one; the current bottleneck is
+// decision velocity, a data platform problem. Four linked panels derive from one event model.
+// This is a context module, not an operational view: static public data, no network calls.
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+
+import { RS, RS_MONO, RS_SANS } from "../../rsTokens";
+import styles from "./BottleneckMap.module.css";
+import CostPanel from "./CostPanel";
+import {
+  COLOR_DIMENSIONS, EVENTS, EVENTS_CHRONO, FULL_WINDOW, SIZE_MODES, YEAR_SERIES,
+  eventDimension, eventDimensionKey, fmtCost,
+} from "./data";
+import EventRecord from "./EventRecord";
+import KpiStrip from "./KpiStrip";
+import MapPanel from "./MapPanel";
+import MixPanel from "./MixPanel";
+import PresenterBanner from "./PresenterBanner";
+import type {
+  ColorByKey, DecoratedEvent, KpiSummary, LaunchEvent, SizeModeKey, TimeWindow,
+} from "./types";
+
+// TODO(P2 backlog): deep-link state (selected event and toggles) into the URL query string for
+// shareable demo states.
+
+function decorate(e: LaunchEvent, colorBy: ColorByKey, sizeMode: SizeModeKey): DecoratedEvent {
+  const d = eventDimension(e, colorBy);
+  return {
+    ...e,
+    sizeValue: sizeMode === "payload" ? Math.max(2, e.payloadT) : e.scale,
+    color: d.color,
+    dimLabel: d.label,
+  };
+}
+
+export default function BottleneckMap() {
+  const [selectedId, setSelectedId] = useState<string | null>("terran1");
+  const [chipFilter, setChipFilter] = useState<string | null>(null);
+  const [sizeMode, setSizeMode] = useState<SizeModeKey>("scale");
+  const [colorBy, setColorBy] = useState<ColorByKey>("type");
+  const [inflationAdjusted, setInflationAdjusted] = useState(true);
+  const [hoveredYear, setHoveredYear] = useState<number | null>(null);
+  const [timeWindow, setTimeWindow] = useState<TimeWindow>(FULL_WINDOW);
+  const [presenterIdx, setPresenterIdx] = useState<number | null>(null);
+
+  const presenting = presenterIdx !== null;
+  const presenterEvent = presenterIdx !== null ? EVENTS_CHRONO[presenterIdx] : null;
+  const presenterYear = presenterEvent ? presenterEvent.year : Infinity;
+  const revealedIds = useMemo<ReadonlySet<string>>(
+    () => new Set(presenting && presenterIdx !== null
+      ? EVENTS_CHRONO.slice(0, presenterIdx + 1).map((e) => e.id) : []),
+    [presenting, presenterIdx],
+  );
+  const focusPanel = presenterEvent ? presenterEvent.focusPanel : null;
+
+  const dimension = COLOR_DIMENSIONS[colorBy];
+  const windowed = timeWindow[0] !== FULL_WINDOW[0] || timeWindow[1] !== FULL_WINDOW[1];
+
+  // Bubbles: resolve color/label for the active dimension; chip filter applies outside presenter mode.
+  const mapEvents = useMemo<DecoratedEvent[]>(() => {
+    const evs = !presenting && chipFilter
+      ? EVENTS.filter((e) => eventDimensionKey(e, colorBy) === chipFilter)
+      : EVENTS;
+    return evs.map((e) => decorate(e, colorBy, sizeMode));
+  }, [chipFilter, colorBy, sizeMode, presenting]);
+
+  const selected = useMemo<DecoratedEvent | null>(() => {
+    const base = presenting ? presenterEvent : EVENTS.find((e) => e.id === selectedId) ?? null;
+    return base ? decorate(base, colorBy, sizeMode) : null;
+  }, [selectedId, presenting, presenterEvent, colorBy, sizeMode]);
+
+  // KPI strip, derived from the active window (full range while presenting).
+  const kpi = useMemo<KpiSummary>(() => {
+    const [y0, y1] = presenting ? FULL_WINDOW : timeWindow;
+    const yrs = YEAR_SERIES.filter((d) => d.year >= y0 && d.year <= y1);
+    const attempts = yrs.reduce((s, d) => s + (d.attempts || 0), 0);
+    const lastReal = [...yrs].reverse().find((d) => d.commercialPct != null);
+    const costYrs = yrs.filter((d) => d.costMeta);
+    const key: "costAdj" | "costNominal" = inflationAdjusted ? "costAdj" : "costNominal";
+    const events = EVENTS.filter((e) => e.year >= y0 && e.year <= y1 + 1).length;
+
+    let cost = "n/a";
+    let costLabel = "in window";
+    if (costYrs.length > 0) {
+      const first = costYrs[0];
+      const last = costYrs[costYrs.length - 1];
+      const firstVal = first[key];
+      const lastVal = last[key];
+      if (costYrs.length >= 2 && firstVal != null && lastVal != null) {
+        cost = `${fmtCost(firstVal)} -> ${fmtCost(lastVal)}`;
+        if (first.costMeta && last.costMeta) costLabel = `${first.costMeta.v} to ${last.costMeta.v}`;
+      } else if (firstVal != null) {
+        cost = fmtCost(firstVal);
+      }
+    }
+
+    return {
+      window: `${y0} - ${y1}`,
+      attempts: attempts.toLocaleString(),
+      share: lastReal?.commercialPct != null ? `${Math.round(lastReal.commercialPct)}%` : "n/a",
+      shareYear: lastReal ? lastReal.year : null,
+      cost, costLabel, events,
+    };
+  }, [timeWindow, inflationAdjusted, presenting]);
+
+  // Presenter keyboard controls. Never captures keys when focus is inside a form field, and never
+  // shadows browser shortcuts (Cmd/Ctrl+P print).
+  useEffect(() => {
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.metaKey || ev.ctrlKey || ev.altKey) return;
+      const t = ev.target as HTMLElement | null;
+      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.tagName === "SELECT" || t.isContentEditable)) return;
+      if ((ev.key === "p" || ev.key === "P") && !presenting) { setPresenterIdx(0); return; }
+      if (!presenting) return;
+      if (ev.key === "ArrowRight") setPresenterIdx((i) => Math.min((i ?? 0) + 1, EVENTS_CHRONO.length - 1));
+      if (ev.key === "ArrowLeft") setPresenterIdx((i) => Math.max((i ?? 0) - 1, 0));
+      if (ev.key === "Escape") setPresenterIdx(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [presenting]);
+
+  const onHoverYear = useCallback((y: number | null) => setHoveredYear(y), []);
+  const onSelect = useCallback((id: string) => setSelectedId(id), []);
+  const onBrush = useCallback(({ startIndex, endIndex }: { startIndex?: number; endIndex?: number }) => {
+    if (startIndex == null || endIndex == null) return;
+    const y0 = YEAR_SERIES[startIndex]?.year ?? FULL_WINDOW[0];
+    const y1 = YEAR_SERIES[endIndex]?.year ?? FULL_WINDOW[1];
+    setTimeWindow([y0, y1]);
+  }, []);
+
+  const presenterAccent = presenterEvent ? eventDimension(presenterEvent, colorBy).color : RS.blue;
+
+  return (
+    <div style={{ fontFamily: RS_SANS, color: RS.text }}>
+      {/* thesis subtitle + presenter toggle */}
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
+        <p style={{ color: RS.dim, fontSize: 13, margin: 0, maxWidth: 680 }}>
+          Every leap solved the previous era&apos;s bottleneck and exposed a new one. The current
+          bottleneck is decision velocity. All four panels derive from one event model:
+          select, hover, or brush anywhere and the rest follows.
+        </p>
+        <button type="button" className={styles.control}
+          aria-label={presenting ? "Exit presenter mode" : "Enter presenter mode"}
+          aria-pressed={presenting}
+          onClick={() => setPresenterIdx(presenting ? null : 0)}
+          style={{
+            background: presenting ? `${RS.red}22` : `${RS.blue}22`,
+            border: `1px solid ${presenting ? RS.red : RS.blue}`,
+            color: presenting ? RS.red : RS.blue,
+            borderRadius: 6, padding: "8px 14px", cursor: "pointer",
+            fontFamily: RS_MONO, fontSize: 11, letterSpacing: 0.5, whiteSpace: "nowrap",
+          }}>
+          {presenting ? "Exit (Esc)" : "Present (P)"}
+        </button>
+      </div>
+
+      {/* presenter banner */}
+      {presenting && presenterEvent && presenterIdx !== null && (
+        <PresenterBanner event={presenterEvent} accent={presenterAccent}
+          idx={presenterIdx} total={EVENTS_CHRONO.length}
+          onPrev={() => setPresenterIdx((i) => Math.max((i ?? 0) - 1, 0))}
+          onNext={() => setPresenterIdx((i) => Math.min((i ?? 0) + 1, EVENTS_CHRONO.length - 1))} />
+      )}
+
+      <KpiStrip kpi={kpi} presenting={presenting} windowed={windowed} inflationAdjusted={inflationAdjusted} />
+
+      {/* controls row */}
+      {!presenting && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8, margin: "14px 0 4px", alignItems: "center" }}>
+          {Object.entries(dimension.lookup).map(([key, v]) => (
+            <button key={key} type="button" className={styles.control}
+              aria-pressed={chipFilter === key}
+              onClick={() => setChipFilter(chipFilter === key ? null : key)}
+              style={{
+                display: "flex", alignItems: "center", gap: 6,
+                background: chipFilter === key ? `${v.color}22` : "transparent",
+                border: `1px solid ${chipFilter === key ? v.color : RS.line}`,
+                borderRadius: 999, padding: "4px 10px", cursor: "pointer",
+                color: chipFilter === key ? v.color : RS.dim,
+                fontFamily: RS_MONO, fontSize: 10, letterSpacing: 0.5,
+                opacity: chipFilter && chipFilter !== key ? 0.45 : 1,
+              }}>
+              <span style={{ width: 8, height: 8, borderRadius: "50%", background: v.color }} />
+              {v.label}
+            </button>
+          ))}
+
+          <div style={{ marginLeft: "auto", display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+            {/* color dimension */}
+            <div style={{ display: "flex", border: `1px solid ${RS.line}`, borderRadius: 6, overflow: "hidden" }}>
+              {(Object.keys(COLOR_DIMENSIONS) as ColorByKey[]).map((key) => (
+                <button key={key} type="button" className={styles.control}
+                  aria-pressed={colorBy === key}
+                  onClick={() => { setColorBy(key); setChipFilter(null); }}
+                  style={{
+                    background: colorBy === key ? RS.barFill : "transparent",
+                    color: colorBy === key ? RS.text : RS.faint,
+                    border: "none", padding: "5px 10px", cursor: "pointer",
+                    fontFamily: RS_MONO, fontSize: 9.5, letterSpacing: 0.3,
+                  }}>
+                  {COLOR_DIMENSIONS[key].label}
+                </button>
+              ))}
+            </div>
+            {/* size mode */}
+            <div style={{ display: "flex", border: `1px solid ${RS.line}`, borderRadius: 6, overflow: "hidden" }}>
+              {SIZE_MODES.map((m) => (
+                <button key={m.key} type="button" className={styles.control} title={m.note}
+                  aria-pressed={sizeMode === m.key}
+                  onClick={() => setSizeMode(m.key)}
+                  style={{
+                    background: sizeMode === m.key ? RS.barFill : "transparent",
+                    color: sizeMode === m.key ? RS.text : RS.faint,
+                    border: "none", padding: "5px 10px", cursor: "pointer",
+                    fontFamily: RS_MONO, fontSize: 9.5, letterSpacing: 0.3,
+                  }}>
+                  {m.label}
+                </button>
+              ))}
+            </div>
+            {/* inflation emphasis */}
+            <button type="button" className={styles.control}
+              aria-label="Emphasize inflation-adjusted cost"
+              aria-pressed={inflationAdjusted}
+              onClick={() => setInflationAdjusted(!inflationAdjusted)}
+              style={{
+                display: "flex", alignItems: "center", gap: 7,
+                background: inflationAdjusted ? `${RS.amber}18` : "transparent",
+                border: `1px solid ${inflationAdjusted ? RS.amber : RS.line}`,
+                borderRadius: 6, padding: "5px 10px", cursor: "pointer",
+                color: inflationAdjusted ? RS.amber : RS.faint,
+                fontFamily: RS_MONO, fontSize: 9.5, letterSpacing: 0.3,
+              }}>
+              <span style={{ width: 22, height: 12, borderRadius: 999, position: "relative",
+                background: inflationAdjusted ? RS.amber : RS.line, transition: "background 0.15s" }}>
+                <span style={{ position: "absolute", top: 1.5, left: inflationAdjusted ? 11.5 : 1.5,
+                  width: 9, height: 9, borderRadius: "50%", background: RS.bg, transition: "left 0.15s" }} />
+              </span>
+              Inflation adjusted (2025 $)
+            </button>
+            {windowed && (
+              <button type="button" className={styles.control}
+                onClick={() => setTimeWindow(FULL_WINDOW)}
+                style={{ background: "transparent", border: `1px solid ${RS.line}`, color: RS.dim,
+                  borderRadius: 6, padding: "5px 10px", cursor: "pointer", fontFamily: RS_MONO, fontSize: 9.5 }}>
+                Reset window
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* panel 1: the bottleneck map */}
+      <div style={{ marginTop: 10 }}>
+        <MapPanel events={mapEvents} selectedId={selected?.id ?? null}
+          presenting={presenting} revealedIds={revealedIds} presenterYear={presenterYear}
+          timeWindow={windowed ? timeWindow : null} hoveredYear={hoveredYear}
+          sizeModeLabel={SIZE_MODES.find((m) => m.key === sizeMode)?.label ?? ""}
+          focused={focusPanel === "map"} dimmed={presenting && focusPanel !== "map"}
+          onHoverYear={onHoverYear} onSelect={onSelect} />
+      </div>
+
+      {/* panels 2 + 3: cost curve and funding mix */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-2.5" style={{ marginTop: 10 }}>
+        <CostPanel inflationAdjusted={inflationAdjusted} hoveredYear={hoveredYear}
+          focused={focusPanel === "cost"} dimmed={presenting && focusPanel !== "cost"}
+          onHoverYear={onHoverYear} />
+        <MixPanel hoveredYear={hoveredYear}
+          focused={focusPanel === "mix"} dimmed={presenting && focusPanel !== "mix"}
+          onHoverYear={onHoverYear} onBrush={onBrush} />
+      </div>
+
+      {/* panel 4: pinned event record */}
+      {selected && <EventRecord event={selected} presenting={presenting} focusPanel={focusPanel} />}
+
+      {/* methodology footer (verbatim; the module makes no domain-expertise claims) */}
+      <div style={{ marginTop: 12, fontFamily: RS_MONO, fontSize: 9.5, color: RS.faint, lineHeight: 1.6 }}>
+        Cadence basis: annual orbital launch attempts (Wikipedia yearly spaceflight series / GCAT); pre-2000 values
+        are close approximations, 2018-2025 are exact. Commercial share: 2022-2025 reported, earlier anchors are
+        coarse estimates. Cost basis: per-launch sticker or marginal price divided by LEO capacity, one consistent
+        basis; inflation adjustment uses approximate CPI multipliers to 2025 dollars. Shuttle program-averaged cost
+        is ~3x its marginal figure. Terran R price point is a 2022 company statement and may not be current.
+        Relativity Space figures are company-stated. This is a context and narrative module; it makes no
+        domain-expertise claims.
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/telemetry/context/BottleneckMap/CostPanel.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/CostPanel.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+// Panel 2: cost to LEO on a log scale. Two lines from the same points: nominal dollars and
+// approximate 2025 dollars; the inflation toggle decides which one is emphasized.
+import React from "react";
+import {
+  CartesianGrid, ComposedChart, Line, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis,
+} from "recharts";
+import type { LineProps, TooltipProps } from "recharts";
+
+import { RS, RS_MONO } from "../../rsTokens";
+import { YEAR_SERIES } from "./data";
+import PanelShell, { yearFromChartState } from "./PanelShell";
+import type { YearPoint } from "./types";
+
+interface CostDotProps {
+  key?: string;
+  cx?: number;
+  cy?: number;
+  payload?: YearPoint;
+}
+
+function CostTip({ active, payload }: TooltipProps<number, string>) {
+  if (!active || !payload || payload.length === 0) return null;
+  const d = payload[0]?.payload as YearPoint | undefined;
+  if (!d?.costMeta || d.costNominal == null || d.costAdj == null) return null;
+  return (
+    <div style={{ background: RS.panel, border: `1px solid ${RS.line}`, borderRadius: 6,
+      padding: "8px 10px", maxWidth: 260, boxShadow: "0 8px 24px rgba(0,0,0,0.5)" }}>
+      <div style={{ fontSize: 12, color: RS.text, fontWeight: 600 }}>{d.costMeta.v}</div>
+      <div style={{ fontSize: 11, color: RS.faint, fontFamily: RS_MONO, marginTop: 3 }}>${d.costNominal.toLocaleString()}/kg nominal</div>
+      <div style={{ fontSize: 11, color: RS.amber, fontFamily: RS_MONO }}>${d.costAdj.toLocaleString()}/kg in 2025 $</div>
+      <div style={{ fontSize: 9.5, color: RS.faint, marginTop: 4, lineHeight: 1.4 }}>{d.costMeta.basis}</div>
+    </div>
+  );
+}
+
+export default function CostPanel({ inflationAdjusted, hoveredYear, focused, dimmed, onHoverYear }: {
+  inflationAdjusted: boolean;
+  hoveredYear: number | null;
+  focused: boolean;
+  dimmed: boolean;
+  onHoverYear: (year: number | null) => void;
+}) {
+  const emphasizedKey: "costAdj" | "costNominal" = inflationAdjusted ? "costAdj" : "costNominal";
+  const mutedKey: "costAdj" | "costNominal" = inflationAdjusted ? "costNominal" : "costAdj";
+
+  // Vehicle label on the emphasized line's dots only.
+  const renderCostDot = (props: CostDotProps): React.ReactElement => {
+    const { cx, cy, payload } = props;
+    const val = payload?.[emphasizedKey];
+    if (cx == null || cy == null || !payload?.costMeta || val == null) return <g key={props.key} />;
+    return (
+      <g key={props.key}>
+        <circle cx={cx} cy={cy} r={3.5} fill={RS.amber} stroke={RS.bg} strokeWidth={1.5} />
+        <text x={cx} y={cy - 8} textAnchor="middle" fill={RS.amber} fontSize={8.5} fontFamily={RS_MONO}>
+          {payload.costMeta.v} ${val >= 10000 ? (val / 1000).toFixed(0) + "k" : val.toLocaleString()}
+        </text>
+      </g>
+    );
+  };
+
+  return (
+    <PanelShell title="Cost to LEO" accent={RS.amber}
+      sub={`log scale · ${inflationAdjusted ? "2025 $ emphasized" : "nominal $ emphasized"}`}
+      focused={focused} dimmed={dimmed}>
+      <ResponsiveContainer width="100%" height={180}>
+        <ComposedChart data={YEAR_SERIES} margin={{ top: 16, right: 16, bottom: 4, left: 0 }}
+          onMouseMove={(s) => onHoverYear(yearFromChartState(s))} onMouseLeave={() => onHoverYear(null)}>
+          <CartesianGrid stroke={RS.line} strokeDasharray="2 6" vertical={false} />
+          <XAxis type="number" dataKey="year" domain={[1955, 2031]}
+            ticks={[1969, 1988, 2005, 2018, 2026]}
+            tick={{ fill: RS.faint, fontSize: 9, fontFamily: RS_MONO }}
+            stroke={RS.line} tickLine={false} allowDataOverflow />
+          <YAxis type="number" scale="log" domain={[900, 60000]}
+            ticks={[1000, 10000, 50000]} tickFormatter={(v: number) => `$${v / 1000}k`}
+            tick={{ fill: RS.faint, fontSize: 9, fontFamily: RS_MONO }}
+            width={42} stroke={RS.line} tickLine={false} />
+          <Tooltip content={<CostTip />} cursor={false} />
+          {hoveredYear != null && (
+            <ReferenceLine x={hoveredYear} stroke={RS.crosshair} strokeDasharray="2 4" strokeOpacity={0.8} />
+          )}
+          <Line dataKey={mutedKey} connectNulls stroke={RS.faint} strokeWidth={1}
+            strokeOpacity={0.5} strokeDasharray="3 4" dot={{ r: 2, fill: RS.faint, strokeWidth: 0 }}
+            activeDot={false} isAnimationActive={false} />
+          <Line dataKey={emphasizedKey} connectNulls stroke={RS.amber} strokeWidth={1.6}
+            strokeOpacity={0.85} dot={renderCostDot as LineProps["dot"]}
+            activeDot={false} isAnimationActive={false} />
+        </ComposedChart>
+      </ResponsiveContainer>
+      <div style={{ padding: "0 12px 8px", fontFamily: RS_MONO, fontSize: 9, color: RS.faint }}>
+        gap between the lines = the inflation illusion. Widest at Saturn V (8.7x), near zero today
+      </div>
+    </PanelShell>
+  );
+}

--- a/repo-b/src/components/telemetry/context/BottleneckMap/EventRecord.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/EventRecord.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+// Panel 4: the pinned event record. Re-keyed by event id so each pin fades in; minHeight damps
+// layout shift while presenter mode steps through events of varying detail length.
+import React from "react";
+
+import { RS, RS_MONO } from "../../rsTokens";
+import styles from "./BottleneckMap.module.css";
+import type { DecoratedEvent, FocusPanelKey } from "./types";
+
+function RecordCell({ heading, color, children, style }: {
+  heading: string; color: string; children: React.ReactNode; style?: React.CSSProperties;
+}) {
+  return (
+    <div style={{ background: RS.panelAlt, border: `1px solid ${RS.line}`, borderRadius: 6,
+      padding: "10px 12px", ...style }}>
+      <div style={{ fontFamily: RS_MONO, fontSize: 9, color, letterSpacing: 1, textTransform: "uppercase" }}>{heading}</div>
+      <div style={{ fontSize: 12.5, marginTop: 3 }}>{children}</div>
+    </div>
+  );
+}
+
+export default function EventRecord({ event, presenting, focusPanel }: {
+  event: DecoratedEvent;
+  presenting: boolean;
+  focusPanel: FocusPanelKey | null;
+}) {
+  return (
+    <div key={event.id} className={`${styles.fade} grid grid-cols-1 lg:grid-cols-2 gap-5`} style={{
+      background: RS.panel, border: `1px solid ${event.color}33`,
+      borderLeft: `3px solid ${event.color}`,
+      borderRadius: 6, padding: 20, marginTop: 10, minHeight: 320,
+      opacity: presenting && focusPanel !== "map" ? 0.95 : 1,
+    }}>
+      <div>
+        <div style={{ fontFamily: RS_MONO, fontSize: 10, letterSpacing: 1.5, color: event.color, textTransform: "uppercase" }}>
+          {event.date} · {event.vehicle} · {event.dimLabel}
+        </div>
+        <h2 style={{ fontSize: 17, fontWeight: 700, margin: "6px 0 8px", color: RS.text }}>{event.name}</h2>
+        <p style={{ color: RS.dim, fontSize: 12.5, lineHeight: 1.6, margin: 0 }}>{event.detail}</p>
+        <div style={{ marginTop: 14, display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+          {event.metrics.map(([k, v]) => (
+            <div key={k} style={{ background: RS.panelAlt, border: `1px solid ${RS.line}`, borderRadius: 6, padding: "8px 10px" }}>
+              <div style={{ fontFamily: RS_MONO, fontSize: 9, color: RS.faint, letterSpacing: 1, textTransform: "uppercase" }}>{k}</div>
+              <div style={{ fontSize: 12, color: RS.text, marginTop: 2, fontFamily: RS_MONO }}>{v}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        <RecordCell heading="Bottleneck solved" color={RS.green}>{event.bottleneckSolved}</RecordCell>
+        <RecordCell heading="New bottleneck created" color={RS.amber}>{event.bottleneckCreated}</RecordCell>
+        <RecordCell heading="Data product implied" color={RS.blue}>{event.dataProduct}</RecordCell>
+        <RecordCell heading="What this rhymes with" color={event.color}
+          style={{ background: `${event.color}10`, border: `1px solid ${event.color}30` }}>
+          <span style={{ fontStyle: "italic", color: RS.text }}>{event.rhyme}</span>
+        </RecordCell>
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/telemetry/context/BottleneckMap/KpiStrip.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/KpiStrip.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+// KPI strip derived from the active time window (full range while presenting). Tiles mirror
+// RsKpi's visual language; the value gets the keyed fade so window changes read as updates.
+import React from "react";
+
+import { RS, RS_MONO, RS_SANS } from "../../rsTokens";
+import styles from "./BottleneckMap.module.css";
+import type { KpiSummary } from "./types";
+
+function KpiTile({ label, value, sub, color }: {
+  label: string; value: string; sub: string; color: string;
+}) {
+  return (
+    <div style={{ background: RS.panel, border: `1px solid ${RS.line}`, borderRadius: 6, padding: "10px 12px" }}>
+      <div style={{ color: RS.faint, fontSize: 11, marginBottom: 2, fontFamily: RS_SANS }}>{label}</div>
+      <div key={value} className={styles.fade}
+        style={{ fontFamily: RS_MONO, fontSize: 16, fontWeight: 600, color }}>{value}</div>
+      <div style={{ color: RS.dim, fontSize: 10, fontFamily: RS_SANS, marginTop: 1 }}>{sub}</div>
+    </div>
+  );
+}
+
+export default function KpiStrip({ kpi, presenting, windowed, inflationAdjusted }: {
+  kpi: KpiSummary;
+  presenting: boolean;
+  windowed: boolean;
+  inflationAdjusted: boolean;
+}) {
+  return (
+    <div className="grid grid-cols-2 xl:grid-cols-4 gap-2.5" style={{ marginTop: 14 }}>
+      <KpiTile label="Active window" value={kpi.window} color={RS.text}
+        sub={presenting ? "presenter mode" : windowed ? "brushed" : "full range"} />
+      <KpiTile label="Orbital attempts" value={kpi.attempts} color={RS.blue} sub="in window" />
+      <KpiTile label="Commercial share" value={kpi.share} color={RS.green}
+        sub={kpi.shareYear != null ? `as of ${kpi.shareYear}` : ""} />
+      <KpiTile label="Cost to LEO" value={kpi.cost} color={RS.amber}
+        sub={`${kpi.costLabel}${inflationAdjusted ? ", 2025 $" : ", nominal"}`} />
+    </div>
+  );
+}

--- a/repo-b/src/components/telemetry/context/BottleneckMap/MapPanel.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/MapPanel.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+// Panel 1: the Bottleneck Map. Bubbles are milestone events on capability bands; bars are world
+// orbital launch attempts per year. Bubble opacity transitions give presenter mode its motion.
+import React from "react";
+import {
+  Bar, CartesianGrid, Cell, ComposedChart, ReferenceLine, ResponsiveContainer, Scatter, Tooltip,
+  XAxis, YAxis,
+} from "recharts";
+import type { ScatterProps, TooltipProps } from "recharts";
+
+import { RS, RS_MONO } from "../../rsTokens";
+import styles from "./BottleneckMap.module.css";
+import { BANDS, YEAR_SERIES } from "./data";
+import PanelShell, { yearFromChartState } from "./PanelShell";
+import type { DecoratedEvent, TimeWindow } from "./types";
+
+// TODO(P1 backlog): connecting arc between the Terran 1 and Terran R bubbles (pathfinder-to-scale
+// lineage), drawn on selection of either.
+// TODO(P1 backlog): bottleneck relay highlighting; selecting an event highlights the event whose
+// solved bottleneck matches the selected event's created bottleneck.
+
+interface BubblePointProps {
+  cx?: number;
+  cy?: number;
+  payload?: DecoratedEvent;
+}
+
+function MapTip({ active, payload }: TooltipProps<number, string>) {
+  if (!active || !payload || payload.length === 0) return null;
+  const d = payload.map((p) => p.payload as DecoratedEvent | undefined).find((p) => p?.id != null);
+  if (!d) return null;
+  return (
+    <div style={{ background: RS.panel, border: `1px solid ${d.color}40`, borderRadius: 6,
+      padding: "10px 12px", maxWidth: 280, boxShadow: "0 8px 24px rgba(0,0,0,0.5)" }}>
+      <div style={{ color: d.color, fontFamily: RS_MONO, fontSize: 10, letterSpacing: 1, textTransform: "uppercase" }}>
+        {d.date} · {d.dimLabel}
+      </div>
+      <div style={{ color: RS.text, fontWeight: 600, fontSize: 13, marginTop: 4 }}>{d.name}</div>
+      <div style={{ color: RS.dim, fontSize: 11, marginTop: 4 }}>Solved: {d.bottleneckSolved}</div>
+      <div style={{ color: RS.faint, fontSize: 10, marginTop: 6, fontFamily: RS_MONO }}>Click to pin full record</div>
+    </div>
+  );
+}
+
+export default function MapPanel({
+  events, selectedId, presenting, revealedIds, presenterYear, timeWindow, hoveredYear,
+  sizeModeLabel, focused, dimmed, onHoverYear, onSelect,
+}: {
+  events: DecoratedEvent[];
+  selectedId: string | null;
+  presenting: boolean;
+  revealedIds: ReadonlySet<string>;
+  presenterYear: number;
+  timeWindow: TimeWindow | null;          // null when the full range is active
+  hoveredYear: number | null;
+  sizeModeLabel: string;
+  focused: boolean;
+  dimmed: boolean;
+  onHoverYear: (year: number | null) => void;
+  onSelect: (id: string) => void;
+}) {
+  const renderBubble = (props: BubblePointProps): React.ReactElement => {
+    const { cx, cy, payload } = props;
+    if (cx == null || cy == null || !payload) return <g />;
+    const r = Math.max(6, Math.sqrt(payload.sizeValue) * 2.4);
+    const color = payload.color;
+    const isSelected = selectedId === payload.id;
+    const dash =
+      payload.outcome === "partial" ? "4 3" :
+      payload.outcome === "planned" ? "2 4" : "none";
+
+    let opacity = 1;
+    if (presenting) {
+      opacity = revealedIds.has(payload.id) ? 1 : 0.07;
+    } else if (timeWindow && (payload.year < timeWindow[0] || payload.year > timeWindow[1] + 1)) {
+      opacity = 0.12;
+    }
+
+    return (
+      <g
+        style={{ cursor: presenting ? "default" : "pointer", opacity, transition: "opacity 650ms ease" }}
+        onClick={() => { if (!presenting) onSelect(payload.id); }}
+      >
+        {isSelected && presenting && (
+          <circle className={styles.pulse} cx={cx} cy={cy} r={r + 5} fill="none" stroke={color} strokeWidth={2} />
+        )}
+        {isSelected && !presenting && (
+          <circle cx={cx} cy={cy} r={r + 6} fill="none" stroke={color} strokeOpacity={0.35} strokeWidth={2} />
+        )}
+        <circle
+          cx={cx} cy={cy} r={r}
+          fill={color} fillOpacity={isSelected ? 0.45 : 0.22}
+          stroke={color} strokeWidth={isSelected ? 2 : 1.5}
+          strokeDasharray={dash}
+        />
+        <circle cx={cx} cy={cy} r={2.5} fill={color} />
+      </g>
+    );
+  };
+
+  return (
+    <PanelShell title="Bottleneck Map" accent={RS.blue}
+      sub="bubbles: events · bars: world orbital attempts/yr"
+      focused={focused} dimmed={dimmed}>
+      <div className="h-[260px] lg:h-[350px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart data={YEAR_SERIES} margin={{ top: 12, right: 28, bottom: 4, left: 8 }}
+            onMouseMove={(s) => onHoverYear(yearFromChartState(s))} onMouseLeave={() => onHoverYear(null)}>
+            <CartesianGrid stroke={RS.line} strokeDasharray="2 6" vertical={false} />
+            <XAxis type="number" dataKey="year" domain={[1955, 2031]}
+              ticks={[1957, 1969, 1981, 1998, 2010, 2015, 2023, 2026, 2030]}
+              tick={{ fill: RS.faint, fontSize: 10, fontFamily: RS_MONO }}
+              stroke={RS.line} tickLine={false} allowDataOverflow />
+            <YAxis yAxisId="band" type="number" domain={[0.4, 5.6]} ticks={[1, 2, 3, 4, 5]}
+              tickFormatter={(v: number) => BANDS.find((b) => b.y === v)?.label || ""}
+              tick={{ fill: RS.dim, fontSize: 10, fontFamily: RS_MONO }}
+              width={210} stroke={RS.line} tickLine={false} />
+            <YAxis yAxisId="cadence" orientation="right" type="number" domain={[0, 347]}
+              ticks={[0, 165, 330]}
+              tick={{ fill: RS.crosshair, fontSize: 9, fontFamily: RS_MONO }}
+              width={34} stroke={RS.line} tickLine={false} />
+            <Tooltip content={<MapTip />} cursor={false} />
+            <Bar yAxisId="cadence" dataKey="attempts" barSize={5} radius={[2, 2, 0, 0]} isAnimationActive={false}>
+              {YEAR_SERIES.map((d) => (
+                <Cell key={d.year}
+                  fill={d.year >= 2021 ? RS.barFillHot : RS.barFill}
+                  fillOpacity={presenting && d.year > presenterYear ? 0.08 : 0.5}
+                  style={{ transition: "fill-opacity 650ms ease" }} />
+              ))}
+            </Bar>
+            {hoveredYear != null && (
+              <ReferenceLine yAxisId="band" x={hoveredYear} stroke={RS.crosshair}
+                strokeDasharray="2 4" strokeOpacity={0.8} />
+            )}
+            <ReferenceLine yAxisId="band" x={2023.22} stroke={RS.violet} strokeOpacity={0.25} strokeDasharray="3 5" />
+            <Scatter yAxisId="band" data={events} dataKey="band"
+              shape={renderBubble as ScatterProps["shape"]}
+              isAnimationActive={false} />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+      <div style={{ display: "flex", justifyContent: "flex-end", padding: "0 16px 8px",
+        fontFamily: RS_MONO, fontSize: 9, color: RS.faint }}>
+        <span>border: solid = flown · dashed = partial · dotted = planned · size = {sizeModeLabel.toLowerCase()}</span>
+      </div>
+    </PanelShell>
+  );
+}

--- a/repo-b/src/components/telemetry/context/BottleneckMap/MixPanel.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/MixPanel.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+// Panel 3: commercial vs government share of orbital attempts, with the time brush that windows
+// the KPI strip and dims out-of-window bubbles on the map.
+import React from "react";
+import {
+  Area, Brush, CartesianGrid, ComposedChart, ReferenceLine, ResponsiveContainer, Tooltip,
+  XAxis, YAxis,
+} from "recharts";
+import type { TooltipProps } from "recharts";
+
+import { RS, RS_MONO } from "../../rsTokens";
+import { YEAR_SERIES } from "./data";
+import PanelShell, { yearFromChartState } from "./PanelShell";
+import type { YearPoint } from "./types";
+
+function MixTip({ active, payload }: TooltipProps<number, string>) {
+  if (!active || !payload || payload.length === 0) return null;
+  const d = payload[0]?.payload as YearPoint | undefined;
+  if (!d || d.commercialPct == null || d.governmentPct == null) return null;
+  return (
+    <div style={{ background: RS.panel, border: `1px solid ${RS.line}`, borderRadius: 6,
+      padding: "8px 10px", boxShadow: "0 8px 24px rgba(0,0,0,0.5)" }}>
+      <div style={{ fontFamily: RS_MONO, fontSize: 10, color: RS.faint }}>{d.year} · {d.attempts} attempts</div>
+      <div style={{ fontSize: 11, color: RS.green, fontFamily: RS_MONO, marginTop: 2 }}>{Math.round(d.commercialPct)}% commercial</div>
+      <div style={{ fontSize: 11, color: RS.blue, fontFamily: RS_MONO }}>{Math.round(d.governmentPct)}% government</div>
+    </div>
+  );
+}
+
+export default function MixPanel({ hoveredYear, focused, dimmed, onHoverYear, onBrush }: {
+  hoveredYear: number | null;
+  focused: boolean;
+  dimmed: boolean;
+  onHoverYear: (year: number | null) => void;
+  onBrush: (range: { startIndex?: number; endIndex?: number }) => void;
+}) {
+  return (
+    <PanelShell title="Who flies: commercial vs government" accent={RS.green}
+      sub="share of orbital attempts · drag below to brush"
+      focused={focused} dimmed={dimmed}>
+      <ResponsiveContainer width="100%" height={180}>
+        <ComposedChart data={YEAR_SERIES} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}
+          onMouseMove={(s) => onHoverYear(yearFromChartState(s))} onMouseLeave={() => onHoverYear(null)}>
+          <CartesianGrid stroke={RS.line} strokeDasharray="2 6" vertical={false} />
+          <XAxis type="number" dataKey="year" domain={[1955, 2031]}
+            ticks={[1957, 1981, 2005, 2025]}
+            tick={{ fill: RS.faint, fontSize: 9, fontFamily: RS_MONO }}
+            stroke={RS.line} tickLine={false} allowDataOverflow />
+          <YAxis type="number" domain={[0, 100]} ticks={[0, 50, 100]}
+            tickFormatter={(v: number) => `${v}%`}
+            tick={{ fill: RS.faint, fontSize: 9, fontFamily: RS_MONO }}
+            width={42} stroke={RS.line} tickLine={false} />
+          <Tooltip content={<MixTip />} cursor={false} />
+          {hoveredYear != null && (
+            <ReferenceLine x={hoveredYear} stroke={RS.crosshair} strokeDasharray="2 4" strokeOpacity={0.8} />
+          )}
+          <Area dataKey="commercialPct" stackId="mix" stroke={RS.green} strokeWidth={1}
+            fill={RS.green} fillOpacity={0.25} connectNulls isAnimationActive={false} />
+          <Area dataKey="governmentPct" stackId="mix" stroke={RS.blue} strokeWidth={1}
+            fill={RS.blue} fillOpacity={0.12} connectNulls isAnimationActive={false} />
+          <Brush dataKey="year" height={18} travellerWidth={8}
+            stroke={RS.crosshair} fill={RS.bg} onChange={onBrush}
+            tickFormatter={() => ""} />
+        </ComposedChart>
+      </ResponsiveContainer>
+      <div style={{ padding: "0 12px 8px", fontFamily: RS_MONO, fontSize: 9, color: RS.faint }}>
+        green = commercial share. 2022-2025 reported (~55% to ~70%); earlier values are coarse estimates
+      </div>
+    </PanelShell>
+  );
+}

--- a/repo-b/src/components/telemetry/context/BottleneckMap/PanelShell.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/PanelShell.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+// Shared panel wrapper for the three chart panels. Mirrors RsPanel's visual language (title bar,
+// radius 6, RS.line border) and adds the presenter-mode focus/dim treatment the prototype's
+// spotlight relies on.
+import React from "react";
+
+import { RS, RS_MONO, RS_SANS } from "../../rsTokens";
+
+export default function PanelShell({ title, sub, focused, dimmed, accent, children }: {
+  title: string;
+  sub?: string;
+  focused?: boolean;
+  dimmed?: boolean;
+  accent: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div style={{
+      background: RS.panel,
+      border: `1px solid ${focused ? `${accent}66` : RS.line}`,
+      boxShadow: focused ? `0 0 0 1px ${accent}40, 0 8px 30px rgba(0,0,0,0.35)` : "none",
+      borderRadius: 6, overflow: "hidden",
+      opacity: dimmed ? 0.45 : 1,
+      transition: "opacity 600ms ease, border-color 600ms ease, box-shadow 600ms ease",
+    }}>
+      <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 8,
+        padding: "8px 12px", borderBottom: `1px solid ${RS.line}` }}>
+        <span style={{ color: RS.dim, fontFamily: RS_SANS, fontSize: 11, letterSpacing: "0.12em",
+          textTransform: "uppercase" }}>{title}</span>
+        {sub && <span style={{ color: RS.faint, fontFamily: RS_MONO, fontSize: 9 }}>{sub}</span>}
+      </div>
+      <div style={{ padding: "8px 4px 0" }}>{children}</div>
+    </div>
+  );
+}
+
+// Coerce a recharts chart-state activeLabel (string | number | undefined) to a year, shared by the
+// three panels' hover handlers.
+export function yearFromChartState(state: { activeLabel?: unknown } | null | undefined): number | null {
+  const v = state?.activeLabel;
+  const y = typeof v === "number" ? v : v != null ? Number(v) : NaN;
+  return Number.isFinite(y) ? y : null;
+}

--- a/repo-b/src/components/telemetry/context/BottleneckMap/PresenterBanner.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/PresenterBanner.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+// Presenter-mode banner: era + step counter, the step caption (keyed fade), and on-screen
+// prev/next controls so the walkthrough works without a keyboard.
+import React from "react";
+
+import { RS, RS_MONO } from "../../rsTokens";
+import styles from "./BottleneckMap.module.css";
+import type { LaunchEvent } from "./types";
+
+function StepButton({ label, onClick, disabled, children }: {
+  label: string; onClick: () => void; disabled: boolean; children: React.ReactNode;
+}) {
+  return (
+    <button type="button" onClick={onClick} disabled={disabled} aria-label={label}
+      className={styles.control}
+      style={{ background: "transparent", border: `1px solid ${RS.line}`, color: RS.dim,
+        borderRadius: 6, padding: "6px 12px", cursor: disabled ? "default" : "pointer",
+        fontFamily: RS_MONO, fontSize: 12, opacity: disabled ? 0.35 : 1 }}>
+      {children}
+    </button>
+  );
+}
+
+export default function PresenterBanner({ event, accent, idx, total, onPrev, onNext }: {
+  event: LaunchEvent;
+  accent: string;
+  idx: number;
+  total: number;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  return (
+    <div style={{ marginTop: 14, background: RS.panel, border: `1px solid ${accent}40`,
+      borderRadius: 6, padding: "12px 16px", display: "flex", alignItems: "center", gap: 16 }}>
+      <StepButton label="Previous step" onClick={onPrev} disabled={idx === 0}>←</StepButton>
+      <div key={idx} className={styles.fade} style={{ flex: 1, minHeight: 44 }}>
+        <div style={{ fontFamily: RS_MONO, fontSize: 10, color: accent, letterSpacing: 1.5, textTransform: "uppercase" }}>
+          {event.era} · {idx + 1} / {total}
+        </div>
+        <div style={{ fontSize: 13.5, color: RS.text, marginTop: 3 }}>{event.caption}</div>
+      </div>
+      <StepButton label="Next step" onClick={onNext} disabled={idx === total - 1}>→</StepButton>
+    </div>
+  );
+}

--- a/repo-b/src/components/telemetry/context/BottleneckMap/data.ts
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/data.ts
@@ -1,0 +1,361 @@
+// Static narrative data for the Bottleneck Map context module. Public, widely cited values;
+// approximations are marked in the methodology footer. This is narrative content, not telemetry:
+// it stays in code, never in Supabase, and the module makes no network calls. All derived series
+// are computed once at module scope.
+
+import { RS } from "../../rsTokens";
+import type {
+  ColorByKey, CostPoint, DimensionEntry, DimensionKey, LaunchEvent, SizeModeKey, TimeWindow,
+  YearPoint,
+} from "./types";
+
+// Two color dimensions for the bubbles
+export const INNOVATION: Record<string, DimensionEntry> = {
+  mission:       { color: RS.blue,   label: "Mission achievement" },
+  cost:          { color: RS.green,  label: "Cost reduction" },
+  reuse:         { color: RS.amber,  label: "Reusability" },
+  manufacturing: { color: RS.violet, label: "Manufacturing" },
+  dataops:       { color: RS.text,   label: "AI / data operations" },
+};
+export const FUNDING: Record<string, DimensionEntry> = {
+  government: { color: RS.blue,   label: "Government program" },
+  costplus:   { color: RS.violet, label: "Cost-plus contract" },
+  fixedprice: { color: RS.green,  label: "Fixed-price commercial" },
+  venture:    { color: RS.amber,  label: "Venture / internal" },
+};
+export const COLOR_DIMENSIONS: Record<ColorByKey, { label: string; lookup: Record<string, DimensionEntry> }> = {
+  type:    { label: "Innovation type", lookup: INNOVATION },
+  funding: { label: "Funding model",  lookup: FUNDING },
+};
+
+export function eventDimensionKey(e: LaunchEvent, colorBy: ColorByKey): DimensionKey {
+  return colorBy === "type" ? e.type : e.funding;
+}
+export function eventDimension(e: LaunchEvent, colorBy: ColorByKey): DimensionEntry {
+  return colorBy === "type" ? INNOVATION[e.type] : FUNDING[e.funding];
+}
+
+export const BANDS: { y: number; label: string }[] = [
+  { y: 1, label: "Government proof of possibility" },
+  { y: 2, label: "Operational spaceflight" },
+  { y: 3, label: "Commercial launch" },
+  { y: 4, label: "Reusable fleet operations" },
+  { y: 5, label: "Autonomous, data-driven production" },
+];
+
+export const SIZE_MODES: { key: SizeModeKey; label: string; note: string }[] = [
+  { key: "scale",   label: "Program scale",  note: "editorial weighting" },
+  { key: "payload", label: "Payload to LEO", note: "vehicle capacity, t" },
+];
+
+// ---------------------------------------------------------------------------
+// Global orbital launch attempts per year, 1957-2025.
+// Basis: Wikipedia "<year> in spaceflight" series / GCAT (J. McDowell).
+// Pre-2000 values are close approximations; 2018+ are exact totals.
+// ---------------------------------------------------------------------------
+export const CADENCE: [number, number][] = [
+  [1957, 3], [1958, 28], [1959, 23], [1960, 39], [1961, 50], [1962, 82],
+  [1963, 70], [1964, 102], [1965, 125], [1966, 132], [1967, 139], [1968, 128],
+  [1969, 125], [1970, 124], [1971, 134], [1972, 113], [1973, 116], [1974, 113],
+  [1975, 132], [1976, 131], [1977, 130], [1978, 128], [1979, 109], [1980, 108],
+  [1981, 126], [1982, 129], [1983, 129], [1984, 129], [1985, 124], [1986, 110],
+  [1987, 114], [1988, 121], [1989, 105], [1990, 121], [1991, 91], [1992, 97],
+  [1993, 83], [1994, 93], [1995, 80], [1996, 77], [1997, 89], [1998, 82],
+  [1999, 78], [2000, 85], [2001, 59], [2002, 65], [2003, 63], [2004, 55],
+  [2005, 55], [2006, 66], [2007, 68], [2008, 69], [2009, 78], [2010, 74],
+  [2011, 84], [2012, 78], [2013, 81], [2014, 92], [2015, 87], [2016, 85],
+  [2017, 91], [2018, 114], [2019, 102], [2020, 114], [2021, 146], [2022, 186],
+  [2023, 223], [2024, 261], [2025, 330],
+];
+const CADENCE_BY_YEAR: Record<number, number> = Object.fromEntries(CADENCE);
+
+// Commercial share of orbital launch attempts, %. Anchors interpolated.
+// 2022-2025 are reported values; earlier anchors are coarse estimates.
+export const SHARE_ANCHORS: [number, number][] = [
+  [1957, 0], [1979, 0], [1985, 5], [1990, 15], [1995, 25], [1998, 35],
+  [2000, 30], [2005, 20], [2010, 25], [2014, 35], [2018, 45], [2020, 50],
+  [2021, 52], [2022, 55], [2023, 65], [2024, 70], [2025, 70],
+];
+export function shareAt(year: number): number {
+  if (year <= SHARE_ANCHORS[0][0]) return SHARE_ANCHORS[0][1];
+  const last = SHARE_ANCHORS[SHARE_ANCHORS.length - 1];
+  if (year >= last[0]) return last[1];
+  for (let i = 0; i < SHARE_ANCHORS.length - 1; i++) {
+    const [x0, v0] = SHARE_ANCHORS[i];
+    const [x1, v1] = SHARE_ANCHORS[i + 1];
+    if (year >= x0 && year <= x1) return v0 + ((year - x0) / (x1 - x0)) * (v1 - v0);
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Cost to LEO: per-launch sticker price / LEO capacity, $/kg.
+// nominal = dollars of the quote year. adj = approx 2025 dollars (CPI).
+// Single consistent basis: vehicle list/marginal price, NOT program-averaged.
+// TODO(P3 backlog): add a dev-cost size dimension once figures are sourced and footnoted.
+// ---------------------------------------------------------------------------
+export const COST_POINTS: Record<number, CostPoint> = {
+  1969: { v: "Saturn V",     nominal: 1320,  adj: 11500, basis: "$185M (1969) / 140 t" },
+  1988: { v: "Shuttle",      nominal: 16400, adj: 44200, basis: "$450M marginal (1988) / 27.5 t. Program-averaged is ~3x higher" },
+  1997: { v: "Titan IV",     nominal: 19900, adj: 39800, basis: "$432M (1997) / 21.7 t" },
+  2005: { v: "Ariane 5 ECA", nominal: 7860,  adj: 12900, basis: "$165M (2005) / 21 t" },
+  2018: { v: "Falcon 9 B5",  nominal: 2720,  adj: 3450,  basis: "$62M list (2018) / 22.8 t" },
+  2019: { v: "Falcon Heavy", nominal: 1520,  adj: 1900,  basis: "$97M recoverable (2018) / 63.8 t" },
+  2026: { v: "Terran R",     nominal: 2340,  adj: 2340,  basis: "$55M company-stated (2022) / 23.5 t reusable. Pricing may not be current" },
+};
+
+// Merged per-year series for bars, cost lines, and funding mix.
+// TODO(P2 backlog): live "next launches" ticker from Launch Library 2 with a precomputed static
+// fallback JSON; the demo must never depend on the network.
+export const YEAR_SERIES: YearPoint[] = [];
+for (let y = 1957; y <= 2026; y++) {
+  const attempts = CADENCE_BY_YEAR[y] ?? null;
+  const pct = attempts != null ? shareAt(y) : null;
+  YEAR_SERIES.push({
+    year: y,
+    attempts,
+    commercialPct: pct,
+    governmentPct: pct != null ? 100 - pct : null,
+    costNominal: COST_POINTS[y]?.nominal ?? null,
+    costAdj: COST_POINTS[y]?.adj ?? null,
+    costMeta: COST_POINTS[y] ?? null,
+  });
+}
+export const FULL_WINDOW: TimeWindow = [1957, 2026];
+
+// ---------------------------------------------------------------------------
+// Event data. Public, widely cited values; approximations marked.
+// focusPanel drives the presenter-mode spotlight: "map" | "cost" | "mix".
+// ---------------------------------------------------------------------------
+export const EVENTS: LaunchEvent[] = [
+  {
+    id: "sputnik", name: "Sputnik 1", date: "1957-10-04", year: 1957.76,
+    band: 1, scale: 18, payloadT: 0.5, type: "mission", funding: "government",
+    outcome: "success", focusPanel: "map",
+    vehicle: "R-7 / Sputnik 8K71PS (USSR)",
+    era: "Proof era",
+    caption: "Orbit access itself is the achievement. Telemetry is two analog channels encoded in beep duration.",
+    detail: "83.6 kg satellite. Two radio transmitters at 20 and 40 MHz. Telemetry was effectively a handful of analog channels: internal temperature and pressure encoded in beep duration.",
+    metrics: [["Payload", "83.6 kg"], ["Telemetry", "~2 analog channels"], ["Orbit lifetime", "92 days"], ["World launches that year", "3"]],
+    bottleneckSolved: "Reaching orbit at all",
+    bottleneckCreated: "Doing anything useful once there",
+    dataProduct: "Doppler tracking as the first orbital data pipeline",
+    rhyme: "Every platform starts with a minimum viable signal.",
+  },
+  {
+    id: "vostok", name: "Vostok 1 (Gagarin)", date: "1961-04-12", year: 1961.28,
+    band: 1, scale: 20, payloadT: 4.7, type: "mission", funding: "government",
+    outcome: "success", focusPanel: "map",
+    vehicle: "Vostok-K (USSR)",
+    era: "Proof era",
+    caption: "Human spaceflight arrives almost fully automated. The human is the backup system.",
+    detail: "First human orbital flight, 108 minutes. Almost fully automated: Gagarin's manual controls were locked behind a sealed envelope code because flight surgeons did not trust human performance in microgravity.",
+    metrics: [["Flight time", "108 min"], ["Control mode", "Automated, human as backup"], ["Crew", "1"], ["World launches that year", "50"]],
+    bottleneckSolved: "Human survival in orbit",
+    bottleneckCreated: "Real-time human safety monitoring",
+    dataProduct: "Biomedical telemetry and real-time mission ops",
+    rhyme: "Automation first, human override second. Familiar pattern.",
+  },
+  {
+    id: "apollo11", name: "Apollo 11", date: "1969-07-20", year: 1969.55,
+    band: 2, scale: 34, payloadT: 140, type: "mission", funding: "government",
+    outcome: "success", focusPanel: "cost",
+    vehicle: "Saturn V (NASA)",
+    era: "Operations era",
+    caption: "Integration at the scale of 400,000 people. Watch the cost panel: nominal dollars hide what Apollo really cost.",
+    detail: "Peak program employment around 400,000 people. The Apollo Guidance Computer ran at 2.048 MHz with about 4 KB of RAM and roughly 145,000 lines of assembly. Saturn V marginal launch cost was about $185M in 1969 dollars, roughly $1.6B today.",
+    metrics: [["Program workforce", "~400,000 people"], ["AGC software", "~145k lines of assembly"], ["AGC memory", "~4 KB RAM / 72 KB ROM"], ["Cost to LEO", "~$1,320/kg nominal, ~$11,500/kg in 2025 $"]],
+    bottleneckSolved: "Systems integration at unprecedented scale",
+    bottleneckCreated: "Sustainable cost. Apollo was not repeatable economics",
+    dataProduct: "Telemetry lineage: thousands of parameters traced from sensor to mission control console",
+    rhyme: "Apollo proved integration. It never proved unit economics.",
+  },
+  {
+    id: "shuttle", name: "Space Shuttle STS-1", date: "1981-04-12", year: 1981.28,
+    band: 2, scale: 28, payloadT: 27.5, type: "reuse", funding: "costplus",
+    outcome: "partial", focusPanel: "cost",
+    vehicle: "Space Shuttle Columbia (NASA)",
+    era: "Operations era",
+    caption: "Reuse is physically proven and economically unproven. The cost curve peaks here, not in the Apollo era.",
+    detail: "First reusable orbital spacecraft. Flew 135 missions over 30 years with 2 loss-of-crew failures. Marginal cost near $450M per flight in late-80s dollars; program-averaged roughly $1.5B. Primary flight software was about 400k lines with a famously low defect rate.",
+    metrics: [["Missions", "135 over 30 years"], ["Marginal cost", "~$450M/flight (1988 $)"], ["Program-averaged", "~$1.5B/flight"], ["Flight software", "~400k LOC, ~1 defect per release"]],
+    bottleneckSolved: "Reuse is physically possible",
+    bottleneckCreated: "Reuse without refurbishment economics is not reuse",
+    dataProduct: "Mission readiness reviews: the original launch-readiness dashboard, run on paper and meetings",
+    rhyme: "Reusable hardware with non-reusable operations. The ops model is the product.",
+  },
+  {
+    id: "iss", name: "ISS assembly begins (Zarya)", date: "1998-11-20", year: 1998.89,
+    band: 2, scale: 24, payloadT: 19.8, type: "mission", funding: "government",
+    outcome: "success", focusPanel: "map",
+    vehicle: "Proton-K (multinational)",
+    era: "Operations era",
+    caption: "Five agencies, 40+ assembly flights, one telemetry standard. Federated governance before the term existed.",
+    detail: "Start of the largest international engineering project in history. Over 40 assembly flights across multiple vehicles and agencies. The ISS now generates terabytes of telemetry and payload data per day.",
+    metrics: [["Assembly flights", "40+"], ["Partner agencies", "5"], ["Continuous crew", "Since Nov 2000"], ["World launches that year", "82"]],
+    bottleneckSolved: "Multi-decade orbital operations",
+    bottleneckCreated: "Logistics cost of sustaining orbit",
+    dataProduct: "Cross-agency data interoperability under one telemetry standard",
+    rhyme: "Federated data governance, twenty years before the term existed.",
+  },
+  {
+    id: "falcon1", name: "Falcon 1 reaches orbit", date: "2008-09-28", year: 2008.74,
+    band: 3, scale: 16, payloadT: 0.67, type: "cost", funding: "venture",
+    outcome: "success", focusPanel: "map",
+    vehicle: "Falcon 1 Flight 4 (SpaceX)",
+    era: "Commercial era",
+    caption: "Private orbit access on attempt four, on venture money. The three failures were the dataset.",
+    detail: "First privately developed liquid-fueled rocket to reach orbit, on the fourth attempt after three failures. The company was weeks from insolvency. Total development cost of roughly $90M to $100M, a fraction of comparable government programs.",
+    metrics: [["Attempts to orbit", "4"], ["Development cost", "~$90M to $100M"], ["Payload to LEO", "~670 kg"], ["World launches that year", "69"]],
+    bottleneckSolved: "Private access to orbit",
+    bottleneckCreated: "Scaling from proof to product",
+    dataProduct: "Failure investigation as the core engineering loop: flights 1 to 3 were the dataset",
+    rhyme: "Three labeled failures were worth more than one lucky success.",
+  },
+  {
+    id: "falcon9", name: "Falcon 9 first flight", date: "2010-06-04", year: 2010.42,
+    band: 3, scale: 24, payloadT: 22.8, type: "cost", funding: "fixedprice",
+    outcome: "success", focusPanel: "cost",
+    vehicle: "Falcon 9 v1.0 (SpaceX)",
+    era: "Commercial era",
+    caption: "Fixed-price contracts plus a commodity engine. NASA estimated cost-plus development would have been ~10x.",
+    detail: "List price of about $62M for 22.8 t to LEO in its later Block 5 form, roughly $2,700/kg. NASA's 2011 analysis estimated Falcon 9 development cost about $390M, versus roughly $4B under traditional cost-plus contracting. Nine-engine architecture made engine production a manufacturing-line problem rather than a bespoke one.",
+    metrics: [["Cost to LEO", "~$2,720/kg nominal (2018 list)"], ["Dev cost (NASA est.)", "~$390M actual vs ~$4B cost-plus"], ["Engines per booster", "9 Merlins"], ["Design philosophy", "Engine as manufactured commodity"]],
+    bottleneckSolved: "Launch cost structure",
+    bottleneckCreated: "Booster expendability still dominates cost",
+    dataProduct: "Engine acceptance test telemetry at production-line scale",
+    rhyme: "When the engine becomes a SKU, the factory becomes the rocket.",
+  },
+  {
+    id: "dragon", name: "Dragon berths with ISS", date: "2012-05-25", year: 2012.40,
+    band: 3, scale: 20, payloadT: 22.8, type: "mission", funding: "fixedprice",
+    outcome: "success", focusPanel: "mix",
+    vehicle: "Falcon 9 / Dragon C2+ (SpaceX)",
+    era: "Commercial era",
+    caption: "NASA buys services instead of vehicles. Watch the funding mix: the commercial share starts its climb here.",
+    detail: "First commercial spacecraft to berth with the ISS. Proved that NASA could buy services instead of vehicles, the contracting model that now underpins Artemis commercial landers and cargo.",
+    metrics: [["Contract model", "Fixed-price service, not cost-plus"], ["NASA COTS investment", "~$396M to SpaceX"], ["World launches that year", "78"]],
+    bottleneckSolved: "Commercial crew/cargo as a service category",
+    bottleneckCreated: "Certification and safety cases for commercial vehicles",
+    dataProduct: "Shared government and commercial review data packages",
+    rhyme: "The procurement model changed before the technology did.",
+  },
+  {
+    id: "f9landing", name: "Falcon 9 booster landing", date: "2015-12-21", year: 2015.97,
+    band: 4, scale: 26, payloadT: 22.8, type: "reuse", funding: "venture",
+    outcome: "success", focusPanel: "map",
+    vehicle: "Falcon 9 Flight 20, OG2 (SpaceX)",
+    era: "Reuse era",
+    caption: "Boosters become fleet assets: tail numbers, utilization, per-unit health. Servers with grid fins.",
+    detail: "First orbital-class booster to land propulsively after delivering payload to orbit. Internally funded development. Shifted launch economics from one-off hardware to fleet asset management: flights per booster, turnaround days, refurbishment cost per cycle.",
+    metrics: [["Landing", "Landing Zone 1, first attempt"], ["Eventual fleet record", "B1067: 30+ flights"], ["Best turnaround", "~3 weeks between flights"], ["World launches that year", "87"]],
+    bottleneckSolved: "Recovering the expensive 70% of the rocket",
+    bottleneckCreated: "Fleet operations: tracking asset health across reflights",
+    dataProduct: "Fleet reuse analytics: per-tail-number health, fatigue, and refurbishment telemetry",
+    rhyme: "Boosters became servers: utilization, uptime, and per-unit health metrics.",
+  },
+  {
+    id: "falconheavy", name: "Falcon Heavy", date: "2018-02-06", year: 2018.10,
+    band: 4, scale: 24, payloadT: 63.8, type: "cost", funding: "venture",
+    outcome: "success", focusPanel: "cost",
+    vehicle: "Falcon Heavy (SpaceX)",
+    era: "Reuse era",
+    caption: "27 engines firing at once, ~$1,500/kg. Heavy lift stops being a national-program exclusive.",
+    detail: "63.8 t to LEO at a list price near $97M with booster recovery, roughly $1,500/kg. Internally funded. Heavy lift stopped being a national-program exclusive. 27 engines firing simultaneously made engine-out tolerance a software and data problem.",
+    metrics: [["Payload to LEO", "63.8 t"], ["Cost to LEO", "~$1,520/kg nominal, ~$1,900/kg in 2025 $"], ["First stage engines", "27 Merlins"], ["World launches that year", "114"]],
+    bottleneckSolved: "Commercial heavy lift",
+    bottleneckCreated: "Demand: heavy lift outran the payload market",
+    dataProduct: "27-engine health monitoring with real-time engine-out decision logic",
+    rhyme: "Redundancy at scale only works if the telemetry layer can arbitrate it.",
+  },
+  {
+    id: "crewdragon", name: "Crew Dragon Demo-2", date: "2020-05-30", year: 2020.41,
+    band: 4, scale: 22, payloadT: 22.8, type: "mission", funding: "fixedprice",
+    outcome: "success", focusPanel: "map",
+    vehicle: "Falcon 9 / Crew Dragon (SpaceX)",
+    era: "Reuse era",
+    caption: "Crew supervise, software flies. The safety case is now mostly a data artifact.",
+    detail: "First commercial vehicle to carry crew to orbit, ending a nine-year US human launch gap. Touchscreen flight interfaces backed by autonomous flight software: crew supervise, software flies.",
+    metrics: [["US crew launch gap closed", "9 years"], ["Primary control mode", "Autonomous, crew supervisory"], ["World launches that year", "114"]],
+    bottleneckSolved: "Commercial human spaceflight certification",
+    bottleneckCreated: "Software assurance as the long pole in safety cases",
+    dataProduct: "Software verification evidence as a first-class deliverable",
+    rhyme: "The safety case is now mostly a data and software artifact.",
+  },
+  {
+    id: "terran1", name: "Terran 1: Good Luck, Have Fun", date: "2023-03-22", year: 2023.22,
+    band: 5, scale: 22, payloadT: 1.25, type: "manufacturing", funding: "venture",
+    outcome: "partial", focusPanel: "map",
+    vehicle: "Terran 1 (Relativity Space)",
+    era: "Production era",
+    caption: "85% printed by mass survives Max-Q on venture funding. A partial flight that fully proved the manufacturing thesis.",
+    detail: "About 85% 3D printed by mass, the largest additively manufactured object to attempt orbital flight. Venture-funded: Relativity has raised over $1.3B including a $650M Series E. Survived Max-Q, validating printed primary structures. Second stage failed to reach orbit. Relativity retired Terran 1 and redirected to Terran R.",
+    metrics: [["Printed by mass", "~85%"], ["Max-Q", "Passed: printed structure validated"], ["Funding", ">$1.3B venture raised (incl. $650M Series E)"], ["Disposition", "Retired as pathfinder"]],
+    bottleneckSolved: "Additive manufacturing at rocket primary-structure scale",
+    bottleneckCreated: "Scaling printed production to a reusable medium-heavy vehicle",
+    dataProduct: "Printer telemetry, NCR clustering, engine-test anomaly detection, build-to-flight lineage",
+    rhyme: "A partial flight that fully proved the manufacturing thesis. Honest framing beats spin.",
+  },
+  {
+    id: "starshipcatch", name: "Starship booster catch", date: "2024-10-13", year: 2024.78,
+    band: 5, scale: 30, payloadT: 100, type: "reuse", funding: "venture",
+    outcome: "success", focusPanel: "map",
+    vehicle: "Starship Flight 5 (SpaceX)",
+    era: "Production era",
+    caption: "The test campaign is the data product. Hardware-rich iteration is CI/CD with cryogenics.",
+    detail: "Super Heavy booster caught by launch tower arms on first attempt. The test campaign itself is the data product: each flight is an instrumented experiment with thousands of channels feeding the next iteration, on a cadence measured in months, not years.",
+    metrics: [["Booster", "Super Heavy, 33 Raptors"], ["Recovery mode", "Tower catch, zero ground transit"], ["Iteration cadence", "Months between full-stack tests"], ["World launches that year", "261"]],
+    bottleneckSolved: "Rapid full-stack iteration with recovery",
+    bottleneckCreated: "Production rate: building vehicles faster than testing consumes them",
+    dataProduct: "Flight-test campaigns as versioned datasets feeding design iteration",
+    rhyme: "Hardware-rich iteration is just CI/CD with cryogenics.",
+  },
+  {
+    id: "fleetscale", name: "Launch at fleet scale", date: "2025-12-31", year: 2025.9,
+    band: 4, scale: 38, payloadT: 22.8, type: "dataops", funding: "fixedprice",
+    outcome: "success", focusPanel: "mix",
+    vehicle: "Falcon 9 / Heavy fleet (SpaceX)",
+    era: "Production era",
+    caption: "330 world attempts, 70% commercial, 165 from one vehicle family. At cadence, launch is a data platform problem.",
+    detail: "2025 set the record: 330 orbital launch attempts worldwide, 165 of them Falcon 9 flights from a single vehicle family. Commercial operators flew about 70% of all attempts. At this cadence, launch is fleet operations: range scheduling, booster assignment, weather modeling, and anomaly disposition are the daily workload, not the exception.",
+    metrics: [["World attempts, 2025", "330 (record)"], ["Falcon 9 alone", "165 flights"], ["Commercial share", "~70% of attempts"], ["Dominant workload", "Scheduling, fleet health, anomaly disposition"]],
+    bottleneckSolved: "Cadence as a repeatable operations discipline",
+    bottleneckCreated: "Decision velocity: humans in the loop become the rate limiter",
+    dataProduct: "Launch operations as a governed data platform: readiness, range, fleet health in one pane",
+    rhyme: "This is the thesis. At cadence, launch is a data platform problem.",
+  },
+  {
+    id: "terranR", name: "Terran R target", date: "2026 (planned)", year: 2026.75,
+    band: 5, scale: 28, payloadT: 33.5, type: "manufacturing", funding: "venture",
+    outcome: "planned", focusPanel: "map",
+    vehicle: "Terran R (Relativity Space)",
+    era: "Production era",
+    caption: "Manufacturable reuse. The advantage is the factory-to-flight data loop.",
+    detail: "Medium-to-heavy reusable launch vehicle, planned for Cape Canaveral with a stated late 2026 target. Relativity has stated more than $3B in launch service agreements across government, commercial, and telecom customers. 13 Aeon R engines on the first stage; payload class of 23.5 t reusable and 33.5 t expendable to LEO.",
+    metrics: [["Stated backlog", ">$3B in LSAs (company-stated)"], ["Payload to LEO", "23.5 t reusable / 33.5 t expendable"], ["First stage", "13 Aeon R engines"], ["Target", "Late 2026, Cape Canaveral (company-stated)"]],
+    bottleneckSolved: "Manufacturable reuse: additive plus conventional hybrid production",
+    bottleneckCreated: "Factory-to-flight data integration at production cadence",
+    dataProduct: "The full stack: printer and machine telemetry, NCR intelligence, engine acceptance analytics, launch readiness lineage",
+    rhyme: "The launch advantage is no longer only design. It is the factory-to-flight data loop.",
+  },
+  {
+    id: "artemis", name: "Artemis commercial systems", date: "2027+ (roadmap)", year: 2028.4,
+    band: 5, scale: 26, payloadT: 100, type: "dataops", funding: "fixedprice",
+    outcome: "planned", focusPanel: "mix",
+    vehicle: "HLS, CLPS, Gateway logistics (NASA + commercial)",
+    era: "Production era",
+    caption: "Mission assurance becomes auditing partner data. Lineage stops being hygiene and becomes the contract.",
+    detail: "NASA's lunar roadmap depends on commercial landers, logistics, and reusable infrastructure. Mission assurance shifts from owning vehicles to auditing partner data: telemetry standards, readiness evidence, and cross-organization lineage become the integration layer.",
+    metrics: [["Model", "NASA buys services, audits data"], ["Integration layer", "Cross-org telemetry and readiness standards"]],
+    bottleneckSolved: "Sustained lunar presence via commercial supply chains",
+    bottleneckCreated: "Multi-party data trust and provenance",
+    dataProduct: "Cross-organization mission readiness with auditable lineage",
+    rhyme: "Governance and lineage stop being internal hygiene and become the contract.",
+  },
+];
+
+export const EVENTS_CHRONO: LaunchEvent[] = [...EVENTS].sort((a, b) => a.year - b.year);
+
+export function fmtCost(v: number): string {
+  return v >= 10000 ? `$${(v / 1000).toFixed(0)}k` : `$${v.toLocaleString()}`;
+}

--- a/repo-b/src/components/telemetry/context/BottleneckMap/types.ts
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/types.ts
@@ -1,0 +1,73 @@
+// Shared types for the Bottleneck Map context module. One event model drives all four panels.
+
+export type InnovationKey = "mission" | "cost" | "reuse" | "manufacturing" | "dataops";
+export type FundingKey = "government" | "costplus" | "fixedprice" | "venture";
+export type DimensionKey = InnovationKey | FundingKey;
+export type ColorByKey = "type" | "funding";
+export type OutcomeKey = "success" | "partial" | "planned";
+export type FocusPanelKey = "map" | "cost" | "mix";
+export type SizeModeKey = "scale" | "payload";
+
+export type TimeWindow = readonly [number, number];
+
+export interface DimensionEntry {
+  color: string;
+  label: string;
+}
+
+export interface CostPoint {
+  v: string;
+  nominal: number;
+  adj: number;
+  basis: string;
+}
+
+export interface YearPoint {
+  year: number;
+  attempts: number | null;
+  commercialPct: number | null;
+  governmentPct: number | null;
+  costNominal: number | null;
+  costAdj: number | null;
+  costMeta: CostPoint | null;
+}
+
+export interface LaunchEvent {
+  id: string;
+  name: string;
+  date: string;
+  year: number;
+  band: number;
+  scale: number;
+  payloadT: number;
+  type: InnovationKey;
+  funding: FundingKey;
+  outcome: OutcomeKey;
+  focusPanel: FocusPanelKey;
+  vehicle: string;
+  era: string;
+  caption: string;
+  detail: string;
+  metrics: [label: string, value: string][];
+  bottleneckSolved: string;
+  bottleneckCreated: string;
+  dataProduct: string;
+  rhyme: string;
+}
+
+// Event decorated with the values the active color/size dimension resolves to.
+export interface DecoratedEvent extends LaunchEvent {
+  sizeValue: number;
+  color: string;
+  dimLabel: string;
+}
+
+export interface KpiSummary {
+  window: string;
+  attempts: string;
+  share: string;
+  shareYear: number | null;
+  cost: string;
+  costLabel: string;
+  events: number;
+}

--- a/repo-b/src/components/telemetry/rsTokens.tsx
+++ b/repo-b/src/components/telemetry/rsTokens.tsx
@@ -10,6 +10,8 @@ export const RS = {
   text: "#D7E2EC", dim: "#7E93A8", faint: "#54677A",
   teal: "#4FD1C5", cyan: "#67E8F9", amber: "#F5B452", red: "#F4715F",
   green: "#6EE7A0", violet: "#A78BFA", blue: "#6CA8F0", gray: "#3D4D60",
+  // Chart-scale tokens used by the Bottleneck Map context module.
+  crosshair: "#3D567A", barFill: "#22324A", barFillHot: "#2E4A6E",
 };
 export const RS_MONO = "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
 export const RS_SANS = "Inter, 'Helvetica Neue', Arial, sans-serif";


### PR DESCRIPTION
Folds the LaunchEvolutionMap prototype into the telemetry environment home page as its narrative on-ramp ("Context: why launch became a data problem"), below the page heading and above the operational sections.

## What changed
- New typed component tree at `repo-b/src/components/telemetry/context/BottleneckMap/` (container + 6 panels + PanelShell + data + types + CSS module). Strict TypeScript, no `any`.
- Styles off the shared `RS` token object in `rsTokens.tsx`; added three chart-scale tokens (`crosshair`, `barFill`, `barFillHot`) instead of hardcoding hex.
- `lem-pulse` / `lem-fade-slide` keyframes moved into a scoped CSS module with the `prefers-reduced-motion` guards preserved.
- Heading + context section render independent of the serving API, so the on-ramp shows even while the operational half is loading or erroring.
- Static narrative data stays in code (no network, no Supabase). Methodology footer and "company-stated" labels are verbatim. Five backlog items left as TODOs.

## Verification
- `npm run build` passes, zero TS errors.
- 8 new unit tests + 26 sibling telemetry tests green.
- Headless walkthrough confirmed the seven interaction contracts, presenter mode 1→16 with no layout shift, reduced-motion, and narrow viewport.
- Not yet run: full Lighthouse accessibility audit (covered structurally with aria-labels, aria-pressed, focus-visible rings, and an input-focus guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)