### PR TITLE
Phase 2 PR 5: Executive Intelligence Home

### DIFF
--- a/repo-b/src/app/app/page.tsx
+++ b/repo-b/src/app/app/page.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import React, { Suspense, useEffect, useMemo, useState } from "react";
+import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 
 import AccountMenu from "@/components/AccountMenu";
-import { useEnv } from "@/components/EnvProvider";
+import { useEnv, type Environment } from "@/components/EnvProvider";
 import { humanIndustry } from "@/components/lab/environments/constants";
+import IntelligenceCardFeed from "@/components/intelligence/IntelligenceCardFeed";
+import {
+  getCards,
+  upsertCard,
+  dismissCard,
+  type IntelCard,
+} from "@/lib/intelligence/cards";
 import { cn } from "@/lib/cn";
 import {
   environmentCatalog,
@@ -46,55 +53,192 @@ const SYSTEM_LINKS = [
   { href: "/lab/system/ai-usage", label: "AI Usage", detail: "Token spend, attribution, and savings recommendations" },
 ] as const;
 
-// ── Mode A: default overview ──────────────────────────────────────────────────
-function CenterModeA({
-  envCount,
-  isPlatformAdmin,
-}: {
-  envCount: number;
-  isPlatformAdmin: boolean;
-}) {
-  return (
-    <div className="space-y-5">
-      <div className="space-y-2">
-        <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-white/45">
-          Execution layer
-        </p>
-        <h2 className="text-[clamp(1.75rem,3.2vw,2.4rem)] font-semibold leading-tight tracking-tight text-white">
-          Ready
-        </h2>
-        <p className="max-w-xl text-sm leading-6 text-white/60">
-          {envCount > 0
-            ? `${envCount} workspace${envCount === 1 ? "" : "s"} provisioned. Select one from the rail on the left to enter.`
-            : "Access is provisioned per environment. Once a workspace is assigned to your account, it will appear in the rail on the left."}
-        </p>
-      </div>
+// Novendor action color — teal/cyan, used for primary CTA and selected accents.
+const ACTION_TEAL = "92, 213, 204";
 
-      <div className="flex flex-wrap items-center gap-3 font-mono text-[10px] uppercase tracking-[0.22em] text-white/45">
-        <span className="inline-flex items-center gap-2">
-          <span
-            className="inline-block h-1.5 w-1.5 rounded-full"
-            style={{ backgroundColor: "rgba(107, 174, 127, 0.95)" }}
-          />
-          AI gateway online
+// Deterministic source_ref for the one seeded dashboard card per environment.
+// Seeding is idempotent: the backend upserts on (env_id, source_ref_key).
+function dashboardSourceRef(envId: string) {
+  return { type: "app_home_dashboard", env_id: envId };
+}
+
+// ── Agent pills: VISUAL-ONLY scaffold (PR 5). No logic, no handlers, no routing. ──
+const AGENT_PILLS = [
+  { label: "CFO", glow: ACTION_TEAL },
+  { label: "Operations", glow: "107, 174, 127" },
+  { label: "Data Quality", glow: "176, 64, 255" },
+  { label: "Risk", glow: "209, 161, 91" },
+] as const;
+
+function AgentPills() {
+  return (
+    <div className="flex flex-wrap items-center gap-2" aria-label="Agents (preview)">
+      <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/35">
+        Agents
+      </span>
+      {AGENT_PILLS.map((agent) => (
+        <span
+          key={agent.label}
+          aria-disabled
+          title="Coming soon"
+          className="inline-flex shrink-0 items-center gap-2 rounded-full border px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] text-white/55"
+          style={{ borderColor: `rgba(${agent.glow}, 0.22)`, background: `rgba(${agent.glow}, 0.06)` }}
+        >
+          <span className="h-1.5 w-1.5 rounded-full" style={{ background: `rgba(${agent.glow}, 0.8)` }} />
+          {agent.label}
         </span>
-        <span className="text-white/20">/</span>
-        <span>{envCount} environment{envCount === 1 ? "" : "s"}</span>
-        {isPlatformAdmin && (
-          <>
-            <span className="text-white/20">/</span>
-            <span style={{ color: "rgba(92, 213, 204, 0.85)" }}>Platform admin</span>
-          </>
-        )}
-      </div>
+      ))}
     </div>
   );
 }
 
-// Novendor action color — teal/cyan, used for primary CTA and selected accents.
-const ACTION_TEAL = "92, 213, 204";
+// ── Derived environment status (PR 5) ─────────────────────────────────────────
+// Honest, derived from KNOWN client-side fields only. No invented health_score,
+// no numeric percentage. promotion_state is NOT available on the client Environment
+// type, so its branches are forward-compat and unreachable this PR — we never fetch it.
+type EnvStatusTone = "teal" | "amber" | "muted";
+type EnvStatus = { label: string; tone: EnvStatusTone; reason: string | null };
 
-// ── Mode B: workspace preview ─────────────────────────────────────────────────
+const PROMO_DEGRADED = new Set(["degraded", "blocked", "failed", "error", "broken"]);
+const PROMO_PENDING = new Set(["pending", "draft", "in_progress", "provisioning", "queued"]);
+
+function deriveEnvironmentStatus(
+  env: Environment | null,
+  anomalyCount: number,
+  bizId: string | null,
+  promotionState?: string | null, // omitted by callers — forward-compat only
+): EnvStatus {
+  if (!env) {
+    return { label: "Status unavailable", tone: "muted", reason: "No environment selected." };
+  }
+  if (typeof env.is_active !== "boolean" || !env.env_id) {
+    return { label: "Status unavailable", tone: "muted", reason: "Required environment fields not loaded." };
+  }
+  // Inactive wins: a dead env's signals are moot.
+  if (env.is_active === false) {
+    return { label: "Inactive", tone: "amber", reason: null };
+  }
+  // Forward-compat (unreachable now — promotionState is always undefined).
+  const ps = promotionState?.toLowerCase();
+  if (ps && PROMO_DEGRADED.has(ps)) {
+    return { label: "Needs attention", tone: "amber", reason: `Promotion state: ${promotionState}` };
+  }
+  // No tenant → intelligence cannot be scoped → fail closed (never use the default tenant).
+  if (!bizId) {
+    return {
+      label: "Status unavailable",
+      tone: "muted",
+      reason: "No tenant (business_id) resolved; intelligence cannot be scoped.",
+    };
+  }
+  // The real signal this PR ships: open anomaly cards for the scoped env.
+  if (anomalyCount > 0) {
+    return {
+      label: "Needs attention",
+      tone: "amber",
+      reason: `${anomalyCount} open anomaly card${anomalyCount === 1 ? "" : "s"}.`,
+    };
+  }
+  if (ps && PROMO_PENDING.has(ps)) {
+    return { label: "In progress", tone: "teal", reason: `Promotion state: ${promotionState}` };
+  }
+  return { label: "Healthy", tone: "teal", reason: "Derived from active state and open cards. Promotion state not loaded." };
+}
+
+// ── Intelligence feed hook (PR 5) ─────────────────────────────────────────────
+// Binds to the SELECTED environment (never hover). Fails closed when there is no
+// real business_id — never falls back to the cards.ts default tenant.
+type FeedState = {
+  cards: IntelCard[];
+  loading: boolean;
+  error: string | null;
+  nullReason: string | null;
+};
+
+function useIntelligenceFeed(env: Environment | null, bizId: string | null) {
+  const [state, setState] = useState<FeedState>({
+    cards: [],
+    loading: false,
+    error: null,
+    nullReason: null,
+  });
+  // Keys we've attempted to seed this mount — guards against double-seed.
+  const seededRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    // Fail closed: no env, or no real tenant → no fetch, no seed.
+    if (!env || !bizId) {
+      setState({
+        cards: [],
+        loading: false,
+        error: null,
+        nullReason: !env ? null : "missing_business_id",
+      });
+      return;
+    }
+
+    let cancelled = false;
+    setState((s) => ({ ...s, loading: true, error: null, nullReason: null }));
+
+    (async () => {
+      const seedKey = `${env.env_id}:${bizId}`;
+      try {
+        const { cards, null_reason } = await getCards(env.env_id, { biz: bizId, limit: 50 });
+        if (cancelled) return;
+        setState({ cards, loading: false, error: null, nullReason: null_reason ?? null });
+
+        // Seed ONE dashboard card only on a clean-empty result (not failure/null_reason).
+        if (cards.length === 0 && !null_reason && !seededRef.current.has(seedKey)) {
+          seededRef.current.add(seedKey); // mark before await — no double-fire
+          const title = env.client_name?.trim() || "Workspace";
+          try {
+            const created = await upsertCard(
+              env.env_id,
+              {
+                card_type: "dashboard",
+                title,
+                summary: `Open the ${humanIndustry(env.industry_type || env.industry)} workspace.`,
+                source_ref: dashboardSourceRef(env.env_id),
+                priority_score: 0,
+                anomaly_flag: false,
+                created_by: "system",
+              },
+              bizId,
+            );
+            // Optimistic insert — NO refetch (avoids the eventual-consistency seed loop).
+            if (!cancelled && created?.id) {
+              setState((s) => ({ ...s, cards: [created, ...s.cards] }));
+            }
+          } catch {
+            // Best-effort: seeding failure is non-fatal; seededRef already marked.
+          }
+        }
+      } catch (cause) {
+        if (cancelled) return;
+        setState({
+          cards: [],
+          loading: false,
+          error: cause instanceof Error ? cause.message : "Failed to load intelligence",
+          nullReason: null,
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // Primitive deps — one fetch per (env, tenant) selection, never per hover.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [env?.env_id, bizId]);
+
+  const removeCard = useCallback((cardId: string) => {
+    setState((s) => ({ ...s, cards: s.cards.filter((c) => c.id !== cardId) }));
+  }, []);
+
+  return { ...state, removeCard };
+}
+
+// ── Mode B: workspace preview (reachable via toggle) ──────────────────────────
 function CenterModeB({
   environment,
   onOpen,
@@ -217,10 +361,12 @@ function workspaceDescription(
   return map[key] || "Operational workspace for the connected business surface.";
 }
 
-// ── Side panel: workspace metadata strip ──────────────────────────────────────
-function SidePanel({
+// ── Environment Status panel (PR 5) — derived status, NOT a health score ──────
+function EnvironmentStatusPanel({
   environment,
+  envStatus,
   envCount,
+  variant = "desktop",
 }: {
   environment: {
     env_id: string;
@@ -230,23 +376,23 @@ function SidePanel({
     industry_type?: string | null;
     workspace_template_key?: string | null;
     is_active?: boolean;
-    created_at?: string;
   } | null;
+  envStatus: EnvStatus;
   envCount: number;
+  variant?: "desktop" | "mobile";
 }) {
   const tone = environment ? environmentTone(environment) : { glow: "148, 163, 184" };
-  const capConfig = environment
-    ? getCapabilityConfig(
-        environment.workspace_template_key,
-        environment.industry_type || environment.industry,
-      )
-    : null;
   const templateLabel = environment?.workspace_template_key
     ? environment.workspace_template_key.replace(/_/g, " ")
     : "—";
 
+  const shellClass =
+    variant === "desktop"
+      ? "hidden w-[280px] shrink-0 xl:block"
+      : "block xl:hidden";
+
   return (
-    <aside className="hidden w-[280px] shrink-0 xl:block">
+    <aside className={shellClass}>
       <div
         className="rounded-md border bg-[rgba(8,11,18,0.7)] p-5"
         style={{
@@ -255,38 +401,48 @@ function SidePanel({
         }}
       >
         <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-white/45">
-          Workspace
+          Environment Status
         </p>
 
         {environment ? (
           <div className="mt-4 space-y-4">
-            <SidePanelRow label="Type" value={capConfig?.entryLabel.replace(/^Open\s+/, "") || "—"} />
-            <SidePanelRow label="Template" value={templateLabel} mono />
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-white/42">
+                Status
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <span
+                  className="inline-block h-1.5 w-1.5 rounded-full"
+                  style={{ backgroundColor: statusToneColor(envStatus.tone) }}
+                />
+                <span
+                  className="text-right text-[13px]"
+                  style={{ color: statusToneColor(envStatus.tone) }}
+                  title={envStatus.reason ?? undefined}
+                >
+                  {envStatus.label}
+                </span>
+              </span>
+            </div>
+            {envStatus.reason ? (
+              <p className="-mt-2 text-right text-[11px] leading-4 text-white/40">
+                {envStatus.reason}
+              </p>
+            ) : null}
             <SidePanelRow
               label="Industry"
               value={humanIndustry(environment.industry_type || environment.industry)}
             />
-            <SidePanelRow
-              label="Status"
-              value={environment.is_active === false ? "Inactive" : "Active"}
-              tone={environment.is_active === false ? "amber" : "teal"}
-            />
-            <SidePanelRow
-              label="Env ID"
-              value={environment.env_id.slice(0, 8)}
-              mono
-            />
+            <SidePanelRow label="Template" value={templateLabel} mono />
+            <SidePanelRow label="Env ID" value={environment.env_id.slice(0, 8)} mono />
           </div>
         ) : (
           <div className="mt-4 space-y-3 text-sm text-white/55">
-            <p>Select a workspace from the rail to see details.</p>
+            <p>Select a workspace from the rail to see its status.</p>
           </div>
         )}
 
-        <div
-          className="mt-6 border-t pt-4"
-          style={{ borderColor: "rgba(232,236,242,0.08)" }}
-        >
+        <div className="mt-6 border-t pt-4" style={{ borderColor: "rgba(232,236,242,0.08)" }}>
           <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-white/45">
             Session
           </p>
@@ -308,6 +464,8 @@ function SidePanel({
           </div>
         </div>
 
+        {/* TODO(PR6): environment comparison mode */}
+
         {environment ? (
           <div
             aria-hidden
@@ -320,6 +478,12 @@ function SidePanel({
       </div>
     </aside>
   );
+}
+
+function statusToneColor(tone: EnvStatusTone): string {
+  if (tone === "amber") return "rgba(209, 161, 91, 0.95)";
+  if (tone === "teal") return "rgba(140, 200, 158, 0.95)";
+  return "rgba(255,255,255,0.55)";
 }
 
 function SidePanelRow({
@@ -354,13 +518,13 @@ function SidePanelRow({
   );
 }
 
-
 function AppIndexPageInner() {
   const searchParams = useSearchParams();
   const { environments, selectedEnv, selectEnv, loading, isPlatformAdmin } = useEnv();
   const [openingEnvId, setOpeningEnvId] = useState<string | null>(null);
   const [hoveredEnvId, setHoveredEnvId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [showPreview, setShowPreview] = useState(false);
 
   const deniedTarget = searchParams.get("denied");
   const selectedEnvironment = useMemo(
@@ -371,11 +535,28 @@ function AppIndexPageInner() {
     ? assertEnvironmentClientName(selectedEnvironment)
     : null;
 
-  // State priority: hovered > selected > null
+  // Hover drives ONLY the workspace preview, never the feed.
   const previewEnvironment = useMemo(
     () => environments.find((e) => e.env_id === hoveredEnvId) ?? selectedEnvironment ?? null,
     [hoveredEnvId, selectedEnvironment, environments],
   );
+
+  // Intelligence feed binds to the SELECTED environment + its tenant (fail-closed).
+  const bizId = selectedEnvironment?.business_id ?? null;
+  const feed = useIntelligenceFeed(selectedEnvironment, bizId);
+  const anomalyCount = useMemo(
+    () => feed.cards.filter((c) => c.anomaly_flag && !c.is_dismissed).length,
+    [feed.cards],
+  );
+  const envStatus = useMemo(
+    () => deriveEnvironmentStatus(selectedEnvironment, anomalyCount, bizId),
+    [selectedEnvironment, anomalyCount, bizId],
+  );
+
+  // Reset the preview toggle when the selected env changes.
+  useEffect(() => {
+    setShowPreview(false);
+  }, [selectedEnvironment?.env_id]);
 
   async function openEnvironment(envId: string, slug?: string | null) {
     setOpeningEnvId(envId);
@@ -399,6 +580,33 @@ function AppIndexPageInner() {
     }
   }
 
+  // Card open: dashboard cards carry {type:'app_home_dashboard', env_id}; route through openEnvironment.
+  const handleCardOpen = useCallback(
+    (card: IntelCard) => {
+      const ref = card.source_ref as { type?: string; env_id?: string } | null;
+      const targetId = ref?.env_id;
+      const target = targetId ? environments.find((e) => e.env_id === targetId) : null;
+      if (target) {
+        void openEnvironment(target.env_id, target.slug || null);
+      }
+      // Non-environment cards have no destination yet (investigations are a later PR) — no-op.
+    },
+    // openEnvironment is a stable closure recreated each render; environments is the real dep.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [environments],
+  );
+
+  const handleCardDismiss = useCallback(
+    (card: IntelCard) => {
+      if (!selectedEnvironment || !bizId) return;
+      feed.removeCard(card.id); // optimistic
+      void dismissCard(selectedEnvironment.env_id, card.id, bizId).catch(() => {
+        // Best-effort; the next load reflects server truth.
+      });
+    },
+    [selectedEnvironment, bizId, feed],
+  );
+
   useEffect(() => {
     if (loading || environments.length !== 1 || isPlatformAdmin || deniedTarget) {
       return;
@@ -413,9 +621,24 @@ function AppIndexPageInner() {
     ? `You do not have access to ${deniedTarget}. Your account can only enter provisioned environments.`
     : null;
 
-  // Determine center panel mode
-  const centerMode: "A" | "B" =
-    previewEnvironment === null ? "A" : "B";
+  const feedSection = (
+    <section
+      className="bm-bridge relative rounded-md border bg-[rgba(8,11,18,0.55)] p-5 backdrop-blur-md"
+      style={{
+        borderColor: "rgba(232,236,242,0.10)",
+        boxShadow: "inset 0 1px 0 0 rgba(255,255,255,0.06), 0 28px 56px -32px rgba(0,0,0,0.7)",
+      }}
+    >
+      <IntelligenceCardFeed
+        cards={feed.cards}
+        loading={feed.loading}
+        error={feed.error}
+        nullReason={feed.nullReason}
+        onOpen={handleCardOpen}
+        onDismiss={handleCardDismiss}
+      />
+    </section>
+  );
 
   return (
     <div className="min-h-screen bg-[#03070e] text-white">
@@ -498,6 +721,20 @@ function AppIndexPageInner() {
               </button>
             ) : null}
           </section>
+
+          {/* Agent pills (visual-only) */}
+          <AgentPills />
+
+          {/* Intelligence feed — the core of the home, kept near the top on mobile too */}
+          {feedSection}
+
+          {/* Environment Status (inline on mobile) */}
+          <EnvironmentStatusPanel
+            environment={previewEnvironment}
+            envStatus={envStatus}
+            envCount={environments.length}
+            variant="mobile"
+          />
 
           {/* Provisioned workspaces list */}
           <section className="rounded-[1.6rem] border border-white/10 bg-white/[0.03] p-4">
@@ -737,7 +974,7 @@ function AppIndexPageInner() {
           {/* Content area */}
           <div className="flex flex-1 px-8 pt-10 pb-8 lg:px-10 xl:px-12 2xl:px-14">
             <div className="grid w-full grid-cols-1 gap-8 xl:grid-cols-[minmax(0,1fr)_280px] 2xl:gap-10">
-              {/* Primary detail panel — anchored top-left */}
+              {/* Primary column — intelligence feed (or workspace preview via toggle) */}
               <div className="min-w-0 space-y-4">
                 {deniedMessage ? (
                   <div
@@ -765,42 +1002,44 @@ function AppIndexPageInner() {
                   </div>
                 ) : null}
 
-                <div
-                  className="relative rounded-md border bg-[rgba(8,11,18,0.7)] p-7 backdrop-blur-md"
-                  style={{
-                    borderColor: previewEnvironment
-                      ? `rgba(${ACTION_TEAL}, 0.22)`
-                      : "rgba(232,236,242,0.10)",
-                    boxShadow: previewEnvironment
-                      ? `inset 0 1px 0 0 rgba(${ACTION_TEAL}, 0.16), 0 0 0 1px rgba(${ACTION_TEAL}, 0.06), 0 28px 56px -32px rgba(0,0,0,0.7)`
-                      : "inset 0 1px 0 0 rgba(255,255,255,0.06), 0 28px 56px -32px rgba(0,0,0,0.7)",
-                  }}
-                >
-                  <div
-                    key={previewEnvironment?.env_id ?? "mode-a"}
-                    className="transition-opacity duration-200"
-                  >
-                    {centerMode === "A" && (
-                      <CenterModeA
-                        envCount={environments.length}
-                        isPlatformAdmin={isPlatformAdmin}
-                      />
-                    )}
-                    {centerMode === "B" && previewEnvironment && (
-                      <CenterModeB
-                        environment={previewEnvironment}
-                        onOpen={() => void openEnvironment(previewEnvironment.env_id, previewEnvironment.slug || null)}
-                        isOpening={openingEnvId === previewEnvironment.env_id}
-                      />
-                    )}
-                  </div>
+                <div className="flex items-center justify-between gap-4">
+                  <AgentPills />
+                  {selectedEnvironment ? (
+                    <button
+                      type="button"
+                      onClick={() => setShowPreview((v) => !v)}
+                      className="shrink-0 font-mono text-[10px] uppercase tracking-[0.2em] text-white/45 transition-colors hover:text-white/75"
+                    >
+                      {showPreview ? "← Intelligence" : "Workspace preview →"}
+                    </button>
+                  ) : null}
                 </div>
+
+                {showPreview && previewEnvironment ? (
+                  <div
+                    className="relative rounded-md border bg-[rgba(8,11,18,0.7)] p-7 backdrop-blur-md"
+                    style={{
+                      borderColor: `rgba(${ACTION_TEAL}, 0.22)`,
+                      boxShadow: `inset 0 1px 0 0 rgba(${ACTION_TEAL}, 0.16), 0 0 0 1px rgba(${ACTION_TEAL}, 0.06), 0 28px 56px -32px rgba(0,0,0,0.7)`,
+                    }}
+                  >
+                    <CenterModeB
+                      environment={previewEnvironment}
+                      onOpen={() => void openEnvironment(previewEnvironment.env_id, previewEnvironment.slug || null)}
+                      isOpening={openingEnvId === previewEnvironment.env_id}
+                    />
+                  </div>
+                ) : (
+                  feedSection
+                )}
               </div>
 
-              {/* Secondary side panel — workspace metadata */}
-              <SidePanel
+              {/* Right column — derived Environment Status */}
+              <EnvironmentStatusPanel
                 environment={previewEnvironment}
+                envStatus={envStatus}
                 envCount={environments.length}
+                variant="desktop"
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary

Phase 2 / PR 5 — rewrites `/app` (`repo-b/src/app/app/page.tsx`) into an **executive intelligence home**. The main content becomes the `IntelligenceCardFeed` (from PR 4), while the existing environment rail and open-flow stay intact. Single-file change (+346/−107).

## Scope included

- **Intelligence feed as the main content**, bound to the **selected** environment (never hover — avoids a per-hover fetch storm).
- **Fail-closed on `business_id`:** if no real tenant resolves, no fetch / no seed, and status shows "Status unavailable". Never falls back to the `cards.ts` default tenant (that would collapse null-tenant envs onto one tenant — a cross-tenant hazard).
- **Idempotent card seeding:** on a clean-empty feed, seed one `dashboard` card per environment via a deterministic `source_ref` (`{type:'app_home_dashboard', env_id}`). Mark-before-await guard, optimistic insert, **no** post-seed refetch (avoids the eventual-consistency seed loop). Backend upserts on `(env_id, source_ref_key)`.
- **Environment Status sidebar** — derived status from existing client-side fields only:
  - `is_active===false` → "Inactive"
  - open anomaly-card count > 0 → "Needs attention"
  - otherwise → "Healthy"
  - no tenant / missing fields → "Status unavailable" (+ reason tooltip)
  - Labeled **"Environment Status"**, not "Health Score". **No numeric percentage, no invented metric.** `promotion_state` branches exist for forward-compat but are never fetched (honest — it's not on the client `Environment` type).
- **Visual-only agent pills** (CFO, Operations, Data Quality, Risk) — `aria-disabled`, no handlers, no routing.
- **Workspace preview** reachable via a toggle; left env rail, `openEnvironment`, `switchPlatformEnvironment`, single-env auto-open all unchanged.
- **Mobile** keeps the feed near the top; status panel renders inline; rail/list/admin sections byte-for-byte.

## Explicit exclusions

real agent logic · investigation backend · trailers/reels · analyzers · mission control · enterprise memory · workflow execution · rich ToolDef metadata · new warehouse work · invented health metrics · new backend. **Comparison mode deferred** (`// TODO(PR6)`).

## Design + review

Designed via a multi-agent workflow (3 design lenses → synthesis → adversarial review). The review caught and I resolved: the platform-admin `business_id` question (verified `/v1/environments` returns `business_id` per env, so the feed works for admins; truly-unbound envs honestly show "Status unavailable"), the `upsertCard` return shape (returns full `IntelCard` → optimistic insert safe), `dashboard` being a valid card_type, and undefined card handlers (now defined: open routes through `openEnvironment` via `source_ref`; dismiss is optimistic + `dismissCard`).

## Tests & checks

- Tree-wide `tsc --noEmit`: 0 errors
- ESLint on `page.tsx`: clean
- No home-page tests exist; `page.tsx` only default-exports (no external importers)
- No backend touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
