### PR TITLE
Wire analyzer findings into the intelligence card feed

### DIFF
--- a/backend/app/routes/business_analyzer.py
+++ b/backend/app/routes/business_analyzer.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 from app.auth.platform import require_environment_access
 from app.observability.logger import emit_log
 from app.services import business_analyzer as svc
+from app.services.analyzer_persist import persist_findings_as_cards
 
 router = APIRouter(prefix="/api/ade/analyze/business", tags=["ade"])
 
@@ -26,13 +27,19 @@ class AnalyzeBody(BaseModel):
     env_id: str
     business_id: UUID
     env_type: str | None = None  # optional override; otherwise resolved from the env row
+    persist: bool = False  # when true, upsert findings as intel cards (default off: read-only)
 
 
 @router.post("")
 def analyze(body: AnalyzeBody, request: Request):
     require_environment_access(request, env_id=body.env_id)
     try:
-        return {**svc.analyze(body.env_id, body.business_id, env_type=body.env_type), "null_reason": None}
+        result = svc.analyze(body.env_id, body.business_id, env_type=body.env_type)
+        cards_upserted = (
+            persist_findings_as_cards(body.env_id, body.business_id, result.get("findings", []))
+            if body.persist else 0
+        )
+        return {**result, "cards_upserted": cards_upserted, "null_reason": None}
     except Exception as exc:  # noqa: BLE001
         emit_log(level="error", service="business_analyzer", action="analyze_failed", message=str(exc), error=exc)
         return {"analyzer_type": "business", "env_type": None, "findings": [], "null_reasons": [],

--- a/backend/app/routes/data_platform_analyzer.py
+++ b/backend/app/routes/data_platform_analyzer.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 from app.auth.platform import require_environment_access
 from app.observability.logger import emit_log
 from app.services import data_platform_analyzer as svc
+from app.services.analyzer_persist import persist_findings_as_cards
 
 router = APIRouter(prefix="/api/ade/analyze/data-platform", tags=["ade"])
 
@@ -24,13 +25,19 @@ router = APIRouter(prefix="/api/ade/analyze/data-platform", tags=["ade"])
 class AnalyzeBody(BaseModel):
     env_id: str
     business_id: UUID
+    persist: bool = False  # when true, upsert findings as intel cards (default off: read-only)
 
 
 @router.post("")
 def analyze(body: AnalyzeBody, request: Request):
     require_environment_access(request, env_id=body.env_id)
     try:
-        return {**svc.analyze(body.env_id, body.business_id), "null_reason": None}
+        result = svc.analyze(body.env_id, body.business_id)
+        cards_upserted = (
+            persist_findings_as_cards(body.env_id, body.business_id, result.get("findings", []))
+            if body.persist else 0
+        )
+        return {**result, "cards_upserted": cards_upserted, "null_reason": None}
     except Exception as exc:  # noqa: BLE001
         emit_log(level="error", service="data_platform_analyzer", action="analyze_failed", message=str(exc), error=exc)
         return {"analyzer_type": "data_platform", "findings": [], "null_reasons": [],

--- a/backend/app/routes/telemetry_analyzer.py
+++ b/backend/app/routes/telemetry_analyzer.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 from app.auth.platform import require_environment_access
 from app.observability.logger import emit_log
 from app.services import telemetry_analyzer as svc
+from app.services.analyzer_persist import persist_findings_as_cards
 
 router = APIRouter(prefix="/api/ade/analyze/telemetry", tags=["ade"])
 
@@ -25,13 +26,19 @@ router = APIRouter(prefix="/api/ade/analyze/telemetry", tags=["ade"])
 class AnalyzeBody(BaseModel):
     env_id: str
     business_id: UUID
+    persist: bool = False  # when true, upsert findings as intel cards (default off: read-only)
 
 
 @router.post("")
 def analyze(body: AnalyzeBody, request: Request):
     require_environment_access(request, env_id=body.env_id)
     try:
-        return {**svc.analyze(body.env_id, body.business_id), "null_reason": None}
+        result = svc.analyze(body.env_id, body.business_id)
+        cards_upserted = (
+            persist_findings_as_cards(body.env_id, body.business_id, result.get("findings", []))
+            if body.persist else 0
+        )
+        return {**result, "cards_upserted": cards_upserted, "null_reason": None}
     except Exception as exc:  # noqa: BLE001 — fail closed, never 500 with fabricated data
         emit_log(level="error", service="telemetry_analyzer", action="analyze_failed", message=str(exc), error=exc)
         return {"analyzer_type": "telemetry", "findings": [], "null_reasons": [],

--- a/backend/app/services/analyzer_persist.py
+++ b/backend/app/services/analyzer_persist.py
@@ -1,0 +1,50 @@
+"""Persist analyzer findings as intelligence cards (connective seam).
+
+Bridges the deterministic AnalyzerFinding contract to the intelligence card feed:
+rehydrate each finding dict, map it through `to_intel_card()` (rule-based, no LLM), and
+upsert it via `intelligence_cards.upsert_card`. Idempotent by (env_id, source_ref_key) —
+the finding's id rides in source_ref, so re-running an analyzer updates cards in place
+rather than duplicating them.
+
+Best-effort and fail-closed: a finding that can't be rehydrated or a card that can't be
+written is skipped (counted, never raised), so a successful analysis is never downgraded
+to a 500 because the optional persist step hit a snag. No LLM, no fabricated numbers.
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.observability.logger import emit_log
+
+
+def persist_findings_as_cards(
+    env_id: str, business_id: str | UUID, findings: list[dict]
+) -> int:
+    """Upsert each finding dict as an intel card. Returns the count actually written.
+
+    Imports are lazy to mirror the existing card-write idiom (analysis_sessions) and to
+    keep the analyzer routes importable even if a downstream module is unavailable.
+    """
+    if not findings:
+        return 0
+    try:
+        from app.services import analyzer_contract, intelligence_cards
+    except Exception as exc:  # noqa: BLE001 — module may be absent; best-effort
+        emit_log(level="warning", service="analyzer_persist", action="import_failed",
+                 message=str(exc), error=exc)
+        return 0
+
+    written = 0
+    for data in findings:
+        try:
+            finding = analyzer_contract.from_dict(data)
+            intelligence_cards.upsert_card(
+                env_id, business_id, **analyzer_contract.to_intel_card(finding)
+            )
+            written += 1
+        except Exception as exc:  # noqa: BLE001 — skip the one finding, keep going
+            emit_log(level="warning", service="analyzer_persist", action="upsert_failed",
+                     message=str(exc), error=exc,
+                     context={"finding_id": (data or {}).get("finding_id")})
+            continue
+    return written

--- a/backend/tests/test_analyzer_persist.py
+++ b/backend/tests/test_analyzer_persist.py
@@ -1,0 +1,101 @@
+"""Tests for the analyzer -> intel card persistence seam (connective PR).
+
+Run: cd backend && python -m pytest tests/test_analyzer_persist.py -x -q
+
+Proves: a finding dict round-trips through from_dict -> to_intel_card -> upsert_card with the
+right kwargs and source_ref (idempotency carrier); the written count is accurate; an empty
+list is a no-op; and a per-finding failure is skipped, not raised (best-effort, fail-closed).
+"""
+import os
+
+os.environ.setdefault("BM_MCP_DRY_RUN", "1")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+os.environ.setdefault("MCP_API_TOKEN", "test-token")
+
+from app.services import analyzer_persist  # noqa: E402
+
+ENV = "test-env"
+BIZ = "00000000-0000-0000-0000-000000000001"
+
+
+def _finding(fid="tel-001", severity="warning", confidence=0.8, evidence=("anomaly_rate=0.15",)):
+    """A valid finding dict as the analyzer services emit (AnalyzerFinding.to_dict())."""
+    return {
+        "finding_id": fid,
+        "env_id": ENV,
+        "analyzer_type": "telemetry",
+        "source_ref": {"source": "telemetry_serving.monitoring", "field": "anomaly_rate"},
+        "severity": severity,
+        "what_changed": "Anomaly rate elevated",
+        "why_it_matters": "Sustained anomalies degrade serving quality.",
+        "confidence": confidence,
+        "evidence_refs": list(evidence),
+        "metric_refs": ["anomaly_rate"],
+        "driver_math": None,
+        "null_reasons": [],
+        "recommendations": [],
+        "next_questions": [],
+        "cost_to_generate_usd": None,
+        "latency_ms": 12,
+        "eval_status": None,
+    }
+
+
+def _capture_upserts(monkeypatch):
+    from app.services import intelligence_cards
+    calls = []
+    monkeypatch.setattr(intelligence_cards, "upsert_card",
+                        lambda env, biz, **kw: calls.append((env, str(biz), kw)) or {"id": f"card-{len(calls)}"})
+    return calls
+
+
+# ── happy path ────────────────────────────────────────────────────────────────
+def test_persists_one_card_per_finding(monkeypatch):
+    calls = _capture_upserts(monkeypatch)
+    n = analyzer_persist.persist_findings_as_cards(ENV, BIZ, [_finding("a"), _finding("b")])
+    assert n == 2
+    assert len(calls) == 2
+
+
+def test_upsert_kwargs_match_to_intel_card(monkeypatch):
+    calls = _capture_upserts(monkeypatch)
+    analyzer_persist.persist_findings_as_cards(ENV, BIZ, [_finding("a", severity="critical",
+                                                                   confidence=0.95)])
+    env, biz, kw = calls[0]
+    assert env == ENV and biz == BIZ
+    # critical -> alert card with anomaly_flag (deterministic mapping, no LLM)
+    assert kw["card_type"] == "alert"
+    assert kw["anomaly_flag"] is True
+    assert kw["created_by"] == "analyzer:telemetry"
+    # source_ref carries the finding id so re-running updates rather than duplicates
+    assert kw["source_ref"]["type"] == "analyzer_finding"
+    assert kw["source_ref"]["finding_id"] == "a"
+
+
+def test_empty_findings_is_noop(monkeypatch):
+    calls = _capture_upserts(monkeypatch)
+    assert analyzer_persist.persist_findings_as_cards(ENV, BIZ, []) == 0
+    assert calls == []
+
+
+# ── fail closed ───────────────────────────────────────────────────────────────
+def test_one_bad_finding_is_skipped_not_raised(monkeypatch):
+    calls = _capture_upserts(monkeypatch)
+    # second finding is invalid (high confidence, no evidence) -> from_dict raises, skipped
+    bad = _finding("bad", confidence=0.9, evidence=())
+    good = _finding("good")
+    n = analyzer_persist.persist_findings_as_cards(ENV, BIZ, [bad, good])
+    assert n == 1            # only the valid one written
+    assert len(calls) == 1
+    assert calls[0][2]["source_ref"]["finding_id"] == "good"
+
+
+def test_upsert_exception_is_swallowed(monkeypatch):
+    from app.services import intelligence_cards
+
+    def boom(env, biz, **kw):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(intelligence_cards, "upsert_card", boom)
+    # never raises; reports zero written
+    assert analyzer_persist.persist_findings_as_cards(ENV, BIZ, [_finding("a")]) == 0

--- a/backend/tests/test_business_analyzer.py
+++ b/backend/tests/test_business_analyzer.py
@@ -166,3 +166,35 @@ def test_route_analyze_fails_closed(client, monkeypatch):
     resp = client.post("/api/ade/analyze/business", json={"env_id": ENV, "business_id": BIZ})
     assert resp.status_code == 200
     assert resp.json()["null_reason"] == "business_analyze_unavailable"
+
+
+# ── persist seam (connective PR) ──────────────────────────────────────────────
+_ONE_FINDING = {"analyzer_type": "business", "env_type": "generic",
+                "findings": [{"finding_id": "x"}], "null_reasons": [], "latency_ms": 5}
+
+
+def test_route_persist_true_upserts_cards(client, monkeypatch):
+    from app.routes import business_analyzer as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    monkeypatch.setattr(svc, "analyze", lambda env, biz, **kw: dict(_ONE_FINDING))
+    calls = []
+    monkeypatch.setattr(route, "persist_findings_as_cards",
+                        lambda env, biz, findings: calls.append(findings) or len(findings))
+    resp = client.post("/api/ade/analyze/business",
+                       json={"env_id": ENV, "business_id": BIZ, "persist": True})
+    assert resp.status_code == 200
+    assert resp.json()["cards_upserted"] == 1
+    assert len(calls) == 1
+
+
+def test_route_persist_default_off(client, monkeypatch):
+    from app.routes import business_analyzer as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    monkeypatch.setattr(svc, "analyze", lambda env, biz, **kw: dict(_ONE_FINDING))
+    called = []
+    monkeypatch.setattr(route, "persist_findings_as_cards",
+                        lambda env, biz, findings: called.append(1) or 0)
+    resp = client.post("/api/ade/analyze/business", json={"env_id": ENV, "business_id": BIZ})
+    assert resp.status_code == 200
+    assert resp.json()["cards_upserted"] == 0
+    assert called == []

--- a/backend/tests/test_data_platform_analyzer.py
+++ b/backend/tests/test_data_platform_analyzer.py
@@ -166,3 +166,35 @@ def test_route_analyze_fails_closed(client, monkeypatch):
     resp = client.post("/api/ade/analyze/data-platform", json={"env_id": ENV, "business_id": BIZ})
     assert resp.status_code == 200
     assert resp.json()["null_reason"] == "data_platform_analyze_unavailable"
+
+
+# ── persist seam (connective PR) ──────────────────────────────────────────────
+_ONE_FINDING = {"analyzer_type": "data_platform", "findings": [{"finding_id": "x"}],
+                "null_reasons": [], "latency_ms": 5}
+
+
+def test_route_persist_true_upserts_cards(client, monkeypatch):
+    from app.routes import data_platform_analyzer as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    monkeypatch.setattr(svc, "analyze", lambda env, biz: dict(_ONE_FINDING))
+    calls = []
+    monkeypatch.setattr(route, "persist_findings_as_cards",
+                        lambda env, biz, findings: calls.append(findings) or len(findings))
+    resp = client.post("/api/ade/analyze/data-platform",
+                       json={"env_id": ENV, "business_id": BIZ, "persist": True})
+    assert resp.status_code == 200
+    assert resp.json()["cards_upserted"] == 1
+    assert len(calls) == 1
+
+
+def test_route_persist_default_off(client, monkeypatch):
+    from app.routes import data_platform_analyzer as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    monkeypatch.setattr(svc, "analyze", lambda env, biz: dict(_ONE_FINDING))
+    called = []
+    monkeypatch.setattr(route, "persist_findings_as_cards",
+                        lambda env, biz, findings: called.append(1) or 0)
+    resp = client.post("/api/ade/analyze/data-platform", json={"env_id": ENV, "business_id": BIZ})
+    assert resp.status_code == 200
+    assert resp.json()["cards_upserted"] == 0
+    assert called == []

--- a/backend/tests/test_telemetry_analyzer.py
+++ b/backend/tests/test_telemetry_analyzer.py
@@ -158,3 +158,35 @@ def test_route_analyze_fails_closed(client, monkeypatch):
     resp = client.post("/api/ade/analyze/telemetry", json={"env_id": ENV, "business_id": BIZ})
     assert resp.status_code == 200
     assert resp.json()["null_reason"] == "telemetry_analyze_unavailable"
+
+
+# ── persist seam (connective PR) ──────────────────────────────────────────────
+_ONE_FINDING = {"analyzer_type": "telemetry", "findings": [{"finding_id": "x"}],
+                "null_reasons": [], "latency_ms": 5}
+
+
+def test_route_persist_true_upserts_cards(client, monkeypatch):
+    from app.routes import telemetry_analyzer as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    monkeypatch.setattr(svc, "analyze", lambda env, biz: dict(_ONE_FINDING))
+    calls = []
+    monkeypatch.setattr(route, "persist_findings_as_cards",
+                        lambda env, biz, findings: calls.append(findings) or len(findings))
+    resp = client.post("/api/ade/analyze/telemetry",
+                       json={"env_id": ENV, "business_id": BIZ, "persist": True})
+    assert resp.status_code == 200
+    assert resp.json()["cards_upserted"] == 1
+    assert len(calls) == 1  # persist invoked exactly once
+
+
+def test_route_persist_default_off(client, monkeypatch):
+    from app.routes import telemetry_analyzer as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    monkeypatch.setattr(svc, "analyze", lambda env, biz: dict(_ONE_FINDING))
+    called = []
+    monkeypatch.setattr(route, "persist_findings_as_cards",
+                        lambda env, biz, findings: called.append(1) or 0)
+    resp = client.post("/api/ade/analyze/telemetry", json={"env_id": ENV, "business_id": BIZ})
+    assert resp.status_code == 200
+    assert resp.json()["cards_upserted"] == 0
+    assert called == []  # persist NOT invoked when flag absent

--- a/repo-b/src/app/app/page.tsx
+++ b/repo-b/src/app/app/page.tsx
@@ -14,6 +14,7 @@ import {
   getCards,
   upsertCard,
   dismissCard,
+  runAnalyzers,
   type IntelCard,
 } from "@/lib/intelligence/cards";
 import { cn } from "@/lib/cn";
@@ -237,7 +238,24 @@ function useIntelligenceFeed(env: Environment | null, bizId: string | null) {
     setState((s) => ({ ...s, cards: s.cards.filter((c) => c.id !== cardId) }));
   }, []);
 
-  return { ...state, removeCard };
+  // Re-pull cards only (no seed) after a user-triggered analyzer run. Authoritative —
+  // shows whatever the analyzers just upserted. Fail-closed without a real tenant.
+  const refetch = useCallback(async () => {
+    if (!env || !bizId) return;
+    setState((s) => ({ ...s, loading: true, error: null }));
+    try {
+      const { cards, null_reason } = await getCards(env.env_id, { biz: bizId, limit: 50 });
+      setState({ cards, loading: false, error: null, nullReason: null_reason ?? null });
+    } catch (cause) {
+      setState((s) => ({
+        ...s,
+        loading: false,
+        error: cause instanceof Error ? cause.message : "Failed to load intelligence",
+      }));
+    }
+  }, [env, bizId]);
+
+  return { ...state, removeCard, refetch };
 }
 
 // ── Mode B: workspace preview (reachable via toggle) ──────────────────────────
@@ -528,6 +546,7 @@ function AppIndexPageInner() {
   const [hoveredEnvId, setHoveredEnvId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showPreview, setShowPreview] = useState(false);
+  const [analyzing, setAnalyzing] = useState(false);
 
   const deniedTarget = searchParams.get("denied");
   const selectedEnvironment = useMemo(
@@ -632,6 +651,21 @@ function AppIndexPageInner() {
     },
     [selectedEnvironment, bizId, router],
   );
+
+  // Run the deterministic analyzers, persisting findings as cards, then refetch the feed.
+  // Fail-closed: no-op without a real env/tenant (the button is disabled in that case).
+  const handleAnalyze = useCallback(async () => {
+    if (!selectedEnvironment || !bizId || analyzing) return;
+    setAnalyzing(true);
+    try {
+      await runAnalyzers(selectedEnvironment.env_id, bizId);
+      await feed.refetch();
+    } catch {
+      // Each analyzer already fails closed server-side; nothing fabricated on error.
+    } finally {
+      setAnalyzing(false);
+    }
+  }, [selectedEnvironment, bizId, analyzing, feed]);
 
   useEffect(() => {
     if (loading || environments.length !== 1 || isPlatformAdmin || deniedTarget) {
@@ -1032,6 +1066,22 @@ function AppIndexPageInner() {
                 <div className="flex items-center justify-between gap-4">
                   <AgentPills />
                   <div className="flex shrink-0 items-center gap-3">
+                    {selectedEnvironment && bizId ? (
+                      <button
+                        type="button"
+                        onClick={() => void handleAnalyze()}
+                        disabled={analyzing}
+                        title="Run the analyzers and add their findings to the feed"
+                        className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.2em] transition-colors disabled:cursor-default disabled:opacity-60"
+                        style={{
+                          borderColor: `rgba(${ACTION_TEAL}, 0.30)`,
+                          color: `rgba(${ACTION_TEAL}, 0.95)`,
+                          background: `rgba(${ACTION_TEAL}, 0.06)`,
+                        }}
+                      >
+                        {analyzing ? "Analyzing…" : "Analyze"}
+                      </button>
+                    ) : null}
                     {selectedEnvironment ? (
                       <InvestigateButton
                         envId={selectedEnvironment.env_id}

--- a/repo-b/src/lib/intelligence/cards.ts
+++ b/repo-b/src/lib/intelligence/cards.ts
@@ -72,6 +72,57 @@ export const bumpCardPriority = (env: string, id: string, delta: number, biz: st
     body: JSON.stringify({ env_id: env, business_id: biz, priority_delta: delta }),
   });
 
+// ── Analyzer trigger (connective seam) ────────────────────────────────────────
+// The three deterministic analyzers (telemetry, data-platform, business) compute
+// findings on the backend; passing persist:true upserts each finding as an intel card
+// (idempotent by source_ref), so running this makes new findings appear in the feed.
+export type AnalyzerKind = "telemetry" | "data-platform" | "business";
+
+export const ANALYZER_KINDS: AnalyzerKind[] = ["telemetry", "data-platform", "business"];
+
+interface AnalyzeResponse {
+  analyzer_type?: string;
+  findings?: unknown[];
+  null_reasons?: unknown[];
+  cards_upserted?: number;
+  null_reason?: string | null;
+}
+
+export interface RunAnalyzersResult {
+  ran: AnalyzerKind[];           // analyzers that returned a response (success or fail-closed)
+  failed: AnalyzerKind[];        // analyzers whose request itself rejected
+  cardsUpserted: number;         // total cards written across all analyzers
+}
+
+// Run the analyzers in parallel and persist their findings as cards. allSettled so one
+// analyzer failing never blocks the others; each analyzer already fails closed server-side.
+export async function runAnalyzers(
+  env: string,
+  biz: string,
+  kinds: AnalyzerKind[] = ANALYZER_KINDS,
+): Promise<RunAnalyzersResult> {
+  const settled = await Promise.allSettled(
+    kinds.map((kind) =>
+      apiFetch<AnalyzeResponse>(`/api/ade/analyze/${kind}`, {
+        method: "POST",
+        body: JSON.stringify({ env_id: env, business_id: biz, persist: true }),
+      }),
+    ),
+  );
+  const ran: AnalyzerKind[] = [];
+  const failed: AnalyzerKind[] = [];
+  let cardsUpserted = 0;
+  settled.forEach((outcome, i) => {
+    if (outcome.status === "fulfilled") {
+      ran.push(kinds[i]);
+      cardsUpserted += outcome.value?.cards_upserted ?? 0;
+    } else {
+      failed.push(kinds[i]);
+    }
+  });
+  return { ran, failed, cardsUpserted };
+}
+
 export const CARD_TYPE_LABELS: Record<CardType, string> = {
   dashboard: "Dashboard",
   report: "Report",


### PR DESCRIPTION
## Summary

Connective PR that makes Phase 4 **visible**. The three deterministic analyzers (telemetry, data-platform, business — PRs 9/10/11) were merged with routes, but their findings went nowhere: the home intelligence feed only ever showed the one seeded dashboard card. This closes the loop end to end.

**Verified gap (on `origin/main`, not assumed):** the analyzer routes computed findings and returned them ephemerally — none called `to_intel_card`/`upsert_card` — and there was no frontend trigger. The feed UI and the `to_intel_card`→`upsert_card` seam were already present and correct.

## Changes (10 files)

**Backend — the persist seam (opt-in, fail-closed)**
- `services/analyzer_persist.py` (new) — `persist_findings_as_cards()` bridges a finding dict → `analyzer_contract.from_dict` → `to_intel_card` → `intelligence_cards.upsert_card`. Idempotent by `source_ref` (the `finding_id` rides in it), so re-running an analyzer **updates** cards rather than duplicating. Best-effort: a bad or unwritable finding is skipped (counted), never raised — the optional persist step can't turn a good analysis into a 500.
- `routes/{telemetry,data_platform,business}_analyzer.py` — add `persist: bool = False` to `AnalyzeBody`; when true, upsert findings and return `cards_upserted`. **Default off** keeps the read-only callers and existing tests unchanged.

**Frontend — the trigger**
- `lib/intelligence/cards.ts` — `runAnalyzers(env, biz)` POSTs all three analyzers in parallel (`Promise.allSettled`) with `persist:true`; reports cards written and which analyzers ran.
- `app/app/page.tsx` — a tool-like **Analyze** button in the feed header, enabled only with a real env + tenant (same fail-closed guard as Investigate). On click it runs the analyzers, then `feed.refetch()` (getCards only, no re-seed). New findings render as the `alert`/`finding` cards the feed already groups; the derived Environment Status picks up new anomalies automatically.

## Honesty / scope

- **No LLM** anywhere — `to_intel_card` is rule-based severity→card_type mapping; analyzers stay deterministic.
- No migration, no new card variant/component, no schema change, no app-shell wrapping.
- REPE quarter-gated KPIs remain **deferred** (out of scope).

## Decisions (per request)

`persist` flag on the existing POST · Analyze runs **all three** analyzers, fail-closed (irrelevant ones return `null_reasons`) · feed **refetch** after run.

## Tests & checks

- `test_analyzer_persist.py` (new): round-trip kwargs match `to_intel_card`, `source_ref` idempotency carrier, empty no-op, per-finding skip + upsert-exception swallow.
- `persist=true`/`persist=false` route test per analyzer.
- **82 passed** across persist + 3 analyzers + contract + cards CRUD; `ruff` clean; `tsc` + `eslint` clean on the two frontend files; `from app.main import app` succeeds (1495 routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
