### PR TITLE
Phase 4 PR 10: Data Platform Analyzer

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -86,6 +86,7 @@ from app.routes import workflow_registry
 from app.routes import audit_dashboard
 from app.routes import analysis_sessions
 from app.routes import telemetry_analyzer
+from app.routes import data_platform_analyzer
 from app.routes import re_uw_reports, re_uw_links, re_pipeline, re_geography, re_intelligence
 from app.routes import re_opportunities
 from app.routes import (
@@ -463,6 +464,7 @@ app.include_router(workflow_registry.router)
 app.include_router(audit_dashboard.router)
 app.include_router(analysis_sessions.router)
 app.include_router(telemetry_analyzer.router)
+app.include_router(data_platform_analyzer.router)
 app.include_router(tracking.router)
 app.include_router(email_integrations.router)
 app.include_router(nv_discovery.router)

--- a/backend/app/routes/data_platform_analyzer.py
+++ b/backend/app/routes/data_platform_analyzer.py
@@ -1,0 +1,48 @@
+"""Data Platform Analyzer API (plan PR 10).
+
+Read-only. Grounds findings in existing DQ/pipeline/audit reads; fails closed with
+null_reasons rather than fabricating numbers. Mounted under /api/ade/analyze.
+
+Paths:
+    POST /api/ade/analyze/data-platform          run the analyzer, return AnalyzerFinding[]
+    GET  /api/ade/analyze/data-platform/summary  compact grounded overview
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Query, Request
+from pydantic import BaseModel
+
+from app.auth.platform import require_environment_access
+from app.observability.logger import emit_log
+from app.services import data_platform_analyzer as svc
+
+router = APIRouter(prefix="/api/ade/analyze/data-platform", tags=["ade"])
+
+
+class AnalyzeBody(BaseModel):
+    env_id: str
+    business_id: UUID
+
+
+@router.post("")
+def analyze(body: AnalyzeBody, request: Request):
+    require_environment_access(request, env_id=body.env_id)
+    try:
+        return {**svc.analyze(body.env_id, body.business_id), "null_reason": None}
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="data_platform_analyzer", action="analyze_failed", message=str(exc), error=exc)
+        return {"analyzer_type": "data_platform", "findings": [], "null_reasons": [],
+                "latency_ms": None, "null_reason": "data_platform_analyze_unavailable"}
+
+
+@router.get("/summary")
+def summary(request: Request, env_id: str = Query(...), business_id: UUID = Query(...)):
+    require_environment_access(request, env_id=env_id)
+    try:
+        return {**svc.summary(env_id, business_id), "null_reason": None}
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="data_platform_analyzer", action="summary_failed", message=str(exc), error=exc)
+        return {"analyzer_type": "data_platform", "finding_count": 0, "by_severity": {},
+                "null_reasons": [], "latency_ms": None, "null_reason": "data_platform_summary_unavailable"}

--- a/backend/app/services/data_platform_analyzer.py
+++ b/backend/app/services/data_platform_analyzer.py
@@ -1,0 +1,208 @@
+"""Data Platform Analyzer (plan PR 10) — real findings, deterministic-first.
+
+Grounds findings in existing reads on main today:
+  - telemetry_stream_etl.stream_health  -> DQ assertion failures, stale freshness
+  - telemetry_stream_etl.stream_live    -> pipeline surface status (fresh/stale/failed)
+  - audit_dashboard.summary             -> tool error rate, estimated-cost spike
+
+Every number comes from a real read. Severity is RULE-BASED. When a source is empty or
+returns a null_reason, the finding is SKIPPED with a recorded null_reason — never a
+fabricated number. Heavy DQ EXECUTION (BigQuery/Databricks) is out of scope; this reads
+the already-computed assertion/status results.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from uuid import UUID
+
+from app.services.analyzer_contract import AnalyzerFinding
+
+ANALYZER_TYPE = "data_platform"
+
+# Rule-based thresholds (frozen, not LLM-assigned).
+TOOL_ERROR_RATE_CRITICAL = 0.25   # >25% of audited calls failing
+TOOL_ERROR_RATE_WARNING = 0.10
+COST_SPIKE_SIGMA = 2.0            # a day's cost > mean + 2*stddev of the window
+
+
+def _fid() -> str:
+    return f"dp-{uuid.uuid4().hex[:12]}"
+
+
+def analyze(env_id: str, business_id: str | UUID) -> dict:
+    started = time.monotonic()
+    biz = business_id if isinstance(business_id, UUID) else UUID(str(business_id))
+    findings: list[AnalyzerFinding] = []
+    null_reasons: list[dict] = []
+
+    findings.extend(_pipeline_findings(env_id, biz, null_reasons))
+    findings.extend(_dq_findings(env_id, biz, null_reasons))
+    findings.extend(_audit_findings(env_id, biz, null_reasons))
+
+    latency_ms = int((time.monotonic() - started) * 1000)
+    findings = [AnalyzerFinding(**{**f.to_dict(), "latency_ms": latency_ms}) for f in findings]
+    return {
+        "analyzer_type": ANALYZER_TYPE,
+        "findings": [f.to_dict() for f in findings],
+        "null_reasons": null_reasons,
+        "latency_ms": latency_ms,
+    }
+
+
+def _safe(call, *, source: str, null_reasons: list[dict]):
+    try:
+        return call()
+    except Exception:  # noqa: BLE001 — fail closed
+        null_reasons.append({"source": source, "reason": f"{source}_unavailable"})
+        return None
+
+
+# ── pipeline status (stream_live.pipeline) ───────────────────────────────────
+def _pipeline_findings(env_id: str, biz: UUID, null_reasons: list[dict]) -> list[AnalyzerFinding]:
+    from app.services import telemetry_stream_etl
+    live = _safe(lambda: telemetry_stream_etl.stream_live(env_id=env_id, business_id=biz),
+                 source="pipeline_status", null_reasons=null_reasons)
+    if live is None:
+        return []
+    pipeline = live.get("pipeline") or {}
+    surfaces = pipeline.get("surfaces") or {}
+    if not surfaces:
+        null_reasons.append({"source": "pipeline_status", "reason": "no_pipeline_status"})
+        return []
+    findings: list[AnalyzerFinding] = []
+    for surface, info in surfaces.items():
+        status = (info or {}).get("status")
+        if status in ("fresh", "unknown", None):
+            continue  # only real degraded states produce a finding
+        ftype = "pipeline_failed" if status == "failed" else "feed_stale"
+        severity = "critical" if status == "failed" else "warning"
+        reason = (info or {}).get("reason")
+        findings.append(AnalyzerFinding(
+            finding_id=_fid(), env_id=env_id, analyzer_type=ANALYZER_TYPE,
+            source_ref={"source": "telemetry_stream_etl.stream_live", "surface": surface,
+                        "status": status, "finding_type": ftype},
+            severity=severity, confidence=0.85,
+            what_changed=f"Pipeline surface '{surface}' is {status}",
+            why_it_matters=("A non-fresh surface means downstream reads may be serving stale or "
+                            "missing data."),
+            evidence_refs=[f"surface={surface}", f"status={status}", f"as_of_ts={(info or {}).get('as_of_ts')}"],
+            metric_refs=[f"pipeline.{surface}.status"],
+            recommendations=[f"Investigate the {surface} pipeline: {reason or 'see pipeline status'}"],
+            next_questions=["Is the ingest worker running and are watermarks advancing?"],
+        ))
+    return findings
+
+
+# ── DQ assertions + freshness (stream_health) ────────────────────────────────
+def _dq_findings(env_id: str, biz: UUID, null_reasons: list[dict]) -> list[AnalyzerFinding]:
+    from app.services import telemetry_stream_etl
+    health = _safe(lambda: telemetry_stream_etl.stream_health(env_id=env_id, business_id=biz),
+                   source="stream_health", null_reasons=null_reasons)
+    if health is None:
+        return []
+    findings: list[AnalyzerFinding] = []
+    assertions = health.get("assertions") or []
+    failed = [a for a in assertions if a.get("passed") is False]
+    if not assertions:
+        null_reasons.append({"source": "dq_assertions", "reason": "no_dq_assertions"})
+    for a in failed:
+        findings.append(AnalyzerFinding(
+            finding_id=_fid(), env_id=env_id, analyzer_type=ANALYZER_TYPE,
+            source_ref={"source": "telemetry_stream_etl.stream_health", "finding_type": "dq_assertion_fail",
+                        "assertion_name": a.get("assertion_name"), "table_name": a.get("table_name")},
+            severity="warning", confidence=0.88,
+            what_changed=f"DQ assertion '{a.get('assertion_name')}' failed on {a.get('table_name')}",
+            why_it_matters="A failing data-quality assertion means a downstream metric may be wrong.",
+            evidence_refs=[f"observed={a.get('observed')}", f"threshold={a.get('threshold')}",
+                           f"run_ts={a.get('run_ts')}"],
+            metric_refs=[str(a.get("assertion_name"))],
+            recommendations=[f"Check {a.get('table_name')}: observed {a.get('observed')} vs {a.get('threshold')}."],
+            next_questions=["What upstream change broke this assertion?"],
+        ))
+    return findings
+
+
+# ── audit error rate + cost spike (audit_dashboard.summary) ──────────────────
+def _audit_findings(env_id: str, biz: UUID, null_reasons: list[dict]) -> list[AnalyzerFinding]:
+    from app.services import audit_dashboard
+    summ = _safe(lambda: audit_dashboard.summary(biz, env_id=env_id),
+                 source="audit_summary", null_reasons=null_reasons)
+    if summ is None:
+        return []
+    if summ.get("null_reason"):
+        null_reasons.append({"source": "audit_summary", "reason": summ["null_reason"]})
+        return []
+    findings: list[AnalyzerFinding] = []
+    total = summ.get("total_decisions") or 0
+    if total > 0 and summ.get("success_rate") is not None:
+        err_rate = round(1.0 - summ["success_rate"], 4)
+        if err_rate >= TOOL_ERROR_RATE_WARNING:
+            severity = "critical" if err_rate >= TOOL_ERROR_RATE_CRITICAL else "warning"
+            findings.append(AnalyzerFinding(
+                finding_id=_fid(), env_id=env_id, analyzer_type=ANALYZER_TYPE,
+                source_ref={"source": "audit_dashboard.summary", "field": "success_rate",
+                            "finding_type": "tool_error_rate"},
+                severity=severity, confidence=0.82,
+                what_changed=f"Tool error rate is {round(err_rate * 100, 2)}% over {summ.get('window_days')}d",
+                why_it_matters="Elevated tool-call failures degrade every surface that depends on them.",
+                evidence_refs=[f"failed={summ.get('failed')}", f"total_decisions={total}"],
+                metric_refs=["success_rate"],
+                recommendations=["Review the top failing tools in the audit dashboard."],
+                next_questions=["Which tool accounts for most failures?"],
+            ))
+    else:
+        null_reasons.append({"source": "audit_summary.error_rate", "reason": "no_decisions"})
+
+    # Cost spike: a day's estimated cost far above the window mean (deterministic stats).
+    series = [d.get("calls") for d in (summ.get("calls_per_day") or []) if isinstance(d.get("calls"), (int, float))]
+    spike = _detect_spike(series)
+    if spike is not None:
+        findings.append(AnalyzerFinding(
+            finding_id=_fid(), env_id=env_id, analyzer_type=ANALYZER_TYPE,
+            source_ref={"source": "audit_dashboard.summary", "field": "calls_per_day",
+                        "finding_type": "cost_spike"},
+            severity="warning", confidence=0.7,
+            what_changed=(f"A day's call volume ({spike['value']}) exceeded the window mean "
+                          f"by > {COST_SPIKE_SIGMA}σ"),
+            why_it_matters="A volume spike drives cost and can indicate a runaway loop or misuse.",
+            evidence_refs=[f"value={spike['value']}", f"mean={spike['mean']}", f"stddev={spike['stddev']}"],
+            metric_refs=["calls_per_day"],
+            recommendations=["Inspect that day's audit activity for an anomaly or runaway caller."],
+            next_questions=["What drove the volume spike?"],
+        ))
+    elif not series:
+        null_reasons.append({"source": "audit_summary.cost", "reason": "no_calls_per_day"})
+    return findings
+
+
+def _detect_spike(series: list[float]) -> dict | None:
+    """Return the max point if it exceeds mean + COST_SPIKE_SIGMA*stddev. Needs >=4 points
+    and a non-zero stddev. Pure, deterministic — no fabrication."""
+    if len(series) < 4:
+        return None
+    n = len(series)
+    mean = sum(series) / n
+    var = sum((x - mean) ** 2 for x in series) / n
+    stddev = var ** 0.5
+    if stddev == 0:
+        return None
+    peak = max(series)
+    if peak > mean + COST_SPIKE_SIGMA * stddev:
+        return {"value": peak, "mean": round(mean, 2), "stddev": round(stddev, 2)}
+    return None
+
+
+def summary(env_id: str, business_id: str | UUID) -> dict:
+    biz = business_id if isinstance(business_id, UUID) else UUID(str(business_id))
+    result = analyze(env_id, biz)
+    by_sev: dict[str, int] = {"info": 0, "warning": 0, "critical": 0}
+    for f in result["findings"]:
+        by_sev[f["severity"]] = by_sev.get(f["severity"], 0) + 1
+    return {
+        "analyzer_type": ANALYZER_TYPE,
+        "finding_count": len(result["findings"]),
+        "by_severity": by_sev,
+        "null_reasons": result["null_reasons"],
+        "latency_ms": result["latency_ms"],
+    }

--- a/backend/tests/test_data_platform_analyzer.py
+++ b/backend/tests/test_data_platform_analyzer.py
@@ -1,0 +1,168 @@
+"""Tests for the Data Platform Analyzer (plan PR 10).
+
+Run: cd backend && python -m pytest tests/test_data_platform_analyzer.py -x -q
+
+Proves: findings come from REAL DQ/pipeline/audit reads (monkeypatched), severity is
+rule-based, empty/null sources fail closed with null_reasons (never a fabricated number),
+and every finding satisfies the AnalyzerFinding contract.
+"""
+import os
+
+os.environ.setdefault("BM_MCP_DRY_RUN", "1")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+os.environ.setdefault("MCP_API_TOKEN", "test-token")
+
+from app.services import data_platform_analyzer as svc  # noqa: E402
+from app.services.analyzer_contract import AnalyzerFinding  # noqa: E402
+
+ENV = "test-env"
+BIZ = "00000000-0000-0000-0000-000000000001"
+
+
+def _patch(monkeypatch, *, live=None, health=None, summary=None):
+    from app.services import telemetry_stream_etl, audit_dashboard
+    monkeypatch.setattr(telemetry_stream_etl, "stream_live",
+                        lambda **kw: live if live is not None else {"pipeline": {"surfaces": {}}})
+    monkeypatch.setattr(telemetry_stream_etl, "stream_health",
+                        lambda **kw: health if health is not None else {"assertions": []})
+    monkeypatch.setattr(audit_dashboard, "summary",
+                        lambda biz, **kw: summary if summary is not None else {
+                            "total_decisions": 0, "null_reason": "no_audit_activity"})
+
+
+# ── pipeline findings ─────────────────────────────────────────────────────────
+def test_failed_pipeline_surface_is_critical(monkeypatch):
+    _patch(monkeypatch, live={"pipeline": {"surfaces": {
+        "silver": {"status": "failed", "as_of_ts": "2026-06-15T00:00:00Z", "reason": "watermark_stalled"}}}})
+    out = svc.analyze(ENV, BIZ)
+    pf = [f for f in out["findings"] if f["source_ref"].get("finding_type") == "pipeline_failed"]
+    assert pf and pf[0]["severity"] == "critical"
+    assert pf[0]["evidence_refs"]
+
+
+def test_stale_surface_is_warning(monkeypatch):
+    _patch(monkeypatch, live={"pipeline": {"surfaces": {
+        "gold": {"status": "stale", "as_of_ts": "x", "reason": "no_new_rows"}}}})
+    out = svc.analyze(ENV, BIZ)
+    fs = [f for f in out["findings"] if f["source_ref"].get("finding_type") == "feed_stale"]
+    assert fs and fs[0]["severity"] == "warning"
+
+
+def test_fresh_surface_produces_no_finding(monkeypatch):
+    _patch(monkeypatch, live={"pipeline": {"surfaces": {"silver": {"status": "fresh", "as_of_ts": "x"}}}})
+    out = svc.analyze(ENV, BIZ)
+    assert not any(f["source_ref"].get("source") == "telemetry_stream_etl.stream_live"
+                   for f in out["findings"])
+
+
+# ── DQ assertion findings ─────────────────────────────────────────────────────
+def test_failed_dq_assertion_finding(monkeypatch):
+    _patch(monkeypatch, health={"assertions": [
+        {"assertion_name": "freshness", "table_name": "tel_stream_readings", "passed": False,
+         "observed": "600s", "threshold": "120s", "run_ts": "x"},
+        {"assertion_name": "row_count", "table_name": "t", "passed": True, "run_ts": "x"},
+    ]})
+    out = svc.analyze(ENV, BIZ)
+    dq = [f for f in out["findings"] if f["source_ref"].get("finding_type") == "dq_assertion_fail"]
+    assert len(dq) == 1  # only the failed one
+    assert dq[0]["severity"] == "warning"
+    assert "freshness" in dq[0]["metric_refs"]
+
+
+def test_no_dq_assertions_records_null_reason(monkeypatch):
+    _patch(monkeypatch, health={"assertions": []})
+    out = svc.analyze(ENV, BIZ)
+    assert any(r["reason"] == "no_dq_assertions" for r in out["null_reasons"])
+
+
+# ── audit error rate + cost spike ─────────────────────────────────────────────
+def test_high_tool_error_rate_is_critical(monkeypatch):
+    _patch(monkeypatch, summary={
+        "total_decisions": 100, "success_rate": 0.6, "failed": 40, "window_days": 30,
+        "calls_per_day": [], "null_reason": None})
+    out = svc.analyze(ENV, BIZ)
+    er = [f for f in out["findings"] if f["source_ref"].get("finding_type") == "tool_error_rate"]
+    assert er and er[0]["severity"] == "critical"  # 40% > 25%
+
+
+def test_cost_spike_detected(monkeypatch):
+    # A clear outlier day among low-volume days.
+    days = [{"calls": v} for v in [10, 12, 11, 9, 13, 200]]
+    _patch(monkeypatch, summary={
+        "total_decisions": 255, "success_rate": 1.0, "failed": 0, "window_days": 30,
+        "calls_per_day": days, "null_reason": None})
+    out = svc.analyze(ENV, BIZ)
+    spike = [f for f in out["findings"] if f["source_ref"].get("finding_type") == "cost_spike"]
+    assert spike and spike[0]["severity"] == "warning"
+
+
+def test_no_cost_spike_for_flat_series(monkeypatch):
+    days = [{"calls": v} for v in [10, 11, 10, 12, 11]]
+    _patch(monkeypatch, summary={
+        "total_decisions": 54, "success_rate": 1.0, "failed": 0, "window_days": 30,
+        "calls_per_day": days, "null_reason": None})
+    out = svc.analyze(ENV, BIZ)
+    assert not any(f["source_ref"].get("finding_type") == "cost_spike" for f in out["findings"])
+
+
+def test_detect_spike_pure():
+    assert svc._detect_spike([10, 11, 10, 12, 11]) is None  # flat
+    assert svc._detect_spike([1, 2]) is None  # too few points
+    assert svc._detect_spike([5, 5, 5, 5]) is None  # zero stddev
+    out = svc._detect_spike([10, 12, 11, 9, 13, 200])
+    assert out is not None and out["value"] == 200
+
+
+# ── fail closed ───────────────────────────────────────────────────────────────
+def test_audit_null_reason_fails_closed(monkeypatch):
+    _patch(monkeypatch, summary={"total_decisions": 0, "null_reason": "no_audit_activity"})
+    out = svc.analyze(ENV, BIZ)
+    assert not any(f["source_ref"].get("source") == "audit_dashboard.summary" for f in out["findings"])
+    assert any(r["reason"] == "no_audit_activity" for r in out["null_reasons"])
+
+
+def test_sources_raising_fails_closed(monkeypatch):
+    from app.services import telemetry_stream_etl, audit_dashboard
+    def boom(**kw):
+        raise RuntimeError("db down")
+    monkeypatch.setattr(telemetry_stream_etl, "stream_live", boom)
+    monkeypatch.setattr(telemetry_stream_etl, "stream_health", boom)
+    monkeypatch.setattr(audit_dashboard, "summary", lambda biz, **kw: (_ for _ in ()).throw(RuntimeError("x")))
+    out = svc.analyze(ENV, BIZ)
+    assert out["findings"] == []
+    reasons = {r["reason"] for r in out["null_reasons"]}
+    assert "pipeline_status_unavailable" in reasons
+    assert "stream_health_unavailable" in reasons
+
+
+# ── contract compliance + summary ─────────────────────────────────────────────
+def test_findings_satisfy_contract(monkeypatch):
+    _patch(monkeypatch,
+           live={"pipeline": {"surfaces": {"silver": {"status": "failed", "as_of_ts": "x", "reason": "r"}}}},
+           health={"assertions": [{"assertion_name": "freshness", "table_name": "t", "passed": False,
+                                   "observed": "x", "threshold": "y", "run_ts": "z"}]},
+           summary={"total_decisions": 100, "success_rate": 0.6, "failed": 40, "window_days": 30,
+                    "calls_per_day": [], "null_reason": None})
+    out = svc.analyze(ENV, BIZ)
+    assert len(out["findings"]) >= 3
+    for f in out["findings"]:
+        AnalyzerFinding(**{k: v for k, v in f.items() if k in AnalyzerFinding.__dataclass_fields__})
+
+
+def test_summary_counts_by_severity(monkeypatch):
+    _patch(monkeypatch, live={"pipeline": {"surfaces": {"silver": {"status": "failed", "as_of_ts": "x"}}}})
+    s = svc.summary(ENV, BIZ)
+    assert s["analyzer_type"] == "data_platform"
+    assert s["finding_count"] == sum(s["by_severity"].values())
+
+
+# ── route ─────────────────────────────────────────────────────────────────────
+def test_route_analyze_fails_closed(client, monkeypatch):
+    from app.routes import data_platform_analyzer as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    def boom(env, biz):
+        raise RuntimeError("x")
+    monkeypatch.setattr(svc, "analyze", boom)
+    resp = client.post("/api/ade/analyze/data-platform", json={"env_id": ENV, "business_id": BIZ})
+    assert resp.status_code == 200
+    assert resp.json()["null_reason"] == "data_platform_analyze_unavailable"


### PR DESCRIPTION
## Summary

Phase 4 / PR 10 — the **Data Platform Analyzer**, the second analyzer on the PR 8.5 `AnalyzerFinding` contract. Deterministic-first; every number from a real read.

## Files (4)

- `backend/app/services/data_platform_analyzer.py` — grounds findings in existing reads:
  - `telemetry_stream_etl.stream_live` → pipeline surface status (`feed_stale` / `pipeline_failed`)
  - `telemetry_stream_etl.stream_health` → `tel_dq_assertions` failures (`dq_assertion_fail`)
  - `audit_dashboard.summary` → `success_rate` (`tool_error_rate`) and `calls_per_day` (`cost_spike`, deterministic >2σ)
- `backend/app/routes/data_platform_analyzer.py` + `main.py` mount — `POST /api/ade/analyze/data-platform`, `GET .../summary`.
- `backend/tests/test_data_platform_analyzer.py` — 14 tests.

## Honesty

- **Severity rule-based**: pipeline failed→critical, stale→warning; DQ fail→warning; tool error rate ≥0.25→critical / ≥0.10→warning; cost spike via a pure mean+2σ check (≥4 points, non-zero stddev).
- **Reads pre-computed DQ/pipeline results** — heavy DQ execution (BigQuery/Databricks) is out of scope; this surfaces the already-computed assertion/status rows.
- A finding is produced only when the real degraded state exists; empty/null/fresh sources are **skipped with a null_reason** — never a fabricated number.
- Every finding satisfies the `AnalyzerFinding` contract.

## Explicit exclusions

DQ execution in BigQuery/Databricks · agents · frontend · write tools · the business analyzer (PR 11).

## Tests & checks

- Backend: 14 PR10 tests; 81 in the analyzer/ADE suite — no regression
- `ruff check app tests`: clean
- `from app.main import app`: succeeds (1493 routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
