### PR TITLE
Phase 3 PR 7: Investigation Workspace Frontend

### DIFF
--- a/repo-b/src/app/app/investigate/[sessionId]/layout.tsx
+++ b/repo-b/src/app/app/investigate/[sessionId]/layout.tsx
@@ -1,0 +1,12 @@
+import { EnvProvider } from "@/components/EnvProvider";
+import { WinstonProviders } from "@/components/Providers";
+
+// Full-bleed standalone investigation workspace (plan PR 7). Provides env context
+// (EnvProvider) but NOT the app shell — the workspace owns the whole viewport.
+export default function InvestigateLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <WinstonProviders>
+      <EnvProvider>{children}</EnvProvider>
+    </WinstonProviders>
+  );
+}

--- a/repo-b/src/app/app/investigate/[sessionId]/page.tsx
+++ b/repo-b/src/app/app/investigate/[sessionId]/page.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { use, useMemo } from "react";
+import Link from "next/link";
+
+import { useEnv } from "@/components/EnvProvider";
+import {
+  useSessionStream, pauseSession, resumeSession, forkSession,
+  type LiveSection, type SectionClaim,
+} from "@/lib/investigation/sessionStream";
+
+// Investigation Workspace (plan PR 7). Full-bleed standalone. Renders ONLY events the
+// backend streams; missing sections show their null_reason. No fabricated content.
+// Steering chat rail is PR 8 — not here.
+
+const STATUS_TONE: Record<string, string> = {
+  idle: "148,163,184", streaming: "92,213,204", paused: "209,161,91",
+  completed: "107,174,127", error: "212,122,114",
+};
+
+export default function InvestigatePage({ params }: { params: Promise<{ sessionId: string }> }) {
+  const { sessionId } = use(params);
+  const { selectedEnv, environments, loading } = useEnv();
+  const env = selectedEnv?.env_id ?? environments[0]?.env_id ?? null;
+  const biz = selectedEnv?.business_id ?? environments[0]?.business_id ?? undefined;
+
+  const stream = useSessionStream(env, sessionId, biz ?? undefined);
+  const tone = STATUS_TONE[stream.status] ?? STATUS_TONE.idle;
+
+  const progress = useMemo(() => {
+    const planned = stream.planSections.length || stream.sections.length;
+    const done = stream.sections.filter((s) => s.status !== "running").length;
+    return { planned, done };
+  }, [stream.planSections, stream.sections]);
+
+  if (!loading && !env) {
+    return (
+      <Shell>
+        <div className="rounded-md border border-white/10 bg-white/[0.04] px-5 py-4 text-sm text-white/70">
+          No environment selected. Open a workspace first, then launch an investigation.
+        </div>
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell>
+      {/* Header */}
+      <header className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <Link href="/app" className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/40 hover:text-white/70">
+            ← Back
+          </Link>
+          <h1 className="mt-1 text-[clamp(1.4rem,2.6vw,2rem)] font-semibold tracking-tight text-white">
+            {stream.title}
+          </h1>
+          <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-white/40">
+            session {sessionId.slice(0, 8)}
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <span
+            className="inline-flex items-center gap-2 rounded-sm px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.18em]"
+            style={{ color: `rgba(${tone},0.95)`, background: `rgba(${tone},0.10)`, border: `1px solid rgba(${tone},0.3)` }}
+          >
+            <span className="h-1.5 w-1.5 rounded-full" style={{ background: `rgba(${tone},0.95)` }} />
+            {stream.status}
+          </span>
+          {stream.status === "streaming" && env && (
+            <ControlButton label="Pause" onClick={() => void pauseSession(env, sessionId, biz ?? undefined)} />
+          )}
+          {stream.status === "paused" && env && (
+            <ControlButton label="Resume" onClick={() => { void resumeSession(env, sessionId, biz ?? undefined).then(() => stream.start()); }} />
+          )}
+          {env && (
+            <ControlButton
+              label="Fork"
+              onClick={() => void forkSession(env, sessionId, `Fork of ${stream.title}`, biz ?? undefined)
+                .then((r) => { if (r?.child_session_id) window.location.href = `/app/investigate/${r.child_session_id}`; })}
+            />
+          )}
+        </div>
+      </header>
+
+      {stream.error ? (
+        <div className="mb-5 rounded-md border border-red-500/25 bg-red-500/10 px-4 py-2.5 text-sm text-red-100">
+          {stream.error}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[200px_minmax(0,1fr)]">
+        {/* Progress tracker */}
+        <aside className="lg:sticky lg:top-6 lg:self-start">
+          <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/40">
+            Progress {progress.done}/{progress.planned || "—"}
+          </p>
+          <ol className="mt-3 space-y-1.5">
+            {(stream.planSections.length ? stream.planSections : stream.sections).map((p) => {
+              const sec = stream.sections.find((s) => s.key === p.key);
+              const state = !sec ? "pending" : sec.status === "running" ? "running" : "done";
+              return (
+                <li key={p.key} className="flex items-center gap-2 text-[13px]">
+                  <StepDot state={state} />
+                  <span className={state === "pending" ? "text-white/40" : "text-white/80"}>
+                    {("title" in p && p.title) || p.key}
+                  </span>
+                </li>
+              );
+            })}
+          </ol>
+        </aside>
+
+        {/* Streamed sections */}
+        <main className="min-w-0 space-y-4">
+          {stream.sections.length === 0 ? (
+            <div className="rounded-md border border-white/10 bg-white/[0.03] px-5 py-8 text-center text-sm text-white/55">
+              {stream.status === "streaming" ? "Investigating…" : "No sections yet."}
+            </div>
+          ) : (
+            stream.sections.map((s) => <SectionCard key={s.key} section={s} />)
+          )}
+
+          {stream.status === "completed" && stream.deliverableCardId ? (
+            <div className="rounded-md border px-4 py-3 text-[13px]"
+              style={{ borderColor: "rgba(107,174,127,0.3)", background: "rgba(107,174,127,0.08)", color: "rgba(140,200,158,0.95)" }}>
+              Investigation complete. A card was added to your intelligence feed.
+            </div>
+          ) : null}
+        </main>
+      </div>
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-[#03070e] text-white">
+      <div className="mx-auto w-full max-w-5xl px-4 py-6 lg:px-8 lg:py-8">{children}</div>
+    </div>
+  );
+}
+
+function ControlButton({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-md border border-white/15 bg-white/[0.04] px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-white/80 transition-colors hover:border-white/30 hover:text-white"
+    >
+      {label}
+    </button>
+  );
+}
+
+function StepDot({ state }: { state: "pending" | "running" | "done" }) {
+  if (state === "done") return <span className="text-[12px] text-[rgba(107,174,127,0.95)]">✓</span>;
+  if (state === "running") return <span className="text-[12px] text-[rgba(92,213,204,0.95)]">→</span>;
+  return <span className="text-[12px] text-white/30">○</span>;
+}
+
+function SectionCard({ section }: { section: LiveSection }) {
+  const unavailable = section.status === "not_available";
+  return (
+    <section
+      className="rounded-md border bg-[rgba(8,11,18,0.6)] p-5"
+      style={{ borderColor: unavailable ? "rgba(209,161,91,0.28)" : "rgba(232,236,242,0.10)" }}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-[15px] font-semibold text-white">{section.title}</h2>
+        {section.status === "running" ? (
+          <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[rgba(92,213,204,0.9)]">running…</span>
+        ) : null}
+      </div>
+
+      {unavailable ? (
+        <p className="mt-2 font-mono text-[12px] text-[rgba(209,161,91,0.95)]">
+          Not available — {section.null_reason}
+        </p>
+      ) : (
+        <ul className="mt-3 space-y-2">
+          {section.claims
+            .filter((c) => c.value !== null && c.value !== undefined)
+            .map((c, i) => <ClaimRow key={i} claim={c} />)}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function ClaimRow({ claim }: { claim: SectionClaim }) {
+  return (
+    <li className="flex items-start gap-2.5 text-[13px] text-white/80">
+      <span className="mt-1.5 inline-block h-1 w-1 shrink-0 rounded-full" style={{ background: "rgba(92,213,204,0.85)" }} />
+      <span className="min-w-0">
+        <span className="text-white">{String(claim.value)}</span>
+        {claim.is_estimate ? <span className="ml-1 text-white/40">(est.)</span> : null}
+        {claim.source_kind ? (
+          <span className="ml-2 font-mono text-[10px] text-white/35" title={JSON.stringify(claim.source_ref ?? {})}>
+            ◆ {claim.source_kind}
+          </span>
+        ) : null}
+      </span>
+    </li>
+  );
+}

--- a/repo-b/src/app/app/page.tsx
+++ b/repo-b/src/app/app/page.tsx
@@ -8,6 +8,7 @@ import AccountMenu from "@/components/AccountMenu";
 import { useEnv, type Environment } from "@/components/EnvProvider";
 import { humanIndustry } from "@/components/lab/environments/constants";
 import IntelligenceCardFeed from "@/components/intelligence/IntelligenceCardFeed";
+import { InvestigateButton } from "@/components/investigation/InvestigateButton";
 import {
   getCards,
   upsertCard,
@@ -1004,15 +1005,25 @@ function AppIndexPageInner() {
 
                 <div className="flex items-center justify-between gap-4">
                   <AgentPills />
-                  {selectedEnvironment ? (
-                    <button
-                      type="button"
-                      onClick={() => setShowPreview((v) => !v)}
-                      className="shrink-0 font-mono text-[10px] uppercase tracking-[0.2em] text-white/45 transition-colors hover:text-white/75"
-                    >
-                      {showPreview ? "← Intelligence" : "Workspace preview →"}
-                    </button>
-                  ) : null}
+                  <div className="flex shrink-0 items-center gap-3">
+                    {selectedEnvironment ? (
+                      <InvestigateButton
+                        envId={selectedEnvironment.env_id}
+                        businessId={selectedEnvironment.business_id ?? undefined}
+                        title={`${selectedEnvironment.client_name} investigation`}
+                        sourceRef={{ type: "environment", env_id: selectedEnvironment.env_id }}
+                      />
+                    ) : null}
+                    {selectedEnvironment ? (
+                      <button
+                        type="button"
+                        onClick={() => setShowPreview((v) => !v)}
+                        className="font-mono text-[10px] uppercase tracking-[0.2em] text-white/45 transition-colors hover:text-white/75"
+                      >
+                        {showPreview ? "← Intelligence" : "Workspace preview →"}
+                      </button>
+                    ) : null}
+                  </div>
                 </div>
 
                 {showPreview && previewEnvironment ? (

--- a/repo-b/src/components/investigation/InvestigateButton.tsx
+++ b/repo-b/src/components/investigation/InvestigateButton.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createSession } from "@/lib/investigation/sessionStream";
+
+// Small launch affordance (plan PR 7): creates an investigation session for the
+// selected environment and navigates to the workspace. Fail-closed: disabled
+// without a real env/tenant. No fabricated content — the backend grounds the session.
+export function InvestigateButton({
+  envId,
+  businessId,
+  title = "Environment investigation",
+  sourceRef,
+  className,
+}: {
+  envId: string | null;
+  businessId?: string | null;
+  title?: string;
+  sourceRef?: Record<string, unknown>;
+  className?: string;
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  const disabled = !envId || busy;
+
+  async function launch() {
+    if (!envId) return;
+    setBusy(true);
+    try {
+      const res = await createSession(envId, title, { source_ref: sourceRef }, businessId ?? undefined);
+      if (res?.session_id) {
+        router.push(`/app/investigate/${res.session_id}`);
+        return;
+      }
+    } catch {
+      /* swallow — leave the button re-enabled so the user can retry */
+    }
+    setBusy(false);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void launch()}
+      disabled={disabled}
+      className={
+        className ??
+        "inline-flex items-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] text-white/75 transition-colors hover:border-white/30 hover:text-white disabled:opacity-50"
+      }
+      title={envId ? "Start a grounded investigation for this environment" : "Select an environment first"}
+    >
+      <span aria-hidden>▶</span> Investigate
+    </button>
+  );
+}
+
+export default InvestigateButton;

--- a/repo-b/src/lib/investigation/sessionStream.ts
+++ b/repo-b/src/lib/investigation/sessionStream.ts
@@ -1,0 +1,252 @@
+"use client";
+
+// Investigation session SSE client (plan PR 7). Consumes the named-event stream from
+// the PR 6 backend (/api/ade/analytics/sessions/{id}/stream) via fetch + ReadableStream
+// (NOT EventSource: we need named events, query params, and NO auto-reconnect — a
+// reconnect would restart a session). Renders ONLY events the backend sends; missing
+// sections surface their null_reason. No fabricated content.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { apiFetch } from "@/lib/api";
+
+const DEFAULT_BUSINESS_ID = "7e1eb000-0000-4000-a000-000000000001";
+
+export type SessionEventType =
+  | "session.created" | "context.captured" | "plan.generated"
+  | "section.started" | "metric.queried" | "chart.generated" | "section.completed"
+  | "user.pause_requested" | "session.paused"
+  | "user.steer_submitted" | "plan.revised" | "session.completed"
+  | "error";
+
+export interface SessionEvent {
+  seq?: number;
+  session_id?: string;
+  run_token?: string | null;
+  [key: string]: unknown;
+}
+
+export interface SectionClaim {
+  source_kind?: string;
+  value?: unknown;
+  is_estimate?: boolean;
+  source_ref?: Record<string, unknown>;
+  null_reason?: string | null;
+}
+
+export interface LiveSection {
+  key: string;
+  title: string;
+  status: "running" | "available" | "not_available";
+  claims: SectionClaim[];
+  null_reason: string | null;
+  duration_ms?: number;
+}
+
+export interface SessionState {
+  id: string;
+  title: string;
+  status: string;
+  plan: { plan_version?: number; sections?: { key: string; title: string }[] };
+  sections: LiveSection[];
+  events: { seq: number; event_type: string; payload: Record<string, unknown> }[];
+  deliverable_card_id: string | null;
+  null_reason: string | null;
+}
+
+export interface SessionListItem {
+  id: string;
+  title: string;
+  status: string;
+  created_at: string | null;
+}
+
+// ── REST helpers (reconnect, control plane) ───────────────────────────────────
+const q = (env: string, biz: string) => ({ env_id: env, business_id: biz });
+
+export const getSession = (env: string, id: string, biz: string = DEFAULT_BUSINESS_ID) =>
+  apiFetch<SessionState>(`/api/ade/analytics/sessions/${encodeURIComponent(id)}`, { params: q(env, biz) });
+
+export const listSessions = (env: string, biz: string = DEFAULT_BUSINESS_ID) =>
+  apiFetch<{ sessions: SessionListItem[]; null_reason: string | null }>(
+    "/api/ade/analytics/sessions", { params: q(env, biz) });
+
+export const createSession = (env: string, title: string, opts: { objective?: string; source_ref?: Record<string, unknown> } = {}, biz: string = DEFAULT_BUSINESS_ID) =>
+  apiFetch<{ session_id: string; status: string }>("/api/ade/analytics/sessions", {
+    method: "POST",
+    body: JSON.stringify({ env_id: env, business_id: biz, title, ...opts }),
+  });
+
+export const pauseSession = (env: string, id: string, biz: string = DEFAULT_BUSINESS_ID) =>
+  apiFetch(`/api/ade/analytics/sessions/${encodeURIComponent(id)}/pause`, {
+    method: "POST", body: JSON.stringify({ env_id: env, business_id: biz }),
+  });
+
+export const resumeSession = (env: string, id: string, biz: string = DEFAULT_BUSINESS_ID) =>
+  apiFetch(`/api/ade/analytics/sessions/${encodeURIComponent(id)}/resume`, {
+    method: "POST", body: JSON.stringify({ env_id: env, business_id: biz }),
+  });
+
+export const forkSession = (env: string, id: string, title: string | undefined, biz: string = DEFAULT_BUSINESS_ID) =>
+  apiFetch<{ child_session_id: string }>(`/api/ade/analytics/sessions/${encodeURIComponent(id)}/fork`, {
+    method: "POST", body: JSON.stringify({ env_id: env, business_id: biz, title }),
+  });
+
+// ── SSE stream hook ───────────────────────────────────────────────────────────
+type StreamStatus = "idle" | "streaming" | "paused" | "completed" | "error";
+
+export interface StreamHook {
+  status: StreamStatus;
+  title: string;
+  planSections: { key: string; title: string }[];
+  sections: LiveSection[];
+  deliverableCardId: string | null;
+  error: string | null;
+  start: () => void;
+  stop: () => void;
+}
+
+export function useSessionStream(env: string | null, sessionId: string, biz: string = DEFAULT_BUSINESS_ID): StreamHook {
+  const [status, setStatus] = useState<StreamStatus>("idle");
+  const [title, setTitle] = useState("Investigation");
+  const [planSections, setPlanSections] = useState<{ key: string; title: string }[]>([]);
+  const [sections, setSections] = useState<LiveSection[]>([]);
+  const [deliverableCardId, setDeliverableCardId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const apply = useCallback((eventType: SessionEventType, data: SessionEvent) => {
+    switch (eventType) {
+      case "plan.generated": {
+        const keys = (data.section_keys as string[]) || [];
+        setPlanSections(keys.map((k) => ({ key: k, title: k.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()) })));
+        setStatus("streaming");
+        break;
+      }
+      case "section.started": {
+        const key = data.section_key as string;
+        setSections((prev) => prev.some((s) => s.key === key) ? prev : [
+          ...prev,
+          { key, title: (data.title as string) || key, status: "running", claims: [], null_reason: null },
+        ]);
+        break;
+      }
+      case "metric.queried": {
+        const key = data.section_key as string;
+        setSections((prev) => prev.map((s) => s.key === key ? {
+          ...s,
+          claims: [...s.claims, {
+            source_kind: data.source_kind as string | undefined,
+            value: data.value,
+            is_estimate: Boolean(data.is_estimate),
+            source_ref: data.source_ref as Record<string, unknown> | undefined,
+            null_reason: (data.null_reason as string | null) ?? null,
+          }],
+        } : s));
+        break;
+      }
+      case "section.completed": {
+        const key = data.section_key as string;
+        setSections((prev) => prev.map((s) => s.key === key ? {
+          ...s,
+          status: (data.status as LiveSection["status"]) || "available",
+          null_reason: (data.null_reason as string | null) ?? null,
+          duration_ms: data.duration_ms as number | undefined,
+        } : s));
+        break;
+      }
+      case "session.paused":
+        setStatus("paused");
+        break;
+      case "session.completed": {
+        const deliverable = data.deliverable as { card_id?: string | null } | undefined;
+        setDeliverableCardId(deliverable?.card_id ?? null);
+        setStatus("completed");
+        break;
+      }
+      case "error":
+        setError((data.error as string) || "stream error");
+        setStatus("error");
+        break;
+      default:
+        break;
+    }
+  }, []);
+
+  const start = useCallback(() => {
+    if (!env) return;
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setError(null);
+    setStatus("streaming");
+
+    (async () => {
+      try {
+        const base = `/api/ade/analytics/sessions/${encodeURIComponent(sessionId)}/stream`;
+        const url = `${base}?env_id=${encodeURIComponent(env)}&business_id=${encodeURIComponent(biz)}`;
+        const resp = await fetch(url, { signal: controller.signal, headers: { Accept: "text/event-stream" } });
+        if (!resp.ok || !resp.body) {
+          setError(`stream failed (${resp.status})`);
+          setStatus("error");
+          return;
+        }
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let currentEvent = "";
+        // Read until the stream ends. NO auto-reconnect (a reconnect restarts a session).
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+          for (const line of lines) {
+            if (line.startsWith("event: ")) {
+              currentEvent = line.slice(7).trim();
+            } else if (line.startsWith("data: ")) {
+              try {
+                apply(currentEvent as SessionEventType, JSON.parse(line.slice(6)));
+              } catch {
+                /* skip malformed frame */
+              }
+            }
+          }
+        }
+        setStatus((s) => (s === "streaming" ? "completed" : s));
+      } catch (e) {
+        if ((e as Error)?.name === "AbortError") return; // intentional stop
+        setError(e instanceof Error ? e.message : "stream error");
+        setStatus("error");
+      }
+    })();
+  }, [env, sessionId, biz, apply]);
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  // Seed title from reconnect state, then begin streaming.
+  useEffect(() => {
+    if (!env) return;
+    let cancelled = false;
+    getSession(env, sessionId, biz)
+      .then((s) => {
+        if (cancelled) return;
+        setTitle(s.title || "Investigation");
+        if (Array.isArray(s.sections)) {
+          setSections(s.sections.map((sec) => ({
+            key: sec.key, title: sec.title || sec.key,
+            status: sec.status, claims: sec.claims || [], null_reason: sec.null_reason ?? null,
+          })));
+        }
+        if (s.deliverable_card_id) setDeliverableCardId(s.deliverable_card_id);
+      })
+      .catch(() => { /* reconnect read is best-effort; stream still drives UI */ });
+    start();
+    return () => { cancelled = true; abortRef.current?.abort(); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [env, sessionId, biz]);
+
+  return { status, title, planSections, sections, deliverableCardId, error, start, stop };
+}


### PR DESCRIPTION
## Summary

Phase 3 / PR 7 — the **Investigation Workspace frontend**. A full-bleed standalone page at `/app/investigate/[sessionId]` that consumes the PR 6 SSE stream and renders the live investigation. Builds on PR 6 (merged).

## Files (5)

- `repo-b/src/lib/investigation/sessionStream.ts` — SSE client (fetch + ReadableStream, named events, no auto-reconnect) + REST helpers (reconnect/create/pause/resume/fork)
- `repo-b/src/app/app/investigate/[sessionId]/page.tsx` — the workspace
- `repo-b/src/app/app/investigate/[sessionId]/layout.tsx` — EnvProvider, no app shell (full-bleed)
- `repo-b/src/components/investigation/InvestigateButton.tsx` — small launch affordance
- `repo-b/src/app/app/page.tsx` — wires the launch button into the home agent row (small)

## Behavior

- **SSE via fetch+reader, not EventSource:** the session stream uses named events, needs query params, and must NOT auto-reconnect (a reconnect would restart a session). `EventSource` does none of those well.
- **Renders only backend events.** Sections append by key as `section.started`/`metric.queried`/`section.completed` arrive. Missing/unavailable sections show their `null_reason` ("Not available — …"). No fabricated content.
- Progress tracker (✓/→/○) from the plan; claim rows show the value, an `(est.)` flag for estimates, and the `source_kind` (◆) with `source_ref` in a tooltip — grounding is visible.
- Pause / Resume / Fork controls map directly to the PR 6 endpoints; resume restarts the client stream.
- On completion, links to the created intel_card.
- Reconnect: `getSession` seeds title + any persisted sections before the stream attaches.
- Mobile degrades to a single column.

## Explicit exclusions

steering chat rail (PR 8) · analyzers · agents · trailers/reels · mission control · enterprise memory. The launch button stayed to one surface (home agent row).

## Tests & checks

- Tree-wide `tsc --noEmit`: 0 errors
- ESLint on all changed files: clean (raw exit 0)
- No backend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
