### PR TITLE
Phase 3 PR 8: Investigation Steering Chat Rail

### DIFF
--- a/repo-b/src/app/app/investigate/[sessionId]/page.tsx
+++ b/repo-b/src/app/app/investigate/[sessionId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useMemo } from "react";
+import { use, useMemo, useState } from "react";
 import Link from "next/link";
 
 import { useEnv } from "@/components/EnvProvider";
@@ -8,10 +8,11 @@ import {
   useSessionStream, pauseSession, resumeSession, forkSession,
   type LiveSection, type SectionClaim,
 } from "@/lib/investigation/sessionStream";
+import { SteeringChatRail } from "@/components/investigation/SteeringChatRail";
 
-// Investigation Workspace (plan PR 7). Full-bleed standalone. Renders ONLY events the
-// backend streams; missing sections show their null_reason. No fabricated content.
-// Steering chat rail is PR 8 — not here.
+// Investigation Workspace (plan PR 7 + steering rail PR 8). Full-bleed standalone.
+// Renders ONLY events the backend streams; missing sections show their null_reason.
+// No fabricated content. The steering rail directs FUTURE sections only.
 
 const STATUS_TONE: Record<string, string> = {
   idle: "148,163,184", streaming: "92,213,204", paused: "209,161,91",
@@ -26,6 +27,7 @@ export default function InvestigatePage({ params }: { params: Promise<{ sessionI
 
   const stream = useSessionStream(env, sessionId, biz ?? undefined);
   const tone = STATUS_TONE[stream.status] ?? STATUS_TONE.idle;
+  const [showSql, setShowSql] = useState(false);
 
   const progress = useMemo(() => {
     const planned = stream.planSections.length || stream.sections.length;
@@ -88,7 +90,7 @@ export default function InvestigatePage({ params }: { params: Promise<{ sessionI
         </div>
       ) : null}
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[200px_minmax(0,1fr)]">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[180px_minmax(0,1fr)_320px]">
         {/* Progress tracker */}
         <aside className="lg:sticky lg:top-6 lg:self-start">
           <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/40">
@@ -117,7 +119,7 @@ export default function InvestigatePage({ params }: { params: Promise<{ sessionI
               {stream.status === "streaming" ? "Investigating…" : "No sections yet."}
             </div>
           ) : (
-            stream.sections.map((s) => <SectionCard key={s.key} section={s} />)
+            stream.sections.map((s) => <SectionCard key={s.key} section={s} showSql={showSql} />)
           )}
 
           {stream.status === "completed" && stream.deliverableCardId ? (
@@ -127,6 +129,16 @@ export default function InvestigatePage({ params }: { params: Promise<{ sessionI
             </div>
           ) : null}
         </main>
+
+        {/* Steering rail (PR 8) */}
+        <SteeringChatRail
+          env={env}
+          sessionId={sessionId}
+          businessId={biz ?? undefined}
+          title={stream.title}
+          steers={stream.steers}
+          onShowSql={() => setShowSql((v) => !v)}
+        />
       </div>
     </Shell>
   );
@@ -158,7 +170,7 @@ function StepDot({ state }: { state: "pending" | "running" | "done" }) {
   return <span className="text-[12px] text-white/30">○</span>;
 }
 
-function SectionCard({ section }: { section: LiveSection }) {
+function SectionCard({ section, showSql }: { section: LiveSection; showSql: boolean }) {
   const unavailable = section.status === "not_available";
   return (
     <section
@@ -167,9 +179,17 @@ function SectionCard({ section }: { section: LiveSection }) {
     >
       <div className="flex items-center justify-between gap-3">
         <h2 className="text-[15px] font-semibold text-white">{section.title}</h2>
-        {section.status === "running" ? (
-          <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[rgba(92,213,204,0.9)]">running…</span>
-        ) : null}
+        <div className="flex items-center gap-2">
+          {section.steeredByVersion ? (
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[rgba(167,139,250,0.9)]"
+              title="This section was produced after a steering instruction">
+              steered v{section.steeredByVersion}
+            </span>
+          ) : null}
+          {section.status === "running" ? (
+            <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[rgba(92,213,204,0.9)]">running…</span>
+          ) : null}
+        </div>
       </div>
 
       {unavailable ? (
@@ -180,26 +200,34 @@ function SectionCard({ section }: { section: LiveSection }) {
         <ul className="mt-3 space-y-2">
           {section.claims
             .filter((c) => c.value !== null && c.value !== undefined)
-            .map((c, i) => <ClaimRow key={i} claim={c} />)}
+            .map((c, i) => <ClaimRow key={i} claim={c} showSql={showSql} />)}
         </ul>
       )}
     </section>
   );
 }
 
-function ClaimRow({ claim }: { claim: SectionClaim }) {
+function ClaimRow({ claim, showSql }: { claim: SectionClaim; showSql: boolean }) {
   return (
-    <li className="flex items-start gap-2.5 text-[13px] text-white/80">
-      <span className="mt-1.5 inline-block h-1 w-1 shrink-0 rounded-full" style={{ background: "rgba(92,213,204,0.85)" }} />
-      <span className="min-w-0">
-        <span className="text-white">{String(claim.value)}</span>
-        {claim.is_estimate ? <span className="ml-1 text-white/40">(est.)</span> : null}
-        {claim.source_kind ? (
-          <span className="ml-2 font-mono text-[10px] text-white/35" title={JSON.stringify(claim.source_ref ?? {})}>
-            ◆ {claim.source_kind}
-          </span>
-        ) : null}
+    <li className="flex flex-col gap-1 text-[13px] text-white/80">
+      <span className="flex items-start gap-2.5">
+        <span className="mt-1.5 inline-block h-1 w-1 shrink-0 rounded-full" style={{ background: "rgba(92,213,204,0.85)" }} />
+        <span className="min-w-0">
+          <span className="text-white">{String(claim.value)}</span>
+          {claim.is_estimate ? <span className="ml-1 text-white/40">(est.)</span> : null}
+          {claim.source_kind ? (
+            <span className="ml-2 font-mono text-[10px] text-white/35" title={JSON.stringify(claim.source_ref ?? {})}>
+              ◆ {claim.source_kind}
+            </span>
+          ) : null}
+        </span>
       </span>
+      {/* Show SQL reveals only the EXISTING provenance already attached — never generated SQL. */}
+      {showSql && claim.source_ref ? (
+        <pre className="ml-5 overflow-x-auto rounded border border-white/10 bg-[rgba(3,7,14,0.6)] px-2 py-1 font-mono text-[10px] text-white/50">
+          {JSON.stringify(claim.source_ref, null, 2)}
+        </pre>
+      ) : null}
     </li>
   );
 }

--- a/repo-b/src/components/investigation/SteeringChatRail.tsx
+++ b/repo-b/src/components/investigation/SteeringChatRail.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState } from "react";
+import { steerSession, forkSession, type SteerRecord } from "@/lib/investigation/sessionStream";
+
+// Steering chat rail (plan PR 8). A steering wheel, not a chatbot. Submits a steering
+// instruction to the PR 6 steer endpoint (which whitelists the verb server-side and
+// applies it to FUTURE sections only — prior sections are never mutated). Renders
+// acknowledgements; every steer is audited backend-side.
+//
+// Honesty constraints:
+//   - Steering text is user input; the backend is the injection boundary (whitelist,
+//     no raw SQL, no tool override). The rail does no client-side SQL/tool work.
+//   - "Show SQL" reveals only EXISTING source_ref provenance already on the page — it
+//     never generates SQL.
+//   - "Save version" has no backend yet → it is INERT (disabled), labeled as such,
+//     rather than faking a save.
+
+type Ack = { id: string; text: string; tone: "ok" | "warn" | "info" };
+
+const COMMAND_CHIPS = [
+  { label: "Focus on…", prefix: "focus on ", kind: "steer" as const },
+  { label: "Ignore…", prefix: "ignore ", kind: "steer" as const },
+  { label: "Compare against…", prefix: "compare against ", kind: "steer" as const },
+  { label: "Find similar", prefix: "find similar", kind: "steer" as const },
+  { label: "Show SQL", prefix: "", kind: "show_sql" as const },
+  { label: "Fork", prefix: "", kind: "fork" as const },
+  { label: "Save version", prefix: "", kind: "save_version" as const },
+];
+
+export function SteeringChatRail({
+  env,
+  sessionId,
+  businessId,
+  title,
+  steers,
+  onShowSql,
+}: {
+  env: string | null;
+  sessionId: string;
+  businessId?: string | null;
+  title: string;
+  steers: SteerRecord[];
+  onShowSql: () => void;
+}) {
+  const [input, setInput] = useState("");
+  const [acks, setAcks] = useState<Ack[]>([]);
+  const [busy, setBusy] = useState(false);
+
+  const pushAck = (text: string, tone: Ack["tone"]) =>
+    setAcks((prev) => [...prev, { id: `${Date.now()}-${Math.random().toString(16).slice(2)}`, text, tone }]);
+
+  async function submitSteer(instruction: string) {
+    const trimmed = instruction.trim();
+    if (!trimmed || !env || busy) return;
+    setBusy(true);
+    pushAck(`You: ${trimmed}`, "info");
+    try {
+      const res = await steerSession(env, sessionId, trimmed, businessId ?? undefined);
+      if (res.status === "revised") {
+        pushAck(`Got it — future sections will reflect that. Prior sections are unchanged. (plan v${res.plan_version})`, "ok");
+      } else if (res.status === "unsupported") {
+        pushAck("That instruction isn't a supported steering command, so nothing was changed.", "warn");
+      } else {
+        pushAck("Session not found.", "warn");
+      }
+    } catch {
+      pushAck("Could not submit steering instruction.", "warn");
+    }
+    setInput("");
+    setBusy(false);
+  }
+
+  async function handleChip(chip: (typeof COMMAND_CHIPS)[number]) {
+    if (chip.kind === "show_sql") {
+      onShowSql();
+      pushAck("Showing the source provenance already attached to each claim.", "info");
+      return;
+    }
+    if (chip.kind === "save_version") {
+      pushAck("Saving a named version isn't available yet — coming in a later release.", "warn");
+      return;
+    }
+    if (chip.kind === "fork") {
+      if (!env) return;
+      pushAck("Forking this investigation…", "info");
+      try {
+        const r = await forkSession(env, sessionId, `Fork of ${title}`, businessId ?? undefined);
+        if (r?.child_session_id) {
+          window.location.href = `/app/investigate/${r.child_session_id}`;
+        }
+      } catch {
+        pushAck("Could not fork the investigation.", "warn");
+      }
+      return;
+    }
+    // steer chips: prefill the input for the user to complete, or submit if complete
+    if (chip.prefix.trim() && chip.prefix.endsWith(" ")) {
+      setInput(chip.prefix);
+    } else {
+      void submitSteer(chip.prefix);
+    }
+  }
+
+  return (
+    <aside className="flex w-full flex-col rounded-md border bg-[rgba(8,11,18,0.6)] lg:w-[320px] lg:shrink-0"
+      style={{ borderColor: "rgba(232,236,242,0.10)" }}>
+      <div className="border-b px-4 py-3" style={{ borderColor: "rgba(232,236,242,0.08)" }}>
+        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/45">Steer</p>
+        <p className="mt-1 text-[11px] leading-4 text-white/45">
+          Direct future sections. Prior findings stay versioned and unchanged.
+        </p>
+      </div>
+
+      {/* Applied steers */}
+      {steers.length > 0 ? (
+        <div className="border-b px-4 py-2" style={{ borderColor: "rgba(232,236,242,0.06)" }}>
+          {steers.map((s) => (
+            <div key={s.steer_id} className="flex items-center gap-2 py-0.5 font-mono text-[10px] text-white/50">
+              <span className="text-[rgba(92,213,204,0.85)]">steered</span>
+              <span>plan v{s.plan_version}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {/* Acknowledgement log */}
+      <div className="flex-1 space-y-2 overflow-y-auto px-4 py-3" style={{ minHeight: 120, maxHeight: 320 }}>
+        {acks.length === 0 ? (
+          <p className="text-[12px] text-white/35">No steering yet. Use a chip or type an instruction.</p>
+        ) : (
+          acks.map((a) => (
+            <div key={a.id} className="text-[12px] leading-5"
+              style={{ color: a.tone === "ok" ? "rgba(140,200,158,0.95)" : a.tone === "warn" ? "rgba(209,161,91,0.95)" : "rgba(255,255,255,0.7)" }}>
+              {a.text}
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Command chips */}
+      <div className="flex flex-wrap gap-1.5 border-t px-4 py-3" style={{ borderColor: "rgba(232,236,242,0.08)" }}>
+        {COMMAND_CHIPS.map((chip) => {
+          const inert = chip.kind === "save_version";
+          return (
+            <button
+              key={chip.label}
+              type="button"
+              onClick={() => void handleChip(chip)}
+              disabled={inert || (!env && chip.kind !== "show_sql")}
+              title={inert ? "Coming in a later release" : undefined}
+              className="rounded-full border border-white/12 bg-white/[0.03] px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-white/65 transition-colors hover:border-white/25 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {chip.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Free-text input */}
+      <form
+        className="flex gap-2 border-t px-4 py-3"
+        style={{ borderColor: "rgba(232,236,242,0.08)" }}
+        onSubmit={(e) => { e.preventDefault(); void submitSteer(input); }}
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Steer the investigation…"
+          disabled={!env || busy}
+          className="min-w-0 flex-1 rounded-md border border-white/12 bg-[rgba(3,7,14,0.6)] px-3 py-1.5 text-[13px] text-white placeholder:text-white/30 focus:border-white/30 focus:outline-none disabled:opacity-50"
+        />
+        <button
+          type="submit"
+          disabled={!env || busy || !input.trim()}
+          className="rounded-md border border-white/15 bg-white/[0.05] px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-white/80 transition-colors hover:border-white/30 hover:text-white disabled:opacity-40"
+        >
+          Send
+        </button>
+      </form>
+    </aside>
+  );
+}
+
+export default SteeringChatRail;

--- a/repo-b/src/lib/investigation/sessionStream.ts
+++ b/repo-b/src/lib/investigation/sessionStream.ts
@@ -40,6 +40,7 @@ export interface LiveSection {
   claims: SectionClaim[];
   null_reason: string | null;
   duration_ms?: number;
+  steeredByVersion?: number; // set when a steer landed while this section was still running
 }
 
 export interface SessionState {
@@ -91,14 +92,35 @@ export const forkSession = (env: string, id: string, title: string | undefined, 
     method: "POST", body: JSON.stringify({ env_id: env, business_id: biz, title }),
   });
 
+export interface SteerResult {
+  status: "revised" | "unsupported" | "not_found";
+  steer_id?: string;
+  plan_version?: number;
+}
+
+// Steering is future-only and injection-safe — the backend whitelists the verb and
+// applies the directive to the TAIL of the plan only; prior sections are never mutated.
+export const steerSession = (env: string, id: string, instruction: string, biz: string = DEFAULT_BUSINESS_ID) =>
+  apiFetch<SteerResult>(`/api/ade/analytics/sessions/${encodeURIComponent(id)}/steer`, {
+    method: "POST", body: JSON.stringify({ env_id: env, business_id: biz, instruction }),
+  });
+
 // ── SSE stream hook ───────────────────────────────────────────────────────────
 type StreamStatus = "idle" | "streaming" | "paused" | "completed" | "error";
+
+export interface SteerRecord {
+  steer_id: string;
+  plan_version: number;
+  instruction_redacted?: string;
+  applies_from_section?: string | null;
+}
 
 export interface StreamHook {
   status: StreamStatus;
   title: string;
   planSections: { key: string; title: string }[];
   sections: LiveSection[];
+  steers: SteerRecord[];
   deliverableCardId: string | null;
   error: string | null;
   start: () => void;
@@ -110,6 +132,7 @@ export function useSessionStream(env: string | null, sessionId: string, biz: str
   const [title, setTitle] = useState("Investigation");
   const [planSections, setPlanSections] = useState<{ key: string; title: string }[]>([]);
   const [sections, setSections] = useState<LiveSection[]>([]);
+  const [steers, setSteers] = useState<SteerRecord[]>([]);
   const [deliverableCardId, setDeliverableCardId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -152,6 +175,22 @@ export function useSessionStream(env: string | null, sessionId: string, biz: str
           null_reason: (data.null_reason as string | null) ?? null,
           duration_ms: data.duration_ms as number | undefined,
         } : s));
+        break;
+      }
+      case "user.steer_submitted":
+        // Acknowledgement only; the authoritative record arrives on plan.revised.
+        break;
+      case "plan.revised": {
+        const rec: SteerRecord = {
+          steer_id: (data.steer_id as string) || "",
+          plan_version: (data.plan_version as number) || 0,
+          applies_from_section: (data.applies_from_section as string | null) ?? null,
+        };
+        setSteers((prev) => prev.some((s) => s.steer_id === rec.steer_id) ? prev : [...prev, rec]);
+        // Tag sections not yet completed as steered-by this version (future-only;
+        // already-completed sections keep their original version and are not mutated).
+        setSections((prev) => prev.map((s) =>
+          s.status === "running" ? { ...s, steeredByVersion: rec.plan_version } : s));
         break;
       }
       case "session.paused":
@@ -248,5 +287,5 @@ export function useSessionStream(env: string | null, sessionId: string, biz: str
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [env, sessionId, biz]);
 
-  return { status, title, planSections, sections, deliverableCardId, error, start, stop };
+  return { status, title, planSections, sections, steers, deliverableCardId, error, start, stop };
 }


### PR DESCRIPTION
## Summary

Phase 3 / PR 8 — the **Investigation Steering Chat Rail**. A steering wheel (not a chatbot) on the investigation workspace that directs FUTURE sections only. Completes the Investigate feature (PR 6 backend + PR 7 workspace + PR 8 steering).

## Files (3)

- `repo-b/src/lib/investigation/sessionStream.ts` — `steerSession` client + capture of `user.steer_submitted`/`plan.revised` events in the SSE hook (exposes a `steers` list + tags running sections with `steeredByVersion`)
- `repo-b/src/components/investigation/SteeringChatRail.tsx` — the rail
- `repo-b/src/app/app/investigate/[sessionId]/page.tsx` — wires the rail as a 3rd column + Show-SQL toggle + "Steered v{n}" labels

## Behavior & honesty constraints

- **Future-only.** Steering submits to the PR 6 steer endpoint, which whitelists the verb server-side and applies the directive to the plan TAIL. Prior (completed) sections keep their version and are never mutated; sections produced after a steer get a "Steered v{n}" label.
- **Injection-safe.** Steering text is user input; the backend is the injection boundary (whitelist; no raw SQL; no tool override). An unsupported instruction changes nothing and the rail says so. The rail itself does no SQL/tool work.
- **"Show SQL"** reveals only the existing `source_ref` provenance already attached to each claim — it never generates SQL.
- **"Save version" is inert** (disabled, "coming in a later release") — there is no backend for it yet, so it fails closed rather than faking a save.
- **Fork** reuses the PR 6 fork endpoint.
- Every steer is audited backend-side (PR 6 records `user.steer_submitted` + `plan.revised`).
- Command chips: Focus on / Ignore / Compare against / Find similar / Show SQL / Fork / Save version.

## Explicit exclusions

actual memory-search implementation · analyzer work · agent logic · forecast engine · trailers/reels · mission control.

## Tests & checks

- Tree-wide `tsc --noEmit`: 0 errors
- ESLint on all changed files: clean (raw exit 0)
- No backend changes (consumes PR 6 endpoints already on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
