### PR TITLE
PR 8.5: Universal AnalyzerFinding Contract

### DIFF
--- a/backend/app/services/analyzer_contract.py
+++ b/backend/app/services/analyzer_contract.py
@@ -1,0 +1,164 @@
+"""Universal AnalyzerFinding contract (plan PR 8.5).
+
+The shared, typed contract every analyzer (telemetry, data-platform, business — PRs 9-11)
+MUST return. Defining it before the analyzers exist keeps Phase 4 from diverging into
+three inconsistent services, and lets the card feed / investigation surfaces consume one
+shape.
+
+Deterministic-first: a finding's facts (severity, what_changed, driver_math, evidence)
+are produced by code/rules/queries. An LLM may later SUMMARIZE a set of findings, but it
+must not be the source of a finding's numbers or its severity. This module contains NO
+analyzer implementation.
+
+Honesty rules (enforced by validation):
+  - severity is RULE-BASED, never LLM-assigned (it is a plain field; analyzers set it
+    from thresholds/evidence, and validation forbids high-severity claims with no evidence).
+  - A finding may not be 'critical' OR carry confidence >= 0.70 without evidence_refs.
+  - confidence bands are documented below and checked for range.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+# ── confidence bands (documented, enforced for range) ─────────────────────────
+# 0.90-1.00  directly measured / reconciled to a governed metric
+# 0.70-0.89  strong evidence, minor assumptions
+# 0.50-0.69  directional / incomplete evidence
+# < 0.50     informational only — may NOT drive a critical severity or an anomaly card
+CONFIDENCE_MIN = 0.0
+CONFIDENCE_MAX = 1.0
+HIGH_CONFIDENCE = 0.70
+
+SEVERITIES = ("info", "warning", "critical")
+ANALYZER_TYPES = ("telemetry", "data_platform", "business")
+EVAL_STATUSES = ("pass", "fail", "pending", None)
+
+# severity -> intel card type + whether it flags an anomaly
+_SEVERITY_CARD = {
+    "critical": ("alert", True),
+    "warning": ("finding", False),
+    "info": ("finding", False),
+}
+
+
+class FindingValidationError(ValueError):
+    """Raised when a finding violates the contract (fail closed; never silently accepted)."""
+
+
+@dataclass(frozen=True)
+class AnalyzerFinding:
+    finding_id: str
+    env_id: str
+    analyzer_type: str                 # 'telemetry' | 'data_platform' | 'business'
+    source_ref: dict                   # {run_id, table_name, metric_key, ...} provenance
+    severity: str                      # 'info' | 'warning' | 'critical' — rule-assigned, never LLM
+    what_changed: str                  # human-readable factual claim
+    why_it_matters: str                # deterministic interpretation, not LLM prose
+    confidence: float                  # 0-1, banded above
+    evidence_refs: list[str] = field(default_factory=list)   # source row ids / metric refs / SQL results
+    metric_refs: list[str] = field(default_factory=list)     # governed metric names
+    driver_math: dict | None = None    # {contributor, contribution_pct, evidence_row}
+    null_reasons: list[str] = field(default_factory=list)    # why any field is None / unavailable
+    recommendations: list[str] = field(default_factory=list) # deterministic action candidates
+    next_questions: list[str] = field(default_factory=list)  # investigation fork suggestions
+    cost_to_generate_usd: float | None = None                # NULL if no priced compute ran
+    latency_ms: int | None = None
+    eval_status: str | None = None     # 'pass' | 'fail' | 'pending' | None
+
+    def __post_init__(self) -> None:
+        validate_finding(self)
+
+    def to_dict(self) -> dict:
+        return {
+            "finding_id": self.finding_id,
+            "env_id": self.env_id,
+            "analyzer_type": self.analyzer_type,
+            "source_ref": self.source_ref,
+            "severity": self.severity,
+            "what_changed": self.what_changed,
+            "why_it_matters": self.why_it_matters,
+            "confidence": self.confidence,
+            "evidence_refs": list(self.evidence_refs),
+            "metric_refs": list(self.metric_refs),
+            "driver_math": self.driver_math,
+            "null_reasons": list(self.null_reasons),
+            "recommendations": list(self.recommendations),
+            "next_questions": list(self.next_questions),
+            "cost_to_generate_usd": self.cost_to_generate_usd,
+            "latency_ms": self.latency_ms,
+            "eval_status": self.eval_status,
+        }
+
+
+_ID_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
+
+
+def validate_finding(f: AnalyzerFinding) -> None:
+    """Raise FindingValidationError on any contract violation. Called in __post_init__
+    so an invalid finding can never be constructed."""
+    if not f.finding_id or not _ID_RE.match(f.finding_id):
+        raise FindingValidationError(f"invalid finding_id: {f.finding_id!r}")
+    if not f.env_id:
+        raise FindingValidationError("env_id is required")
+    if f.analyzer_type not in ANALYZER_TYPES:
+        raise FindingValidationError(f"unknown analyzer_type: {f.analyzer_type!r}")
+    if f.severity not in SEVERITIES:
+        raise FindingValidationError(f"unknown severity: {f.severity!r}")
+    if not isinstance(f.source_ref, dict):
+        raise FindingValidationError("source_ref must be a dict")
+    if not f.what_changed or not f.what_changed.strip():
+        raise FindingValidationError("what_changed is required")
+    if not (CONFIDENCE_MIN <= f.confidence <= CONFIDENCE_MAX):
+        raise FindingValidationError(f"confidence out of range: {f.confidence}")
+    if f.eval_status not in EVAL_STATUSES:
+        raise FindingValidationError(f"unknown eval_status: {f.eval_status!r}")
+
+    # The load-bearing honesty rule: a high-confidence OR critical finding must carry
+    # evidence. No evidence -> it cannot claim high confidence or critical severity.
+    has_evidence = bool(f.evidence_refs)
+    if f.confidence >= HIGH_CONFIDENCE and not has_evidence:
+        raise FindingValidationError(
+            f"confidence {f.confidence} >= {HIGH_CONFIDENCE} requires non-empty evidence_refs"
+        )
+    if f.severity == "critical" and not has_evidence:
+        raise FindingValidationError("severity 'critical' requires non-empty evidence_refs")
+    # An informational-confidence finding (< 0.5) may not drive a critical severity.
+    if f.severity == "critical" and f.confidence < 0.5:
+        raise FindingValidationError("severity 'critical' requires confidence >= 0.5")
+    if f.cost_to_generate_usd is not None and f.cost_to_generate_usd < 0:
+        raise FindingValidationError("cost_to_generate_usd may not be negative")
+
+
+def to_intel_card(finding: AnalyzerFinding) -> dict:
+    """Map a finding to intelligence_cards.upsert_card(**kwargs). Deterministic, no LLM.
+
+    Severity drives card_type + anomaly_flag (rule-based); priority scales with
+    confidence and severity; source_ref carries the finding id for idempotency and
+    drill-through. Returns the kwargs dict so the caller owns the actual write.
+    """
+    card_type, anomaly = _SEVERITY_CARD[finding.severity]
+    severity_weight = {"critical": 1.0, "warning": 0.6, "info": 0.3}[finding.severity]
+    priority = round(min(1.0, severity_weight * max(0.0, min(1.0, finding.confidence))), 4)
+    summary = finding.why_it_matters or finding.what_changed
+    return {
+        "card_type": card_type,
+        "title": finding.what_changed[:200],
+        "summary": summary,
+        "source_ref": {
+            "type": "analyzer_finding",
+            "finding_id": finding.finding_id,
+            "analyzer_type": finding.analyzer_type,
+            **finding.source_ref,
+        },
+        "priority_score": priority,
+        "anomaly_flag": anomaly,
+        "created_by": f"analyzer:{finding.analyzer_type}",
+    }
+
+
+def from_dict(data: dict[str, Any]) -> AnalyzerFinding:
+    """Build (and validate) a finding from a plain dict. Unknown keys are ignored."""
+    allowed = AnalyzerFinding.__dataclass_fields__.keys()
+    return AnalyzerFinding(**{k: v for k, v in data.items() if k in allowed})

--- a/backend/tests/test_analyzer_contract.py
+++ b/backend/tests/test_analyzer_contract.py
@@ -1,0 +1,143 @@
+"""Tests for the Universal AnalyzerFinding contract (plan PR 8.5).
+
+Run: cd backend && python -m pytest tests/test_analyzer_contract.py -x -q
+
+Proves the contract fails closed: a high-confidence or critical finding with no evidence
+is rejected; severity is rule-based; to_intel_card maps deterministically.
+"""
+import os
+
+import pytest
+
+os.environ.setdefault("BM_MCP_DRY_RUN", "1")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+
+from app.services.analyzer_contract import (  # noqa: E402
+    AnalyzerFinding, FindingValidationError, to_intel_card, from_dict,
+    SEVERITIES, ANALYZER_TYPES, HIGH_CONFIDENCE,
+)
+
+
+def _finding(**over):
+    base = dict(
+        finding_id="f-001", env_id="env-1", analyzer_type="business",
+        source_ref={"metric_key": "fpy"}, severity="warning",
+        what_changed="First-pass yield fell 6 points", why_it_matters="Concentrated at one station",
+        confidence=0.8, evidence_refs=["row-1"], metric_refs=["first_pass_yield"],
+    )
+    base.update(over)
+    return AnalyzerFinding(**base)
+
+
+# ── construction + happy path ─────────────────────────────────────────────────
+def test_valid_finding_constructs():
+    f = _finding()
+    assert f.finding_id == "f-001"
+    assert f.severity in SEVERITIES
+    assert f.analyzer_type in ANALYZER_TYPES
+
+
+def test_to_dict_roundtrips_through_from_dict():
+    f = _finding()
+    f2 = from_dict(f.to_dict())
+    assert f2.to_dict() == f.to_dict()
+
+
+# ── the load-bearing honesty rules ────────────────────────────────────────────
+def test_high_confidence_without_evidence_is_rejected():
+    with pytest.raises(FindingValidationError, match="evidence_refs"):
+        _finding(confidence=HIGH_CONFIDENCE, evidence_refs=[])
+
+
+def test_low_confidence_without_evidence_is_allowed():
+    # Below the high-confidence threshold, no evidence is permitted (informational).
+    f = _finding(confidence=0.4, severity="info", evidence_refs=[])
+    assert f.confidence == 0.4
+
+
+def test_critical_without_evidence_is_rejected():
+    # No evidence_refs -> rejected. (At confidence 0.9 the high-confidence rule fires
+    # first; both paths forbid an evidence-free critical finding.)
+    with pytest.raises(FindingValidationError, match="evidence_refs"):
+        _finding(severity="critical", evidence_refs=[], confidence=0.9)
+
+
+def test_critical_without_evidence_at_mid_confidence_is_rejected():
+    # At confidence 0.6 the high-confidence rule does NOT fire, so the critical-needs-
+    # evidence rule is the one that rejects it.
+    with pytest.raises(FindingValidationError, match="critical"):
+        _finding(severity="critical", evidence_refs=[], confidence=0.6)
+
+
+def test_critical_with_low_confidence_is_rejected():
+    with pytest.raises(FindingValidationError, match="critical"):
+        _finding(severity="critical", confidence=0.4, evidence_refs=["row-1"])
+
+
+def test_critical_with_evidence_and_confidence_is_allowed():
+    f = _finding(severity="critical", confidence=0.92, evidence_refs=["row-1", "row-2"])
+    assert f.severity == "critical"
+
+
+# ── field validation ──────────────────────────────────────────────────────────
+def test_unknown_severity_rejected():
+    with pytest.raises(FindingValidationError, match="severity"):
+        _finding(severity="catastrophic")
+
+
+def test_unknown_analyzer_type_rejected():
+    with pytest.raises(FindingValidationError, match="analyzer_type"):
+        _finding(analyzer_type="weather")
+
+
+def test_confidence_out_of_range_rejected():
+    with pytest.raises(FindingValidationError, match="confidence"):
+        _finding(confidence=1.4)
+
+
+def test_empty_what_changed_rejected():
+    with pytest.raises(FindingValidationError, match="what_changed"):
+        _finding(what_changed="  ")
+
+
+def test_bad_finding_id_rejected():
+    with pytest.raises(FindingValidationError, match="finding_id"):
+        _finding(finding_id="bad id with spaces")
+
+
+def test_negative_cost_rejected():
+    with pytest.raises(FindingValidationError, match="cost"):
+        _finding(cost_to_generate_usd=-1.0)
+
+
+# ── to_intel_card mapping (deterministic) ─────────────────────────────────────
+def test_to_intel_card_critical_maps_to_alert_with_anomaly():
+    f = _finding(severity="critical", confidence=0.95, evidence_refs=["r1"])
+    card = to_intel_card(f)
+    assert card["card_type"] == "alert"
+    assert card["anomaly_flag"] is True
+    assert card["created_by"] == "analyzer:business"
+    assert card["source_ref"]["finding_id"] == "f-001"
+    assert 0.0 <= card["priority_score"] <= 1.0
+
+
+def test_to_intel_card_warning_maps_to_finding_no_anomaly():
+    card = to_intel_card(_finding(severity="warning"))
+    assert card["card_type"] == "finding"
+    assert card["anomaly_flag"] is False
+
+
+def test_to_intel_card_priority_scales_with_confidence_and_severity():
+    hi = to_intel_card(_finding(severity="critical", confidence=0.95, evidence_refs=["r"]))
+    lo = to_intel_card(_finding(severity="info", confidence=0.5))
+    assert hi["priority_score"] > lo["priority_score"]
+
+
+def test_to_intel_card_kwargs_are_upsert_card_compatible():
+    # Mirrors intelligence_cards.upsert_card signature (card_type, title, summary,
+    # source_ref, priority_score, anomaly_flag, created_by).
+    card = to_intel_card(_finding())
+    assert set(card.keys()) == {
+        "card_type", "title", "summary", "source_ref", "priority_score",
+        "anomaly_flag", "created_by",
+    }

--- a/repo-b/src/lib/analyzer/types.ts
+++ b/repo-b/src/lib/analyzer/types.ts
@@ -1,0 +1,56 @@
+// Universal AnalyzerFinding contract — TypeScript mirror (plan PR 8.5).
+//
+// Every UI that consumes analyzer output (cards, future reels, investigation sections,
+// agent feeds) imports this type — no inline type invention. Mirrors the Python contract
+// in backend/app/services/analyzer_contract.py. Keep the two in sync.
+
+export type AnalyzerType = "telemetry" | "data_platform" | "business";
+export type FindingSeverity = "info" | "warning" | "critical";
+export type FindingEvalStatus = "pass" | "fail" | "pending" | null;
+
+export interface FindingDriverMath {
+  contributor: string;
+  contribution_pct: number;
+  evidence_row?: string;
+}
+
+export interface AnalyzerFinding {
+  finding_id: string;
+  env_id: string;
+  analyzer_type: AnalyzerType;
+  source_ref: Record<string, unknown>;
+  severity: FindingSeverity;
+  what_changed: string;
+  why_it_matters: string;
+  confidence: number; // 0-1, banded (see CONFIDENCE_BANDS)
+  evidence_refs: string[];
+  metric_refs: string[];
+  driver_math: FindingDriverMath | null;
+  null_reasons: string[];
+  recommendations: string[];
+  next_questions: string[];
+  cost_to_generate_usd: number | null;
+  latency_ms: number | null;
+  eval_status: FindingEvalStatus;
+}
+
+// Documented confidence bands (mirror of the Python contract).
+export const CONFIDENCE_BANDS = {
+  measured: [0.9, 1.0], // directly measured / reconciled to a governed metric
+  strong: [0.7, 0.89], // strong evidence, minor assumptions
+  directional: [0.5, 0.69], // directional / incomplete evidence
+  informational: [0.0, 0.49], // informational only — cannot drive critical/anomaly
+} as const;
+
+export const HIGH_CONFIDENCE = 0.7;
+
+// Client-side guard mirroring the contract's load-bearing rule. Analyzers validate
+// server-side; this lets the UI defensively reject a malformed finding rather than
+// render an ungrounded high-confidence/critical claim.
+export function isFindingHonest(f: AnalyzerFinding): boolean {
+  const hasEvidence = f.evidence_refs.length > 0;
+  if (f.confidence >= HIGH_CONFIDENCE && !hasEvidence) return false;
+  if (f.severity === "critical" && !hasEvidence) return false;
+  if (f.severity === "critical" && f.confidence < 0.5) return false;
+  return true;
+}


### PR DESCRIPTION
## Summary

PR 8.5 — the **Universal AnalyzerFinding contract**. The shared typed contract that Telemetry, Data Platform, and Business analyzers (PRs 9–11) will all return. Defining it *before* the analyzers prevents Phase 4 from diverging into three inconsistent services and lets cards/investigation surfaces consume one shape.

No analyzer implementation in this PR.

## Files (3)

- `backend/app/services/analyzer_contract.py` — frozen `AnalyzerFinding` dataclass; `validate_finding()` runs in `__post_init__` (an invalid finding can't be constructed); `to_intel_card()` deterministic mapping; `from_dict()`.
- `repo-b/src/lib/analyzer/types.ts` — literal TypeScript mirror + `isFindingHonest()` client guard.
- `backend/tests/test_analyzer_contract.py` — 18 tests.

## Contract fields

`finding_id`, `env_id`, `analyzer_type`, `source_ref`, `severity`, `what_changed`, `why_it_matters`, `driver_math`, `evidence_refs`, `metric_refs`, `confidence`, `null_reasons`, `recommendations`, `next_questions`, `cost_to_generate_usd`, `latency_ms`, `eval_status`.

## Honesty rules (enforced)

- **No high-confidence (≥0.70) or `critical` finding without `evidence_refs`.** The load-bearing rule — checked in `__post_init__`, so it's structural.
- **Severity is rule-based, not LLM-assigned** — it's a plain field analyzers set from thresholds/evidence; validation forbids high-severity claims with no evidence.
- **Confidence bands documented** (measured 0.90–1.0 / strong 0.70–0.89 / directional 0.50–0.69 / informational <0.50) and range-checked.
- A `critical` finding requires confidence ≥ 0.5.
- `to_intel_card()` maps deterministically: severity → (card_type, anomaly_flag) — critical→alert+anomaly, warning/info→finding; priority = severity_weight × confidence. Returns exactly the kwargs `intelligence_cards.upsert_card` expects.

## Explicit exclusions

telemetry/data-platform/business analyzer implementations · agents · reels · enterprise memory · mission control.

## Tests & checks

- Backend: 18/18 (`test_analyzer_contract.py`) — construction, evidence rules, field validation, card mapping
- `ruff check app tests`: clean
- `from app.main import app`: succeeds (1486 routes)
- Tree-wide `tsc --noEmit`: 0 errors; ESLint on the TS type: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
