### PR TITLE
fix: finish PR #168 cleanup — unblock Backend Lint, Frontend Lint, and First-Mile gate

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -133,6 +133,12 @@ async def lifespan(app: FastAPI):
     git_sha = resolve_git_sha()
     db_fp = resolve_db_fingerprint()
 
+    # Background task handles, cancelled on shutdown below. None until a future
+    # phase wires their creation; the shutdown loop guards on `is not None`.
+    stream_task = None
+    stream_etl_task = None
+    stargate_autoplay_task = None
+
     emit_log(
         level="info", service="backend", action="startup.begin",
         message="Backend starting",

--- a/repo-b/src/components/repe/workspace/__tests__/repeNavigation.test.ts
+++ b/repo-b/src/components/repe/workspace/__tests__/repeNavigation.test.ts
@@ -13,13 +13,14 @@ describe("REPE navigation model", () => {
   });
 
   it("follows the institutional workflow section order", () => {
+    // The Automation/Winston group was removed in "Remove Winston AI chat
+    // surfaces" (84026f10); the workflow now ends at Governance.
     expect(groups.map((group) => group.label)).toEqual([
       "Portfolio",
       "Investor Operations",
       "Fund Accounting",
       "Analytics",
       "Governance",
-      "Automation",
     ]);
   });
 
@@ -29,7 +30,6 @@ describe("REPE navigation model", () => {
     expect(groups[2]?.items.map((item) => item.label)).toEqual(["Period Close", "Variance"]);
     expect(groups[3]?.items.map((item) => item.label)).toEqual(["Models", "Fund Decomposition", "Dashboards", "Saved Analyses", "Operator Diagnostics", "Reports", "Sustainability"]);
     expect(groups[4]?.items.map((item) => item.label)).toEqual(["Documents", "Approvals", "AI Audit"]);
-    expect(groups[5]?.items.map((item) => item.label)).toEqual(["Winston"]);
   });
 
   it("always includes Sustainability in Analytics even when the legacy flag is off", () => {
@@ -40,6 +40,5 @@ describe("REPE navigation model", () => {
     expect(getActiveRepeGroupKey(`${base}/assets/asset-123`, groups)).toBe("portfolio");
     expect(getActiveRepeGroupKey(`${base}/controls`, groups)).toBe("governance");
     expect(getActiveRepeGroupKey(`${base}/variance`, groups)).toBe("fund-accounting");
-    expect(getActiveRepeGroupKey(`${base}/winston`, groups)).toBe("automation");
   });
 });

--- a/repo-b/tests/global-commandbar.spec.ts
+++ b/repo-b/tests/global-commandbar.spec.ts
@@ -86,7 +86,12 @@ async function mockWinstonFirstMile(page: Page, options: {
   return askPayloads;
 }
 
-test.describe("Winston companion", () => {
+// Skipped: PR #168 ("Remove Winston AI chat surfaces") intentionally removed the
+// Winston chat backend (/api/ai/gateway/*) that this companion bootstraps from,
+// so these browser specs test a deliberately-retired surface. Winston chat is
+// being rebuilt elsewhere; re-enable (or replace) this suite when the new
+// surface lands. Tracked in ADO Story #557.
+test.describe.skip("Winston companion", () => {
   test("renders the floating launcher, traps focus in the drawer, and closes on escape", async ({ page, context, baseURL }) => {
     if (!baseURL) throw new Error("baseURL missing");
     await seedAuthCookie(baseURL, context);


### PR DESCRIPTION
## Problem

Merged PR #168 ("Remove Winston AI chat surfaces", `84026f10`) was an incomplete cleanup. It removed the Winston chat backend and pages but left three artifacts that now fail CI for **every** PR targeting `main`:

1. **Backend Lint** — `app/main.py:237` references `stream_task` / `stream_etl_task` / `stargate_autoplay_task` in the lifespan shutdown loop, but #168 deleted their creation → 3× ruff `F821 Undefined name`.
2. **Frontend Lint (unit)** — `repeNavigation.test.ts` still asserts the removed Automation/Winston nav group → 3 failing tests.
3. **First-Mile Release Gate** — `global-commandbar.spec.ts` Playwright specs boot the Winston companion, which can no longer bootstrap (its `/api/ai/gateway/*` backend is gone) → gate fails.

## Fixes

1. **`backend/app/main.py`** — initialize the three task handles to `None` at the top of `lifespan()`. The shutdown loop already guards `if _task is not None`, so this is a behavior-preserving no-op matching current reality. `ruff check app tests` → clean.
2. **`repeNavigation.test.ts`** — drop the Automation/Winston group from the expected nav order and the `/winston → automation` active-key assertion. Matches the deliberate removal. `vitest` → 4 passed.
3. **`global-commandbar.spec.ts`** — mark the `Winston companion` describe block `describe.skip`. Winston chat is being rebuilt elsewhere (product direction 2026-06-12), so the gate should not test a retired surface. The GlobalCommandBar/WinstonCompanionSurface UI components are left in place for potential reuse.

## Tracking

ADO Story **#557** (Platform-Core) tracks the real resolution: remove the leftover companion UI or repoint it at the new chat backend, then re-enable/replace the First-Mile specs.

## Why one PR

All three failures share a single root cause — #168's incomplete cleanup — and all three block `main`. Fixing them together restores green CI for all downstream PRs (including #169 Phase 3B) in one merge.

## Verification

- `ruff check app tests` → clean
- `vitest run repeNavigation.test.ts` → 4 passed
- First-Mile gate: Winston companion specs skipped (no longer testing deleted functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)