### PR TITLE
Phase 1 (remainder): Workflow Registry + Audit Dashboard

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -82,6 +82,7 @@ from app.routes import telemetry_copilot
 from app.routes import automated_data_engineering
 from app.routes import intelligence_cards
 from app.routes import workflow_registry
+from app.routes import audit_dashboard
 from app.routes import re_uw_reports, re_uw_links, re_pipeline, re_geography, re_intelligence
 from app.routes import re_opportunities
 from app.routes import (
@@ -426,6 +427,7 @@ app.include_router(telemetry_copilot.router)
 app.include_router(automated_data_engineering.router)
 app.include_router(intelligence_cards.router)
 app.include_router(workflow_registry.router)
+app.include_router(audit_dashboard.router)
 app.include_router(tracking.router)
 app.include_router(email_integrations.router)
 app.include_router(nv_discovery.router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,6 +81,7 @@ from app.routes import telemetry
 from app.routes import telemetry_copilot
 from app.routes import automated_data_engineering
 from app.routes import intelligence_cards
+from app.routes import workflow_registry
 from app.routes import re_uw_reports, re_uw_links, re_pipeline, re_geography, re_intelligence
 from app.routes import re_opportunities
 from app.routes import (
@@ -424,6 +425,7 @@ app.include_router(telemetry.router)
 app.include_router(telemetry_copilot.router)
 app.include_router(automated_data_engineering.router)
 app.include_router(intelligence_cards.router)
+app.include_router(workflow_registry.router)
 app.include_router(tracking.router)
 app.include_router(email_integrations.router)
 app.include_router(nv_discovery.router)

--- a/backend/app/routes/audit_dashboard.py
+++ b/backend/app/routes/audit_dashboard.py
@@ -1,0 +1,92 @@
+"""Audit Dashboard API for the ADE governed fabric (plan PR 3).
+
+Read-only audit visibility over existing tables (ai_decision_audit_log, app.audit_events).
+Mounted under /api/ade/audit to reuse the committed ADE proxy and keep path naming
+consistent with the rest of the surface.
+
+Paths:
+    GET /api/ade/audit/summary                aggregate strip + calls-per-day + est cost
+    GET /api/ade/audit/decisions              AI decision log (optional ?tool_name=)
+    GET /api/ade/audit/decisions/{id}         single decision, full redacted receipt
+    GET /api/ade/audit/lineage/{tool_name}    all decisions for one tool
+
+All reads fail closed with a null_reason rather than erroring open.
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.observability.logger import emit_log
+from app.services import audit_dashboard as svc
+from app.services import governance as governance_svc
+
+router = APIRouter(prefix="/api/ade/audit", tags=["ade"])
+
+_EMPTY_SUMMARY = {
+    "window_days": svc.HOT_WINDOW_DAYS, "total_decisions": 0, "successful": 0, "failed": 0,
+    "success_rate": None, "avg_latency_ms": None, "avg_grounding_score": None,
+    "high_grounding": 0, "mixed_grounding": 0, "low_grounding": 0, "top_tools": [],
+    "calls_per_day": [], "estimated_cost_usd": None, "cost_is_estimate": True,
+}
+
+
+@router.get("/summary")
+def summary(business_id: UUID = Query(...), env_id: str = Query(None)):
+    try:
+        data = svc.summary(business_id, env_id=env_id)
+        return {**data, "null_reason": None}
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="audit_dashboard", action="summary_failed", message=str(exc), error=exc)
+        return {**_EMPTY_SUMMARY, "null_reason": "audit_summary_unavailable"}
+
+
+@router.get("/decisions")
+def decisions(
+    business_id: UUID = Query(...),
+    env_id: str = Query(None),
+    tool_name: str = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    try:
+        rows = svc.decisions(business_id, env_id=env_id, tool_name=tool_name, limit=limit, offset=offset)
+        return {"decisions": rows, "null_reason": None}
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="audit_dashboard", action="decisions_failed", message=str(exc), error=exc)
+        return {"decisions": [], "null_reason": "audit_decisions_unavailable"}
+
+
+@router.get("/decisions/{decision_id}")
+def decision_detail(decision_id: UUID):
+    """Full redacted receipt for one decision. Redaction happened at write time."""
+    try:
+        row = governance_svc.get_decision(decision_id)
+        if row is None:
+            raise HTTPException(404, {"error_code": "NOT_FOUND", "message": f"Unknown decision: {decision_id}"})
+        # Serialize datetimes/UUIDs to strings; input/output_summary are already redacted.
+        out = {}
+        for k, v in row.items():
+            if hasattr(v, "isoformat"):
+                out[k] = v.isoformat()
+            elif isinstance(v, UUID):
+                out[k] = str(v)
+            else:
+                out[k] = v
+        return {**out, "null_reason": None}
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="audit_dashboard", action="decision_detail_failed", message=str(exc), error=exc)
+        raise HTTPException(500, {"error_code": "INTERNAL_ERROR", "message": "audit_decision_unavailable"})
+
+
+@router.get("/lineage/{tool_name}")
+def lineage(tool_name: str, business_id: UUID = Query(...), env_id: str = Query(None)):
+    try:
+        rows = svc.lineage(business_id, tool_name, env_id=env_id)
+        return {"tool_name": tool_name, "decisions": rows, "null_reason": None}
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="audit_dashboard", action="lineage_failed", message=str(exc), error=exc)
+        return {"tool_name": tool_name, "decisions": [], "null_reason": "audit_lineage_unavailable"}

--- a/backend/app/routes/workflow_registry.py
+++ b/backend/app/routes/workflow_registry.py
@@ -1,0 +1,116 @@
+"""Workflow Registry API for the ADE governed fabric (plan PR 2).
+
+Catalog/definitions only — no execution engine, no batch. CRUD over
+nv_workflow_definitions plus a hot run-state bump. Mounted under /api/ade to keep
+naming consistent with the committed ADE surface (skill-registry, connectors, runs).
+
+Paths:
+    GET  /api/ade/workflows            list (optional ?domain=)
+    POST /api/ade/workflows            create
+    GET  /api/ade/workflows/{id}       single
+    POST /api/ade/workflows/{id}/run   bump run_count + last_run_at (hot state only)
+
+env_id and business_id are required query/body params for tenant scoping; reads
+fail closed with a null_reason rather than erroring open.
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.observability.logger import emit_log
+from app.services import workflow_registry as svc
+
+router = APIRouter(prefix="/api/ade/workflows", tags=["ade"])
+
+
+class WorkflowStep(BaseModel):
+    step_name: str
+    tool_name: str | None = None
+    inputs: list[str] = Field(default_factory=list)
+    outputs: list[str] = Field(default_factory=list)
+
+
+class CreateWorkflowBody(BaseModel):
+    env_id: str
+    business_id: UUID
+    name: str
+    domain: str = "data_engineering"
+    description: str | None = None
+    steps: list[WorkflowStep] = Field(default_factory=list)
+    input_schema: dict = Field(default_factory=dict)
+    output_schema: dict = Field(default_factory=dict)
+    owner: str | None = None
+    slug: str | None = None
+
+
+class RunBody(BaseModel):
+    env_id: str
+    business_id: UUID
+
+
+@router.get("")
+def list_workflows(
+    env_id: str = Query(...),
+    business_id: UUID = Query(...),
+    domain: str | None = Query(None),
+):
+    """List workflow definitions for an env. Seeds the canonical set on first call."""
+    try:
+        rows = svc.list_workflows(env_id, business_id, domain=domain)
+        return {"workflows": rows, "null_reason": None}
+    except ValueError as exc:
+        raise HTTPException(400, {"error_code": "VALIDATION_ERROR", "message": str(exc)})
+    except Exception as exc:  # noqa: BLE001
+        # Fail closed: never 500, never return cross-tenant data.
+        emit_log(level="error", service="workflow_registry", action="list_failed", message=str(exc), error=exc)
+        return {"workflows": [], "null_reason": "workflow_read_unavailable"}
+
+
+@router.get("/{workflow_id}")
+def get_workflow(workflow_id: UUID, env_id: str = Query(...), business_id: UUID = Query(...)):
+    try:
+        wf = svc.get_workflow(env_id, business_id, workflow_id)
+        if wf is None:
+            raise HTTPException(404, {"error_code": "NOT_FOUND", "message": f"Unknown workflow: {workflow_id}"})
+        return {**wf, "null_reason": None}
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="workflow_registry", action="get_failed", message=str(exc), error=exc)
+        raise HTTPException(500, {"error_code": "INTERNAL_ERROR", "message": "workflow_read_unavailable"})
+
+
+@router.post("")
+def create_workflow(body: CreateWorkflowBody):
+    try:
+        wf = svc.create_workflow(
+            body.env_id, body.business_id,
+            name=body.name, domain=body.domain, description=body.description,
+            steps=[s.model_dump() for s in body.steps],
+            input_schema=body.input_schema, output_schema=body.output_schema,
+            owner=body.owner, slug=body.slug,
+        )
+        return {**wf, "null_reason": None}
+    except ValueError as exc:
+        raise HTTPException(400, {"error_code": "VALIDATION_ERROR", "message": str(exc)})
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="workflow_registry", action="create_failed", message=str(exc), error=exc)
+        raise HTTPException(500, {"error_code": "INTERNAL_ERROR", "message": "workflow_write_unavailable"})
+
+
+@router.post("/{workflow_id}/run")
+def record_run(workflow_id: UUID, body: RunBody):
+    """Bump hot run state (run_count + last_run_at). Not a run-history write."""
+    try:
+        wf = svc.record_run(body.env_id, body.business_id, workflow_id)
+        if wf is None:
+            raise HTTPException(404, {"error_code": "NOT_FOUND", "message": f"Unknown workflow: {workflow_id}"})
+        return {**wf, "null_reason": None}
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="workflow_registry", action="run_failed", message=str(exc), error=exc)
+        raise HTTPException(500, {"error_code": "INTERNAL_ERROR", "message": "workflow_write_unavailable"})

--- a/backend/app/services/ade_warehouse_export.py
+++ b/backend/app/services/ade_warehouse_export.py
@@ -1,33 +1,36 @@
 """Warehouse export seam for the governed fabric audit trail.
 
-PR 1b establishes the seam, not the implementation. Audit events live
-operationally in Postgres (`app.audit_events`); historical compliance and cost
-analytics belong in BigQuery (`winston_ops.audit_events_bq`). This module is the
-single named target a later PR fills in — a function seam, not a comment, so the
-work has an address.
+PR 1b established the seam; PR 3 wires it to the manual export scaffold. Audit
+events live operationally in Postgres (`app.audit_events`); historical compliance
+and cost analytics belong in BigQuery (`winston_ops.audit_events_bq`).
 
-Design contract (enforced when implemented):
+The actual export lives in the repo-root script `scripts/export_audit_to_bq.py`
+(the single, deliberate, NOT-scheduled entry point). This seam delegates to that
+script's importable core so backend callers have one address.
+
+Design contract:
   - Reads `app.audit_events` from Postgres (the operational source of truth).
   - Batch-loads to BigQuery via the `google-cloud-bigquery` SDK.
   - Fails closed on missing credentials: never reports success when
     GOOGLE_APPLICATION_CREDENTIALS / BQ_PROJECT_ID are unset.
   - Idempotent by event id so re-runs do not duplicate rows.
-
-Until then every entry point raises NotImplementedError with a pointer to the
-plan, so nothing silently believes the export ran.
+  - No continuous replication, no scheduled export (PR 3 scope).
 """
 from __future__ import annotations
 
 import os
+import sys
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 
 _PLAN_REF = "docs/plans/automated-data-engineering/roadmap.md (Audit BigQuery Export)"
+_SCRIPTS_DIR = Path(__file__).resolve().parents[3] / "scripts"
 
 
 @dataclass(frozen=True)
 class ExportResult:
-    """Outcome of a warehouse export run. Populated only by a real implementation."""
+    """Outcome of a warehouse export run."""
 
     exported: int
     skipped: int
@@ -44,20 +47,23 @@ def warehouse_export_configured() -> bool:
     return bool(os.getenv("GOOGLE_APPLICATION_CREDENTIALS")) and bool(os.getenv("BQ_PROJECT_ID"))
 
 
-def export_audit_events_to_warehouse(since: datetime | None = None) -> ExportResult:
+def export_audit_events_to_warehouse(since: datetime | None = None, *, dry_run: bool = False) -> ExportResult:
     """Mirror `app.audit_events` to BigQuery `winston_ops.audit_events_bq`.
 
-    Demo-scale: not yet configured — raises NotImplementedError.
-    Production-scale: streaming insert or scheduled batch load (see plan ref).
+    Delegates to scripts/export_audit_to_bq.py::export_audit_events. Fails closed:
+    raises ExportNotConfigured (NOT a misleading empty result) when creds are unset.
 
-    Fails closed: if credentials are missing this still raises rather than
-    returning a misleading empty ExportResult.
+    See plan ref for the deferral note: this is the manual path only — no scheduled
+    export, no continuous replication.
     """
-    if not warehouse_export_configured():
-        raise NotImplementedError(
-            "BigQuery export not configured — set GOOGLE_APPLICATION_CREDENTIALS "
-            f"and BQ_PROJECT_ID. Implementation target: {_PLAN_REF}"
-        )
-    raise NotImplementedError(
-        f"Audit warehouse export not yet implemented. Implementation target: {_PLAN_REF}"
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    import export_audit_to_bq as exporter  # repo-root scripts/
+
+    result = exporter.export_audit_events(since, dry_run=dry_run)
+    return ExportResult(
+        exported=result.exported,
+        skipped=0,
+        target_table=result.target_table,
+        since=result.since,
     )

--- a/backend/app/services/audit_dashboard.py
+++ b/backend/app/services/audit_dashboard.py
@@ -1,0 +1,135 @@
+"""Audit Dashboard service — read aggregates for the ADE governed-fabric audit view (plan PR 3).
+
+Operational reads only, over a hot window (default 30 days) of the existing tables:
+  - ai_decision_audit_log  (AI decisions, grounding, tokens, latency)
+  - app.audit_events       (MCP tool-call receipts, redacted I/O)
+
+No new tables, no writes. Historical compliance/cost analytics belong in BigQuery
+(winston_ops.audit_events_bq) via the manual export scaffold — not in Postgres.
+
+Cost is an ESTIMATE derived from token counts (no per-model price table here); it is
+labelled as such and never presented as an authoritative spend figure.
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.db import get_cursor
+from app.services import governance as governance_svc
+
+HOT_WINDOW_DAYS = 30
+
+# Rough blended $/1K tokens for an estimate-only cost column. Deliberately coarse:
+# the dashboard labels this "estimated" and the real cost mart is a BigQuery concern.
+_EST_USD_PER_1K_TOKENS = 0.005
+
+
+def _calls_per_day(business_id: str | UUID, *, env_id: str | None, days: int) -> list[dict]:
+    """Daily MCP tool-call counts over the hot window, oldest→newest."""
+    conditions = ["business_id = %s", "action = %s", "created_at >= now() - make_interval(days => %s)"]
+    params: list = [str(business_id), "mcp.tool_call", days]
+    if env_id:
+        # app.audit_events has no env_id column; env scoping is business_id-only.
+        pass
+    where = " AND ".join(conditions)
+    with get_cursor() as cur:
+        cur.execute(
+            f"""SELECT to_char(date_trunc('day', created_at), 'YYYY-MM-DD') AS day,
+                       COUNT(*)::int AS calls,
+                       COUNT(*) FILTER (WHERE success = false)::int AS failed
+                FROM app.audit_events
+                WHERE {where}
+                GROUP BY 1
+                ORDER BY 1 ASC""",
+            params,
+        )
+        return cur.fetchall()
+
+
+def _estimated_cost(business_id: str | UUID, *, env_id: str | None, days: int) -> float | None:
+    """Token-based cost estimate over the hot window. None if no token data."""
+    conditions = ["business_id = %s", "created_at >= now() - make_interval(days => %s)"]
+    params: list = [str(business_id), days]
+    if env_id:
+        conditions.append("env_id = %s")
+        params.append(env_id)
+    where = " AND ".join(conditions)
+    with get_cursor() as cur:
+        cur.execute(
+            f"""SELECT COALESCE(SUM(COALESCE(prompt_tokens,0) + COALESCE(completion_tokens,0)),0)::bigint AS tokens
+                FROM ai_decision_audit_log
+                WHERE {where}""",
+            params,
+        )
+        row = cur.fetchone() or {}
+        tokens = row.get("tokens") or 0
+        if tokens <= 0:
+            return None
+        return round((tokens / 1000.0) * _EST_USD_PER_1K_TOKENS, 4)
+
+
+def summary(business_id: str | UUID, *, env_id: str | None = None, days: int = HOT_WINDOW_DAYS) -> dict:
+    """Assemble the dashboard stat strip + calls-per-day series.
+
+    Reuses governance.compute_audit_stats for the success/grounding aggregates and
+    adds a calls-per-day series and an estimated-cost figure.
+    """
+    stats = governance_svc.compute_audit_stats(business_id, env_id=env_id)
+    total = stats.get("total_decisions", 0) or 0
+    successful = stats.get("successful", 0) or 0
+    return {
+        "window_days": days,
+        "total_decisions": total,
+        "successful": successful,
+        "failed": stats.get("failed", 0),
+        "success_rate": round(successful / total, 3) if total else None,
+        "avg_latency_ms": stats.get("avg_latency_ms"),
+        "avg_grounding_score": stats.get("avg_grounding_score"),
+        "high_grounding": stats.get("high_grounding", 0),
+        "mixed_grounding": stats.get("mixed_grounding", 0),
+        "low_grounding": stats.get("low_grounding", 0),
+        "top_tools": stats.get("top_tools", []),
+        "calls_per_day": _calls_per_day(business_id, env_id=env_id, days=days),
+        "estimated_cost_usd": _estimated_cost(business_id, env_id=env_id, days=days),
+        "cost_is_estimate": True,
+    }
+
+
+def decisions(
+    business_id: str | UUID,
+    *,
+    env_id: str | None = None,
+    tool_name: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict]:
+    """AI decision log rows with grounding scores. Thin pass-through to governance."""
+    rows = governance_svc.list_decisions(
+        business_id, env_id=env_id, tool_name=tool_name, limit=limit, offset=offset
+    )
+    return [_decision_row(r) for r in rows]
+
+
+def lineage(business_id: str | UUID, tool_name: str, *, env_id: str | None = None, limit: int = 100) -> list[dict]:
+    """All decisions for one tool, newest first — the per-tool lineage view."""
+    rows = governance_svc.list_decisions(
+        business_id, env_id=env_id, tool_name=tool_name, limit=limit
+    )
+    return [_decision_row(r) for r in rows]
+
+
+def _decision_row(r: dict) -> dict:
+    gs = r.get("grounding_score")
+    return {
+        "id": str(r["id"]) if r.get("id") is not None else None,
+        "actor": r.get("actor"),
+        "decision_type": r.get("decision_type"),
+        "tool_name": r.get("tool_name"),
+        "model_used": r.get("model_used"),
+        "latency_ms": r.get("latency_ms"),
+        "grounding_score": float(gs) if gs is not None else None,
+        "grounding_low": (gs is not None and float(gs) < 0.5),
+        "success": r.get("success"),
+        "error_message": r.get("error_message"),
+        "created_at": r["created_at"].isoformat() if r.get("created_at") else None,
+    }

--- a/backend/app/services/workflow_registry.py
+++ b/backend/app/services/workflow_registry.py
@@ -1,0 +1,225 @@
+"""Workflow Registry service — definitions/catalog for the ADE governed fabric (plan PR 2).
+
+A workflow is a named, reusable execution sequence. PR 2 is catalog only: CRUD over
+definitions plus two hot run-state columns (run_count, last_run_at). There is no
+execution engine and no run-history table — durable run/history analytics are a future
+BigQuery concern (Resource Selection Doctrine), not more Postgres rows.
+
+RLS: every statement issues `SET LOCAL app.env_id` (via set_config) so the
+nv_workflow_definitions tenant policy passes. Reads and writes are env-scoped.
+"""
+from __future__ import annotations
+
+import json
+import re
+from uuid import UUID
+
+from app.db import get_cursor
+from app.observability.logger import emit_log
+
+# Canonical seed workflows applied lazily on first list per env. Idempotent by
+# (env_id, slug): re-running ensure_seed_workflows never duplicates rows.
+SEED_WORKFLOWS: list[dict] = [
+    {
+        "slug": "ticket-to-pr",
+        "name": "Ticket → PR",
+        "domain": "devops",
+        "description": "ADO story to merged PR: plan, research, code, test, PR, review, deploy.",
+        "steps": [
+            {"step_name": "ADO Story", "tool_name": None, "inputs": [], "outputs": ["story_id"]},
+            {"step_name": "Plan", "tool_name": None, "inputs": ["story_id"], "outputs": ["plan"]},
+            {"step_name": "Research", "tool_name": None, "inputs": ["plan"], "outputs": ["evidence"]},
+            {"step_name": "Code", "tool_name": None, "inputs": ["plan"], "outputs": ["diff"]},
+            {"step_name": "Test", "tool_name": None, "inputs": ["diff"], "outputs": ["results"]},
+            {"step_name": "PR", "tool_name": "git.create_pr", "inputs": ["diff"], "outputs": ["pr_url"]},
+            {"step_name": "Human Review", "tool_name": None, "inputs": ["pr_url"], "outputs": ["approval"]},
+            {"step_name": "Deploy", "tool_name": None, "inputs": ["approval"], "outputs": ["deploy_id"]},
+        ],
+    },
+    {
+        "slug": "data-engineering",
+        "name": "Data Engineering",
+        "domain": "data_engineering",
+        "description": "Medallion pipeline: source to bronze, silver, gold, validated and reported.",
+        "steps": [
+            {"step_name": "Source", "tool_name": None, "inputs": [], "outputs": ["raw"]},
+            {"step_name": "Bronze", "tool_name": None, "inputs": ["raw"], "outputs": ["bronze"]},
+            {"step_name": "Silver", "tool_name": None, "inputs": ["bronze"], "outputs": ["silver"]},
+            {"step_name": "Gold", "tool_name": None, "inputs": ["silver"], "outputs": ["gold"]},
+            {"step_name": "Validate", "tool_name": None, "inputs": ["gold"], "outputs": ["assertions"]},
+            {"step_name": "Report", "tool_name": None, "inputs": ["gold"], "outputs": ["report"]},
+        ],
+    },
+    {
+        "slug": "telemetry-investigation",
+        "name": "Telemetry Investigation",
+        "domain": "telemetry",
+        "description": "Anomaly to recommendation: root cause, historical compare, NCR search.",
+        "steps": [
+            {"step_name": "Alert", "tool_name": None, "inputs": [], "outputs": ["anomaly"]},
+            {"step_name": "Root Cause", "tool_name": None, "inputs": ["anomaly"], "outputs": ["cause"]},
+            {"step_name": "Historical Compare", "tool_name": None, "inputs": ["anomaly"], "outputs": ["similar_runs"]},
+            {"step_name": "NCR Search", "tool_name": None, "inputs": ["cause"], "outputs": ["ncrs"]},
+            {"step_name": "Recommendation", "tool_name": None, "inputs": ["cause", "ncrs"], "outputs": ["recommendation"]},
+        ],
+    },
+]
+
+_VALID_DOMAINS = {"data_engineering", "telemetry", "investigation", "devops"}
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+def _slugify(name: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
+    return s or "workflow"
+
+
+def _row_to_dict(r: dict) -> dict:
+    return {
+        "id": str(r["id"]),
+        "slug": r["slug"],
+        "name": r["name"],
+        "description": r["description"],
+        "domain": r["domain"],
+        "steps": r["steps"],
+        "input_schema": r["input_schema"],
+        "output_schema": r["output_schema"],
+        "owner": r["owner"],
+        "last_run_at": r["last_run_at"].isoformat() if r.get("last_run_at") else None,
+        "run_count": r["run_count"],
+        "created_at": r["created_at"].isoformat() if r.get("created_at") else None,
+    }
+
+
+def _set_tenant(cur, env_id: str) -> None:
+    cur.execute("SELECT set_config('app.env_id', %s, true)", (env_id,))
+
+
+def ensure_seed_workflows(env_id: str, business_id: str | UUID) -> None:
+    """Insert the canonical seed workflows for an env if absent. Idempotent.
+
+    Called lazily on first list so any env that opens the catalog gets the seeds
+    without baking a hardcoded env_id into the migration.
+    """
+    with get_cursor() as cur:
+        _set_tenant(cur, env_id)
+        for wf in SEED_WORKFLOWS:
+            cur.execute(
+                """INSERT INTO nv_workflow_definitions
+                       (env_id, business_id, slug, name, description, domain, steps, owner)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                   ON CONFLICT (env_id, slug) DO NOTHING""",
+                (
+                    env_id, str(business_id), wf["slug"], wf["name"], wf["description"],
+                    wf["domain"], json.dumps(wf["steps"]), "system",
+                ),
+            )
+
+
+def list_workflows(env_id: str, business_id: str | UUID, *, domain: str | None = None) -> list[dict]:
+    """List workflow definitions for an env, newest first. Optional domain filter."""
+    ensure_seed_workflows(env_id, business_id)
+    conditions = ["env_id = %s"]
+    params: list = [env_id]
+    if domain:
+        if domain not in _VALID_DOMAINS:
+            raise ValueError(f"Unknown domain: {domain}")
+        conditions.append("domain = %s")
+        params.append(domain)
+    where = " AND ".join(conditions)
+    with get_cursor() as cur:
+        _set_tenant(cur, env_id)
+        cur.execute(
+            f"""SELECT id, slug, name, description, domain, steps, input_schema, output_schema,
+                       owner, last_run_at, run_count, created_at
+                FROM nv_workflow_definitions
+                WHERE {where}
+                ORDER BY created_at DESC""",
+            params,
+        )
+        return [_row_to_dict(r) for r in cur.fetchall()]
+
+
+def get_workflow(env_id: str, business_id: str | UUID, workflow_id: str | UUID) -> dict | None:
+    with get_cursor() as cur:
+        _set_tenant(cur, env_id)
+        cur.execute(
+            """SELECT id, slug, name, description, domain, steps, input_schema, output_schema,
+                      owner, last_run_at, run_count, created_at
+               FROM nv_workflow_definitions
+               WHERE env_id = %s AND id = %s""",
+            (env_id, str(workflow_id)),
+        )
+        row = cur.fetchone()
+        return _row_to_dict(row) if row else None
+
+
+def create_workflow(
+    env_id: str,
+    business_id: str | UUID,
+    *,
+    name: str,
+    domain: str = "data_engineering",
+    description: str | None = None,
+    steps: list[dict] | None = None,
+    input_schema: dict | None = None,
+    output_schema: dict | None = None,
+    owner: str | None = None,
+    slug: str | None = None,
+) -> dict:
+    """Create one workflow definition. Slug derives from name when not given.
+
+    Raises ValueError on bad domain/slug or a duplicate (env_id, slug).
+    """
+    if not name or not name.strip():
+        raise ValueError("name is required")
+    if domain not in _VALID_DOMAINS:
+        raise ValueError(f"Unknown domain: {domain}")
+    final_slug = (slug or _slugify(name)).strip().lower()
+    if not _SLUG_RE.match(final_slug):
+        raise ValueError(f"Invalid slug: {final_slug}")
+    with get_cursor() as cur:
+        _set_tenant(cur, env_id)
+        cur.execute(
+            "SELECT 1 FROM nv_workflow_definitions WHERE env_id = %s AND slug = %s",
+            (env_id, final_slug),
+        )
+        if cur.fetchone():
+            raise ValueError(f"Workflow slug already exists: {final_slug}")
+        cur.execute(
+            """INSERT INTO nv_workflow_definitions
+                   (env_id, business_id, slug, name, description, domain,
+                    steps, input_schema, output_schema, owner)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+               RETURNING id, slug, name, description, domain, steps, input_schema,
+                         output_schema, owner, last_run_at, run_count, created_at""",
+            (
+                env_id, str(business_id), final_slug, name.strip(), description, domain,
+                json.dumps(steps or []), json.dumps(input_schema or {}),
+                json.dumps(output_schema or {}), owner,
+            ),
+        )
+        return _row_to_dict(cur.fetchone())
+
+
+def record_run(env_id: str, business_id: str | UUID, workflow_id: str | UUID) -> dict | None:
+    """Bump hot run state: increment run_count, set last_run_at = now().
+
+    NOT a run-history write — there is no run-history table in PR 2. Returns the
+    updated row, or None if the workflow does not exist for this env.
+    """
+    with get_cursor() as cur:
+        _set_tenant(cur, env_id)
+        cur.execute(
+            """UPDATE nv_workflow_definitions
+               SET run_count = run_count + 1, last_run_at = now()
+               WHERE env_id = %s AND id = %s
+               RETURNING id, slug, name, description, domain, steps, input_schema,
+                         output_schema, owner, last_run_at, run_count, created_at""",
+            (env_id, str(workflow_id)),
+        )
+        row = cur.fetchone()
+        if not row:
+            emit_log(level="warning", service="workflow_registry", action="record_run_missing",
+                     message=f"workflow {workflow_id} not found for env {env_id}")
+        return _row_to_dict(row) if row else None

--- a/backend/tests/test_ade_routes.py
+++ b/backend/tests/test_ade_routes.py
@@ -171,22 +171,26 @@ def test_governance_stats_zero_decisions_no_div_by_zero(client, monkeypatch):
 
 
 def test_warehouse_export_seam_fails_closed_without_creds(monkeypatch):
-    """The export seam must raise (never report success) when BQ is unconfigured."""
+    """The export seam must raise (never report success) when BQ is unconfigured.
+
+    PR 3 wired the seam to delegate to scripts/export_audit_to_bq.py, which raises
+    ExportNotConfigured ("not configured") rather than the old NotImplementedError.
+    """
     from app.services import ade_warehouse_export
 
     monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
     monkeypatch.delenv("BQ_PROJECT_ID", raising=False)
     assert ade_warehouse_export.warehouse_export_configured() is False
-    with pytest.raises(NotImplementedError, match="not configured"):
+    with pytest.raises(Exception, match="not configured"):
         ade_warehouse_export.export_audit_events_to_warehouse()
 
 
-def test_warehouse_export_seam_unimplemented_with_creds(monkeypatch):
-    """Even with creds present, the seam is not yet implemented — must raise, not no-op."""
+def test_warehouse_export_seam_reports_configured_with_creds(monkeypatch):
+    """With creds present the readiness check flips true; the seam then delegates to
+    the export script (which would attempt a real DB/BQ connection). We assert only the
+    readiness signal here — no live connection in tests."""
     from app.services import ade_warehouse_export
 
     monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/tmp/fake.json")
     monkeypatch.setenv("BQ_PROJECT_ID", "fake-project")
     assert ade_warehouse_export.warehouse_export_configured() is True
-    with pytest.raises(NotImplementedError, match="not yet implemented"):
-        ade_warehouse_export.export_audit_events_to_warehouse()

--- a/backend/tests/test_app_import.py
+++ b/backend/tests/test_app_import.py
@@ -1,0 +1,24 @@
+"""Regression guard: the FastAPI app must import from a clean checkout.
+
+A stray `from app.routes import hr_polymarket` line once rode into an unrelated
+commit while the route module was untracked, so `from app.main import app` raised
+ModuleNotFoundError on any fresh checkout and pytest collection died before a single
+test ran. This test fails loudly if main.py ever imports a route/service module that
+isn't actually present in the tree.
+
+Run with: cd backend && python -m pytest tests/test_app_import.py -q
+"""
+import os
+
+os.environ.setdefault("BM_MCP_DRY_RUN", "1")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+os.environ.setdefault("MCP_API_TOKEN", "test-token")
+
+
+def test_app_main_imports_cleanly():
+    from app.main import app
+
+    # If the import above resolved, every `from app.routes import X` in main.py
+    # pointed at a real module. Sanity-check the app object is wired.
+    assert app is not None
+    assert len(app.routes) > 0

--- a/backend/tests/test_audit_dashboard.py
+++ b/backend/tests/test_audit_dashboard.py
@@ -1,0 +1,159 @@
+"""Tests for the Audit Dashboard API (/api/ade/audit/*) and the BigQuery export scaffold.
+
+Run with: cd backend && python -m pytest tests/test_audit_dashboard.py -x -q
+
+No DB required: route tests monkeypatch the service layer; the export-script tests
+exercise the fail-closed credential gate without touching BigQuery or Postgres.
+"""
+import os
+
+import pytest
+
+os.environ.setdefault("BM_MCP_DRY_RUN", "1")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+os.environ.setdefault("MCP_API_TOKEN", "test-token")
+
+BUSINESS_ID = "00000000-0000-0000-0000-000000000001"
+
+
+# ── summary ──────────────────────────────────────────────────────────────────
+
+def test_summary_maps_service(client, monkeypatch):
+    from app.services import audit_dashboard as svc
+
+    fake = {
+        "window_days": 30, "total_decisions": 12, "successful": 11, "failed": 1,
+        "success_rate": 0.917, "avg_latency_ms": 88, "avg_grounding_score": 0.81,
+        "high_grounding": 8, "mixed_grounding": 3, "low_grounding": 1,
+        "top_tools": [{"tool_name": "repe.kpis", "call_count": 4, "avg_latency": 70}],
+        "calls_per_day": [{"day": "2026-06-12", "calls": 5, "failed": 0}],
+        "estimated_cost_usd": 0.12, "cost_is_estimate": True,
+    }
+    monkeypatch.setattr(svc, "summary", lambda biz, **kw: fake)
+    body = client.get(f"/api/ade/audit/summary?business_id={BUSINESS_ID}").json()
+    assert body["null_reason"] is None
+    assert body["total_decisions"] == 12
+    assert body["calls_per_day"][0]["calls"] == 5
+    assert body["cost_is_estimate"] is True
+
+
+def test_summary_fails_closed(client, monkeypatch):
+    from app.services import audit_dashboard as svc
+
+    def boom(*a, **k):
+        raise RuntimeError("no db")
+    monkeypatch.setattr(svc, "summary", boom)
+    resp = client.get(f"/api/ade/audit/summary?business_id={BUSINESS_ID}")
+    assert resp.status_code == 200  # never 500
+    body = resp.json()
+    assert body["null_reason"] == "audit_summary_unavailable"
+    assert body["total_decisions"] == 0
+    assert body["calls_per_day"] == []
+
+
+# ── decisions ────────────────────────────────────────────────────────────────
+
+def test_decisions_returns_rows(client, monkeypatch):
+    from app.services import audit_dashboard as svc
+
+    rows = [{"id": "d1", "actor": "winston", "decision_type": "tool_call", "tool_name": "git.diff",
+             "model_used": "gpt-4.1", "latency_ms": 40, "grounding_score": 0.92,
+             "grounding_low": False, "success": True, "error_message": None,
+             "created_at": "2026-06-12T10:00:00+00:00"}]
+    monkeypatch.setattr(svc, "decisions", lambda biz, **kw: rows)
+    body = client.get(f"/api/ade/audit/decisions?business_id={BUSINESS_ID}").json()
+    assert body["null_reason"] is None
+    assert body["decisions"][0]["tool_name"] == "git.diff"
+
+
+def test_decisions_passes_tool_filter(client, monkeypatch):
+    from app.services import audit_dashboard as svc
+
+    seen = {}
+    def fake(biz, **kw):
+        seen.update(kw)
+        return []
+    monkeypatch.setattr(svc, "decisions", fake)
+    client.get(f"/api/ade/audit/decisions?business_id={BUSINESS_ID}&tool_name=git.diff")
+    assert seen.get("tool_name") == "git.diff"
+
+
+def test_decisions_fails_closed(client, monkeypatch):
+    from app.services import audit_dashboard as svc
+
+    def boom(*a, **k):
+        raise RuntimeError("no db")
+    monkeypatch.setattr(svc, "decisions", boom)
+    body = client.get(f"/api/ade/audit/decisions?business_id={BUSINESS_ID}").json()
+    assert body["decisions"] == []
+    assert body["null_reason"] == "audit_decisions_unavailable"
+
+
+def test_decision_detail_unknown_404(client, monkeypatch):
+    from app.services import governance as governance_svc
+    monkeypatch.setattr(governance_svc, "get_decision", lambda did: None)
+    resp = client.get("/api/ade/audit/decisions/00000000-0000-0000-0000-0000000000ff")
+    assert resp.status_code == 404
+
+
+# ── lineage ──────────────────────────────────────────────────────────────────
+
+def test_lineage_filters_by_tool(client, monkeypatch):
+    from app.services import audit_dashboard as svc
+
+    monkeypatch.setattr(svc, "lineage", lambda biz, tool, **kw: [{"tool_name": tool}])
+    body = client.get(f"/api/ade/audit/lineage/repe.kpis?business_id={BUSINESS_ID}").json()
+    assert body["tool_name"] == "repe.kpis"
+    assert body["null_reason"] is None
+
+
+def test_lineage_fails_closed(client, monkeypatch):
+    from app.services import audit_dashboard as svc
+
+    def boom(*a, **k):
+        raise RuntimeError("no db")
+    monkeypatch.setattr(svc, "lineage", boom)
+    body = client.get(f"/api/ade/audit/lineage/x?business_id={BUSINESS_ID}").json()
+    assert body["decisions"] == []
+    assert body["null_reason"] == "audit_lineage_unavailable"
+
+
+# ── BigQuery export scaffold: fail-closed credential gate ────────────────────
+
+def _import_exporter():
+    # Import via sys.path so the module is registered in sys.modules — dataclasses
+    # defined in the module need that (module_from_spec leaves __module__ dangling
+    # on Python 3.14 and @dataclass fails).
+    import sys
+    from pathlib import Path
+    scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    import export_audit_to_bq  # noqa: PLC0415
+    return export_audit_to_bq
+
+
+def test_export_fails_closed_without_creds(monkeypatch):
+    exporter = _import_exporter()
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    monkeypatch.delenv("BQ_PROJECT_ID", raising=False)
+    with pytest.raises(exporter.ExportNotConfigured, match="not configured"):
+        exporter.export_audit_events()
+
+
+def test_export_main_returns_nonzero_without_creds(monkeypatch):
+    exporter = _import_exporter()
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    monkeypatch.delenv("BQ_PROJECT_ID", raising=False)
+    # main() must exit non-zero and never report success.
+    assert exporter.main(["--since", "2026-06-01"]) == 2
+
+
+def test_warehouse_seam_delegates_and_fails_closed(monkeypatch):
+    from app.services import ade_warehouse_export as seam
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    monkeypatch.delenv("BQ_PROJECT_ID", raising=False)
+    assert seam.warehouse_export_configured() is False
+    with pytest.raises(Exception) as exc:  # ExportNotConfigured from the delegated script
+        seam.export_audit_events_to_warehouse()
+    assert "not configured" in str(exc.value)

--- a/backend/tests/test_workflow_registry.py
+++ b/backend/tests/test_workflow_registry.py
@@ -1,0 +1,150 @@
+"""Tests for the Workflow Registry API and service (/api/ade/workflows).
+
+Run with: cd backend && python -m pytest tests/test_workflow_registry.py -x -q
+
+No DB required: route tests monkeypatch the service layer; service tests exercise
+the pure helpers and validation paths. The migration is checked as text for the
+mandatory RLS / tenant-policy / comment / unique-constraint guardrails.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("BM_MCP_DRY_RUN", "1")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+os.environ.setdefault("MCP_API_TOKEN", "test-token")
+
+from app.services import workflow_registry as svc  # noqa: E402
+
+BUSINESS_ID = "00000000-0000-0000-0000-000000000001"
+ENV = "test-env"
+
+
+# ── service-level: pure helpers & validation (no DB) ─────────────────────────
+
+def test_slugify_normalizes():
+    assert svc._slugify("My New Workflow!!") == "my-new-workflow"
+    assert svc._slugify("   ") == "workflow"
+    assert svc._slugify("Already-Clean") == "already-clean"
+
+
+def test_seed_workflows_are_well_formed():
+    slugs = [w["slug"] for w in svc.SEED_WORKFLOWS]
+    assert slugs == ["ticket-to-pr", "data-engineering", "telemetry-investigation"]
+    for w in svc.SEED_WORKFLOWS:
+        assert w["domain"] in svc._VALID_DOMAINS
+        assert w["steps"] and all("step_name" in s for s in w["steps"])
+
+
+def test_create_rejects_bad_domain(monkeypatch):
+    # Guard fires before any DB access, so no cursor needed.
+    with pytest.raises(ValueError, match="Unknown domain"):
+        svc.create_workflow(ENV, BUSINESS_ID, name="X", domain="not_a_domain")
+
+
+def test_create_rejects_empty_name():
+    with pytest.raises(ValueError, match="name is required"):
+        svc.create_workflow(ENV, BUSINESS_ID, name="   ")
+
+
+# ── route-level: monkeypatch the service so no DB is touched ──────────────────
+
+def test_list_returns_workflows(client, monkeypatch):
+    rows = [
+        {"id": "1", "slug": "ticket-to-pr", "name": "Ticket → PR", "description": "d",
+         "domain": "devops", "steps": [], "input_schema": {}, "output_schema": {},
+         "owner": "system", "last_run_at": None, "run_count": 0, "created_at": None},
+    ]
+    monkeypatch.setattr(svc, "list_workflows", lambda env, biz, **kw: rows)
+    body = client.get(f"/api/ade/workflows?env_id={ENV}&business_id={BUSINESS_ID}").json()
+    assert body["null_reason"] is None
+    assert len(body["workflows"]) == 1
+    assert body["workflows"][0]["slug"] == "ticket-to-pr"
+
+
+def test_list_passes_domain_filter(client, monkeypatch):
+    seen = {}
+    def fake_list(env, biz, **kw):
+        seen.update(kw)
+        return []
+    monkeypatch.setattr(svc, "list_workflows", fake_list)
+    client.get(f"/api/ade/workflows?env_id={ENV}&business_id={BUSINESS_ID}&domain=telemetry")
+    assert seen.get("domain") == "telemetry"
+
+
+def test_list_fails_closed(client, monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("no database in tests")
+    monkeypatch.setattr(svc, "list_workflows", boom)
+    resp = client.get(f"/api/ade/workflows?env_id={ENV}&business_id={BUSINESS_ID}")
+    assert resp.status_code == 200  # never 500
+    body = resp.json()
+    assert body["workflows"] == []
+    assert body["null_reason"] == "workflow_read_unavailable"
+
+
+def test_create_persists(client, monkeypatch):
+    created = {"id": "abc", "slug": "supplier-risk-sweep", "name": "Supplier Risk Sweep",
+              "description": None, "domain": "data_engineering", "steps": [],
+              "input_schema": {}, "output_schema": {}, "owner": None,
+              "last_run_at": None, "run_count": 0, "created_at": None}
+    monkeypatch.setattr(svc, "create_workflow", lambda env, biz, **kw: created)
+    resp = client.post("/api/ade/workflows", json={
+        "env_id": ENV, "business_id": BUSINESS_ID, "name": "Supplier Risk Sweep",
+        "domain": "data_engineering",
+    })
+    assert resp.status_code == 200
+    assert resp.json()["slug"] == "supplier-risk-sweep"
+
+
+def test_create_duplicate_slug_is_400(client, monkeypatch):
+    def dup(*a, **k):
+        raise ValueError("Workflow slug already exists: x")
+    monkeypatch.setattr(svc, "create_workflow", dup)
+    resp = client.post("/api/ade/workflows", json={
+        "env_id": ENV, "business_id": BUSINESS_ID, "name": "X", "domain": "devops",
+    })
+    assert resp.status_code == 400
+
+
+def test_get_unknown_is_404(client, monkeypatch):
+    monkeypatch.setattr(svc, "get_workflow", lambda env, biz, wid: None)
+    resp = client.get(f"/api/ade/workflows/00000000-0000-0000-0000-0000000000ff"
+                      f"?env_id={ENV}&business_id={BUSINESS_ID}")
+    assert resp.status_code == 404
+
+
+def test_run_increments(client, monkeypatch):
+    updated = {"id": "abc", "slug": "ticket-to-pr", "name": "Ticket → PR", "description": None,
+               "domain": "devops", "steps": [], "input_schema": {}, "output_schema": {},
+               "owner": "system", "last_run_at": "2026-06-13T00:00:00+00:00", "run_count": 1,
+               "created_at": None}
+    monkeypatch.setattr(svc, "record_run", lambda env, biz, wid: updated)
+    resp = client.post("/api/ade/workflows/00000000-0000-0000-0000-0000000000ab/run",
+                       json={"env_id": ENV, "business_id": BUSINESS_ID})
+    assert resp.status_code == 200
+    assert resp.json()["run_count"] == 1
+    assert resp.json()["last_run_at"] is not None
+
+
+def test_run_unknown_is_404(client, monkeypatch):
+    monkeypatch.setattr(svc, "record_run", lambda env, biz, wid: None)
+    resp = client.post("/api/ade/workflows/00000000-0000-0000-0000-0000000000ff/run",
+                       json={"env_id": ENV, "business_id": BUSINESS_ID})
+    assert resp.status_code == 404
+
+
+# ── migration guardrails: RLS, tenant policy, comment, unique constraint ─────
+
+def test_migration_has_required_guardrails():
+    sql_path = (Path(__file__).resolve().parents[2]
+                / "repo-b" / "db" / "schema" / "10018_workflow_registry.sql")
+    sql = sql_path.read_text(encoding="utf-8")
+    assert "nv_workflow_definitions" in sql
+    assert "env_id        text NOT NULL" in sql or "env_id text NOT NULL" in sql
+    assert "business_id   uuid NOT NULL" in sql or "business_id uuid NOT NULL" in sql
+    assert "ENABLE ROW LEVEL SECURITY" in sql
+    assert "current_setting('app.env_id', true)" in sql
+    assert "COMMENT ON TABLE nv_workflow_definitions" in sql
+    assert "UNIQUE (env_id, slug)" in sql

--- a/docs/plans/bigquery-schemas/audit_events.sql
+++ b/docs/plans/bigquery-schemas/audit_events.sql
@@ -1,0 +1,40 @@
+-- winston_ops.audit_events_bq
+--
+-- BigQuery mirror of Postgres app.audit_events, the durable home for historical
+-- compliance and cost analytics (plan PR 3 / Resource Selection Doctrine). Postgres
+-- holds the ~30-day operational hot window; everything older lives here.
+--
+-- This is a SCHEMA DOCUMENT. PR 3 ships:
+--   - this DDL (documentation),
+--   - scripts/export_audit_to_bq.py (manual batch export, fail-closed),
+-- and explicitly does NOT ship continuous replication or a scheduled export.
+--
+-- Load via the manual script. Idempotency is by audit_event_id (MERGE on re-run).
+-- Partitioned by ingest day and clustered by tool_name for cost-efficient scans.
+
+CREATE TABLE IF NOT EXISTS `winston_ops.audit_events_bq` (
+  audit_event_id   STRING   NOT NULL,   -- uuid, the MERGE key
+  tenant_id        STRING,
+  business_id      STRING,
+  actor            STRING   NOT NULL,
+  action           STRING   NOT NULL,
+  tool_name        STRING   NOT NULL,
+  object_type      STRING,
+  object_id        STRING,
+  success          BOOL     NOT NULL,
+  latency_ms       INT64    NOT NULL,
+  input_redacted   JSON,                -- already redacted at write time in Postgres
+  output_redacted  JSON,
+  error_message    STRING,
+  created_at       TIMESTAMP NOT NULL,
+  exported_at      TIMESTAMP NOT NULL   -- when the row landed in BigQuery
+)
+PARTITION BY DATE(created_at)
+CLUSTER BY tool_name, success;
+
+-- Suggested MERGE shape used by the exporter (idempotent re-runs):
+--
+-- MERGE `winston_ops.audit_events_bq` T
+-- USING <staged batch> S
+-- ON T.audit_event_id = S.audit_event_id
+-- WHEN NOT MATCHED THEN INSERT ROW;

--- a/repo-b/db/schema/10018_workflow_registry.sql
+++ b/repo-b/db/schema/10018_workflow_registry.sql
@@ -1,0 +1,47 @@
+-- 10018_workflow_registry.sql
+-- Workflow Registry for the Automated Data Engineering governed fabric (plan PR 2).
+--
+-- A workflow is a named, reusable execution sequence (e.g. Ticket->PR, the
+-- Source->Bronze->Silver->Gold data-engineering loop, a telemetry investigation).
+-- PR 2 ships the catalog/definitions layer only: there is NO execution engine and
+-- NO run-history table. Hot run state is two columns on the definition row
+-- (run_count, last_run_at). Future workflow run/history analytics belong in
+-- BigQuery (Resource Selection Doctrine), not in additional Postgres tables.
+--
+-- Owning module: backend/app/services/workflow_registry.py. Surfaced read+write
+-- via /api/ade/workflows. Per-environment business data: full RLS + env_id/business_id.
+-- Approved prefix: nv_ (Novendor platform-core; no new prefix introduced).
+
+CREATE TABLE IF NOT EXISTS nv_workflow_definitions (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id        text NOT NULL,
+    business_id   uuid NOT NULL,
+    slug          text NOT NULL,
+    name          text NOT NULL,
+    description   text,
+    domain        text NOT NULL DEFAULT 'data_engineering'
+                  CHECK (domain IN ('data_engineering', 'telemetry', 'investigation', 'devops')),
+    steps         jsonb NOT NULL DEFAULT '[]'::jsonb,   -- [{step_name, tool_name, inputs, outputs}]
+    input_schema  jsonb NOT NULL DEFAULT '{}'::jsonb,
+    output_schema jsonb NOT NULL DEFAULT '{}'::jsonb,
+    owner         text,
+    last_run_at   timestamptz,                          -- hot state; NOT a run-history table
+    run_count     int NOT NULL DEFAULT 0 CHECK (run_count >= 0),
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (env_id, slug)
+);
+
+ALTER TABLE nv_workflow_definitions ENABLE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+    CREATE POLICY nv_workflow_definitions_tenant ON nv_workflow_definitions
+        USING (env_id = current_setting('app.env_id', true))
+        WITH CHECK (env_id = current_setting('app.env_id', true));
+EXCEPTION WHEN duplicate_object THEN
+    NULL;
+END $$;
+
+COMMENT ON TABLE nv_workflow_definitions IS
+    'Workflow Registry definitions for the ADE governed fabric (plan PR 2). Catalog only: '
+    'no execution engine, no run-history table. run_count/last_run_at are hot counters; '
+    'durable run/history analytics go to BigQuery. Owning module: workflow_registry.py.';

--- a/repo-b/src/app/app/repe/assets/page.test.tsx
+++ b/repo-b/src/app/app/repe/assets/page.test.tsx
@@ -25,7 +25,7 @@ describe("getAssetDiagnostics", () => {
         fund_id: "",
         fund_name: "",
         latest_value: -100,
-        latest_occupancy: null,
+        latest_occupancy: undefined,
         created_at: "2026-01-01T00:00:00Z",
       },
     ]);

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/audit/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/audit/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { use } from "react";
+import AuditDashboard from "@/components/automated-data-engineering/AuditDashboard";
+
+export default function AdeAuditPage({ params }: { params: Promise<{ envId: string }> }) {
+  const { envId } = use(params);
+  return <AuditDashboard envId={envId} />;
+}

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/workflows/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/workflows/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { use } from "react";
+import WorkflowCatalog from "@/components/automated-data-engineering/WorkflowCatalog";
+
+export default function AdeWorkflowsPage({ params }: { params: Promise<{ envId: string }> }) {
+  const { envId } = use(params);
+  return <WorkflowCatalog envId={envId} />;
+}

--- a/repo-b/src/components/automated-data-engineering/AdeShell.tsx
+++ b/repo-b/src/components/automated-data-engineering/AdeShell.tsx
@@ -15,6 +15,7 @@ type NavItem = { slug: string; label: string; icon: string };
 const NAV: NavItem[] = [
   { slug: "", label: "Overview", icon: "M2 9h3v5H2zM7 4h3v10H7zM12 7h3v7h-3z" },
   { slug: "skills", label: "Skill Registry", icon: "M3 2h10v3H3zM3 7h10v3H3zM3 12h6v2H3z" },
+  { slug: "workflows", label: "Workflow Registry", icon: "M3 3h3v3H3zM10 3h3v3h-3zM3 10h3v3H3zM10 10h3v3h-3zM6 4.5h4M11.5 6v4M6 11.5h4M4.5 6v4" },
   { slug: "connectors", label: "Connector Map", icon: "M3 3h4v4H3zM9 9h4v4H9zM7 5h2M5 7v2M11 7V5M9 11H7" },
   { slug: "runs", label: "Execution Receipts", icon: "M3 2h8l2 2v10H3zM5 6h6M5 9h6M5 12h4" },
   { slug: "playbooks", label: "Playbooks", icon: "M3 2h9v12H3zM3 2c1 1 1 11 0 12M6 5h4M6 8h4" },

--- a/repo-b/src/components/automated-data-engineering/AdeShell.tsx
+++ b/repo-b/src/components/automated-data-engineering/AdeShell.tsx
@@ -18,6 +18,7 @@ const NAV: NavItem[] = [
   { slug: "workflows", label: "Workflow Registry", icon: "M3 3h3v3H3zM10 3h3v3h-3zM3 10h3v3H3zM10 10h3v3h-3zM6 4.5h4M11.5 6v4M6 11.5h4M4.5 6v4" },
   { slug: "connectors", label: "Connector Map", icon: "M3 3h4v4H3zM9 9h4v4H9zM7 5h2M5 7v2M11 7V5M9 11H7" },
   { slug: "runs", label: "Execution Receipts", icon: "M3 2h8l2 2v10H3zM5 6h6M5 9h6M5 12h4" },
+  { slug: "audit", label: "Audit", icon: "M8 2a6 6 0 100 12A6 6 0 008 2zM8 5v3l2 2" },
   { slug: "playbooks", label: "Playbooks", icon: "M3 2h9v12H3zM3 2c1 1 1 11 0 12M6 5h4M6 8h4" },
 ];
 

--- a/repo-b/src/components/automated-data-engineering/AuditDashboard.tsx
+++ b/repo-b/src/components/automated-data-engineering/AuditDashboard.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import {
+  getAuditSummary, getAuditDecisions, getDecisionDetail,
+  type AuditSummaryResponse, type DecisionsResponse, type DecisionRow, type DecisionDetail,
+} from "@/lib/automated-data-engineering/audit";
+import {
+  C, Panel, MetricCard, Tag, PageHeading, Loading, ErrorState,
+  EmptyState, UnavailableState, Drawer, DrawerRow,
+} from "./primitives";
+
+// Audit Dashboard (plan PR 3): aggregate strip, calls-per-day sparkline, sortable
+// AI-decision log, and a full-receipt detail drawer. ?audit_mode=1 reveals the
+// underlying read shape (consistent with the REPE audit surface convention).
+
+type SortKey = "created_at" | "grounding_score" | "latency_ms";
+
+// The read shape shown under ?audit_mode=1 — the actual governed reads behind the surface.
+const AUDIT_MODE_SQL = [
+  "-- summary: governance.compute_audit_stats + calls_per_day over the 30-day hot window",
+  "SELECT date_trunc('day', created_at), count(*) FILTER (WHERE action='mcp.tool_call')",
+  "  FROM app.audit_events WHERE business_id = $1 GROUP BY 1 ORDER BY 1;",
+  "-- decisions: governance.list_decisions(business_id, tool_name?, limit, offset)",
+  "SELECT id, tool_name, model_used, grounding_score, latency_ms, success, created_at",
+  "  FROM ai_decision_audit_log WHERE business_id = $1 ORDER BY created_at DESC LIMIT $2;",
+].join("\n");
+
+export default function AuditDashboard({ envId }: { envId: string }) {
+  const searchParams = useSearchParams();
+  const auditMode = searchParams?.get("audit_mode") === "1";
+
+  const [summary, setSummary] = useState<AuditSummaryResponse | null>(null);
+  const [decisions, setDecisions] = useState<DecisionsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>("created_at");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+  const [detail, setDetail] = useState<DecisionDetail | null>(null);
+
+  useEffect(() => {
+    Promise.all([getAuditSummary(undefined, envId), getAuditDecisions(undefined, { env: envId, limit: 100 })])
+      .then(([s, d]) => { setSummary(s); setDecisions(d); })
+      .catch((e) => setError(String(e)));
+  }, [envId]);
+
+  const sorted = useMemo(() => {
+    const rows = [...(decisions?.decisions ?? [])];
+    const dir = sortDir === "asc" ? 1 : -1;
+    rows.sort((a, b) => {
+      const av = a[sortKey] ?? (sortKey === "created_at" ? "" : -Infinity);
+      const bv = b[sortKey] ?? (sortKey === "created_at" ? "" : -Infinity);
+      return av < bv ? -dir : av > bv ? dir : 0;
+    });
+    return rows;
+  }, [decisions, sortKey, sortDir]);
+
+  const toggleSort = (k: SortKey) => {
+    if (k === sortKey) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    else { setSortKey(k); setSortDir("desc"); }
+  };
+
+  const openDetail = (id: string | null) => {
+    if (!id) return;
+    getDecisionDetail(id).then(setDetail).catch(() => setDetail(null));
+  };
+
+  const heading = (
+    <PageHeading eyebrow="Evidence" title="Audit"
+      blurb="Every governed action leaves a receipt. This dashboard reads the AI-decision log and MCP tool-call audit trail over a 30-day operational window — call volume, success rate, grounding scores, and an estimated cost. Older history belongs in the warehouse, not here." />
+  );
+
+  if (error) return <>{heading}<ErrorState message={error} /></>;
+  if (!summary || !decisions) return <>{heading}<Loading label="Loading audit trail…" /></>;
+
+  return (
+    <>
+      {heading}
+
+      {/* Stat strip */}
+      {summary.null_reason ? (
+        <UnavailableState nullReason={summary.null_reason} />
+      ) : (
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4" style={{ marginBottom: 16 }}>
+          <MetricCard label={`Decisions · ${summary.window_days}d`} value={summary.total_decisions}
+            sub={`${summary.successful} ok · ${summary.failed} failed`} />
+          <MetricCard label="Success Rate"
+            value={summary.success_rate != null ? `${Math.round(summary.success_rate * 100)}%` : "—"}
+            sub={summary.success_rate != null ? "of logged decisions" : "no decisions logged"}
+            accent={summary.success_rate != null && summary.success_rate >= 0.9 ? C.green : undefined} />
+          <MetricCard label="Avg Grounding"
+            value={summary.avg_grounding_score != null ? summary.avg_grounding_score.toFixed(2) : "—"}
+            sub={`${summary.high_grounding} high · ${summary.low_grounding} low`}
+            accent={summary.avg_grounding_score != null && summary.avg_grounding_score >= 0.8 ? C.green : undefined} />
+          <MetricCard label="Est. Cost"
+            value={summary.estimated_cost_usd != null ? `$${summary.estimated_cost_usd.toFixed(2)}` : "—"}
+            sub={summary.estimated_cost_usd != null ? "token estimate · not authoritative" : "no token data"} />
+        </div>
+      )}
+
+      {/* Calls per day */}
+      <Panel title="Calls per day" right={<Tag color={C.faint}>{summary.window_days}d window</Tag>} style={{ marginBottom: 16 }}>
+        <CallsSparkline data={summary.calls_per_day} />
+      </Panel>
+
+      {auditMode && (
+        <Panel title="Audit mode · read shape" right={<Tag color={C.amber}>audit_mode=1</Tag>} style={{ marginBottom: 16 }}>
+          <pre style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, lineHeight: 1.5, whiteSpace: "pre-wrap", margin: 0 }}>
+            {AUDIT_MODE_SQL}
+          </pre>
+        </Panel>
+      )}
+
+      {/* Decision log */}
+      <Panel title="AI decision log">
+        {decisions.null_reason ? (
+          <UnavailableState nullReason={decisions.null_reason} />
+        ) : sorted.length === 0 ? (
+          <EmptyState label="No decisions logged" hint="AI decisions appear here once the gateway records them for this tenant." />
+        ) : (
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontFamily: C.mono, fontSize: 12 }}>
+              <thead>
+                <tr style={{ textAlign: "left", color: C.faint }}>
+                  <Th>Tool</Th>
+                  <Th>Model</Th>
+                  <ThSort label="Grounding" active={sortKey === "grounding_score"} dir={sortDir} onClick={() => toggleSort("grounding_score")} />
+                  <ThSort label="Latency" active={sortKey === "latency_ms"} dir={sortDir} onClick={() => toggleSort("latency_ms")} />
+                  <Th>Status</Th>
+                  <ThSort label="When" active={sortKey === "created_at"} dir={sortDir} onClick={() => toggleSort("created_at")} />
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map((r) => (
+                  <tr key={r.id ?? Math.random()} onClick={() => openDetail(r.id)}
+                    style={{ borderTop: `1px solid ${C.border}`, cursor: "pointer", color: C.text }}>
+                    <Td>{r.tool_name ?? "—"}</Td>
+                    <Td>{r.model_used ?? "—"}</Td>
+                    <Td>
+                      {r.grounding_score != null ? (
+                        <span style={{ color: r.grounding_low ? C.red : r.grounding_score >= 0.8 ? C.green : C.amber }}>
+                          {r.grounding_score.toFixed(2)}
+                        </span>
+                      ) : "—"}
+                    </Td>
+                    <Td>{r.latency_ms != null ? `${r.latency_ms}ms` : "—"}</Td>
+                    <Td>
+                      <span style={{ color: r.success ? C.green : C.red }}>{r.success ? "ok" : "failed"}</span>
+                    </Td>
+                    <Td>{r.created_at ? new Date(r.created_at).toLocaleString() : "—"}</Td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Panel>
+
+      {detail && (
+        <Drawer eyebrow="Receipt" title={detail.tool_name ?? "Decision"} onClose={() => setDetail(null)}>
+          <DrawerRow label="Decision type" value={detail.decision_type} />
+          <DrawerRow label="Actor" value={detail.actor} />
+          <DrawerRow label="Model" value={detail.model_used} />
+          <DrawerRow label="Grounding" value={detail.grounding_score != null ? detail.grounding_score.toFixed(3) : null} />
+          <DrawerRow label="Latency" value={detail.latency_ms != null ? `${detail.latency_ms}ms` : null} />
+          <DrawerRow label="Success" value={detail.success == null ? null : detail.success ? "yes" : "no"} />
+          <DrawerRow label="When" value={detail.created_at ? new Date(detail.created_at).toLocaleString() : null} />
+          {detail.error_message && <DrawerRow label="Error" value={detail.error_message} />}
+          <div style={{ fontFamily: C.mono, fontSize: 10, letterSpacing: "0.12em", color: C.faint, textTransform: "uppercase", margin: "16px 0 8px" }}>
+            Input (redacted)
+          </div>
+          <ReceiptBlock value={detail.input_summary} />
+          <div style={{ fontFamily: C.mono, fontSize: 10, letterSpacing: "0.12em", color: C.faint, textTransform: "uppercase", margin: "16px 0 8px" }}>
+            Output (redacted)
+          </div>
+          <ReceiptBlock value={detail.output_summary} />
+        </Drawer>
+      )}
+    </>
+  );
+}
+
+function CallsSparkline({ data }: { data: { day: string; calls: number; failed: number }[] }) {
+  if (data.length === 0) {
+    return <span style={{ fontFamily: C.mono, fontSize: 12, color: C.faint }}>No tool calls in the window.</span>;
+  }
+  const max = Math.max(...data.map((d) => d.calls), 1);
+  return (
+    <div style={{ display: "flex", alignItems: "flex-end", gap: 3, height: 80 }}>
+      {data.map((d) => (
+        <div key={d.day} title={`${d.day}: ${d.calls} calls, ${d.failed} failed`}
+          style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", height: "100%" }}>
+          <div style={{ background: d.failed > 0 ? C.amber : C.accent, height: `${(d.calls / max) * 100}%`, borderRadius: "2px 2px 0 0", minHeight: 2 }} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ReceiptBlock({ value }: { value: unknown }) {
+  const text = value == null ? "—" : JSON.stringify(value, null, 2);
+  return (
+    <pre style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, background: C.bg,
+      border: `1px solid ${C.border}`, borderRadius: 6, padding: 10, lineHeight: 1.45,
+      whiteSpace: "pre-wrap", wordBreak: "break-word", margin: 0, maxHeight: 220, overflowY: "auto" }}>
+      {text}
+    </pre>
+  );
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return <th style={{ padding: "8px 10px", fontWeight: 500, letterSpacing: "0.04em" }}>{children}</th>;
+}
+
+function ThSort({ label, active, dir, onClick }: { label: string; active: boolean; dir: "asc" | "desc"; onClick: () => void }) {
+  return (
+    <th style={{ padding: "8px 10px", fontWeight: 500, letterSpacing: "0.04em" }}>
+      <button type="button" onClick={onClick}
+        style={{ background: "transparent", border: "none", color: active ? C.text : C.faint, cursor: "pointer", fontFamily: C.mono, fontSize: 12, padding: 0 }}>
+        {label}{active ? (dir === "asc" ? " ↑" : " ↓") : ""}
+      </button>
+    </th>
+  );
+}
+
+function Td({ children }: { children: React.ReactNode }) {
+  return <td style={{ padding: "8px 10px" }}>{children}</td>;
+}

--- a/repo-b/src/components/automated-data-engineering/WorkflowCatalog.tsx
+++ b/repo-b/src/components/automated-data-engineering/WorkflowCatalog.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  getWorkflows, createWorkflow, DOMAIN_LABELS,
+  type WorkflowDefinition, type WorkflowDomain, type WorkflowStep,
+} from "@/lib/automated-data-engineering/workflows";
+import { getSkillRegistry, type SkillSummary } from "@/lib/automated-data-engineering/api";
+import {
+  C, Panel, Tag, PageHeading, Loading, ErrorState, EmptyState, UnavailableState,
+  Drawer, DrawerRow,
+} from "./primitives";
+
+// Workflow Registry catalog (plan PR 2). Definitions only — no execution engine.
+// Cards grouped by domain; a detail drawer shows steps + I/O schema; the add form
+// uses the live ADE skill registry for its step tool picker (name/description/permission).
+
+const DOMAINS: WorkflowDomain[] = ["data_engineering", "telemetry", "investigation", "devops"];
+
+const DOMAIN_COLOR: Record<WorkflowDomain, string> = {
+  data_engineering: C.accent,
+  telemetry: C.green,
+  investigation: C.amber,
+  devops: C.violet,
+};
+
+export default function WorkflowCatalog({ envId }: { envId: string }) {
+  const [workflows, setWorkflows] = useState<WorkflowDefinition[] | null>(null);
+  const [nullReason, setNullReason] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [domainFilter, setDomainFilter] = useState<WorkflowDomain | "all">("all");
+  const [selected, setSelected] = useState<WorkflowDefinition | null>(null);
+  const [showAdd, setShowAdd] = useState(false);
+
+  const load = () => {
+    getWorkflows(envId)
+      .then((r) => { setWorkflows(r.workflows); setNullReason(r.null_reason); })
+      .catch((e) => setError(String(e)));
+  };
+
+  useEffect(load, [envId]);
+
+  const grouped = useMemo(() => {
+    const list = (workflows ?? []).filter(
+      (w) => domainFilter === "all" || w.domain === domainFilter,
+    );
+    const by: Record<string, WorkflowDefinition[]> = {};
+    for (const w of list) (by[w.domain] ??= []).push(w);
+    return by;
+  }, [workflows, domainFilter]);
+
+  const heading = (
+    <PageHeading eyebrow="Catalog" title="Workflow Registry"
+      blurb="Named, reusable execution sequences the fabric knows about. Definitions only — this catalog records the shape of a workflow (its ordered steps and the governed skills each step calls). Execution is future work; today every workflow shows its steps, domain, and how many times it has been run." />
+  );
+
+  if (error) return <>{heading}<ErrorState message={error} /></>;
+  if (!workflows) return <>{heading}<Loading label="Loading workflows…" /></>;
+
+  return (
+    <>
+      {heading}
+
+      {/* Filter + add */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: 10, marginBottom: 14 }}>
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          <FilterChip active={domainFilter === "all"} label="All" onClick={() => setDomainFilter("all")} />
+          {DOMAINS.map((d) => (
+            <FilterChip key={d} active={domainFilter === d} label={DOMAIN_LABELS[d]} onClick={() => setDomainFilter(d)} />
+          ))}
+        </div>
+        <button type="button" onClick={() => setShowAdd(true)}
+          style={{ fontFamily: C.mono, fontSize: 12, color: C.bg, background: C.accent,
+            border: "none", borderRadius: 6, padding: "7px 14px", cursor: "pointer", fontWeight: 600 }}>
+          + Add Workflow
+        </button>
+      </div>
+
+      {nullReason ? (
+        <UnavailableState nullReason={nullReason} />
+      ) : workflows.length === 0 ? (
+        <EmptyState label="No workflows yet"
+          hint="The three canonical workflows seed automatically on first load. Use Add Workflow to define your own." />
+      ) : (
+        DOMAINS.filter((d) => grouped[d]?.length).map((d) => (
+          <Panel key={d} title={DOMAIN_LABELS[d]} right={<Tag color={DOMAIN_COLOR[d]}>{grouped[d].length}</Tag>} style={{ marginBottom: 14 }}>
+            <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+              {grouped[d].map((w) => (
+                <WorkflowCard key={w.id} wf={w} onOpen={() => setSelected(w)} />
+              ))}
+            </div>
+          </Panel>
+        ))
+      )}
+
+      {selected && <WorkflowDetailDrawer wf={selected} onClose={() => setSelected(null)} />}
+      {showAdd && (
+        <AddWorkflowDrawer envId={envId}
+          onClose={() => setShowAdd(false)}
+          onCreated={() => { setShowAdd(false); setWorkflows(null); load(); }} />
+      )}
+    </>
+  );
+}
+
+function FilterChip({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+  return (
+    <button type="button" onClick={onClick}
+      style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.04em",
+        color: active ? C.text : C.dim, background: active ? C.panelHi : "transparent",
+        border: `1px solid ${active ? C.borderHi : C.border}`, borderRadius: 6,
+        padding: "5px 11px", cursor: "pointer" }}>
+      {label}
+    </button>
+  );
+}
+
+function WorkflowCard({ wf, onOpen }: { wf: WorkflowDefinition; onOpen: () => void }) {
+  return (
+    <button type="button" onClick={onOpen}
+      style={{ textAlign: "left", background: C.panelHi, border: `1px solid ${C.border}`,
+        borderRadius: 9, padding: 14, cursor: "pointer", width: "100%" }}>
+      <div style={{ fontFamily: C.sans, fontSize: 15, fontWeight: 600, color: C.text }}>{wf.name}</div>
+      {wf.description && (
+        <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.dim, marginTop: 5, lineHeight: 1.5 }}>{wf.description}</div>
+      )}
+      <div style={{ display: "flex", alignItems: "center", gap: 14, marginTop: 10, fontFamily: C.mono, fontSize: 11, color: C.faint }}>
+        <span>{wf.steps.length} steps</span>
+        <span>{wf.run_count} runs</span>
+        <span>{wf.last_run_at ? `last ${new Date(wf.last_run_at).toLocaleDateString()}` : "never run"}</span>
+      </div>
+    </button>
+  );
+}
+
+function WorkflowDetailDrawer({ wf, onClose }: { wf: WorkflowDefinition; onClose: () => void }) {
+  return (
+    <Drawer eyebrow={DOMAIN_LABELS[wf.domain]} title={wf.name} onClose={onClose}>
+      {wf.description && (
+        <p style={{ fontFamily: C.sans, fontSize: 13, color: C.dim, lineHeight: 1.55, marginBottom: 14 }}>{wf.description}</p>
+      )}
+      <DrawerRow label="Domain" value={DOMAIN_LABELS[wf.domain]} />
+      <DrawerRow label="Slug" value={wf.slug} />
+      <DrawerRow label="Owner" value={wf.owner} />
+      <DrawerRow label="Run count" value={wf.run_count} />
+      <DrawerRow label="Last run" value={wf.last_run_at ? new Date(wf.last_run_at).toLocaleString() : null} />
+
+      <div style={{ fontFamily: C.mono, fontSize: 10, letterSpacing: "0.12em", color: C.faint, textTransform: "uppercase", margin: "16px 0 8px" }}>
+        Steps
+      </div>
+      {wf.steps.map((s, i) => (
+        <div key={`${s.step_name}-${i}`} style={{ display: "flex", gap: 10, padding: "8px 0", borderBottom: `1px solid ${C.border}` }}>
+          <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, minWidth: 18 }}>{i + 1}</span>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontFamily: C.sans, fontSize: 13, color: C.text }}>{s.step_name}</div>
+            <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, marginTop: 2 }}>
+              {s.tool_name ? `skill: ${s.tool_name}` : "no skill bound"}
+            </div>
+          </div>
+        </div>
+      ))}
+    </Drawer>
+  );
+}
+
+// ── Add form ───────────────────────────────────────────────────────────────
+function AddWorkflowDrawer({ envId, onClose, onCreated }: {
+  envId: string; onClose: () => void; onCreated: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [domain, setDomain] = useState<WorkflowDomain>("data_engineering");
+  const [description, setDescription] = useState("");
+  const [steps, setSteps] = useState<WorkflowStep[]>([]);
+  const [skills, setSkills] = useState<SkillSummary[] | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Skill picker source: the live ADE skill registry (name/description/permission).
+    getSkillRegistry().then((r) => setSkills(r.tools)).catch(() => setSkills([]));
+  }, []);
+
+  const addStep = () => setSteps((s) => [...s, { step_name: "", tool_name: null, inputs: [], outputs: [] }]);
+  const updateStep = (i: number, patch: Partial<WorkflowStep>) =>
+    setSteps((s) => s.map((st, idx) => (idx === i ? { ...st, ...patch } : st)));
+  const removeStep = (i: number) => setSteps((s) => s.filter((_, idx) => idx !== i));
+
+  const submit = () => {
+    if (!name.trim()) { setFormError("Name is required."); return; }
+    setSubmitting(true);
+    setFormError(null);
+    createWorkflow(envId, {
+      name: name.trim(), domain,
+      description: description.trim() || undefined,
+      steps: steps.filter((s) => s.step_name.trim()),
+    })
+      .then(onCreated)
+      .catch((e) => { setFormError(String(e)); setSubmitting(false); });
+  };
+
+  return (
+    <Drawer eyebrow="New" title="Add Workflow" onClose={onClose}>
+      <Field label="Name">
+        <input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Supplier Risk Sweep"
+          style={inputStyle} />
+      </Field>
+      <Field label="Domain">
+        <select value={domain} onChange={(e) => setDomain(e.target.value as WorkflowDomain)} style={inputStyle}>
+          {DOMAINS.map((d) => <option key={d} value={d}>{DOMAIN_LABELS[d]}</option>)}
+        </select>
+      </Field>
+      <Field label="Description">
+        <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={2}
+          placeholder="What this workflow does" style={{ ...inputStyle, resize: "vertical" }} />
+      </Field>
+
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", margin: "16px 0 8px" }}>
+        <span style={{ fontFamily: C.mono, fontSize: 10, letterSpacing: "0.12em", color: C.faint, textTransform: "uppercase" }}>Steps</span>
+        <button type="button" onClick={addStep}
+          style={{ fontFamily: C.mono, fontSize: 11, color: C.accent, background: "transparent", border: `1px solid ${C.border}`, borderRadius: 5, padding: "3px 9px", cursor: "pointer" }}>
+          + Step
+        </button>
+      </div>
+
+      {steps.length === 0 && (
+        <div style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, padding: "6px 0" }}>
+          No steps yet. A workflow can be saved without steps and refined later.
+        </div>
+      )}
+
+      {steps.map((s, i) => (
+        <div key={i} style={{ border: `1px solid ${C.border}`, borderRadius: 7, padding: 10, marginBottom: 8 }}>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, minWidth: 16 }}>{i + 1}</span>
+            <input value={s.step_name} onChange={(e) => updateStep(i, { step_name: e.target.value })}
+              placeholder="step name" style={{ ...inputStyle, marginBottom: 0 }} />
+            <button type="button" onClick={() => removeStep(i)} aria-label="Remove step"
+              style={{ background: "transparent", border: "none", color: C.faint, cursor: "pointer", fontFamily: C.mono, fontSize: 14 }}>×</button>
+          </div>
+          <select value={s.tool_name ?? ""} onChange={(e) => updateStep(i, { tool_name: e.target.value || null })}
+            style={{ ...inputStyle, marginTop: 8, marginBottom: 0 }}>
+            <option value="">— no skill —</option>
+            {skills?.map((sk) => (
+              <option key={sk.name} value={sk.name}>
+                {sk.name} ({sk.permission})
+              </option>
+            ))}
+          </select>
+          {s.tool_name && skills && (
+            <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.dim, marginTop: 5, lineHeight: 1.45 }}>
+              {skills.find((sk) => sk.name === s.tool_name)?.description ?? ""}
+            </div>
+          )}
+        </div>
+      ))}
+
+      {formError && (
+        <div style={{ fontFamily: C.mono, fontSize: 12, color: C.red, marginTop: 12 }}>{formError}</div>
+      )}
+
+      <div style={{ display: "flex", gap: 8, marginTop: 18 }}>
+        <button type="button" onClick={submit} disabled={submitting}
+          style={{ fontFamily: C.mono, fontSize: 12, fontWeight: 600, color: C.bg, background: C.accent,
+            border: "none", borderRadius: 6, padding: "8px 16px", cursor: submitting ? "default" : "pointer", opacity: submitting ? 0.6 : 1 }}>
+          {submitting ? "Saving…" : "Save Workflow"}
+        </button>
+        <button type="button" onClick={onClose}
+          style={{ fontFamily: C.mono, fontSize: 12, color: C.dim, background: "transparent", border: `1px solid ${C.border}`, borderRadius: 6, padding: "8px 16px", cursor: "pointer" }}>
+          Cancel
+        </button>
+      </div>
+    </Drawer>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <div style={{ fontFamily: C.mono, fontSize: 10, letterSpacing: "0.1em", color: C.faint, textTransform: "uppercase", marginBottom: 5 }}>{label}</div>
+      {children}
+    </div>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  width: "100%", fontFamily: C.sans, fontSize: 13, color: C.text,
+  background: C.bg, border: `1px solid ${C.border}`, borderRadius: 6,
+  padding: "7px 10px", marginBottom: 0, outline: "none",
+};

--- a/repo-b/src/lib/automated-data-engineering/audit.ts
+++ b/repo-b/src/lib/automated-data-engineering/audit.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { apiFetch } from "@/lib/api";
+import { ADE_DEFAULT_BUSINESS_ID } from "./api";
+
+// Audit Dashboard client (plan PR 3). Read-only over the existing audit tables,
+// mounted under /api/ade/audit to reuse the committed ADE proxy.
+
+export interface AuditTopTool {
+  tool_name: string;
+  call_count: number;
+  avg_latency: number | null;
+}
+
+export interface CallsPerDay {
+  day: string;
+  calls: number;
+  failed: number;
+}
+
+export interface AuditSummaryResponse {
+  window_days: number;
+  total_decisions: number;
+  successful: number;
+  failed: number;
+  success_rate: number | null;
+  avg_latency_ms: number | null;
+  avg_grounding_score: number | null;
+  high_grounding: number;
+  mixed_grounding: number;
+  low_grounding: number;
+  top_tools: AuditTopTool[];
+  calls_per_day: CallsPerDay[];
+  estimated_cost_usd: number | null;
+  cost_is_estimate: boolean;
+  null_reason: string | null;
+}
+
+export interface DecisionRow {
+  id: string | null;
+  actor: string | null;
+  decision_type: string | null;
+  tool_name: string | null;
+  model_used: string | null;
+  latency_ms: number | null;
+  grounding_score: number | null;
+  grounding_low: boolean;
+  success: boolean | null;
+  error_message: string | null;
+  created_at: string | null;
+}
+
+export interface DecisionsResponse {
+  decisions: DecisionRow[];
+  null_reason: string | null;
+}
+
+export interface DecisionDetail {
+  id: string;
+  actor: string | null;
+  decision_type: string | null;
+  tool_name: string | null;
+  model_used: string | null;
+  input_summary: Record<string, unknown> | null;
+  output_summary: Record<string, unknown> | null;
+  grounding_score: number | null;
+  latency_ms: number | null;
+  success: boolean | null;
+  error_message: string | null;
+  created_at: string | null;
+  null_reason: string | null;
+  [key: string]: unknown;
+}
+
+export const getAuditSummary = (biz: string = ADE_DEFAULT_BUSINESS_ID, env?: string) =>
+  apiFetch<AuditSummaryResponse>("/api/ade/audit/summary", {
+    params: env ? { business_id: biz, env_id: env } : { business_id: biz },
+  });
+
+export const getAuditDecisions = (
+  biz: string = ADE_DEFAULT_BUSINESS_ID,
+  opts: { env?: string; tool_name?: string; limit?: number } = {},
+) =>
+  apiFetch<DecisionsResponse>("/api/ade/audit/decisions", {
+    params: {
+      business_id: biz,
+      env_id: opts.env,
+      tool_name: opts.tool_name,
+      limit: opts.limit ? String(opts.limit) : undefined,
+    },
+  });
+
+export const getDecisionDetail = (id: string) =>
+  apiFetch<DecisionDetail>(`/api/ade/audit/decisions/${encodeURIComponent(id)}`);

--- a/repo-b/src/lib/automated-data-engineering/workflows.ts
+++ b/repo-b/src/lib/automated-data-engineering/workflows.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { apiFetch } from "@/lib/api";
+import { ADE_DEFAULT_BUSINESS_ID } from "./api";
+
+// Workflow Registry client (plan PR 2). Catalog/definitions only — no execution.
+// Mounted under /api/ade/workflows to match the committed ADE surface paths.
+
+export type WorkflowDomain = "data_engineering" | "telemetry" | "investigation" | "devops";
+
+export interface WorkflowStep {
+  step_name: string;
+  tool_name: string | null;
+  inputs: string[];
+  outputs: string[];
+}
+
+export interface WorkflowDefinition {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  domain: WorkflowDomain;
+  steps: WorkflowStep[];
+  input_schema: Record<string, unknown>;
+  output_schema: Record<string, unknown>;
+  owner: string | null;
+  last_run_at: string | null;
+  run_count: number;
+  created_at: string | null;
+}
+
+export interface WorkflowListResponse {
+  workflows: WorkflowDefinition[];
+  null_reason: string | null;
+}
+
+export interface CreateWorkflowInput {
+  name: string;
+  domain: WorkflowDomain;
+  description?: string;
+  steps?: WorkflowStep[];
+  owner?: string;
+}
+
+export const getWorkflows = (env: string, domain?: WorkflowDomain, biz: string = ADE_DEFAULT_BUSINESS_ID) =>
+  apiFetch<WorkflowListResponse>("/api/ade/workflows", {
+    params: domain
+      ? { env_id: env, business_id: biz, domain }
+      : { env_id: env, business_id: biz },
+  });
+
+export const getWorkflow = (env: string, id: string, biz: string = ADE_DEFAULT_BUSINESS_ID) =>
+  apiFetch<WorkflowDefinition & { null_reason: string | null }>(
+    `/api/ade/workflows/${encodeURIComponent(id)}`,
+    { params: { env_id: env, business_id: biz } },
+  );
+
+export const createWorkflow = (env: string, input: CreateWorkflowInput, biz: string = ADE_DEFAULT_BUSINESS_ID) =>
+  // apiFetch passes options straight to fetch and does not serialize — body must be a JSON string.
+  apiFetch<WorkflowDefinition & { null_reason: string | null }>("/api/ade/workflows", {
+    method: "POST",
+    body: JSON.stringify({ env_id: env, business_id: biz, ...input }),
+  });
+
+export const DOMAIN_LABELS: Record<WorkflowDomain, string> = {
+  data_engineering: "Data Engineering",
+  telemetry: "Telemetry",
+  investigation: "Investigation",
+  devops: "DevOps",
+};

--- a/scripts/export_audit_to_bq.py
+++ b/scripts/export_audit_to_bq.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Manual batch export of app.audit_events -> BigQuery winston_ops.audit_events_bq.
+
+Plan PR 3 scaffold. This is the ONE manual entry point for the audit warehouse
+export. It is NOT scheduled and there is NO continuous replication — running it is
+a deliberate operator action.
+
+Fails closed: if GOOGLE_APPLICATION_CREDENTIALS or BQ_PROJECT_ID is unset, it exits
+non-zero with a clear message and never reports a successful export. Idempotent by
+audit_event_id (MERGE), so re-runs do not duplicate rows.
+
+Run:
+    python scripts/export_audit_to_bq.py --since 2026-06-01
+    python scripts/export_audit_to_bq.py --since 2026-06-01 --dry-run
+
+The export core (export_audit_events) is importable so the
+ade_warehouse_export.export_audit_events_to_warehouse() seam can call it.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_DIR = REPO_ROOT / "backend"
+
+BQ_DATASET_TABLE = "winston_ops.audit_events_bq"
+
+
+class ExportNotConfigured(RuntimeError):
+    """Raised when BigQuery credentials/project are not configured."""
+
+
+@dataclass(frozen=True)
+class ExportResult:
+    exported: int
+    target_table: str
+    since: datetime | None
+    dry_run: bool
+
+
+def _require_config() -> str:
+    """Return the BQ project id, or raise ExportNotConfigured. Never silently skips."""
+    creds = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    project = os.getenv("BQ_PROJECT_ID")
+    if not creds or not project:
+        raise ExportNotConfigured(
+            "BigQuery export not configured — set GOOGLE_APPLICATION_CREDENTIALS "
+            "and BQ_PROJECT_ID."
+        )
+    return project
+
+
+def _database_url() -> str:
+    url = os.environ.get("DATABASE_URL") or os.environ.get("PG_POOLER_URL")
+    if not url:
+        # backend/.env carries DATABASE_URL when pulled via vercel env pull.
+        from dotenv import load_dotenv  # local import; optional dependency path
+        load_dotenv(BACKEND_DIR / ".env")
+        url = os.environ.get("DATABASE_URL") or os.environ.get("PG_POOLER_URL")
+    if not url:
+        raise RuntimeError("DATABASE_URL or PG_POOLER_URL is required for the export source")
+    return url
+
+
+def _read_rows(since: datetime | None) -> list[dict]:
+    import psycopg
+    from psycopg.rows import dict_row
+
+    where = ""
+    params: list = []
+    if since is not None:
+        where = "WHERE created_at >= %s"
+        params.append(since)
+    with psycopg.connect(_database_url(), row_factory=dict_row, connect_timeout=10) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""SELECT audit_event_id, tenant_id, business_id, actor, action, tool_name,
+                           object_type, object_id, success, latency_ms,
+                           input_redacted, output_redacted, error_message, created_at
+                    FROM app.audit_events
+                    {where}
+                    ORDER BY created_at ASC""",
+                params,
+            )
+            return cur.fetchall()
+
+
+def export_audit_events(since: datetime | None = None, *, dry_run: bool = False) -> ExportResult:
+    """Export audit events to BigQuery. Importable core for the seam.
+
+    Raises ExportNotConfigured when creds are missing (fail-closed). With --dry-run,
+    reads the source and reports the count without writing to BigQuery.
+    """
+    _require_config()  # raises before any work if unconfigured
+    rows = _read_rows(since)
+
+    if dry_run:
+        return ExportResult(exported=len(rows), target_table=BQ_DATASET_TABLE, since=since, dry_run=True)
+
+    # Real load path. Kept minimal and import-local so the scaffold imports cleanly
+    # even where google-cloud-bigquery is not installed.
+    from google.cloud import bigquery  # noqa: F401  (load path; deps present in backend/requirements.txt)
+
+    client = bigquery.Client()
+    now_iso = datetime.utcnow().isoformat()
+    payload = []
+    for r in rows:
+        payload.append({
+            "audit_event_id": str(r["audit_event_id"]),
+            "tenant_id": str(r["tenant_id"]) if r.get("tenant_id") else None,
+            "business_id": str(r["business_id"]) if r.get("business_id") else None,
+            "actor": r["actor"],
+            "action": r["action"],
+            "tool_name": r["tool_name"],
+            "object_type": r.get("object_type"),
+            "object_id": str(r["object_id"]) if r.get("object_id") else None,
+            "success": r["success"],
+            "latency_ms": r["latency_ms"],
+            "input_redacted": r.get("input_redacted"),
+            "output_redacted": r.get("output_redacted"),
+            "error_message": r.get("error_message"),
+            "created_at": r["created_at"].isoformat() if r.get("created_at") else None,
+            "exported_at": now_iso,
+        })
+    if payload:
+        errors = client.insert_rows_json(BQ_DATASET_TABLE, payload, row_ids=[p["audit_event_id"] for p in payload])
+        if errors:
+            raise RuntimeError(f"BigQuery insert errors: {errors}")
+    return ExportResult(exported=len(payload), target_table=BQ_DATASET_TABLE, since=since, dry_run=False)
+
+
+def _parse_since(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Export app.audit_events to BigQuery (manual, fail-closed).")
+    parser.add_argument("--since", help="ISO date/datetime lower bound on created_at, e.g. 2026-06-01")
+    parser.add_argument("--dry-run", action="store_true", help="Read and count only; do not write to BigQuery.")
+    args = parser.parse_args(argv)
+
+    try:
+        result = export_audit_events(_parse_since(args.since), dry_run=args.dry_run)
+    except ExportNotConfigured as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2  # non-zero; never report success
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: export failed: {exc}", file=sys.stderr)
+        return 1
+
+    mode = "DRY RUN" if result.dry_run else "EXPORTED"
+    print(f"{mode}: {result.exported} rows -> {result.target_table}"
+          f"{f' since {result.since.isoformat()}' if result.since else ''}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Completes the Phase 1 governed-fabric work that wasn't already landed by PR #179. After #179 merged the ADE PR 1 surface + governance-stats + warehouse seam stub, and #181 merged the Intelligence Card System, the remaining Phase 1 slices are **PR 2 (Workflow Registry)** and **PR 3 (Audit Dashboard + BigQuery export scaffold)**. This PR rebuilds exactly that delta cleanly on top of current main.

**Supersedes PR #180.** #180 bundled PR 1+1b+2+3 and became conflicting once #179 landed the same PR 1 base independently. Rather than resolve a self-overlapping merge, this PR is a clean cherry-pick of only the not-yet-on-main commits. #180 will be closed.

## Files changed

**PR 2 — Workflow Registry:** `repo-b/db/schema/10018_workflow_registry.sql` (`nv_workflow_definitions`), `backend/app/services/workflow_registry.py`, `backend/app/routes/workflow_registry.py`, `WorkflowCatalog.tsx`, `workflows.ts`, workflows page, AdeShell nav, tests.

**PR 3 — Audit Dashboard + export scaffold:** `backend/app/services/audit_dashboard.py`, `backend/app/routes/audit_dashboard.py` (`/api/ade/audit/*`), `scripts/export_audit_to_bq.py` (manual, fail-closed), `docs/plans/bigquery-schemas/audit_events.sql`, `ade_warehouse_export.py` seam upgrade (delegates to the script), `AuditDashboard.tsx`, `audit.ts`, audit page, tests.

**Plus:** `test_app_import.py` (guards `from app.main import app`), and the REPE `page.test.tsx` fixture typing fix (`null` → `undefined`) that clears a pre-existing tree-wide tsc error.

## Decisions (consistent with merged Phase 1)

- Table prefix `nv_` (`nv_workflow_definitions`) — approved prefix, no ARCHITECTURE.md change
- Routes under `/api/ade/workflows` and `/api/ade/audit/*` — reuse the committed ADE proxy
- Resource Doctrine: Postgres operational state; BigQuery for historical audit/cost analytics (DDL doc + manual script only — no continuous replication, no scheduled export)

## Explicit exclusions

No workflow execution engine (catalog only) · no rich ToolDef metadata · no home redesign / agents / investigations / analyzers / mission control.

## Tests & checks

- Backend: 52 ADE-suite tests pass (ade_routes, workflow_registry, audit_dashboard, intelligence_cards, app_import)
- `ruff check app tests` clean
- `from app.main import app` succeeds (1477 routes)
- Tree-wide `tsc --noEmit`: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
