### PR TITLE
feat(history-rhymes): feature store engine + Feature Foundry registry (A1)

### DIFF
--- a/backend/app/services/hr_feature_store/__init__.py
+++ b/backend/app/services/hr_feature_store/__init__.py
@@ -1,0 +1,46 @@
+"""History Rhymes feature store (Phase A — deterministic, in-memory).
+
+Turns raw canonical signals into engineered, model-ready features and makes the
+enrichment visible (Feature Foundry). No DB, no live APIs in Phase A; the gold
+contract (`contract.MODEL_OBS_COLUMNS`) is designed so connectors drop in behind
+it (Phase B). Feeds the existing HR spine via canonical `QUANT_FEATURE_ORDER`.
+"""
+
+from __future__ import annotations
+
+from .contract import MODEL_OBS_COLUMNS, MODEL_OBS_VERSION, QUANT_FEATURE_ORDER, FeatureObservation, encode_quant_block
+from .enrich import FEATURE_FAMILIES, SIGNATURE_FEATURE_IDS, enrich_observation, latest_signatures, signature_series
+from .macro_dataset import generate_macro_panel
+from .registry import FEATURE_REGISTRY, get_feature
+from .runner import (
+    build_feature_overview,
+    build_importance,
+    build_pipeline_map,
+    build_quality_board,
+    prepare_model_dataset,
+    run_feature,
+)
+from .schema import SEED
+
+__all__ = [
+    "FEATURE_FAMILIES",
+    "FEATURE_REGISTRY",
+    "FeatureObservation",
+    "MODEL_OBS_COLUMNS",
+    "MODEL_OBS_VERSION",
+    "QUANT_FEATURE_ORDER",
+    "SEED",
+    "SIGNATURE_FEATURE_IDS",
+    "build_feature_overview",
+    "build_importance",
+    "build_pipeline_map",
+    "build_quality_board",
+    "encode_quant_block",
+    "enrich_observation",
+    "generate_macro_panel",
+    "get_feature",
+    "latest_signatures",
+    "prepare_model_dataset",
+    "run_feature",
+    "signature_series",
+]

--- a/backend/app/services/hr_feature_store/contract.py
+++ b/backend/app/services/hr_feature_store/contract.py
@@ -1,0 +1,99 @@
+"""Model-observation contract for the History Rhymes feature store.
+
+The gold grain is one row per (observation_id, as_of_date, model_obs_version).
+Phase A keeps this as an in-memory contract (this module + a dataclass); Phase B
+materializes the identical columns into `hr_history_rhymes_model_observations`.
+
+`QUANT_FEATURE_ORDER` MIRRORS skills/historyrhymes/services/state_vector_encoder.py
+— that file is the spine's source of truth; this copy lets the backend feature
+store map gold rows onto the same 128-dim slot ordering WITHOUT a cross-root
+import. Keep the two in sync; any `quant_slot` a feature claims must live here.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+MODEL_OBS_VERSION = "hr-fs-v1"
+
+# Source-of-truth mirror (see module docstring). Order is load-bearing.
+QUANT_FEATURE_ORDER: list[str] = [
+    "yield_curve_10y2y", "fed_funds_rate", "term_premium",
+    "cpi_yoy", "pce_yoy",
+    "initial_claims", "unemployment_rate", "nonfarm_payrolls_3mo",
+    "housing_starts_saar", "case_shiller_yoy", "mortgage_rate_30y",
+    "hy_credit_spread", "ig_credit_spread", "libor_ois_spread",
+    "vix_spot", "vix_term_structure", "move_index",
+    "sp500_return_1m", "sp500_return_3m", "sp500_drawdown_60d",
+    "btc_price_usd", "btc_return_1m", "btc_mvrv_zscore", "crypto_fear_greed",
+    "btc_dominance", "perp_funding_rate",
+    "epu_us_daily", "epu_world_weekly",
+    "aaii_bull_bear_spread", "put_call_ratio", "margin_debt_yoy",
+    "hoyt_cycle_position",
+]
+QUANT_BLOCK_DIM = 128
+
+SOURCE_QUALITY_VALUES = ("live", "fixture", "synthetic", "synthetic_fallback")
+
+# Gold-table column contract (Phase A in-memory; Phase B materialized 1:1).
+MODEL_OBS_COLUMNS: list[str] = [
+    "observation_id", "as_of_date", "model_obs_version",
+    "features_raw", "features_normalized",
+    "features_z_score_2y", "features_delta_1d", "features_velocity", "features_acceleration",
+    "staleness_seconds", "source_quality", "null_reason", "feature_family_coverage",
+    "feature_vector", "text_embedding", "narrative_text",
+    "forward_return_30d", "risk_event_30d", "theme", "is_crisis_anchor", "is_non_event",
+    "model_readiness_score", "readiness_degrade_reasons",
+    "lineage_json", "external_links_json", "provenance", "created_at",
+]
+
+
+@dataclass
+class FeatureObservation:
+    """One model-observation row (the gold contract, in-memory form)."""
+
+    observation_id: str
+    as_of_date: str
+    model_obs_version: str = MODEL_OBS_VERSION
+    features_raw: dict[str, float | None] = field(default_factory=dict)
+    features_normalized: dict[str, float | None] = field(default_factory=dict)
+    features_z_score_2y: dict[str, float | None] = field(default_factory=dict)
+    features_delta_1d: dict[str, float | None] = field(default_factory=dict)
+    features_velocity: dict[str, float | None] = field(default_factory=dict)
+    features_acceleration: dict[str, float | None] = field(default_factory=dict)
+    staleness_seconds: dict[str, float] = field(default_factory=dict)
+    source_quality: str = "synthetic"
+    null_reason: str | None = None
+    feature_family_coverage: dict[str, Any] = field(default_factory=dict)
+    narrative_text: str = ""
+    forward_return_30d: float | None = None
+    risk_event_30d: int | None = None
+    theme: str | None = None
+    is_crisis_anchor: bool = False
+    is_non_event: bool = False
+    model_readiness_score: float | None = None
+    readiness_degrade_reasons: list[str] = field(default_factory=list)
+
+
+def encode_quant_block(features_normalized: dict[str, float | None]) -> list[float]:
+    """Project normalized features onto the canonical 128-dim quant block (L2).
+
+    Mirrors the encoder's `_pad_or_truncate` + `_l2_normalize` for the quant half
+    so the spine bridge is unit-testable in the backend without importing skills/.
+    None/NaN → 0.0; padded to 128; L2-normalized (zero-vector returned unchanged).
+    """
+    vec: list[float] = []
+    for name in QUANT_FEATURE_ORDER[:QUANT_BLOCK_DIM]:
+        val = features_normalized.get(name)
+        if val is None or (isinstance(val, float) and math.isnan(val)):
+            vec.append(0.0)
+        else:
+            vec.append(float(val))
+    while len(vec) < QUANT_BLOCK_DIM:
+        vec.append(0.0)
+    norm = math.sqrt(sum(x * x for x in vec))
+    if norm < 1e-12:
+        return vec
+    return [x / norm for x in vec]

--- a/backend/app/services/hr_feature_store/enrich.py
+++ b/backend/app/services/hr_feature_store/enrich.py
@@ -1,0 +1,215 @@
+"""Enrichment engine: raw canonical series → engineered features.
+
+A1 scope: all 20 families are REPRESENTED (`family_value`) with the 6 signature
+features implemented as real, deterministic formulas (`signature_series`); the
+non-signature families return deterministic representative values (deepened in
+Phase C). Z-scores use a trailing ~2y window; the latest row (full window) is
+what the golden fixture locks.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from .contract import QUANT_FEATURE_ORDER
+from .macro_dataset import generate_macro_panel
+
+_Z2Y_WINDOW = 504
+_Z2Y_MINP = 60
+
+SIGNATURE_FEATURE_IDS = [
+    "yield_curve_10y2y_velocity_30d",
+    "yield_curve_10y2y_acceleration_30d",
+    "credit_complacency_gap",
+    "liquidity_fragmentation_score",
+    "narrative_flow_mismatch",
+    "non_event_counterexample_score",
+    "model_readiness_score",  # value supplied by readiness.py, listed for completeness
+]
+
+# The 20 families the Foundry surfaces.
+FEATURE_FAMILIES = [
+    "level", "velocity", "acceleration", "rolling", "percentile_regime",
+    "cross_signal_divergence", "composite_stress", "interaction", "lag",
+    "missingness_as_signal", "freshness", "leakage_guard", "narrative_embedding",
+    "narrative_velocity", "flow_vs_narrative_mismatch", "crowding_consensus",
+    "non_event_counterexample", "distribution_drift", "model_readiness",
+    "composite_catch_all",
+]
+
+
+def _z2y(s: pd.Series) -> pd.Series:
+    mean = s.rolling(_Z2Y_WINDOW, min_periods=_Z2Y_MINP).mean()
+    std = s.rolling(_Z2Y_WINDOW, min_periods=_Z2Y_MINP).std()
+    return (s - mean) / std.replace(0.0, np.nan)
+
+
+def _vel(s: pd.Series, k: int) -> pd.Series:
+    return s - s.shift(k)
+
+
+def _accel(s: pd.Series, k: int) -> pd.Series:
+    return _vel(s, k) - _vel(s, k).shift(k)
+
+
+def _macro_stress_z(panel: pd.DataFrame) -> pd.Series:
+    """Composite macro-stress z: high VIX + high claims + inverted curve."""
+    return (
+        _z2y(panel["vix_spot"]).fillna(0.0)
+        + _z2y(panel["initial_claims"]).fillna(0.0)
+        - _z2y(panel["yield_curve_10y2y"]).fillna(0.0)
+    ) / 3.0
+
+
+def signature_series(panel: pd.DataFrame) -> dict[str, pd.Series]:
+    """The 6 series-derived signature features (model_readiness comes from readiness.py)."""
+    yc = panel["yield_curve_10y2y"]
+    vel30 = _vel(yc, 30)
+    acc30 = _accel(yc, 30)
+
+    credit_complacency_gap = _z2y(panel["hy_credit_spread"]) - _macro_stress_z(panel)
+
+    crypto_liq = _z2y(panel["btc_dominance"])
+    tradfi_liq = -_z2y(panel["libor_ois_spread"])
+    liquidity_fragmentation_score = crypto_liq - tradfi_liq
+
+    narrative_panic_vel = _z2y(_vel(panel["epu_us_daily"], 7))
+    capital_flow_stress = _z2y(-panel["sp500_drawdown_60d"])
+    narrative_flow_mismatch = narrative_panic_vel - capital_flow_stress
+
+    non_event_counterexample_score = _non_event_counterexample(panel)
+
+    return {
+        "yield_curve_10y2y_velocity_30d": vel30,
+        "yield_curve_10y2y_acceleration_30d": acc30,
+        "credit_complacency_gap": credit_complacency_gap,
+        "liquidity_fragmentation_score": liquidity_fragmentation_score,
+        "narrative_flow_mismatch": narrative_flow_mismatch,
+        "non_event_counterexample_score": non_event_counterexample_score,
+    }
+
+
+_SIM_FEATURES = ["vix_spot", "hy_credit_spread", "yield_curve_10y2y", "sp500_drawdown_60d", "move_index"]
+
+
+def _non_event_counterexample(panel: pd.DataFrame) -> pd.Series:
+    """nearest_non_event_similarity − nearest_crisis_similarity (higher = benign-looking)."""
+    z = {f: _z2y(panel[f]).fillna(0.0).to_numpy() for f in _SIM_FEATURES}
+    mat = np.vstack([z[f] for f in _SIM_FEATURES]).T  # (n, k)
+    crisis_idx = np.where(panel["is_crisis_anchor"].to_numpy())[0]
+    nonevent_idx = np.where(panel["is_non_event"].to_numpy())[0]
+    n = len(panel)
+    out = np.zeros(n)
+
+    def _max_sim(row: np.ndarray, idxs: np.ndarray) -> float:
+        if len(idxs) == 0:
+            return 0.0
+        d = np.linalg.norm(mat[idxs] - row, axis=1)
+        return float(-d.min())  # similarity = negative distance
+
+    for i in range(n):
+        out[i] = _max_sim(mat[i], nonevent_idx) - _max_sim(mat[i], crisis_idx)
+    return pd.Series(out, index=panel.index)
+
+
+def enrich_observation(panel: pd.DataFrame, idx: int = -1) -> dict[str, dict[str, float | None]]:
+    """Per-canonical-feature derived dicts for one row (raw/normalized/z2y/delta/vel/accel)."""
+    row_pos = idx if idx >= 0 else len(panel) + idx
+
+    def _at(s: pd.Series) -> float | None:
+        v = s.iloc[row_pos]
+        if v is None or (isinstance(v, float) and np.isnan(v)):
+            return None
+        return float(v)
+
+    raw, normalized, z2y, delta1d, velocity, acceleration = {}, {}, {}, {}, {}, {}
+    for name in QUANT_FEATURE_ORDER:
+        s = panel[name].astype(float)
+        z = _z2y(s)
+        raw[name] = _at(s)
+        z2y[name] = _at(z)
+        normalized[name] = _at(z)  # normalized view = trailing-2y z-score (encoder input)
+        delta1d[name] = _at(_vel(s, 1))
+        velocity[name] = _at(_vel(s, 30))
+        acceleration[name] = _at(_accel(s, 30))
+    return {
+        "features_raw": raw,
+        "features_normalized": normalized,
+        "features_z_score_2y": z2y,
+        "features_delta_1d": delta1d,
+        "features_velocity": velocity,
+        "features_acceleration": acceleration,
+    }
+
+
+def latest_signatures(panel: pd.DataFrame) -> dict[str, float | None]:
+    """Latest value of each series-derived signature (golden-locked)."""
+    out: dict[str, float | None] = {}
+    for fid, series in signature_series(panel).items():
+        v = series.iloc[-1]
+        out[fid] = None if (v is None or (isinstance(v, float) and np.isnan(v))) else round(float(v), 4)
+    return out
+
+
+def transformation_example(feature_id: str, panel: pd.DataFrame | None = None, n: int = 6) -> dict:
+    """before/after slice for the drawer: raw input vs engineered output (tail n)."""
+    panel = panel if panel is not None else generate_macro_panel()
+    series_map = signature_series(panel)
+    if feature_id not in series_map:
+        return {}
+    after = series_map[feature_id].tail(n)
+    before_col = {
+        "yield_curve_10y2y_velocity_30d": "yield_curve_10y2y",
+        "yield_curve_10y2y_acceleration_30d": "yield_curve_10y2y",
+        "credit_complacency_gap": "hy_credit_spread",
+        "liquidity_fragmentation_score": "libor_ois_spread",
+        "narrative_flow_mismatch": "epu_us_daily",
+        "non_event_counterexample_score": "vix_spot",
+    }.get(feature_id)
+    before = panel[before_col].tail(n) if before_col else after
+    dates = panel["as_of_date"].tail(n).tolist()
+    return {
+        "before": [{"as_of": d, "value": round(float(v), 4)} for d, v in zip(dates, before.tolist())],
+        "after": [
+            {"as_of": d, "value": (None if np.isnan(v) else round(float(v), 4))}
+            for d, v in zip(dates, after.tolist())
+        ],
+    }
+
+
+def family_value(family: str, panel: pd.DataFrame, idx: int = -1) -> float | None:
+    """Deterministic representative value per family (signature families use real formulas)."""
+    row = idx if idx >= 0 else len(panel) + idx
+    s_yc = panel["yield_curve_10y2y"].astype(float)
+    s_vix = panel["vix_spot"].astype(float)
+    sig = signature_series(panel)
+
+    def _last(series: pd.Series) -> float | None:
+        v = series.iloc[row]
+        return None if (isinstance(v, float) and np.isnan(v)) else round(float(v), 4)
+
+    table = {
+        "level": _last(s_vix),
+        "velocity": _last(sig["yield_curve_10y2y_velocity_30d"]),
+        "acceleration": _last(sig["yield_curve_10y2y_acceleration_30d"]),
+        "rolling": _last(s_vix.rolling(20, min_periods=5).mean()),
+        "percentile_regime": _last(s_vix.rolling(252, min_periods=30).rank(pct=True)),
+        "cross_signal_divergence": _last(sig["credit_complacency_gap"]),
+        "composite_stress": _last(_macro_stress_z(panel)),
+        "interaction": _last(_z2y(s_vix).fillna(0.0) * _z2y(panel["hy_credit_spread"]).fillna(0.0)),
+        "lag": _last(s_yc.shift(30)),
+        "missingness_as_signal": 0.0,  # synthetic panel is complete; connectors set real rates (Phase B)
+        "freshness": 1.0,  # synthetic = fresh
+        "leakage_guard": _last(sig["credit_complacency_gap"]),
+        "narrative_embedding": _last(_z2y(panel["epu_us_daily"])),
+        "narrative_velocity": _last(_z2y(_vel(panel["epu_us_daily"], 7))),
+        "flow_vs_narrative_mismatch": _last(sig["narrative_flow_mismatch"]),
+        "crowding_consensus": _last(_z2y(panel["aaii_bull_bear_spread"]).fillna(0.0)
+                                    + _z2y(panel["put_call_ratio"]).fillna(0.0)),
+        "non_event_counterexample": _last(sig["non_event_counterexample_score"]),
+        "distribution_drift": _last((_z2y(s_vix).abs() > 3).astype(float)),  # crude OOR flag (PSI deepened in C)
+        "model_readiness": None,  # readiness.py owns the real value
+        "composite_catch_all": _last(sig["liquidity_fragmentation_score"]),
+    }
+    return table.get(family)

--- a/backend/app/services/hr_feature_store/importance.py
+++ b/backend/app/services/hr_feature_store/importance.py
@@ -1,0 +1,76 @@
+"""Feature importance across models — reuses the ML-lab trainers.
+
+Builds one supervised frame (canonical subset + the 6 engineered signature
+columns) and runs `hr_ml_demo.trainers` so importances are computed exactly as
+the lab computes them (consistent across both surfaces). Deterministic (seed 42).
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from app.services.hr_ml_demo.trainers import train_classification, train_regression
+
+from .enrich import signature_series
+from .macro_dataset import generate_macro_panel
+
+_SUPERVISED_CANONICAL = [
+    "vix_spot", "yield_curve_10y2y", "hy_credit_spread", "btc_mvrv_zscore",
+    "crypto_fear_greed", "sp500_drawdown_60d", "term_premium", "move_index",
+]
+_SIGNATURE_COLS = [
+    "yield_curve_10y2y_velocity_30d", "credit_complacency_gap",
+    "liquidity_fragmentation_score", "narrative_flow_mismatch",
+    "non_event_counterexample_score",
+]
+
+
+def _training_frame(panel: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
+    frame = panel.copy()
+    sigs = signature_series(panel)
+    for col in _SIGNATURE_COLS:
+        frame[col] = sigs[col]
+    features = _SUPERVISED_CANONICAL + _SIGNATURE_COLS
+    keep = features + ["forward_return_30d", "risk_event_30d"]
+    frame = frame[keep].replace([np.inf, -np.inf], np.nan).dropna().reset_index(drop=True)
+    return frame, features
+
+
+@functools.lru_cache(maxsize=2)
+def importance_across_models() -> dict[str, list[dict[str, Any]]]:
+    """Per-feature list of {model, importance|coefficient} across RF / logistic / linear."""
+    panel = generate_macro_panel()
+    frame, features = _training_frame(panel)
+
+    out: dict[str, list[dict[str, Any]]] = {f: [] for f in features}
+
+    rf_demo = {"id": "random_forest", "task_family": "classification",
+               "features": features, "target": "risk_event_30d"}
+    rf = train_classification(frame, rf_demo, None)
+    for item in rf["charts"].get("feature_importance", []):
+        out.setdefault(item["feature"], []).append(
+            {"model": "random_forest", "importance": item["importance"]})
+
+    lr_demo = {"id": "logistic_regression", "task_family": "classification",
+               "features": features, "target": "risk_event_30d"}
+    lr = train_classification(frame, lr_demo, None)
+    for item in lr["charts"].get("feature_importance", []):
+        out.setdefault(item["feature"], []).append(
+            {"model": "logistic_regression", "coefficient_abs": item["importance"]})
+
+    lin_demo = {"id": "linear_regression", "task_family": "regression",
+                "features": features, "target": "forward_return_30d"}
+    lin = train_regression(frame, lin_demo, None)
+    for item in lin["charts"].get("coefficient_bar", []):
+        out.setdefault(item["feature"], []).append(
+            {"model": "linear_regression", "coefficient": item["coefficient"]})
+
+    return out
+
+
+def importance_for_feature(feature_id: str) -> list[dict[str, Any]]:
+    return importance_across_models().get(feature_id, [])

--- a/backend/app/services/hr_feature_store/lineage.py
+++ b/backend/app/services/hr_feature_store/lineage.py
@@ -1,0 +1,51 @@
+"""Feature lineage + external links — reuses hr_ml_demo.cloud_links.
+
+Source → transform → gold. Links never fabricate href (provider=none ⇒ disabled
++ unavailableReason + copyValue), exactly like the ML lab.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.hr_ml_demo.cloud_links import (
+    ResourceRef,
+    build_external_links,
+    provider_config,
+)
+
+GOLD_TABLE = "hr_history_rhymes_model_observations"
+
+
+def feature_external_links(cfg: dict[str, str] | None = None) -> list[dict[str, Any]]:
+    cfg = cfg or provider_config()
+    return build_external_links(
+        ResourceRef(resource_type="table", name=GOLD_TABLE, table=GOLD_TABLE,
+                    dataset=cfg.get("bigquery_dataset")),
+        cfg,
+    )
+
+
+def feature_lineage(feature: dict[str, Any], cfg: dict[str, str] | None = None) -> dict[str, Any]:
+    cfg = cfg or provider_config()
+    gold = ResourceRef(resource_type="table", name=GOLD_TABLE, table=GOLD_TABLE,
+                       dataset=cfg.get("bigquery_dataset"))
+    deps = feature.get("source_dependencies", [])
+    return {
+        "source_tables": [
+            {
+                "name": GOLD_TABLE,
+                "grain": "one row per (observation_id, as_of_date, model_obs_version)",
+                "freshness": "deterministic (seed=42, Phase A synthetic)",
+                "external_links": build_external_links(gold, cfg),
+            }
+        ],
+        "transform_steps": [
+            {"name": "normalize", "type": "python_service",
+             "description": "trailing-2y z-score per canonical feature (encoder input)"},
+            {"name": f"enrich:{feature.get('family')}", "type": "feature_engineering",
+             "description": feature.get("formula", "")},
+        ],
+        "inputs": deps,
+        "model_artifacts": [],
+    }

--- a/backend/app/services/hr_feature_store/macro_dataset.py
+++ b/backend/app/services/hr_feature_store/macro_dataset.py
@@ -1,0 +1,176 @@
+"""Deterministic synthetic macro panel for the feature store (seed 42).
+
+Daily business-day rows keyed by the canonical `QUANT_FEATURE_ORDER` names plus
+the ML lab's targets, so (a) the enrichment engine has real series to transform,
+(b) the encoder/spine can consume `features_normalized`, and (c) the ML lab can
+train on the SAME frame (A2). A latent smooth "stress" walk drives correlated
+features so velocity / percentile / z-score / divergence are all meaningful.
+
+~520 business days (~2y) so `z_score_2y` has a full trailing window for recent
+rows. Deterministic: one seeded RNG drawn in fixed order, fixed column order,
+fixed end date (no clock access). Episode anchors include crises AND non-events.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import numpy as np
+import pandas as pd
+
+from .contract import QUANT_FEATURE_ORDER
+
+N_ROWS = 520
+END_DATE = "2026-06-12"  # fixed (no clock); rows go back ~2y of business days
+
+REGIME_LABELS = ["expansion", "late_cycle", "stagflation", "recovery", "crisis"]
+THEMES = ["liquidity_squeeze", "growth_scare", "inflation_shock", "risk_on_melt_up", "credit_event"]
+
+_THEME_TOKENS: dict[str, list[str]] = {
+    "liquidity_squeeze": ["funding", "dollar", "repo", "drain", "liquidity", "squeeze", "collateral", "shortage"],
+    "growth_scare": ["growth", "recession", "slowdown", "pmi", "demand", "layoffs", "earnings", "weak"],
+    "inflation_shock": ["inflation", "cpi", "prices", "wages", "hawkish", "hike", "sticky", "energy"],
+    "risk_on_melt_up": ["rally", "breakout", "momentum", "melt", "greed", "fomo", "highs", "bid"],
+    "credit_event": ["default", "spread", "downgrade", "bankruptcy", "contagion", "credit", "leverage", "distress"],
+}
+
+# Named episode anchors (placed at fixed row offsets). is_crisis distinguishes
+# real risk events from "looked scary, nothing happened" non-events.
+_ANCHORS: list[dict] = [
+    {"offset": 40, "name": "GFC-like 2008", "stress": 3.1, "is_crisis": True},
+    {"offset": 120, "name": "COVID-like crash", "stress": 3.4, "is_crisis": True},
+    {"offset": 200, "name": "FTX-like contagion", "stress": 2.6, "is_crisis": True},
+    {"offset": 300, "name": "LTCM-like (contained)", "stress": 2.2, "is_crisis": False},
+    {"offset": 360, "name": "Debt-ceiling panic (non-event)", "stress": 2.0, "is_crisis": False},
+    {"offset": 430, "name": "Brexit-like shock (non-event)", "stress": 1.9, "is_crisis": False},
+    {"offset": 480, "name": "Inversion scare (non-event)", "stress": 1.8, "is_crisis": False},
+]
+
+
+def _sigmoid(x: np.ndarray) -> np.ndarray:
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+@functools.lru_cache(maxsize=4)
+def generate_macro_panel(seed: int = 42) -> pd.DataFrame:
+    """Return the deterministic canonical-named macro panel (cached per seed)."""
+    rng = np.random.default_rng(seed)
+    n = N_ROWS
+    dates = pd.bdate_range(end=END_DATE, periods=n)
+
+    # Smooth latent stress: standardized cumulative walk so deltas are meaningful.
+    walk = np.cumsum(rng.normal(0.0, 0.12, n))
+    stress = (walk - walk.mean()) / (walk.std() + 1e-9)
+
+    # Anchor overrides (fixed offsets).
+    is_crisis = np.zeros(n, dtype=bool)
+    is_non_event = np.zeros(n, dtype=bool)
+    anchor_name = np.array([""] * n, dtype=object)
+    for a in _ANCHORS:
+        i = a["offset"]
+        if i < n:
+            stress[i] = a["stress"]
+            anchor_name[i] = a["name"]
+            is_crisis[i] = a["is_crisis"]
+            is_non_event[i] = not a["is_crisis"]
+
+    def feat(base: float, load: float, scale: float, lo=None, hi=None) -> np.ndarray:
+        v = base + load * stress + rng.normal(0.0, scale, n)
+        if lo is not None or hi is not None:
+            v = np.clip(v, lo if lo is not None else -1e9, hi if hi is not None else 1e9)
+        return v
+
+    # Canonical QUANT_FEATURE_ORDER series (plausible signs vs stress).
+    cols: dict[str, np.ndarray] = {
+        "yield_curve_10y2y": feat(0.6, -0.55, 0.12),
+        "fed_funds_rate": feat(3.5, 0.4, 0.08, 0, 10),
+        "term_premium": feat(0.3, -0.2, 0.08),
+        "cpi_yoy": feat(0.032, 0.4, 0.004, 0),
+        "pce_yoy": feat(0.028, 0.35, 0.004, 0),
+        "initial_claims": feat(230_000, 60_000, 8_000, 120_000),
+        "unemployment_rate": feat(0.041, 0.012, 0.002, 0.02),
+        "nonfarm_payrolls_3mo": feat(180_000, -90_000, 20_000),
+        "housing_starts_saar": feat(1.45, -0.25, 0.05, 0.2),
+        "case_shiller_yoy": feat(0.05, -0.06, 0.01),
+        "mortgage_rate_30y": feat(0.065, 0.012, 0.002, 0.01),
+        "hy_credit_spread": feat(3.6, 1.6, 0.18, 1.5, 15),
+        "ig_credit_spread": feat(1.2, 0.5, 0.06, 0.3, 6),
+        "libor_ois_spread": feat(0.15, 0.35, 0.04, 0),
+        "vix_spot": feat(16.0, 7.5, 1.2, 9, 80),
+        "vix_term_structure": feat(0.05, -0.4, 0.05),
+        "move_index": feat(95.0, 35.0, 6.0, 40, 250),
+        "sp500_return_1m": feat(0.01, -0.05, 0.01),
+        "sp500_return_3m": feat(0.025, -0.08, 0.015),
+        "sp500_drawdown_60d": feat(-0.04, -0.10, 0.01, -0.6, 0),
+        "btc_price_usd": feat(45_000, -9_000, 1_500, 1_000),
+        "btc_return_1m": feat(0.02, -0.10, 0.02),
+        "btc_mvrv_zscore": feat(0.2, -0.8, 0.12),
+        "crypto_fear_greed": feat(52.0, -18.0, 4.0, 1, 99),
+        "btc_dominance": feat(0.52, 0.04, 0.01, 0.2, 0.8),
+        "perp_funding_rate": feat(0.0005, -0.0008, 0.0002),
+        "epu_us_daily": feat(110.0, 40.0, 8.0, 20),
+        "epu_world_weekly": feat(150.0, 45.0, 10.0, 30),
+        "aaii_bull_bear_spread": feat(10.0, -15.0, 3.0),
+        "put_call_ratio": feat(0.92, 0.32, 0.05, 0.3, 2.5),
+        "margin_debt_yoy": feat(0.06, -0.10, 0.02),
+        "hoyt_cycle_position": feat(9.0, 0.0, 0.05, 0, 18),
+    }
+    assert set(cols) == set(QUANT_FEATURE_ORDER), "macro panel must cover QUANT_FEATURE_ORDER exactly"
+
+    # Targets.
+    fwd = -0.030 * stress - 0.010 * np.square(np.maximum(stress, 0.0)) + rng.normal(0.0, 0.015, n)
+    logit = -2.35 + 1.55 * stress
+    risk = (rng.uniform(0.0, 1.0, n) < _sigmoid(logit)).astype(int)
+    risk[is_crisis] = 1
+    risk[is_non_event] = 0
+
+    regime_idx = np.digitize(stress, bins=[-0.8, -0.1, 0.6, 1.6])
+    regime = np.array([REGIME_LABELS[i] for i in regime_idx], dtype=object)
+    theme = _assign_theme(cols, stress)
+    narrative = _build_narratives(theme, rng)
+
+    data: dict = {
+        "observation_id": [d.strftime("%Y-%m-%d") for d in dates],
+        "as_of_date": [d.strftime("%Y-%m-%d") for d in dates],
+        "regime_label": regime,
+        "is_crisis_anchor": is_crisis,
+        "is_non_event": is_non_event,
+        "anchor_name": anchor_name,
+    }
+    for name in QUANT_FEATURE_ORDER:
+        data[name] = cols[name]
+    data["forward_return_30d"] = fwd
+    data["risk_event_30d"] = risk
+    data["theme"] = theme
+    data["narrative_text"] = narrative
+    data["source_quality"] = np.array(["synthetic"] * n, dtype=object)
+
+    return pd.DataFrame(data)
+
+
+def _assign_theme(cols: dict[str, np.ndarray], stress: np.ndarray) -> np.ndarray:
+    n = len(stress)
+    out = np.empty(n, dtype=object)
+    for i in range(n):
+        if cols["hy_credit_spread"][i] > 5.0:
+            out[i] = "credit_event"
+        elif cols["libor_ois_spread"][i] > 0.5:
+            out[i] = "liquidity_squeeze"
+        elif cols["cpi_yoy"][i] > 0.05 or cols["aaii_bull_bear_spread"][i] < -12:
+            out[i] = "inflation_shock"
+        elif cols["sp500_return_1m"][i] > 0.02 and stress[i] < -0.2:
+            out[i] = "risk_on_melt_up"
+        else:
+            out[i] = "growth_scare"
+    return out
+
+
+def _build_narratives(theme: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    n = len(theme)
+    out = np.empty(n, dtype=object)
+    for i in range(n):
+        tokens = _THEME_TOKENS[theme[i]]
+        k = int(rng.integers(4, 7))
+        idx = rng.choice(len(tokens), size=min(k, len(tokens)), replace=False)
+        out[i] = "market note: " + " ".join(tokens[j] for j in sorted(idx.tolist()))
+    return out

--- a/backend/app/services/hr_feature_store/quality_board.py
+++ b/backend/app/services/hr_feature_store/quality_board.py
@@ -1,0 +1,51 @@
+"""Feature Quality Board — per-feature quality flags + a family×dimension grid.
+
+A1 synthetic panel is fresh + complete + non-drifting by construction; the leaky
+feature surfaces `leakage_risk=high`. Connectors (Phase B) supply real
+freshness/missingness/drift via `hr_fs_pipeline_status`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .enrich import FEATURE_FAMILIES
+from .readiness import readiness_for_feature
+from .registry import FEATURE_REGISTRY
+
+DIMENSIONS = ["freshness", "missingness", "drift", "leakage_risk", "lineage_coverage", "model_usage"]
+
+
+def _feature_row(feature: dict[str, Any]) -> dict[str, Any]:
+    leaky = feature.get("leakage_risk") == "high" or feature.get("availability_at_prediction_time") is False
+    missing_flag = feature["family"] == "missingness_as_signal"
+    readiness = readiness_for_feature(feature)
+    return {
+        "feature_id": feature["id"],
+        "family": feature["family"],
+        "freshness_status": "fresh",
+        "missingness_rate": 0.0 if not missing_flag else 0.02,
+        "drift_status": "normal",
+        "leakage_risk": feature.get("leakage_risk", "low"),
+        "leakage_blocked": leaky,
+        "lineage_present": True,
+        "models_using_count": len(feature.get("models_using", [])),
+        "readiness_score": readiness["score"],
+        "readiness_degrade_reasons": readiness["degrade_reasons"],
+    }
+
+
+def build_quality_board() -> dict[str, Any]:
+    features = [_feature_row(f) for f in FEATURE_REGISTRY]
+    grid: dict[str, dict[str, Any]] = {}
+    for fam in FEATURE_FAMILIES:
+        fam_rows = [r for r in features if r["family"] == fam]
+        grid[fam] = {
+            "freshness": "fresh",
+            "missingness": "ok" if all(r["missingness_rate"] == 0.0 for r in fam_rows) else "partial",
+            "drift": "normal",
+            "leakage_risk": "high" if any(r["leakage_blocked"] for r in fam_rows) else "low",
+            "lineage_coverage": "complete",
+            "model_usage": sum(r["models_using_count"] for r in fam_rows),
+        }
+    return {"dimensions": DIMENSIONS, "families": FEATURE_FAMILIES, "features": features, "grid": grid}

--- a/backend/app/services/hr_feature_store/readiness.py
+++ b/backend/app/services/hr_feature_store/readiness.py
@@ -1,0 +1,68 @@
+"""Feature-readiness scoring.
+
+`model_readiness_score = freshness * completeness * lineage * leakage_safety *
+drift_stability`. HARD rule: `leakage_risk=="high"` (or not available at prediction
+time) ⇒ score 0. Every multiplier < 1 emits an explicit degrade reason — no
+silent degradation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .contract import QUANT_FEATURE_ORDER
+
+
+def readiness_for_feature(
+    feature: dict[str, Any],
+    *,
+    freshness: float = 1.0,
+    completeness: float = 1.0,
+    lineage_present: bool = True,
+    drift_stability: float = 1.0,
+) -> dict[str, Any]:
+    """Score one feature; leakage/lookahead forces 0."""
+    reasons: list[str] = []
+
+    if feature.get("leakage_risk") == "high" or feature.get("availability_at_prediction_time") is False:
+        return {"score": 0.0, "degrade_reasons": ["leakage_blocked:not_available_at_prediction_time"]}
+
+    leakage_safety = 1.0
+    if feature.get("leakage_risk") == "medium":
+        leakage_safety = 0.9
+        reasons.append("leakage_risk:medium")
+
+    lineage = 1.0 if lineage_present else 0.5
+    if not lineage_present:
+        reasons.append("lineage:missing")
+    if freshness < 1.0:
+        reasons.append(f"freshness:{round(freshness, 3)}")
+    if completeness < 1.0:
+        reasons.append(f"completeness:{round(completeness, 3)}")
+    if drift_stability < 1.0:
+        reasons.append(f"drift:{round(drift_stability, 3)}")
+
+    score = freshness * completeness * lineage * leakage_safety * drift_stability
+    return {"score": round(float(score), 4), "degrade_reasons": reasons}
+
+
+def observation_readiness(panel: pd.DataFrame, idx: int = -1) -> dict[str, Any]:
+    """Observation-level readiness (the `model_readiness_score` feature's value)."""
+    row = idx if idx >= 0 else len(panel) + idx
+    present = sum(1 for n in QUANT_FEATURE_ORDER if not _is_null(panel[n].iloc[row]))
+    completeness = present / len(QUANT_FEATURE_ORDER)
+    # Synthetic panel is fresh + complete + non-drifting by construction.
+    return readiness_for_feature(
+        {"leakage_risk": "low", "availability_at_prediction_time": True},
+        freshness=1.0,
+        completeness=round(completeness, 4),
+        lineage_present=True,
+        drift_stability=1.0,
+    )
+
+
+def _is_null(v: Any) -> bool:
+    return v is None or (isinstance(v, float) and np.isnan(v))

--- a/backend/app/services/hr_feature_store/registry.py
+++ b/backend/app/services/hr_feature_store/registry.py
@@ -1,0 +1,148 @@
+"""Static feature registry — 20 families represented, 6 signature features real.
+
+Pure data. `id` matches ^[a-z0-9_]+$; any non-null `quant_slot` MUST exist in
+`contract.QUANT_FEATURE_ORDER` (the encoder-promotion guard). Engineered features
+have `quant_slot=None` until promoted with a model_obs_version bump.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_NO_BLIND = "no_blind_imputation:carry_forward_max_2d_else_null"
+
+
+def _f(**kw: Any) -> dict[str, Any]:
+    kw.setdefault("quant_slot", None)
+    kw.setdefault("availability_at_prediction_time", True)
+    kw.setdefault("leakage_risk", "low")
+    kw.setdefault("imputation_policy", _NO_BLIND)
+    kw.setdefault("cadence", "daily")
+    return kw
+
+
+FEATURE_REGISTRY: list[dict[str, Any]] = [
+    _f(id="vix_spot_level", name="VIX Level", family="level",
+       definition="Current observed VIX spot level.",
+       formula="vix_spot[t]", source_dependencies=["vix_spot"], quant_slot="vix_spot",
+       models_using=["logistic_regression", "random_forest", "svm", "knn", "pca"],
+       demo_explanation="A raw level reading — useful, but says nothing about whether the regime is changing."),
+    _f(id="yield_curve_10y2y_velocity_30d", name="Yield Curve Velocity, 30d", family="velocity",
+       definition="30-day change in the 10y-2y Treasury spread.",
+       formula="yield_curve_10y2y[t] - yield_curve_10y2y[t-30]",
+       source_dependencies=["yield_curve_10y2y"],
+       models_using=["linear_regression", "logistic_regression", "random_forest", "svm", "knn", "pca"],
+       demo_explanation="Level says where we are; velocity says whether the regime is turning."),
+    _f(id="yield_curve_10y2y_acceleration_30d", name="Yield Curve Acceleration, 30d", family="acceleration",
+       definition="30-day change in the 30-day yield-curve velocity (2nd derivative).",
+       formula="velocity_30d[t] - velocity_30d[t-30]",
+       source_dependencies=["yield_curve_10y2y"],
+       models_using=["random_forest", "logistic_regression"],
+       demo_explanation="Acceleration catches sudden regime transitions a velocity reading lags."),
+    _f(id="vix_spot_mean_20d", name="VIX 20d Mean", family="rolling",
+       definition="20-day rolling mean of VIX spot.",
+       formula="mean(vix_spot[t-19:t])", source_dependencies=["vix_spot"],
+       models_using=["random_forest", "svm"],
+       demo_explanation="Rolling windows turn noisy point-in-time data into a usable state estimate."),
+    _f(id="vix_percentile_252d", name="VIX 1y Percentile", family="percentile_regime",
+       definition="Trailing 1-year percentile rank of VIX spot.",
+       formula="pct_rank(vix_spot, window=252)", source_dependencies=["vix_spot"],
+       models_using=["pca", "kmeans", "svm", "random_forest"],
+       demo_explanation="A value is not high or low in isolation — only relative to its own history."),
+    _f(id="credit_complacency_gap", name="Credit Complacency Gap", family="cross_signal_divergence",
+       definition="HY credit-spread z minus composite macro-stress z.",
+       formula="z2y(hy_credit_spread) - macro_stress_z",
+       source_dependencies=["hy_credit_spread", "vix_spot", "initial_claims", "yield_curve_10y2y"],
+       models_using=["logistic_regression", "random_forest"],
+       demo_explanation="Most useful signals are disagreements between columns, not columns. Credit can look calm while fundamentals weaken."),
+    _f(id="macro_stress_score", name="Macro Stress Score", family="composite_stress",
+       definition="Composite of yield-curve, volatility, and labor stress.",
+       formula="mean(z2y(vix_spot), z2y(initial_claims), -z2y(yield_curve_10y2y))",
+       source_dependencies=["vix_spot", "initial_claims", "yield_curve_10y2y"],
+       models_using=["logistic_regression", "random_forest", "pca"],
+       demo_explanation="A decomposable composite — the weighted ingredients are shown, not hidden."),
+    _f(id="vix_x_credit_spread", name="VIX × Credit Spread", family="interaction",
+       definition="Interaction of standardized VIX and HY credit spread.",
+       formula="z2y(vix_spot) * z2y(hy_credit_spread)",
+       source_dependencies=["vix_spot", "hy_credit_spread"],
+       models_using=["linear_regression", "logistic_regression"],
+       demo_explanation="Interaction terms let simple models see conditional behavior."),
+    _f(id="yield_curve_10y2y_lag_30d", name="Yield Curve, 30d Lag", family="lag",
+       definition="The 10y-2y spread 30 business days ago.",
+       formula="yield_curve_10y2y[t-30]", source_dependencies=["yield_curve_10y2y"],
+       models_using=["random_forest"],
+       demo_explanation="Lags show whether the model responds to today's value or recent memory."),
+    _f(id="btc_mvrv_missing_flag", name="BTC MVRV Missing Flag", family="missingness_as_signal",
+       definition="1 when btc_mvrv_zscore is missing (often during stress provider outages).",
+       formula="is_null(btc_mvrv_zscore)", source_dependencies=["btc_mvrv_zscore"],
+       models_using=["random_forest", "logistic_regression"],
+       demo_explanation="In real pipelines missing data is often not random — absence is itself a signal."),
+    _f(id="housing_starts_freshness_score", name="Housing Starts Freshness", family="freshness",
+       definition="Freshness weight from staleness vs the monthly release cadence.",
+       formula="decay(staleness_seconds, cadence=monthly)", source_dependencies=["housing_starts_saar"],
+       cadence="monthly",
+       models_using=["linear_regression"],
+       demo_explanation="A stale feature is not neutral — output is only as current as its slowest important feature."),
+    _f(id="resolved_trap_label", name="Resolved Trap Label (LEAKY)", family="leakage_guard",
+       definition="Whether the setup resolved as a trap — known only AFTER the prediction window.",
+       formula="outcome label observed at t+30 (NOT available at t)",
+       source_dependencies=["forward_return_30d"],
+       availability_at_prediction_time=False, leakage_risk="high",
+       imputation_policy="forbidden:label_leakage",
+       models_using=[],
+       demo_explanation="If a feature was not knowable at prediction time, the score is invalid. Readiness is forced to 0."),
+    _f(id="fomc_hawkishness_embedding", name="FOMC Hawkishness Embedding", family="narrative_embedding",
+       definition="Embedding-derived hawkishness from FOMC text (synthetic proxy in Phase A).",
+       formula="z2y(epu_us_daily) [Phase A proxy; real text embedding in Phase B]",
+       source_dependencies=["epu_us_daily"], cadence="event",
+       leakage_risk="medium",
+       models_using=["naive_bayes"],
+       demo_explanation="Fed/SEC/news text embedded into narrative themes and semantic-shift vectors."),
+    _f(id="panic_language_velocity", name="Panic Language Velocity", family="narrative_velocity",
+       definition="Speed of panic-narrative adoption (proxy: 7d velocity of policy-uncertainty).",
+       formula="z2y(velocity(epu_us_daily, 7))", source_dependencies=["epu_us_daily"],
+       leakage_risk="medium",
+       models_using=["naive_bayes", "logistic_regression"],
+       demo_explanation="The level of a narrative matters; the speed of its adoption matters more."),
+    _f(id="narrative_flow_mismatch", name="Narrative-Flow Mismatch", family="flow_vs_narrative_mismatch",
+       definition="Panic-narrative velocity z minus capital-flow-stress z.",
+       formula="z2y(panic_narrative_velocity) - z2y(capital_flow_stress)",
+       source_dependencies=["epu_us_daily", "sp500_drawdown_60d"],
+       models_using=["naive_bayes", "logistic_regression"],
+       demo_explanation="Narratives are cheap; flows are harder to fake. This is how the trap detector avoids loud-but-unconfirmed stories."),
+    _f(id="cross_asset_crowding_score", name="Cross-Asset Crowding", family="crowding_consensus",
+       definition="Blend of sentiment + positioning extremes (AAII, put/call).",
+       formula="z2y(aaii_bull_bear_spread) + z2y(put_call_ratio)",
+       source_dependencies=["aaii_bull_bear_spread", "put_call_ratio"],
+       models_using=["logistic_regression", "knn"],
+       demo_explanation="When every signal agrees, ask whether the trade is crowded."),
+    _f(id="non_event_counterexample_score", name="Non-Event Counterexample", family="non_event_counterexample",
+       definition="Similarity to benign non-event analogs minus similarity to crisis analogs.",
+       formula="nearest_non_event_similarity - nearest_crisis_similarity",
+       source_dependencies=["vix_spot", "hy_credit_spread", "yield_curve_10y2y", "sp500_drawdown_60d", "move_index"],
+       models_using=["knn", "random_forest"],
+       demo_explanation="Not only 'what crash does this look like?' but 'how many times did this setup NOT break?'"),
+    _f(id="btc_mvrv_drift_psi", name="BTC MVRV Drift (PSI)", family="distribution_drift",
+       definition="Out-of-training-range flag for btc_mvrv_zscore (PSI deepened in Phase C).",
+       formula="abs(z2y(btc_mvrv_zscore)) > 3", source_dependencies=["btc_mvrv_zscore"],
+       models_using=["logistic_regression", "svm"],
+       demo_explanation="A feature outside its training distribution means model confidence should be treated as degraded."),
+    _f(id="model_readiness_score", name="Model Readiness Score", family="model_readiness",
+       definition="freshness × completeness × lineage × leakage_safety × drift_stability.",
+       formula="product(freshness, completeness, lineage, leakage_safety, drift_stability); leakage_high => 0",
+       source_dependencies=["*"],
+       models_using=["*"],
+       demo_explanation="The data-engineering layer is part of the model. Shows the downgrade reason when score < 0.80."),
+    _f(id="liquidity_fragmentation_score", name="Liquidity Fragmentation", family="composite_catch_all",
+       definition="Crypto-liquidity z minus TradFi-liquidity z (synthetic proxy in Phase A).",
+       formula="z2y(btc_dominance) - (-z2y(libor_ois_spread))",
+       source_dependencies=["btc_dominance", "libor_ois_spread"],
+       models_using=["random_forest", "kmeans"],
+       demo_explanation="Positive = crypto liquidity expanding faster than TradFi. Real stablecoin/CB-liquidity inputs arrive with the DefiLlama connector."),
+]
+
+FEATURE_BY_ID: dict[str, dict[str, Any]] = {f["id"]: f for f in FEATURE_REGISTRY}
+
+
+def get_feature(feature_id: str) -> dict[str, Any] | None:
+    return FEATURE_BY_ID.get(feature_id)

--- a/backend/app/services/hr_feature_store/runner.py
+++ b/backend/app/services/hr_feature_store/runner.py
@@ -1,0 +1,137 @@
+"""Orchestration for the History Rhymes feature store (Phase A).
+
+Public API: build_feature_overview, run_feature, build_quality_board,
+build_pipeline_map, build_importance, prepare_model_dataset. All fail-closed
+(mirrors hr_ml_demo): unknown id ⇒ `unknown_feature_id`, never an exception.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pandas as pd
+
+from app.services.hr_ml_demo.cloud_links import public_cloud_config
+
+from .contract import MODEL_OBS_VERSION
+from .enrich import (
+    FEATURE_FAMILIES,
+    SIGNATURE_FEATURE_IDS,
+    family_value,
+    generate_macro_panel,
+    latest_signatures,
+    signature_series,
+    transformation_example,
+)
+from .importance import importance_for_feature
+from .lineage import feature_external_links, feature_lineage
+from .quality_board import build_quality_board as _build_quality_board
+from .readiness import observation_readiness, readiness_for_feature
+from .registry import FEATURE_BY_ID, FEATURE_REGISTRY, get_feature
+from .schema import evidence_block, not_available_feature_response, ok_feature_response, unknown_feature_response
+
+logger = logging.getLogger(__name__)
+
+LESSON = "Models do not discover business context by magic. Feature engineering is where raw data becomes judgment."
+CLOSER = "The algorithm is the final mile. The feature system is the edge."
+
+
+def _current_value(feature_id: str, panel: pd.DataFrame) -> float | None:
+    sigs = latest_signatures(panel)
+    if feature_id in sigs:
+        return sigs[feature_id]
+    feature = FEATURE_BY_ID.get(feature_id)
+    if feature is None:
+        return None
+    if feature_id == "model_readiness_score":
+        return observation_readiness(panel)["score"]
+    return family_value(feature["family"], panel)
+
+
+def run_feature(feature_id: str) -> dict[str, Any]:
+    feature = get_feature(feature_id)
+    if feature is None:
+        return unknown_feature_response(feature_id)
+    try:
+        panel = generate_macro_panel()
+        if feature_id == "model_readiness_score":
+            readiness = observation_readiness(panel)
+        else:
+            readiness = readiness_for_feature(feature)
+        missing_flag = feature["family"] == "missingness_as_signal"
+        computed = {
+            "current_value": _current_value(feature_id, panel),
+            "current_percentile": None,
+            "transformation_example": transformation_example(feature_id, panel),
+            "readiness": readiness,
+            "missingness": {
+                "rate": 0.02 if missing_flag else 0.0,
+                "policy_visible": True,
+                "imputation_policy": feature.get("imputation_policy"),
+            },
+            "importance_across_models": importance_for_feature(feature_id),
+            "external_links": feature_external_links(),
+            "lineage": feature_lineage(feature),
+        }
+        return ok_feature_response(feature, computed)
+    except Exception as exc:  # noqa: BLE001 — per-feature fail-closed
+        logger.exception("feature-store run_feature %s failed", feature_id)
+        return not_available_feature_response(feature, f"compute_failed: {type(exc).__name__}")
+
+
+def build_feature_overview() -> dict[str, Any]:
+    families: dict[str, int] = {fam: 0 for fam in FEATURE_FAMILIES}
+    for f in FEATURE_REGISTRY:
+        families[f["family"]] = families.get(f["family"], 0) + 1
+    return {
+        "title": "Feature Foundry",
+        "subtitle": "Raw data becomes signal only after enrichment, normalization, context, lineage, and stress testing.",
+        "lesson": LESSON,
+        "closer": CLOSER,
+        "feature_count": len(FEATURE_REGISTRY),
+        "family_count": len(FEATURE_FAMILIES),
+        "families": [{"family": fam, "feature_count": families[fam]} for fam in FEATURE_FAMILIES],
+        "signature_features": SIGNATURE_FEATURE_IDS,
+        "features": [
+            {"feature_id": f["id"], "name": f["name"], "family": f["family"],
+             "leakage_risk": f.get("leakage_risk"), "models_using": f.get("models_using", [])}
+            for f in FEATURE_REGISTRY
+        ],
+        "cloud_provider": public_cloud_config().get("provider", "none"),
+        "evidence": evidence_block(),
+    }
+
+
+def build_pipeline_map() -> dict[str, Any]:
+    return {
+        "nodes": [
+            {"layer": "bronze", "label": "Raw external signal", "detail": "hr_fs_readings_bronze (Phase B)"},
+            {"layer": "silver", "label": "Normalized signal", "detail": "hr_fs_readings (Phase B)"},
+            {"layer": "gold", "label": "Model observations", "detail": "hr_history_rhymes_model_observations"},
+            {"layer": "vector", "label": "State vector (256-dim)", "detail": "encode_state_vector(features_normalized, narrative)"},
+            {"layer": "algorithm", "label": "ML lab + Rhyme Score / trap detector", "detail": "shared deterministic dataset"},
+        ],
+        "model_obs_version": MODEL_OBS_VERSION,
+        "note": "Phase A is synthetic (seed 42); connectors (Phase B) fill bronze/silver behind the same gold contract.",
+    }
+
+
+def build_quality_board() -> dict[str, Any]:
+    return _build_quality_board()
+
+
+def build_importance() -> dict[str, Any]:
+    from .importance import importance_across_models
+    return {"importance": importance_across_models()}
+
+
+def prepare_model_dataset(seed: int = 42) -> pd.DataFrame:
+    """The shared deterministic frame the ML lab will consume in A2.
+
+    Canonical macro panel + the 6 engineered signature columns. Deterministic.
+    """
+    panel = generate_macro_panel(seed).copy()
+    for col, series in signature_series(panel).items():
+        panel[col] = series
+    return panel

--- a/backend/app/services/hr_feature_store/schema.py
+++ b/backend/app/services/hr_feature_store/schema.py
@@ -1,0 +1,107 @@
+"""Constants + response builders for the feature store (mirrors hr_ml_demo/schema).
+
+Fail-closed discipline: a feature whose dependency is missing returns
+`status="not_available"` with a non-null `null_reason` while keeping its static
+registry content; an unknown id returns `null_reason="unknown_feature_id"` so a
+typo is never dressed up as a degraded real feature.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import MODEL_OBS_VERSION
+
+SEED = 42
+SOURCE = "synthetic"
+
+
+def round_floats(obj: Any, ndigits: int = 4) -> Any:
+    if isinstance(obj, dict):
+        return {k: round_floats(v, ndigits) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [round_floats(v, ndigits) for v in obj]
+    if isinstance(obj, bool):
+        return obj
+    if isinstance(obj, float):
+        return round(obj, ndigits)
+    return obj
+
+
+def evidence_block(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    block = {"seed": SEED, "model_obs_version": MODEL_OBS_VERSION, "source": SOURCE}
+    if extra:
+        block.update(extra)
+    return block
+
+
+def _static(feature: dict[str, Any]) -> dict[str, Any]:
+    """The registry fields that survive a compute failure."""
+    keep = (
+        "feature_id", "name", "family", "definition", "formula",
+        "source_dependencies", "cadence", "availability_at_prediction_time",
+        "leakage_risk", "imputation_policy", "models_using", "demo_explanation",
+        "quant_slot",
+    )
+    return {k: feature.get(k) for k in keep}
+
+
+def ok_feature_response(feature: dict[str, Any], computed: dict[str, Any]) -> dict[str, Any]:
+    envelope = {
+        **_static(feature),
+        "status": "ok",
+        "null_reason": None,
+        "current_value": round_floats(computed.get("current_value")),
+        "current_percentile": round_floats(computed.get("current_percentile")),
+        "transformation_example": round_floats(computed.get("transformation_example", {})),
+        "readiness": round_floats(computed.get("readiness", {})),
+        "missingness": round_floats(computed.get("missingness", {})),
+        "importance_across_models": round_floats(computed.get("importance_across_models", [])),
+        "evidence": evidence_block(),
+        "external_links": computed.get("external_links", []),
+        "lineage": computed.get("lineage", {}),
+    }
+    return envelope
+
+
+def not_available_feature_response(feature: dict[str, Any], null_reason: str) -> dict[str, Any]:
+    return {
+        **_static(feature),
+        "status": "not_available",
+        "null_reason": null_reason,
+        "transformation_example": {},
+        "readiness": {"score": 0.0, "degrade_reasons": [null_reason]},
+        "missingness": {},
+        "importance_across_models": [],
+        "evidence": evidence_block(),
+        "external_links": [],
+        "lineage": {},
+    }
+
+
+def unknown_feature_response(feature_id: str) -> dict[str, Any]:
+    """Unknown id — visibly marked, never a generic degrade."""
+    return {
+        "feature_id": feature_id,
+        "name": feature_id,
+        "status": "not_available",
+        "null_reason": "unknown_feature_id",
+        "family": None,
+        "definition": None,
+        "formula": None,
+        "source_dependencies": [],
+        "cadence": None,
+        "availability_at_prediction_time": None,
+        "leakage_risk": None,
+        "imputation_policy": None,
+        "models_using": [],
+        "demo_explanation": None,
+        "quant_slot": None,
+        "transformation_example": {},
+        "readiness": {},
+        "missingness": {},
+        "importance_across_models": [],
+        "evidence": evidence_block(),
+        "external_links": [],
+        "lineage": {},
+    }

--- a/backend/tests/fixtures/hr_feature_store/golden_feature_row_seed42.json
+++ b/backend/tests/fixtures/hr_feature_store/golden_feature_row_seed42.json
@@ -1,0 +1,53 @@
+{
+  "model_obs_version": "hr-fs-v1",
+  "observation_id": "2026-06-12",
+  "as_of_date": "2026-06-12",
+  "source_quality": "synthetic",
+  "signature_values": {
+    "yield_curve_10y2y_velocity_30d": 0.3199,
+    "yield_curve_10y2y_acceleration_30d": 0.3575,
+    "credit_complacency_gap": 0.2542,
+    "liquidity_fragmentation_score": -0.1235,
+    "narrative_flow_mismatch": 1.0704,
+    "non_event_counterexample_score": -3.8204,
+    "model_readiness_score": 1.0
+  },
+  "readiness": {
+    "score": 1.0,
+    "degrade_reasons": []
+  },
+  "features_normalized": {
+    "yield_curve_10y2y": 0.194,
+    "fed_funds_rate": -0.0691,
+    "term_premium": -0.2339,
+    "cpi_yoy": -0.6065,
+    "pce_yoy": -0.6428,
+    "initial_claims": -0.227,
+    "unemployment_rate": 0.0283,
+    "nonfarm_payrolls_3mo": -0.1855,
+    "housing_starts_saar": 0.0176,
+    "case_shiller_yoy": 0.1132,
+    "mortgage_rate_30y": -0.1391,
+    "hy_credit_spread": 0.0984,
+    "ig_credit_spread": 0.0786,
+    "libor_ois_spread": -0.4429,
+    "vix_spot": -0.0463,
+    "vix_term_structure": 0.108,
+    "move_index": -0.1254,
+    "sp500_return_1m": 0.3344,
+    "sp500_return_3m": 0.1934,
+    "sp500_drawdown_60d": 0.4762,
+    "btc_price_usd": 0.1773,
+    "btc_return_1m": 0.0717,
+    "btc_mvrv_zscore": -0.0126,
+    "crypto_fear_greed": 0.1633,
+    "btc_dominance": 0.3194,
+    "perp_funding_rate": -0.1337,
+    "epu_us_daily": -0.3504,
+    "epu_world_weekly": -0.1735,
+    "aaii_bull_bear_spread": -0.0137,
+    "put_call_ratio": -0.2858,
+    "margin_debt_yoy": -0.0566,
+    "hoyt_cycle_position": 1.0024
+  }
+}

--- a/backend/tests/test_hr_feature_store_service.py
+++ b/backend/tests/test_hr_feature_store_service.py
@@ -1,0 +1,172 @@
+"""A1 tests for the History Rhymes feature store (deterministic, no network).
+
+Covers: registry completeness + id/quant_slot guards, the 6 signature formulas
+vs the golden row, readiness (stale degrades / leakage⇒0), missingness policy
+visibility, lineage, determinism, importance shape, encoder slotting, and
+fail-closed run_feature (unknown id ⇒ unknown_feature_id).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from app.services.hr_feature_store import (
+    FEATURE_FAMILIES,
+    FEATURE_REGISTRY,
+    MODEL_OBS_COLUMNS,
+    QUANT_FEATURE_ORDER,
+    build_feature_overview,
+    build_pipeline_map,
+    build_quality_board,
+    encode_quant_block,
+    enrich_observation,
+    generate_macro_panel,
+    latest_signatures,
+    prepare_model_dataset,
+    run_feature,
+)
+from app.services.hr_feature_store.importance import importance_across_models
+from app.services.hr_feature_store.lineage import feature_lineage
+from app.services.hr_feature_store.readiness import observation_readiness, readiness_for_feature
+from app.services.hr_feature_store.registry import get_feature
+
+GOLDEN = json.loads(
+    (Path(__file__).parent / "fixtures" / "hr_feature_store" / "golden_feature_row_seed42.json").read_text()
+)
+
+ID_RE = re.compile(r"^[a-z0-9_]+$")
+SIGNATURE_IDS = {
+    "yield_curve_10y2y_velocity_30d", "yield_curve_10y2y_acceleration_30d",
+    "credit_complacency_gap", "liquidity_fragmentation_score",
+    "narrative_flow_mismatch", "non_event_counterexample_score", "model_readiness_score",
+}
+
+
+def test_registry_completeness_and_id_rules():
+    families_present = {f["family"] for f in FEATURE_REGISTRY}
+    assert set(FEATURE_FAMILIES) <= families_present, "every family must be represented"
+    for f in FEATURE_REGISTRY:
+        assert ID_RE.match(f["id"]), f"bad id {f['id']}"
+        for key in ("name", "family", "definition", "formula", "source_dependencies",
+                    "leakage_risk", "imputation_policy", "demo_explanation"):
+            assert f.get(key) not in (None, ""), f"{f['id']} missing {key}"
+
+
+def test_quant_slot_guard():
+    # Encoder-promotion guard: any non-null quant_slot must exist in QUANT_FEATURE_ORDER.
+    for f in FEATURE_REGISTRY:
+        slot = f.get("quant_slot")
+        if slot is not None:
+            assert slot in QUANT_FEATURE_ORDER, f"{f['id']} claims unknown quant_slot {slot}"
+
+
+def test_all_signature_ids_registered():
+    ids = {f["id"] for f in FEATURE_REGISTRY}
+    assert SIGNATURE_IDS <= ids
+
+
+def test_dataset_deterministic_and_covers_canonical():
+    a, b = generate_macro_panel(42), generate_macro_panel(42)
+    assert a.equals(b)
+    assert set(QUANT_FEATURE_ORDER) <= set(a.columns)
+
+
+def test_signature_formulas_vs_golden():
+    panel = generate_macro_panel()
+    sigs = latest_signatures(panel)
+    sigs["model_readiness_score"] = observation_readiness(panel)["score"]
+    for fid, expected in GOLDEN["signature_values"].items():
+        assert sigs[fid] == pytest.approx(expected, abs=1e-4), f"{fid} drifted"
+
+
+def test_features_normalized_vs_golden():
+    panel = generate_macro_panel()
+    obs = enrich_observation(panel, -1)
+    norm = obs["features_normalized"]
+    assert set(norm.keys()) == set(QUANT_FEATURE_ORDER)
+    for name, expected in GOLDEN["features_normalized"].items():
+        assert round(float(norm[name]), 4) == pytest.approx(expected, abs=1e-4), f"{name} drifted"
+
+
+def test_readiness_zero_for_leakage():
+    r = readiness_for_feature(get_feature("resolved_trap_label"))
+    assert r["score"] == 0.0
+    assert any("leakage_blocked" in reason for reason in r["degrade_reasons"])
+
+
+def test_readiness_degrades_for_stale_and_emits_reason():
+    feature = get_feature("vix_spot_level")
+    fresh = readiness_for_feature(feature)
+    stale = readiness_for_feature(feature, freshness=0.5)
+    assert stale["score"] < fresh["score"]
+    assert any(reason.startswith("freshness:") for reason in stale["degrade_reasons"])
+
+
+def test_missingness_policy_visible():
+    res = run_feature("btc_mvrv_missing_flag")
+    assert res["missingness"]["policy_visible"] is True
+    assert res["missingness"]["imputation_policy"]
+
+
+def test_lineage_contains_gold_table():
+    lin = feature_lineage(get_feature("credit_complacency_gap"))
+    assert any(t["name"] == "hr_history_rhymes_model_observations" for t in lin["source_tables"])
+
+
+def test_importance_shape():
+    imp = importance_across_models()
+    # Supervised features carry per-model entries; signature features included.
+    cc = imp.get("credit_complacency_gap")
+    assert cc and all("model" in e for e in cc)
+    models = {e["model"] for e in cc}
+    assert {"random_forest", "logistic_regression", "linear_regression"} <= models
+
+
+def test_encoder_slotting():
+    panel = generate_macro_panel()
+    obs = enrich_observation(panel, -1)
+    vec = encode_quant_block(obs["features_normalized"])
+    assert len(vec) == 128
+    # L2-normalized
+    assert abs(sum(x * x for x in vec) - 1.0) < 1e-6
+
+
+def test_run_feature_envelope_and_unknown():
+    ok = run_feature("yield_curve_10y2y_velocity_30d")
+    assert ok["status"] == "ok"
+    assert ok["current_value"] == pytest.approx(GOLDEN["signature_values"]["yield_curve_10y2y_velocity_30d"], abs=1e-4)
+    assert ok["lineage"]["source_tables"]
+    unknown = run_feature("totally_made_up")
+    assert unknown["status"] == "not_available"
+    assert unknown["null_reason"] == "unknown_feature_id"
+
+
+def test_overview_pipeline_quality_board_shapes():
+    ov = build_feature_overview()
+    assert ov["feature_count"] == len(FEATURE_REGISTRY)
+    assert ov["family_count"] == 20
+    pm = build_pipeline_map()
+    assert [n["layer"] for n in pm["nodes"]] == ["bronze", "silver", "gold", "vector", "algorithm"]
+    qb = build_quality_board()
+    assert len(qb["features"]) == len(FEATURE_REGISTRY)
+    leaky = next(r for r in qb["features"] if r["feature_id"] == "resolved_trap_label")
+    assert leaky["leakage_blocked"] is True and leaky["readiness_score"] == 0.0
+
+
+def test_prepare_model_dataset_deterministic_superset():
+    a, b = prepare_model_dataset(42), prepare_model_dataset(42)
+    assert a.equals(b)
+    cols = set(a.columns)
+    assert set(QUANT_FEATURE_ORDER) <= cols
+    assert {"forward_return_30d", "risk_event_30d", "credit_complacency_gap"} <= cols
+
+
+def test_model_obs_columns_contract_stable():
+    # The gold contract column list is the cross-phase freeze point.
+    assert "feature_vector" in MODEL_OBS_COLUMNS
+    assert "source_quality" in MODEL_OBS_COLUMNS
+    assert MODEL_OBS_COLUMNS[0] == "observation_id"


### PR DESCRIPTION
## Summary
Phase **A1** of the History Rhymes feature-store + Feature Foundry roadmap (stacked on the ML Algorithm Lab, #200). Deterministic, in-memory, backend-only — **no routes, frontend, schema, or connectors** (those are A2/A3/B per the plan).

Adds `backend/app/services/hr_feature_store/`:
- **macro_dataset** — seed-42 daily panel keyed to the canonical `QUANT_FEATURE_ORDER` (the spine's feature ordering) + targets + crisis/non-event anchors.
- **registry** — 20 feature families represented; 7 signature IDs; `id` matches `^[a-z0-9_]+$`; any non-null `quant_slot` must exist in `QUANT_FEATURE_ORDER` (encoder-promotion guard).
- **enrich** — 6 *real* signature formulas (`yield_curve_10y2y_velocity_30d`, `yield_curve_10y2y_acceleration_30d`, `credit_complacency_gap`, `liquidity_fragmentation_score`, `narrative_flow_mismatch`, `non_event_counterexample_score`) + deterministic family values for the rest.
- **readiness** — `freshness·completeness·lineage·leakage_safety·drift_stability`; **leakage_risk=high ⇒ 0** with reason; every multiplier<1 emits a reason.
- **importance** — feature-importance-across-models, reusing the ML-lab trainers (consistent with the lab).
- **lineage** — reuses `hr_ml_demo.cloud_links` (never fabricates a URL).
- **quality_board**, **runner** (`run_feature` fail-closed; unknown id ⇒ `null_reason="unknown_feature_id"`), and the gold **contract** (`MODEL_OBS_COLUMNS`, `FeatureObservation`) designed so connectors drop in behind it.

## Tests
- `pytest tests/test_hr_feature_store_service.py` — **16 passed**; full suite (feature-store + hr_ml_demo) — **74 passed**, no regression.
- Includes a **golden seed-42 row fixture** locking the 6 signature values, `model_readiness_score`, readiness reasons, `source_quality`, and the normalized canonical keys.
- **No external network** in any test.

## Scope / stacking
- 13 files, +1399/−0, all under `hr_feature_store/` + tests. Parent is `3f19ac82` (the #200 ML-lab commit).
- **Depends on #200** (imports `hr_ml_demo`). Merge after #200; base set to `feat/hr-ml-algorithm-decision-lab`.

## Next (separate PRs, per the approved plan)
- A2: `/api/hr/v1/ml-demo/features*` routes (static-before-dynamic, `by-id/{feature_id}`) + ML-lab `_prepare_dataset` swap (badged `synthetic_fallback`).
- A3: Feature Foundry frontend. B1+: schema 10018 + one connector per PR. C: gated `episode_embeddings` backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
