### PR TITLE
Phase 2 PR 4: Intelligence Card System

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -80,6 +80,7 @@ from app.routes import consulting
 from app.routes import telemetry
 from app.routes import telemetry_copilot
 from app.routes import automated_data_engineering
+from app.routes import intelligence_cards
 from app.routes import re_uw_reports, re_uw_links, re_pipeline, re_geography, re_intelligence
 from app.routes import re_opportunities
 from app.routes import (
@@ -422,6 +423,7 @@ app.include_router(consulting.router)
 app.include_router(telemetry.router)
 app.include_router(telemetry_copilot.router)
 app.include_router(automated_data_engineering.router)
+app.include_router(intelligence_cards.router)
 app.include_router(tracking.router)
 app.include_router(email_integrations.router)
 app.include_router(nv_discovery.router)

--- a/backend/app/routes/intelligence_cards.py
+++ b/backend/app/routes/intelligence_cards.py
@@ -1,0 +1,102 @@
+"""Intelligence Card System API (plan PR 4, Phase 2).
+
+CRUD over the living-feed card model. Mounted under /api/ade/intel to reuse the
+committed ADE proxy and keep path naming consistent with the rest of the surface.
+
+Paths:
+    GET   /api/ade/intel/cards            list (anomaly + priority + recency ordered)
+    POST  /api/ade/intel/cards            upsert (idempotent by env_id + source_ref)
+    PATCH /api/ade/intel/cards/{id}       dismiss or bump priority
+
+No home-page wiring, no agents/investigations — those are later Phase 2 PRs.
+Reads fail closed with a null_reason rather than erroring open.
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.observability.logger import emit_log
+from app.services import intelligence_cards as svc
+
+router = APIRouter(prefix="/api/ade/intel", tags=["ade"])
+
+
+class UpsertCardBody(BaseModel):
+    env_id: str
+    business_id: UUID
+    card_type: str
+    title: str
+    summary: str | None = None
+    source_ref: dict = Field(default_factory=dict)
+    priority_score: float = 0.0
+    anomaly_flag: bool = False
+    created_by: str | None = "system"
+
+
+class PatchCardBody(BaseModel):
+    env_id: str
+    business_id: UUID
+    dismiss: bool | None = None
+    priority_delta: float | None = None
+
+
+@router.get("/cards")
+def list_cards(
+    env_id: str = Query(...),
+    business_id: UUID = Query(...),
+    limit: int = Query(50, ge=1, le=200),
+    include_dismissed: bool = Query(False),
+    card_type: str = Query(None),
+):
+    try:
+        rows = svc.list_cards(
+            env_id, business_id, limit=limit,
+            include_dismissed=include_dismissed, card_type=card_type,
+        )
+        return {"cards": rows, "null_reason": None}
+    except ValueError as exc:
+        raise HTTPException(400, {"error_code": "VALIDATION_ERROR", "message": str(exc)})
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="intelligence_cards", action="list_failed", message=str(exc), error=exc)
+        return {"cards": [], "null_reason": "intel_cards_unavailable"}
+
+
+@router.post("/cards")
+def upsert_card(body: UpsertCardBody):
+    try:
+        card = svc.upsert_card(
+            body.env_id, body.business_id,
+            card_type=body.card_type, title=body.title, summary=body.summary,
+            source_ref=body.source_ref, priority_score=body.priority_score,
+            anomaly_flag=body.anomaly_flag, created_by=body.created_by,
+        )
+        return {**card, "null_reason": None}
+    except ValueError as exc:
+        raise HTTPException(400, {"error_code": "VALIDATION_ERROR", "message": str(exc)})
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="intelligence_cards", action="upsert_failed", message=str(exc), error=exc)
+        raise HTTPException(500, {"error_code": "INTERNAL_ERROR", "message": "intel_cards_write_unavailable"})
+
+
+@router.patch("/cards/{card_id}")
+def patch_card(card_id: UUID, body: PatchCardBody):
+    """Dismiss a card or bump its priority. Exactly one action per call."""
+    try:
+        if body.dismiss:
+            card = svc.dismiss_card(body.env_id, body.business_id, card_id)
+        elif body.priority_delta is not None:
+            card = svc.bump_priority(body.env_id, body.business_id, card_id, body.priority_delta)
+        else:
+            raise HTTPException(400, {"error_code": "VALIDATION_ERROR",
+                                     "message": "provide dismiss=true or priority_delta"})
+        if card is None:
+            raise HTTPException(404, {"error_code": "NOT_FOUND", "message": f"Unknown card: {card_id}"})
+        return {**card, "null_reason": None}
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="intelligence_cards", action="patch_failed", message=str(exc), error=exc)
+        raise HTTPException(500, {"error_code": "INTERNAL_ERROR", "message": "intel_cards_write_unavailable"})

--- a/backend/app/services/intelligence_cards.py
+++ b/backend/app/services/intelligence_cards.py
@@ -1,0 +1,168 @@
+"""Intelligence Card System service — the living-feed data model (plan PR 4, Phase 2).
+
+A card represents a unit of the executive intelligence feed (dashboard, report, story,
+investigation, forecast, finding, or alert). PR 4 is the data model + CRUD only: no
+home-page wiring, no agents/investigations/analyzers producing cards yet.
+
+Operational state only: priority_score + anomaly_flag order the feed. Engagement
+analytics are a future BigQuery concern, not more Postgres columns.
+
+RLS: every statement issues `SET LOCAL app.env_id` (via set_config) so the
+nv_intel_cards tenant policy passes. Reads and writes are env-scoped.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from uuid import UUID
+
+from app.db import get_cursor
+from app.observability.logger import emit_log
+
+CARD_TYPES = {"dashboard", "report", "story", "investigation", "forecast", "finding", "alert"}
+CREATED_BY_PATTERN_HINT = "'system' | 'user' | 'agent:<type>' | 'autopilot'"
+
+
+def _source_ref_key(source_ref: dict | None) -> str:
+    """Deterministic key for idempotent upsert. Stable across dict key ordering."""
+    canonical = json.dumps(source_ref or {}, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:32]
+
+
+def _set_tenant(cur, env_id: str) -> None:
+    cur.execute("SELECT set_config('app.env_id', %s, true)", (env_id,))
+
+
+def _row_to_dict(r: dict) -> dict:
+    return {
+        "id": str(r["id"]),
+        "card_type": r["card_type"],
+        "title": r["title"],
+        "summary": r["summary"],
+        "source_ref": r["source_ref"],
+        "priority_score": r["priority_score"],
+        "anomaly_flag": r["anomaly_flag"],
+        "created_by": r["created_by"],
+        "is_dismissed": r["is_dismissed"],
+        "last_updated_at": r["last_updated_at"].isoformat() if r.get("last_updated_at") else None,
+        "created_at": r["created_at"].isoformat() if r.get("created_at") else None,
+    }
+
+
+def upsert_card(
+    env_id: str,
+    business_id: str | UUID,
+    *,
+    card_type: str,
+    title: str,
+    summary: str | None = None,
+    source_ref: dict | None = None,
+    priority_score: float = 0.0,
+    anomaly_flag: bool = False,
+    created_by: str | None = "system",
+) -> dict:
+    """Create or update a card, idempotent by (env_id, source_ref).
+
+    A second call with the same env_id + source_ref updates the existing row
+    (title/summary/priority/anomaly/last_updated_at) rather than inserting a duplicate.
+    """
+    if card_type not in CARD_TYPES:
+        raise ValueError(f"Unknown card_type: {card_type}")
+    if not title or not title.strip():
+        raise ValueError("title is required")
+    key = _source_ref_key(source_ref)
+    with get_cursor() as cur:
+        _set_tenant(cur, env_id)
+        cur.execute(
+            """INSERT INTO nv_intel_cards
+                   (env_id, business_id, card_type, title, summary, source_ref, source_ref_key,
+                    priority_score, anomaly_flag, created_by)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+               ON CONFLICT (env_id, source_ref_key) DO UPDATE SET
+                   card_type = EXCLUDED.card_type,
+                   title = EXCLUDED.title,
+                   summary = EXCLUDED.summary,
+                   priority_score = EXCLUDED.priority_score,
+                   anomaly_flag = EXCLUDED.anomaly_flag,
+                   last_updated_at = now()
+               RETURNING id, card_type, title, summary, source_ref, priority_score,
+                         anomaly_flag, created_by, is_dismissed, last_updated_at, created_at""",
+            (
+                env_id, str(business_id), card_type, title.strip(), summary,
+                json.dumps(source_ref or {}), key, priority_score, anomaly_flag, created_by,
+            ),
+        )
+        return _row_to_dict(cur.fetchone())
+
+
+def list_cards(
+    env_id: str,
+    business_id: str | UUID,
+    *,
+    limit: int = 50,
+    include_dismissed: bool = False,
+    card_type: str | None = None,
+) -> list[dict]:
+    """List cards for an env, anomaly + highest priority + most recent first."""
+    conditions = ["env_id = %s"]
+    params: list = [env_id]
+    if not include_dismissed:
+        conditions.append("is_dismissed = false")
+    if card_type:
+        if card_type not in CARD_TYPES:
+            raise ValueError(f"Unknown card_type: {card_type}")
+        conditions.append("card_type = %s")
+        params.append(card_type)
+    where = " AND ".join(conditions)
+    params.append(limit)
+    with get_cursor() as cur:
+        _set_tenant(cur, env_id)
+        cur.execute(
+            f"""SELECT id, card_type, title, summary, source_ref, priority_score,
+                       anomaly_flag, created_by, is_dismissed, last_updated_at, created_at
+                FROM nv_intel_cards
+                WHERE {where}
+                ORDER BY anomaly_flag DESC, priority_score DESC, last_updated_at DESC
+                LIMIT %s""",
+            params,
+        )
+        return [_row_to_dict(r) for r in cur.fetchall()]
+
+
+def dismiss_card(env_id: str, business_id: str | UUID, card_id: str | UUID) -> dict | None:
+    """Soft-dismiss a card so it drops out of the default feed. Returns updated row or None."""
+    with get_cursor() as cur:
+        _set_tenant(cur, env_id)
+        cur.execute(
+            """UPDATE nv_intel_cards
+               SET is_dismissed = true, last_updated_at = now()
+               WHERE env_id = %s AND id = %s
+               RETURNING id, card_type, title, summary, source_ref, priority_score,
+                         anomaly_flag, created_by, is_dismissed, last_updated_at, created_at""",
+            (env_id, str(card_id)),
+        )
+        row = cur.fetchone()
+        return _row_to_dict(row) if row else None
+
+
+def bump_priority(env_id: str, business_id: str | UUID, card_id: str | UUID, delta: float) -> dict | None:
+    """Adjust a card's priority (float-up when an anomaly fires). Clamped to [0, 1].
+
+    Event-triggered mechanism only — PR 4 ships the lever, not the callers.
+    """
+    with get_cursor() as cur:
+        _set_tenant(cur, env_id)
+        cur.execute(
+            """UPDATE nv_intel_cards
+               SET priority_score = LEAST(1.0, GREATEST(0.0, priority_score + %s)),
+                   last_updated_at = now()
+               WHERE env_id = %s AND id = %s
+               RETURNING id, card_type, title, summary, source_ref, priority_score,
+                         anomaly_flag, created_by, is_dismissed, last_updated_at, created_at""",
+            (delta, env_id, str(card_id)),
+        )
+        row = cur.fetchone()
+        if not row:
+            emit_log(level="warning", service="intelligence_cards", action="bump_missing",
+                     message=f"card {card_id} not found for env {env_id}")
+        return _row_to_dict(row) if row else None

--- a/backend/tests/test_intelligence_cards.py
+++ b/backend/tests/test_intelligence_cards.py
@@ -1,0 +1,156 @@
+"""Tests for the Intelligence Card System API and service (/api/ade/intel/*).
+
+Run with: cd backend && python -m pytest tests/test_intelligence_cards.py -x -q
+
+No DB required: route tests monkeypatch the service layer; service tests exercise the
+pure helpers and validation. The migration is checked as text for the mandatory RLS /
+tenant-policy / comment / business_id / card_type CHECK guardrails.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("BM_MCP_DRY_RUN", "1")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+os.environ.setdefault("MCP_API_TOKEN", "test-token")
+
+from app.services import intelligence_cards as svc  # noqa: E402
+
+BUSINESS_ID = "00000000-0000-0000-0000-000000000001"
+ENV = "test-env"
+
+
+def _card(**over):
+    base = {
+        "id": "c1", "card_type": "finding", "title": "Yield drop", "summary": "s",
+        "source_ref": {"type": "metric", "id": "fpy"}, "priority_score": 0.5,
+        "anomaly_flag": False, "created_by": "system", "is_dismissed": False,
+        "last_updated_at": "2026-06-14T00:00:00+00:00", "created_at": "2026-06-14T00:00:00+00:00",
+    }
+    base.update(over)
+    return base
+
+
+# ── service-level: pure helpers & validation (no DB) ─────────────────────────
+
+def test_source_ref_key_is_order_stable():
+    assert svc._source_ref_key({"a": 1, "b": 2}) == svc._source_ref_key({"b": 2, "a": 1})
+    assert svc._source_ref_key({"a": 1}) != svc._source_ref_key({"a": 2})
+    assert svc._source_ref_key(None) == svc._source_ref_key({})
+
+
+def test_upsert_rejects_bad_card_type():
+    with pytest.raises(ValueError, match="Unknown card_type"):
+        svc.upsert_card(ENV, BUSINESS_ID, card_type="banner", title="x")
+
+
+def test_upsert_rejects_empty_title():
+    with pytest.raises(ValueError, match="title is required"):
+        svc.upsert_card(ENV, BUSINESS_ID, card_type="finding", title="  ")
+
+
+def test_card_types_complete():
+    assert svc.CARD_TYPES == {
+        "dashboard", "report", "story", "investigation", "forecast", "finding", "alert"
+    }
+
+
+# ── route-level: monkeypatch the service so no DB is touched ──────────────────
+
+def test_list_returns_cards(client, monkeypatch):
+    monkeypatch.setattr(svc, "list_cards", lambda env, biz, **kw: [_card()])
+    body = client.get(f"/api/ade/intel/cards?env_id={ENV}&business_id={BUSINESS_ID}").json()
+    assert body["null_reason"] is None
+    assert body["cards"][0]["card_type"] == "finding"
+
+
+def test_list_passes_filters(client, monkeypatch):
+    seen = {}
+    def fake(env, biz, **kw):
+        seen.update(kw)
+        return []
+    monkeypatch.setattr(svc, "list_cards", fake)
+    client.get(f"/api/ade/intel/cards?env_id={ENV}&business_id={BUSINESS_ID}"
+               f"&include_dismissed=true&card_type=alert&limit=10")
+    assert seen.get("include_dismissed") is True
+    assert seen.get("card_type") == "alert"
+    assert seen.get("limit") == 10
+
+
+def test_list_fails_closed(client, monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("no db")
+    monkeypatch.setattr(svc, "list_cards", boom)
+    resp = client.get(f"/api/ade/intel/cards?env_id={ENV}&business_id={BUSINESS_ID}")
+    assert resp.status_code == 200  # never 500
+    body = resp.json()
+    assert body["cards"] == []
+    assert body["null_reason"] == "intel_cards_unavailable"
+
+
+def test_upsert_creates(client, monkeypatch):
+    monkeypatch.setattr(svc, "upsert_card", lambda env, biz, **kw: _card(card_type=kw["card_type"], title=kw["title"]))
+    resp = client.post("/api/ade/intel/cards", json={
+        "env_id": ENV, "business_id": BUSINESS_ID,
+        "card_type": "alert", "title": "Feed stale",
+    })
+    assert resp.status_code == 200
+    assert resp.json()["card_type"] == "alert"
+
+
+def test_upsert_bad_type_is_400(client, monkeypatch):
+    def bad(*a, **k):
+        raise ValueError("Unknown card_type: x")
+    monkeypatch.setattr(svc, "upsert_card", bad)
+    resp = client.post("/api/ade/intel/cards", json={
+        "env_id": ENV, "business_id": BUSINESS_ID, "card_type": "x", "title": "t",
+    })
+    assert resp.status_code == 400
+
+
+def test_patch_dismiss(client, monkeypatch):
+    monkeypatch.setattr(svc, "dismiss_card", lambda env, biz, cid: _card(is_dismissed=True))
+    resp = client.patch("/api/ade/intel/cards/00000000-0000-0000-0000-0000000000ab",
+                        json={"env_id": ENV, "business_id": BUSINESS_ID, "dismiss": True})
+    assert resp.status_code == 200
+    assert resp.json()["is_dismissed"] is True
+
+
+def test_patch_bump_priority(client, monkeypatch):
+    monkeypatch.setattr(svc, "bump_priority", lambda env, biz, cid, delta: _card(priority_score=0.9))
+    resp = client.patch("/api/ade/intel/cards/00000000-0000-0000-0000-0000000000ab",
+                        json={"env_id": ENV, "business_id": BUSINESS_ID, "priority_delta": 0.4})
+    assert resp.status_code == 200
+    assert resp.json()["priority_score"] == 0.9
+
+
+def test_patch_requires_an_action(client):
+    resp = client.patch("/api/ade/intel/cards/00000000-0000-0000-0000-0000000000ab",
+                        json={"env_id": ENV, "business_id": BUSINESS_ID})
+    assert resp.status_code == 400
+
+
+def test_patch_unknown_card_404(client, monkeypatch):
+    monkeypatch.setattr(svc, "dismiss_card", lambda env, biz, cid: None)
+    resp = client.patch("/api/ade/intel/cards/00000000-0000-0000-0000-0000000000ff",
+                        json={"env_id": ENV, "business_id": BUSINESS_ID, "dismiss": True})
+    assert resp.status_code == 404
+
+
+# ── migration guardrails ─────────────────────────────────────────────────────
+
+def test_migration_has_required_guardrails():
+    sql_path = (Path(__file__).resolve().parents[2]
+                / "repo-b" / "db" / "schema" / "10019_intelligence_cards.sql")
+    sql = sql_path.read_text(encoding="utf-8")
+    assert "nv_intel_cards" in sql
+    assert "env_id          text NOT NULL" in sql or "env_id text NOT NULL" in sql
+    assert "business_id     uuid NOT NULL" in sql or "business_id uuid NOT NULL" in sql
+    assert "ENABLE ROW LEVEL SECURITY" in sql
+    assert "current_setting('app.env_id', true)" in sql
+    assert "COMMENT ON TABLE nv_intel_cards" in sql
+    assert "UNIQUE (env_id, source_ref_key)" in sql
+    # 7-type CHECK present
+    for t in ("dashboard", "report", "story", "investigation", "forecast", "finding", "alert"):
+        assert f"'{t}'" in sql

--- a/repo-b/db/schema/10019_intelligence_cards.sql
+++ b/repo-b/db/schema/10019_intelligence_cards.sql
@@ -1,0 +1,52 @@
+-- 10019_intelligence_cards.sql
+-- Intelligence Card System for the executive intelligence surface (plan PR 4, Phase 2).
+--
+-- A card is a unit of the living feed: it can represent a dashboard, report, story,
+-- investigation, forecast, finding, or alert. PR 4 ships the data model + components
+-- only — no home-page wiring (PR 5), no agents/investigations/analyzers.
+--
+-- Operational state only: priority_score and anomaly_flag drive float-up ordering in
+-- the feed. Card engagement trends (impressions, clicks, dismissals, fork rate) belong
+-- in BigQuery (winston_analytics.card_performance), not in more Postgres columns.
+--
+-- Owning module: backend/app/services/intelligence_cards.py. Surfaced read+write via
+-- /api/ade/intel/cards. Per-environment business data: full RLS + env_id/business_id.
+-- Approved prefix: nv_ (Novendor platform-core; no new prefix introduced).
+
+CREATE TABLE IF NOT EXISTS nv_intel_cards (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id          text NOT NULL,
+    business_id     uuid NOT NULL,
+    card_type       text NOT NULL
+                    CHECK (card_type IN ('dashboard', 'report', 'story', 'investigation', 'forecast', 'finding', 'alert')),
+    title           text NOT NULL,
+    summary         text,
+    source_ref      jsonb NOT NULL DEFAULT '{}'::jsonb,   -- {type, id, ...} provenance of the card
+    source_ref_key  text NOT NULL,                        -- deterministic key for idempotent upsert
+    priority_score  double precision NOT NULL DEFAULT 0,  -- 0-1, drives float-up ordering
+    anomaly_flag    boolean NOT NULL DEFAULT false,
+    created_by      text,                                 -- 'system' | 'agent:cfo' | 'user' | 'autopilot'
+    is_dismissed    boolean NOT NULL DEFAULT false,
+    last_updated_at timestamptz NOT NULL DEFAULT now(),
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (env_id, source_ref_key)
+);
+
+-- Feed read path: env-scoped, non-dismissed first, highest priority + most recent on top.
+CREATE INDEX IF NOT EXISTS nv_intel_cards_feed_idx
+    ON nv_intel_cards (env_id, is_dismissed, priority_score DESC, last_updated_at DESC);
+
+ALTER TABLE nv_intel_cards ENABLE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+    CREATE POLICY nv_intel_cards_tenant ON nv_intel_cards
+        USING (env_id = current_setting('app.env_id', true))
+        WITH CHECK (env_id = current_setting('app.env_id', true));
+EXCEPTION WHEN duplicate_object THEN
+    NULL;
+END $$;
+
+COMMENT ON TABLE nv_intel_cards IS
+    'Intelligence Card System living feed (plan PR 4). Operational state only: '
+    'priority_score/anomaly_flag drive float-up ordering. Card engagement analytics go to '
+    'BigQuery (winston_analytics.card_performance). Owning module: intelligence_cards.py.';

--- a/repo-b/src/components/intelligence/IntelligenceCard.tsx
+++ b/repo-b/src/components/intelligence/IntelligenceCard.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+import { Card } from "@/components/ui/Card";
+import { type IntelCard, type CardType, CARD_TYPE_LABELS } from "@/lib/intelligence/cards";
+
+// One card in the executive intelligence feed (plan PR 4). Variant accents per
+// card_type; hover reveals actions; anomaly_flag glows and pulses. No home wiring
+// and no live investigation — "Fork Investigation" is present but inert until PR 6.
+
+// Per-type accent classes (Tailwind bm-* token families used across the app).
+const TYPE_ACCENT: Record<CardType, { bar: string; chip: string; icon: string }> = {
+  dashboard:     { bar: "bg-bm-accent",     chip: "text-bm-accent",         icon: "▤" },
+  report:        { bar: "bg-bm-muted",      chip: "text-bm-text-secondary", icon: "▦" },
+  story:         { bar: "bg-bm-success",    chip: "text-bm-success",        icon: "❧" },
+  investigation: { bar: "bg-bm-warning",    chip: "text-bm-warning",        icon: "⌕" },
+  forecast:      { bar: "bg-bm-purple",     chip: "text-bm-purple",         icon: "📈" },
+  finding:       { bar: "bg-bm-accent",     chip: "text-bm-accent",         icon: "◆" },
+  alert:         { bar: "bg-bm-danger",     chip: "text-bm-danger",         icon: "▲" },
+};
+
+export interface IntelligenceCardProps {
+  card: IntelCard;
+  onOpen?: (card: IntelCard) => void;
+  onDismiss?: (card: IntelCard) => void;
+  onForkInvestigation?: (card: IntelCard) => void; // inert until PR 6
+  className?: string;
+}
+
+export function IntelligenceCard({
+  card, onOpen, onDismiss, onForkInvestigation, className,
+}: IntelligenceCardProps) {
+  const accent = TYPE_ACCENT[card.card_type] ?? TYPE_ACCENT.report;
+  const anomaly = card.anomaly_flag;
+
+  return (
+    <Card
+      hover
+      variant={anomaly ? "danger" : "default"}
+      className={cn(
+        "group relative overflow-hidden p-4 transition-all duration-200",
+        anomaly && "shadow-[0_0_0_1px_var(--bm-danger-border),0_0_18px_-4px_var(--bm-danger)]",
+        className,
+      )}
+    >
+      {/* Left accent bar */}
+      <span className={cn("absolute inset-y-0 left-0 w-[3px]", accent.bar)} aria-hidden />
+
+      {/* Anomaly pulsing dot */}
+      {anomaly && (
+        <span className="absolute right-3 top-3 flex h-2 w-2" aria-label="needs attention">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-bm-danger opacity-75" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-bm-danger" />
+        </span>
+      )}
+
+      <div className="pl-2">
+        <div className="flex items-center gap-2">
+          <span className={cn("text-xs", accent.chip)} aria-hidden>{accent.icon}</span>
+          <span className={cn("font-mono text-[10px] uppercase tracking-wider", accent.chip)}>
+            {CARD_TYPE_LABELS[card.card_type]}
+          </span>
+          {card.created_by && card.created_by !== "system" && (
+            <span className="font-mono text-[10px] text-bm-text-muted">· {card.created_by}</span>
+          )}
+        </div>
+
+        <h3 className="mt-1.5 text-sm font-semibold text-bm-text">{card.title}</h3>
+        {card.summary && (
+          <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-bm-text-muted">{card.summary}</p>
+        )}
+
+        {/* Hover-revealed actions */}
+        <div className="mt-3 flex items-center gap-2 opacity-0 transition-opacity duration-150 group-hover:opacity-100">
+          {onOpen && (
+            <button type="button" onClick={() => onOpen(card)}
+              className="rounded border border-bm-border px-2 py-1 font-mono text-[11px] text-bm-text hover:border-bm-border-hi">
+              Open
+            </button>
+          )}
+          {onDismiss && (
+            <button type="button" onClick={() => onDismiss(card)}
+              className="rounded border border-bm-border px-2 py-1 font-mono text-[11px] text-bm-text-muted hover:border-bm-border-hi">
+              Dismiss
+            </button>
+          )}
+          {/* Inert until PR 6 (investigation backend). Disabled, not wired. */}
+          <button type="button" disabled
+            title="Investigations arrive in a later release"
+            onClick={() => onForkInvestigation?.(card)}
+            className="cursor-not-allowed rounded border border-bm-border px-2 py-1 font-mono text-[11px] text-bm-text-muted opacity-60">
+            Fork Investigation
+          </button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+export default IntelligenceCard;

--- a/repo-b/src/components/intelligence/IntelligenceCardFeed.tsx
+++ b/repo-b/src/components/intelligence/IntelligenceCardFeed.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+import { StateCard } from "@/components/ui/StateCard";
+import { IntelligenceCard } from "./IntelligenceCard";
+import { type IntelCard } from "@/lib/intelligence/cards";
+
+// The executive intelligence feed (plan PR 4). Groups cards into Needs Attention
+// (anomaly), Today, and This Week. Reorder is a CSS transition; cards are already
+// server-sorted (anomaly, priority, recency). No home wiring (PR 5).
+
+export interface IntelligenceCardFeedProps {
+  cards: IntelCard[];
+  loading?: boolean;
+  error?: string | null;
+  nullReason?: string | null;
+  onOpen?: (card: IntelCard) => void;
+  onDismiss?: (card: IntelCard) => void;
+  onForkInvestigation?: (card: IntelCard) => void;
+  className?: string;
+}
+
+type Group = { key: string; label: string; cards: IntelCard[] };
+
+function startOfToday(): number {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+function groupCards(cards: IntelCard[]): Group[] {
+  const todayStart = startOfToday();
+  const weekStart = todayStart - 6 * 24 * 60 * 60 * 1000;
+
+  const attention: IntelCard[] = [];
+  const today: IntelCard[] = [];
+  const week: IntelCard[] = [];
+  const earlier: IntelCard[] = [];
+
+  for (const c of cards) {
+    if (c.anomaly_flag) { attention.push(c); continue; }
+    const ts = c.last_updated_at ? new Date(c.last_updated_at).getTime() : 0;
+    if (ts >= todayStart) today.push(c);
+    else if (ts >= weekStart) week.push(c);
+    else earlier.push(c);
+  }
+
+  return [
+    { key: "attention", label: "Needs Attention", cards: attention },
+    { key: "today", label: "Today", cards: today },
+    { key: "week", label: "This Week", cards: week },
+    { key: "earlier", label: "Earlier", cards: earlier },
+  ].filter((g) => g.cards.length > 0);
+}
+
+export function IntelligenceCardFeed({
+  cards, loading, error, nullReason,
+  onOpen, onDismiss, onForkInvestigation, className,
+}: IntelligenceCardFeedProps) {
+  if (loading) return <StateCard state="loading" />;
+  if (error) {
+    return <StateCard state="error" title="Could not load the feed" message={error} />;
+  }
+  if (nullReason) {
+    return (
+      <StateCard
+        state="empty"
+        title="Feed unavailable"
+        description={`null_reason: ${nullReason}`}
+      />
+    );
+  }
+  if (cards.length === 0) {
+    return (
+      <StateCard
+        state="empty"
+        title="No findings yet"
+        description="Winston will surface observations here as your environments generate data."
+      />
+    );
+  }
+
+  const groups = groupCards(cards);
+
+  return (
+    <div className={cn("flex flex-col gap-6", className)}>
+      {groups.map((g) => (
+        <section key={g.key}>
+          <h2 className={cn(
+            "mb-2 font-mono text-[11px] uppercase tracking-wider",
+            g.key === "attention" ? "text-bm-danger" : "text-bm-text-muted",
+          )}>
+            {g.label}
+            <span className="ml-2 text-bm-text-muted">{g.cards.length}</span>
+          </h2>
+          <div className="grid grid-cols-1 gap-3 transition-all duration-300 sm:grid-cols-2 lg:grid-cols-3">
+            {g.cards.map((c) => (
+              <IntelligenceCard
+                key={c.id}
+                card={c}
+                onOpen={onOpen}
+                onDismiss={onDismiss}
+                onForkInvestigation={onForkInvestigation}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+export default IntelligenceCardFeed;

--- a/repo-b/src/lib/intelligence/cards.ts
+++ b/repo-b/src/lib/intelligence/cards.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { apiFetch } from "@/lib/api";
+
+// Intelligence Card System client (plan PR 4). Data model + components only — no
+// home wiring (PR 5). Mounted under /api/ade/intel to reuse the committed ADE proxy.
+
+export type CardType =
+  | "dashboard" | "report" | "story" | "investigation" | "forecast" | "finding" | "alert";
+
+export interface IntelCard {
+  id: string;
+  card_type: CardType;
+  title: string;
+  summary: string | null;
+  source_ref: Record<string, unknown>;
+  priority_score: number;
+  anomaly_flag: boolean;
+  created_by: string | null;
+  is_dismissed: boolean;
+  last_updated_at: string | null;
+  created_at: string | null;
+}
+
+export interface CardListResponse {
+  cards: IntelCard[];
+  null_reason: string | null;
+}
+
+export interface UpsertCardInput {
+  card_type: CardType;
+  title: string;
+  summary?: string;
+  source_ref?: Record<string, unknown>;
+  priority_score?: number;
+  anomaly_flag?: boolean;
+  created_by?: string;
+}
+
+const DEFAULT_BUSINESS_ID = "7e1eb000-0000-4000-a000-000000000001";
+
+export const getCards = (
+  env: string,
+  opts: { biz?: string; limit?: number; includeDismissed?: boolean; cardType?: CardType } = {},
+) =>
+  apiFetch<CardListResponse>("/api/ade/intel/cards", {
+    params: {
+      env_id: env,
+      business_id: opts.biz ?? DEFAULT_BUSINESS_ID,
+      limit: opts.limit ? String(opts.limit) : undefined,
+      include_dismissed: opts.includeDismissed ? "true" : undefined,
+      card_type: opts.cardType,
+    },
+  });
+
+export const upsertCard = (env: string, input: UpsertCardInput, biz: string = DEFAULT_BUSINESS_ID) =>
+  // apiFetch passes options straight to fetch and does not serialize — body must be a JSON string.
+  apiFetch<IntelCard & { null_reason: string | null }>("/api/ade/intel/cards", {
+    method: "POST",
+    body: JSON.stringify({ env_id: env, business_id: biz, ...input }),
+  });
+
+export const dismissCard = (env: string, id: string, biz: string = DEFAULT_BUSINESS_ID) =>
+  apiFetch<IntelCard & { null_reason: string | null }>(`/api/ade/intel/cards/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    body: JSON.stringify({ env_id: env, business_id: biz, dismiss: true }),
+  });
+
+export const bumpCardPriority = (env: string, id: string, delta: number, biz: string = DEFAULT_BUSINESS_ID) =>
+  apiFetch<IntelCard & { null_reason: string | null }>(`/api/ade/intel/cards/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    body: JSON.stringify({ env_id: env, business_id: biz, priority_delta: delta }),
+  });
+
+export const CARD_TYPE_LABELS: Record<CardType, string> = {
+  dashboard: "Dashboard",
+  report: "Report",
+  story: "Story",
+  investigation: "Investigation",
+  forecast: "Forecast",
+  finding: "Finding",
+  alert: "Alert",
+};


### PR DESCRIPTION
## Summary

Phase 2 / PR 4 — the **Intelligence Card System**, the first product primitive of the executive intelligence surface. Data model + two components + API only.

A card is a unit of the living feed (dashboard, report, story, investigation, forecast, finding, alert). `priority_score` + `anomaly_flag` order the feed (anomaly → priority → recency).

**Rebased onto `main` after PR #179 merged the ADE PR 1 base.** This PR is now a clean standalone Phase 2 diff (8 files) on top of current main — it does NOT depend on PR #180. (PR #180 is now redundant/conflicting with #179 and needs a separate scope decision — see that PR.)

## Files changed (8)

- `repo-b/db/schema/10019_intelligence_cards.sql` — `nv_intel_cards`
- `backend/app/services/intelligence_cards.py`, `backend/app/routes/intelligence_cards.py`
- `backend/app/main.py` (mount, +2 lines)
- `backend/tests/test_intelligence_cards.py`
- `repo-b/src/lib/intelligence/cards.ts`
- `repo-b/src/components/intelligence/IntelligenceCard.tsx`, `IntelligenceCardFeed.tsx`

## Scope included

`nv_intel_cards` migration (RLS, tenant policy, 7-type CHECK, idempotent `source_ref_key` + `UNIQUE(env_id, source_ref_key)`, feed index, table comment); CRUD service + routes under `/api/ade/intel/cards` (upsert idempotent, list anomaly/priority/recency, dismiss, bump_priority clamped 0–1, fail-closed); `IntelligenceCard` (7 variants, anomaly glow + pulse, hover actions); `IntelligenceCardFeed` (Needs Attention / Today / This Week / Earlier groups, StateCard states).

## Explicit exclusions

home redesign · agents · investigations (backend) · trailers/reels · analyzers · mission control · workflow execution · rich ToolDef metadata. "Fork Investigation" button is present but **inert/disabled** until the PR 6 investigation backend exists.

## Decisions

- Route path: `/api/ade/intel/cards` (reuses the committed ADE proxy)
- Table prefix: `nv_intel_cards` (approved `nv_` prefix; no ARCHITECTURE.md change)
- Resource Doctrine: Postgres stores operational card state; card-performance analytics (impressions/clicks/dismissals/fork-rate) → BigQuery `winston_analytics.card_performance`, documented only

## Tests & checks

- Backend: 14 intel tests pass
- `ruff check app tests` clean (CI parity)
- `from app.main import app` succeeds (1469 routes)
- Tree-wide `tsc --noEmit`: 0 errors
- Review Gate 4: passed (all 7 types render, priority sort, anomaly→Needs Attention, dismiss removes, idempotent upsert, bump clamp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
