### PR TITLE
Phase 4 PR 11: Business Analyzer

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -87,6 +87,7 @@ from app.routes import audit_dashboard
 from app.routes import analysis_sessions
 from app.routes import telemetry_analyzer
 from app.routes import data_platform_analyzer
+from app.routes import business_analyzer
 from app.routes import re_uw_reports, re_uw_links, re_pipeline, re_geography, re_intelligence
 from app.routes import re_opportunities
 from app.routes import (
@@ -465,6 +466,7 @@ app.include_router(audit_dashboard.router)
 app.include_router(analysis_sessions.router)
 app.include_router(telemetry_analyzer.router)
 app.include_router(data_platform_analyzer.router)
+app.include_router(business_analyzer.router)
 app.include_router(tracking.router)
 app.include_router(email_integrations.router)
 app.include_router(nv_discovery.router)

--- a/backend/app/routes/business_analyzer.py
+++ b/backend/app/routes/business_analyzer.py
@@ -1,0 +1,51 @@
+"""Business Analyzer API (plan PR 11).
+
+Read-only. Env-type dispatch (consulting / accounting / generic), grounded in existing
+reads; fails closed with null_reasons rather than fabricating numbers. Mounted under
+/api/ade/analyze.
+
+Paths:
+    POST /api/ade/analyze/business          run the analyzer, return AnalyzerFinding[]
+    GET  /api/ade/analyze/business/summary  compact grounded overview
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Query, Request
+from pydantic import BaseModel
+
+from app.auth.platform import require_environment_access
+from app.observability.logger import emit_log
+from app.services import business_analyzer as svc
+
+router = APIRouter(prefix="/api/ade/analyze/business", tags=["ade"])
+
+
+class AnalyzeBody(BaseModel):
+    env_id: str
+    business_id: UUID
+    env_type: str | None = None  # optional override; otherwise resolved from the env row
+
+
+@router.post("")
+def analyze(body: AnalyzeBody, request: Request):
+    require_environment_access(request, env_id=body.env_id)
+    try:
+        return {**svc.analyze(body.env_id, body.business_id, env_type=body.env_type), "null_reason": None}
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="business_analyzer", action="analyze_failed", message=str(exc), error=exc)
+        return {"analyzer_type": "business", "env_type": None, "findings": [], "null_reasons": [],
+                "latency_ms": None, "null_reason": "business_analyze_unavailable"}
+
+
+@router.get("/summary")
+def summary(request: Request, env_id: str = Query(...), business_id: UUID = Query(...),
+            env_type: str = Query(None)):
+    require_environment_access(request, env_id=env_id)
+    try:
+        return {**svc.summary(env_id, business_id, env_type=env_type), "null_reason": None}
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="business_analyzer", action="summary_failed", message=str(exc), error=exc)
+        return {"analyzer_type": "business", "env_type": None, "finding_count": 0, "by_severity": {},
+                "null_reasons": [], "latency_ms": None, "null_reason": "business_summary_unavailable"}

--- a/backend/app/services/business_analyzer.py
+++ b/backend/app/services/business_analyzer.py
@@ -1,0 +1,205 @@
+"""Business Analyzer (plan PR 11) — real findings, deterministic-first, env-type dispatch.
+
+For any environment, produces operational signals grounded in real reads. Dispatches on
+the environment's industry/template:
+  - consulting          -> execution_tasks.board_summary (overdue tasks, TODAY-cap pressure)
+  - accounting/finance  -> nv_accounting_kpis.compute_kpis (cash status tiles)
+  - generic (always)    -> audit_dashboard.summary (tool error rate) as a universal floor
+
+Severity is RULE-BASED. Every number comes from a real read; when a source is empty or
+returns a null_reason / unavailable status, the finding is SKIPPED with a recorded
+null_reason — never a fabricated number. No LLM. No per-finding model calls.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from uuid import UUID
+
+from app.services.analyzer_contract import AnalyzerFinding
+
+ANALYZER_TYPE = "business"
+
+# Rule-based thresholds.
+OVERDUE_WARNING = 1          # any overdue task is worth a warning
+OVERDUE_CRITICAL = 5
+TODAY_CAP = 8                # the consulting board's forced-prioritization cap
+TOOL_ERROR_RATE_WARNING = 0.10
+TOOL_ERROR_RATE_CRITICAL = 0.25
+
+_CONSULTING_HINTS = ("consulting", "consulting_revenue_os", "cro")
+_ACCOUNTING_HINTS = ("accounting", "finance", "novendor", "bookkeeping")
+
+
+def _fid() -> str:
+    return f"biz-{uuid.uuid4().hex[:12]}"
+
+
+def _resolve_env_type(env_id: str) -> str:
+    """Best-effort env classification from the environment row. 'generic' on any failure."""
+    try:
+        from app.services import lab
+        row = lab.get_environment(env_id)
+        if not row:
+            return "generic"
+        hint = f"{row.get('industry_type') or ''} {row.get('industry') or ''} " \
+               f"{row.get('workspace_template_key') or ''}".lower()
+        if any(h in hint for h in _CONSULTING_HINTS):
+            return "consulting"
+        if any(h in hint for h in _ACCOUNTING_HINTS):
+            return "accounting"
+        return "generic"
+    except Exception:  # noqa: BLE001
+        return "generic"
+
+
+def analyze(env_id: str, business_id: str | UUID, *, env_type: str | None = None) -> dict:
+    started = time.monotonic()
+    biz = business_id if isinstance(business_id, UUID) else UUID(str(business_id))
+    resolved = env_type or _resolve_env_type(env_id)
+    findings: list[AnalyzerFinding] = []
+    null_reasons: list[dict] = []
+
+    if resolved == "consulting":
+        findings.extend(_consulting_findings(env_id, biz, null_reasons))
+    elif resolved == "accounting":
+        findings.extend(_accounting_findings(env_id, biz, null_reasons))
+    # Universal floor: audit error rate applies to every environment.
+    findings.extend(_audit_findings(env_id, biz, null_reasons))
+
+    latency_ms = int((time.monotonic() - started) * 1000)
+    findings = [AnalyzerFinding(**{**f.to_dict(), "latency_ms": latency_ms}) for f in findings]
+    return {
+        "analyzer_type": ANALYZER_TYPE,
+        "env_type": resolved,
+        "findings": [f.to_dict() for f in findings],
+        "null_reasons": null_reasons,
+        "latency_ms": latency_ms,
+    }
+
+
+def _safe(call, *, source: str, null_reasons: list[dict]):
+    try:
+        return call()
+    except Exception:  # noqa: BLE001
+        null_reasons.append({"source": source, "reason": f"{source}_unavailable"})
+        return None
+
+
+# ── consulting (execution_tasks.board_summary) ───────────────────────────────
+def _consulting_findings(env_id: str, biz: UUID, null_reasons: list[dict]) -> list[AnalyzerFinding]:
+    from app.services import execution_tasks
+    board = _safe(lambda: execution_tasks.board_summary(env_id=env_id, business_id=biz),
+                  source="board_summary", null_reasons=null_reasons)
+    if board is None:
+        return []
+    findings: list[AnalyzerFinding] = []
+    overdue = board.get("overdue_count") or 0
+    today = board.get("today_count") or 0
+
+    if overdue >= OVERDUE_WARNING:
+        severity = "critical" if overdue >= OVERDUE_CRITICAL else "warning"
+        findings.append(AnalyzerFinding(
+            finding_id=_fid(), env_id=env_id, analyzer_type=ANALYZER_TYPE,
+            source_ref={"source": "execution_tasks.board_summary", "field": "overdue_count",
+                        "signal_type": "bottleneck"},
+            severity=severity, confidence=0.85,
+            what_changed=f"{overdue} task{'' if overdue == 1 else 's'} are overdue",
+            why_it_matters="Overdue tasks signal commitments slipping past their due dates.",
+            evidence_refs=[f"overdue_count={overdue}", f"today_count={today}",
+                           f"this_week_count={board.get('this_week_count')}"],
+            metric_refs=["overdue_count"],
+            recommendations=["Re-prioritize or reschedule the overdue items on the board."],
+            next_questions=["Which workstream owns the overdue tasks?"],
+        ))
+    if today > TODAY_CAP:
+        findings.append(AnalyzerFinding(
+            finding_id=_fid(), env_id=env_id, analyzer_type=ANALYZER_TYPE,
+            source_ref={"source": "execution_tasks.board_summary", "field": "today_count",
+                        "signal_type": "risk"},
+            severity="warning", confidence=0.78,
+            what_changed=f"TODAY column holds {today} tasks (cap is {TODAY_CAP})",
+            why_it_matters="An over-cap TODAY column defeats forced prioritization and dilutes focus.",
+            evidence_refs=[f"today_count={today}", f"cap={TODAY_CAP}"],
+            metric_refs=["today_count"],
+            recommendations=["Trim TODAY back toward the cap; move non-urgent items to This Week."],
+            next_questions=["What can move out of TODAY without missing a commitment?"],
+        ))
+    return findings
+
+
+# ── accounting (nv_accounting_kpis.compute_kpis) ─────────────────────────────
+def _accounting_findings(env_id: str, biz: UUID, null_reasons: list[dict]) -> list[AnalyzerFinding]:
+    from app.services import nv_accounting_kpis
+    kpis = _safe(lambda: nv_accounting_kpis.compute_kpis(env_id=env_id, business_id=str(biz)),
+                 source="accounting_kpis", null_reasons=null_reasons)
+    if kpis is None:
+        return []
+    tiles = kpis.get("kpis") or []
+    # A tile that reports 'unavailable' status is disclosed as a null_reason, never coerced.
+    cash = next((t for t in tiles if t.get("key") in ("cash-balance", "cash_balance")), None)
+    if cash is None:
+        null_reasons.append({"source": "accounting_kpis", "reason": "no_cash_balance_tile"})
+        return []
+    if cash.get("status") == "unavailable":
+        null_reasons.append({"source": "accounting_kpis.cash_balance", "reason": "cash_balance_unavailable"})
+        return []
+    # Real value present: an informational leading-indicator finding (no fabricated thresholds).
+    return [AnalyzerFinding(
+        finding_id=_fid(), env_id=env_id, analyzer_type=ANALYZER_TYPE,
+        source_ref={"source": "nv_accounting_kpis.compute_kpis", "field": "cash_balance",
+                    "signal_type": "leading_indicator"},
+        severity="info", confidence=0.7,
+        what_changed=f"Cash balance tile reports {cash.get('value')}",
+        why_it_matters="Cash position is a leading indicator for the operating runway.",
+        evidence_refs=[f"value={cash.get('value')}", f"status={cash.get('status')}"],
+        metric_refs=["cash_balance"],
+        recommendations=[],
+        next_questions=["Is the 30-day cash trend improving or declining?"],
+    )]
+
+
+# ── universal floor: audit error rate ────────────────────────────────────────
+def _audit_findings(env_id: str, biz: UUID, null_reasons: list[dict]) -> list[AnalyzerFinding]:
+    from app.services import audit_dashboard
+    summ = _safe(lambda: audit_dashboard.summary(biz, env_id=env_id),
+                 source="audit_summary", null_reasons=null_reasons)
+    if summ is None:
+        return []
+    if summ.get("null_reason") or not (summ.get("total_decisions") or 0):
+        null_reasons.append({"source": "audit_summary", "reason": summ.get("null_reason") or "no_decisions"})
+        return []
+    if summ.get("success_rate") is None:
+        null_reasons.append({"source": "audit_summary", "reason": "no_success_rate"})
+        return []
+    err_rate = round(1.0 - summ["success_rate"], 4)
+    if err_rate < TOOL_ERROR_RATE_WARNING:
+        return []
+    severity = "critical" if err_rate >= TOOL_ERROR_RATE_CRITICAL else "warning"
+    return [AnalyzerFinding(
+        finding_id=_fid(), env_id=env_id, analyzer_type=ANALYZER_TYPE,
+        source_ref={"source": "audit_dashboard.summary", "field": "success_rate", "signal_type": "risk"},
+        severity=severity, confidence=0.8,
+        what_changed=f"Tool error rate is {round(err_rate * 100, 2)}% over {summ.get('window_days')}d",
+        why_it_matters="Failing tool calls degrade every operational surface in the environment.",
+        evidence_refs=[f"failed={summ.get('failed')}", f"total_decisions={summ.get('total_decisions')}"],
+        metric_refs=["success_rate"],
+        recommendations=["Review the top failing tools in the audit dashboard."],
+        next_questions=["Which tool accounts for most failures?"],
+    )]
+
+
+def summary(env_id: str, business_id: str | UUID, *, env_type: str | None = None) -> dict:
+    biz = business_id if isinstance(business_id, UUID) else UUID(str(business_id))
+    result = analyze(env_id, biz, env_type=env_type)
+    by_sev: dict[str, int] = {"info": 0, "warning": 0, "critical": 0}
+    for f in result["findings"]:
+        by_sev[f["severity"]] = by_sev.get(f["severity"], 0) + 1
+    return {
+        "analyzer_type": ANALYZER_TYPE,
+        "env_type": result["env_type"],
+        "finding_count": len(result["findings"]),
+        "by_severity": by_sev,
+        "null_reasons": result["null_reasons"],
+        "latency_ms": result["latency_ms"],
+    }

--- a/backend/tests/test_business_analyzer.py
+++ b/backend/tests/test_business_analyzer.py
@@ -1,0 +1,168 @@
+"""Tests for the Business Analyzer (plan PR 11).
+
+Run: cd backend && python -m pytest tests/test_business_analyzer.py -x -q
+
+Proves: env-type dispatch, findings from REAL reads (monkeypatched), rule-based severity,
+empty/null/unavailable sources fail closed with null_reasons (never a fabricated number),
+and every finding satisfies the AnalyzerFinding contract.
+"""
+import os
+
+os.environ.setdefault("BM_MCP_DRY_RUN", "1")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+os.environ.setdefault("MCP_API_TOKEN", "test-token")
+
+from app.services import business_analyzer as svc  # noqa: E402
+from app.services.analyzer_contract import AnalyzerFinding  # noqa: E402
+
+ENV = "test-env"
+BIZ = "00000000-0000-0000-0000-000000000001"
+
+_NO_AUDIT = {"total_decisions": 0, "null_reason": "no_audit_activity"}
+
+
+def _patch_audit(monkeypatch, value=None):
+    from app.services import audit_dashboard
+    monkeypatch.setattr(audit_dashboard, "summary", lambda biz, **kw: value or _NO_AUDIT)
+
+
+# ── env-type dispatch ─────────────────────────────────────────────────────────
+def test_resolve_consulting_env(monkeypatch):
+    from app.services import lab
+    monkeypatch.setattr(lab, "get_environment", lambda e: {"industry_type": "consulting",
+                                                           "workspace_template_key": "consulting_revenue_os"})
+    assert svc._resolve_env_type(ENV) == "consulting"
+
+
+def test_resolve_generic_on_failure(monkeypatch):
+    from app.services import lab
+    monkeypatch.setattr(lab, "get_environment", lambda e: (_ for _ in ()).throw(RuntimeError("x")))
+    assert svc._resolve_env_type(ENV) == "generic"
+
+
+# ── consulting findings (board_summary) ───────────────────────────────────────
+def test_overdue_tasks_warning(monkeypatch):
+    from app.services import execution_tasks
+    monkeypatch.setattr(execution_tasks, "board_summary", lambda **kw: {
+        "overdue_count": 2, "today_count": 4, "this_week_count": 6})
+    _patch_audit(monkeypatch)
+    out = svc.analyze(ENV, BIZ, env_type="consulting")
+    od = [f for f in out["findings"] if f["source_ref"].get("field") == "overdue_count"]
+    assert od and od[0]["severity"] == "warning"
+    assert od[0]["evidence_refs"]
+
+
+def test_many_overdue_is_critical(monkeypatch):
+    from app.services import execution_tasks
+    monkeypatch.setattr(execution_tasks, "board_summary", lambda **kw: {
+        "overdue_count": 7, "today_count": 3, "this_week_count": 2})
+    _patch_audit(monkeypatch)
+    out = svc.analyze(ENV, BIZ, env_type="consulting")
+    od = [f for f in out["findings"] if f["source_ref"].get("field") == "overdue_count"]
+    assert od[0]["severity"] == "critical"
+
+
+def test_today_cap_exceeded_finding(monkeypatch):
+    from app.services import execution_tasks
+    monkeypatch.setattr(execution_tasks, "board_summary", lambda **kw: {
+        "overdue_count": 0, "today_count": 12, "this_week_count": 1})
+    _patch_audit(monkeypatch)
+    out = svc.analyze(ENV, BIZ, env_type="consulting")
+    cap = [f for f in out["findings"] if f["source_ref"].get("field") == "today_count"]
+    assert cap and cap[0]["severity"] == "warning"
+
+
+def test_healthy_board_no_findings(monkeypatch):
+    from app.services import execution_tasks
+    monkeypatch.setattr(execution_tasks, "board_summary", lambda **kw: {
+        "overdue_count": 0, "today_count": 5, "this_week_count": 8})
+    _patch_audit(monkeypatch)
+    out = svc.analyze(ENV, BIZ, env_type="consulting")
+    assert not any(f["source_ref"].get("source") == "execution_tasks.board_summary"
+                   for f in out["findings"])
+
+
+# ── accounting findings (compute_kpis) ────────────────────────────────────────
+def test_accounting_cash_balance_finding(monkeypatch):
+    from app.services import nv_accounting_kpis
+    monkeypatch.setattr(nv_accounting_kpis, "compute_kpis", lambda **kw: {
+        "kpis": [{"key": "cash-balance", "value": "$120k", "status": "available"}]})
+    _patch_audit(monkeypatch)
+    out = svc.analyze(ENV, BIZ, env_type="accounting")
+    cash = [f for f in out["findings"] if f["source_ref"].get("field") == "cash_balance"]
+    assert cash and cash[0]["severity"] == "info"
+
+
+def test_accounting_unavailable_fails_closed(monkeypatch):
+    from app.services import nv_accounting_kpis
+    monkeypatch.setattr(nv_accounting_kpis, "compute_kpis", lambda **kw: {
+        "kpis": [{"key": "cash-balance", "value": None, "status": "unavailable"}]})
+    _patch_audit(monkeypatch)
+    out = svc.analyze(ENV, BIZ, env_type="accounting")
+    assert not any(f["source_ref"].get("field") == "cash_balance" for f in out["findings"])
+    assert any(r["reason"] == "cash_balance_unavailable" for r in out["null_reasons"])
+
+
+# ── universal audit floor ─────────────────────────────────────────────────────
+def test_audit_floor_applies_to_generic(monkeypatch):
+    from app.services import lab
+    monkeypatch.setattr(lab, "get_environment", lambda e: {"industry_type": "general"})
+    _patch_audit(monkeypatch, {"total_decisions": 100, "success_rate": 0.6, "failed": 40,
+                               "window_days": 30, "null_reason": None})
+    out = svc.analyze(ENV, BIZ)
+    er = [f for f in out["findings"] if f["source_ref"].get("field") == "success_rate"]
+    assert er and er[0]["severity"] == "critical"
+    assert out["env_type"] == "generic"
+
+
+def test_audit_no_decisions_fails_closed(monkeypatch):
+    from app.services import lab
+    monkeypatch.setattr(lab, "get_environment", lambda e: {"industry_type": "general"})
+    _patch_audit(monkeypatch, {"total_decisions": 0, "null_reason": "no_audit_activity"})
+    out = svc.analyze(ENV, BIZ)
+    assert out["findings"] == []
+    assert any(r["reason"] in ("no_audit_activity", "no_decisions") for r in out["null_reasons"])
+
+
+# ── fail closed on raises ─────────────────────────────────────────────────────
+def test_consulting_source_raises_fails_closed(monkeypatch):
+    from app.services import execution_tasks
+    monkeypatch.setattr(execution_tasks, "board_summary",
+                        lambda **kw: (_ for _ in ()).throw(RuntimeError("db")))
+    _patch_audit(monkeypatch)
+    out = svc.analyze(ENV, BIZ, env_type="consulting")
+    assert any(r["reason"] == "board_summary_unavailable" for r in out["null_reasons"])
+
+
+# ── contract compliance + summary + route ─────────────────────────────────────
+def test_findings_satisfy_contract(monkeypatch):
+    from app.services import execution_tasks
+    monkeypatch.setattr(execution_tasks, "board_summary", lambda **kw: {
+        "overdue_count": 7, "today_count": 12, "this_week_count": 1})
+    _patch_audit(monkeypatch, {"total_decisions": 100, "success_rate": 0.6, "failed": 40,
+                               "window_days": 30, "null_reason": None})
+    out = svc.analyze(ENV, BIZ, env_type="consulting")
+    assert len(out["findings"]) >= 3
+    for f in out["findings"]:
+        AnalyzerFinding(**{k: v for k, v in f.items() if k in AnalyzerFinding.__dataclass_fields__})
+
+
+def test_summary_counts_by_severity(monkeypatch):
+    _patch_audit(monkeypatch, {"total_decisions": 100, "success_rate": 0.6, "failed": 40,
+                               "window_days": 30, "null_reason": None})
+    from app.services import lab
+    monkeypatch.setattr(lab, "get_environment", lambda e: {"industry_type": "general"})
+    s = svc.summary(ENV, BIZ)
+    assert s["analyzer_type"] == "business"
+    assert s["finding_count"] == sum(s["by_severity"].values())
+
+
+def test_route_analyze_fails_closed(client, monkeypatch):
+    from app.routes import business_analyzer as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    def boom(env, biz, **kw):
+        raise RuntimeError("x")
+    monkeypatch.setattr(svc, "analyze", boom)
+    resp = client.post("/api/ade/analyze/business", json={"env_id": ENV, "business_id": BIZ})
+    assert resp.status_code == 200
+    assert resp.json()["null_reason"] == "business_analyze_unavailable"


### PR DESCRIPTION
## Summary

Phase 4 / PR 11 — the **Business Analyzer**, the third and final analyzer on the PR 8.5 `AnalyzerFinding` contract. Env-type dispatch, deterministic-first. Completes the Phase 4 analyzer trio (telemetry + data-platform + business) on one shared contract.

## Files (4)

- `backend/app/services/business_analyzer.py` — dispatches on the environment's industry/template:
  - **consulting** → `execution_tasks.board_summary` (overdue tasks → bottleneck; TODAY-cap pressure → risk)
  - **accounting** → `nv_accounting_kpis.compute_kpis` (cash position; fail-closed on `unavailable` tiles)
  - **generic (always)** → `audit_dashboard.summary` tool error rate, a universal floor for every env
- `backend/app/routes/business_analyzer.py` + `main.py` mount — `POST /api/ade/analyze/business` (optional `env_type` override), `GET .../summary`.
- `backend/tests/test_business_analyzer.py` — 14 tests.

## Honesty

- **Severity rule-based**: overdue ≥5→critical / ≥1→warning; TODAY over cap(8)→warning; tool error rate ≥0.25→critical / ≥0.10→warning; cash balance→info leading-indicator.
- Findings only when the real signal exists; empty/null/`unavailable` sources (e.g. a cash tile with no imported transactions) are **skipped with a null_reason** — never a fabricated number.
- No LLM, no per-finding model calls. Every finding satisfies the `AnalyzerFinding` contract.

## Explicit exclusions

agents · frontend · write tools · LLM summarization · REPE quarter-gated KPIs (deferred — they need a resolved released quarter; out of scope for this cut).

## Tests & checks

- Backend: 14 PR11 tests; 95 in the analyzer/ADE suite — no regression
- `ruff check app tests`: clean
- `from app.main import app`: succeeds (1495 routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
