### PR TITLE
fix(repe): dashboard widgets show diagnostic empty-state for degraded reads (ADO #641)

### DIFF
--- a/repo-b/src/components/repe/dashboards/WidgetRenderer.degraded.test.tsx
+++ b/repo-b/src/components/repe/dashboards/WidgetRenderer.degraded.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Regression guard — REPE dashboard widgets must surface a degraded authoritative
+ * read as an explicit diagnostic empty-state, never a silent blank or zeroed widget.
+ *
+ * Context: follow-up to the repe_fast_path fix (PR #203, ADO #641). The fast path
+ * now produces real data via the full pipeline, but the dashboard widgets fetched
+ * statement endpoints and ignored null_reason / state_origin, so a degraded or
+ * not-released read rendered blank. These tests lock the fix:
+ *   - degraded null_reason  -> DiagnosticEmptyState (reason shown, no $0)
+ *   - healthy released data  -> normal widget render (unchanged)
+ *   - HTTP error             -> diagnostic, not blank
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import WidgetRenderer from "@/components/repe/dashboards/WidgetRenderer";
+
+const ENV = "env-1";
+const BIZ = "11111111-1111-1111-1111-111111111111";
+
+function widget(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "w1",
+    type: "metrics_strip",
+    config: {
+      title: "Fund KPIs",
+      entity_type: "investment",
+      entity_ids: ["inv-1"],
+      quarter: "2026Q2",
+      metrics: [{ key: "noi", label: "NOI" }],
+      ...overrides,
+    },
+    layout: { x: 0, y: 0, w: 4, h: 2 },
+  } as never;
+}
+
+function mockFetchOnce(body: unknown, ok = true, status = 200) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: async () => body,
+  }) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("WidgetRenderer degraded-state handling", () => {
+  it("renders a diagnostic empty-state when the read carries a null_reason", async () => {
+    mockFetchOnce({ lines: [], null_reason: "authoritative_state_not_released" });
+    render(<WidgetRenderer widget={widget()} envId={ENV} businessId={BIZ} quarter="2026Q2" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/null_reason: authoritative_state_not_released/i)).toBeInTheDocument();
+    });
+    // Must NOT fabricate a zero value.
+    expect(screen.queryByText("$0")).not.toBeInTheDocument();
+    expect(screen.getByText(/No authoritative data to display/i)).toBeInTheDocument();
+  });
+
+  it("renders a diagnostic empty-state on an HTTP error (not blank)", async () => {
+    mockFetchOnce({}, false, 503);
+    render(<WidgetRenderer widget={widget()} envId={ENV} businessId={BIZ} quarter="2026Q2" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/null_reason: data_unavailable/i)).toBeInTheDocument();
+    });
+  });
+
+  it("flags a released-but-empty payload (zero lines) as no-data, not a blank shell", async () => {
+    mockFetchOnce({ lines: [], state_origin: "authoritative" });
+    render(<WidgetRenderer widget={widget()} envId={ENV} businessId={BIZ} quarter="2026Q2" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/null_reason: no_statement_data/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders normally (no diagnostic) when authoritative data is present", async () => {
+    mockFetchOnce({ lines: [{ line_code: "noi", amount: 1234000 }], state_origin: "authoritative" });
+    render(<WidgetRenderer widget={widget()} envId={ENV} businessId={BIZ} quarter="2026Q2" />);
+
+    // Healthy path: the diagnostic empty-state must NOT appear.
+    await waitFor(() => {
+      expect(screen.queryByText(/No authoritative data to display/i)).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText(/null_reason:/i)).not.toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/repe/dashboards/WidgetRenderer.tsx
+++ b/repo-b/src/components/repe/dashboards/WidgetRenderer.tsx
@@ -40,6 +40,19 @@ interface Props {
 /* --------------------------------------------------------------------------
  * Fetch a single entity + period from the statements API
  * -------------------------------------------------------------------------- */
+/** Why a widget could not render real authoritative numbers. Surfaced as an
+ *  explicit diagnostic empty-state instead of a silent blank/zeroed widget. */
+type WidgetDiagnostic = { reason: string; detail?: string } | null;
+
+type StatementFetch = {
+  /** line_code -> amount; empty when the read was degraded/unavailable. */
+  values: Record<string, number>;
+  /** True only when the response was a healthy 2xx with a usable payload. */
+  ok: boolean;
+  /** Why the read is not usable, if known (null_reason / state_origin / http). */
+  diagnostic: WidgetDiagnostic;
+};
+
 async function fetchStatementData(
   entityType: string,
   entityId: string,
@@ -50,7 +63,7 @@ async function fetchStatementData(
   comparison: string,
   envId: string,
   businessId: string,
-): Promise<Record<string, number>> {
+): Promise<StatementFetch> {
   const basePath = entityType === "investment"
     ? `/api/re/v2/investments/${entityId}/statements`
     : `/api/re/v2/assets/${entityId}/statements`;
@@ -66,12 +79,33 @@ async function fetchStatementData(
   });
 
   const res = await fetch(`${basePath}?${params}`);
+  if (!res.ok) {
+    return { values: {}, ok: false, diagnostic: { reason: "data_unavailable", detail: `HTTP ${res.status}` } };
+  }
   const json = await res.json();
+
+  // Fail closed on an explicit authoritative null_reason / non-authoritative
+  // origin — never render fabricated or zeroed numbers for a released period.
+  const nullReason: string | undefined = json?.null_reason ?? undefined;
+  const stateOrigin: string | undefined = json?.state_origin ?? undefined;
+  if (nullReason) {
+    return { values: {}, ok: false, diagnostic: { reason: nullReason } };
+  }
+  if (stateOrigin && stateOrigin !== "authoritative" && stateOrigin !== "decomposition_overlay") {
+    return { values: {}, ok: false, diagnostic: { reason: "not_authoritative", detail: stateOrigin } };
+  }
+
+  const lines = json?.lines ?? [];
   const map: Record<string, number> = {};
-  for (const line of json.lines ?? []) {
+  for (const line of lines) {
     map[line.line_code] = line.amount;
   }
-  return map;
+  // A released, authoritative payload with zero lines is still "no data" — flag
+  // it rather than rendering an empty shell.
+  if (lines.length === 0) {
+    return { values: map, ok: false, diagnostic: { reason: "no_statement_data" } };
+  }
+  return { values: map, ok: true, diagnostic: null };
 }
 
 /* --------------------------------------------------------------------------
@@ -87,6 +121,7 @@ function useWidgetData(
   const [data, setData] = useState<Record<string, unknown>[] | null>(null);
   const [seriesLines, setSeriesLines] = useState<LineDef[] | null>(null);
   const [loading, setLoading] = useState(false);
+  const [diagnostic, setDiagnostic] = useState<WidgetDiagnostic>(null);
 
   useEffect(() => {
     const entityType = widget.config.entity_type || "asset";
@@ -94,6 +129,8 @@ function useWidgetData(
     const effectiveQuarter = widget.config.quarter || quarter;
     const groupBy = widget.config.group_by;
     const timeGrain = widget.config.time_grain;
+
+    setDiagnostic(null);
 
     if (!entityIds?.length || !effectiveQuarter) {
       setData(null);
@@ -148,16 +185,20 @@ function useWidgetData(
             });
           });
 
+          // First degraded read across the grid becomes the widget diagnostic.
+          let firstDiag: WidgetDiagnostic = null;
           // Fetch all entity x period combos in parallel
           const fetches = periods.map(async (period) => {
             const row: Record<string, unknown> = { quarter: period };
             const entityFetches = entitiesToFetch.map(async (eid) => {
-              const values = await fetchStatementData(
+              const fetched = await fetchStatementData(
                 entityType, eid, period, statement, periodType, scenario, comparison, envId, businessId,
               );
+              if (!fetched.ok && !firstDiag) firstDiag = fetched.diagnostic;
               const eName = entityNames?.[eid] ?? eid.slice(0, 8);
               metrics.forEach((m: WidgetMetricRef) => {
-                row[`${eName}_${m.key}`] = values[m.key] ?? 0;
+                // Only populate from an ok read; never coerce a degraded read to 0.
+                if (fetched.ok) row[`${eName}_${m.key}`] = fetched.values[m.key] ?? 0;
               });
             });
             await Promise.all(entityFetches);
@@ -166,34 +207,60 @@ function useWidgetData(
 
           const results = await Promise.all(fetches);
           chartData.push(...results);
-          setData(chartData);
-          setSeriesLines(lines);
+          // Every cell degraded (rows carry only `quarter`) => diagnostic, not a blank chart.
+          const anyData = results.some((r) => Object.keys(r).length > 1);
+          if (!anyData && firstDiag) {
+            setDiagnostic(firstDiag);
+            setData(null);
+            setSeriesLines(null);
+          } else {
+            setData(chartData);
+            setSeriesLines(lines);
+          }
         } else if (needsMultiPeriod) {
           // Single-entity multi-period (standard trend line)
+          let firstDiag: WidgetDiagnostic = null;
           const periodFetches = periods.map(async (period) => {
-            const values = await fetchStatementData(
+            const fetched = await fetchStatementData(
               entityType, entitiesToFetch[0], period, statement, periodType, scenario, comparison, envId, businessId,
             );
+            if (!fetched.ok && !firstDiag) firstDiag = fetched.diagnostic;
             const row: Record<string, unknown> = { quarter: period };
-            for (const [k, v] of Object.entries(values)) {
-              row[k] = v;
+            if (fetched.ok) {
+              for (const [k, v] of Object.entries(fetched.values)) row[k] = v;
             }
             return row;
           });
           const chartData = await Promise.all(periodFetches);
-          setData(chartData);
-          setSeriesLines(null); // use default metric-based lines
+          const anyData = chartData.some((r) => Object.keys(r).length > 1);
+          if (!anyData && firstDiag) {
+            setDiagnostic(firstDiag);
+            setData(null);
+            setSeriesLines(null);
+          } else {
+            setData(chartData);
+            setSeriesLines(null); // use default metric-based lines
+          }
         } else {
           // Single entity, single period (original behavior)
-          const values = await fetchStatementData(
+          const fetched = await fetchStatementData(
             entityType, entitiesToFetch[0], periods[0], statement, periodType, scenario, comparison, envId, businessId,
           );
-          setData([values]);
-          setSeriesLines(null);
+          if (!fetched.ok) {
+            // Degraded / not-released / no-data: surface the reason, do not render
+            // a blank or zeroed widget.
+            setDiagnostic(fetched.diagnostic);
+            setData(null);
+            setSeriesLines(null);
+          } else {
+            setData([fetched.values]);
+            setSeriesLines(null);
+          }
         }
       } catch {
         setData(null);
         setSeriesLines(null);
+        setDiagnostic({ reason: "data_unavailable", detail: "fetch_error" });
       } finally {
         setLoading(false);
       }
@@ -202,7 +269,7 @@ function useWidgetData(
     return () => controller.abort();
   }, [widget, envId, businessId, quarter, entityNames]);
 
-  return { data, seriesLines, loading };
+  return { data, seriesLines, loading, diagnostic };
 }
 
 /* --------------------------------------------------------------------------
@@ -541,8 +608,37 @@ function SensitivityHeatWidget({ widget }: { widget: DashboardWidget }) {
 /* --------------------------------------------------------------------------
  * Main renderer
  * -------------------------------------------------------------------------- */
+/** Human-readable label for a widget diagnostic reason code. Falls back to the
+ *  raw code so an unknown reason is still surfaced (never silently blank). */
+function diagnosticLabel(reason: string): string {
+  const map: Record<string, string> = {
+    authoritative_state_not_released: "Not released",
+    authoritative_state_not_found: "No snapshot found",
+    not_authoritative: "Not an authoritative source",
+    no_statement_data: "No data for this period",
+    data_unavailable: "Data unavailable",
+    out_of_scope_requires_waterfall: "Requires waterfall (out of scope)",
+  };
+  return map[reason] ?? reason;
+}
+
+/** Explicit diagnostic empty-state. Replaces a silent blank/zeroed widget when
+ *  the authoritative read was degraded, not released, or returned no data. */
+function DiagnosticEmptyState({ diagnostic }: { diagnostic: { reason: string; detail?: string } }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-1 text-center px-3">
+      <span className="text-amber-500 text-lg leading-none">&#9888;</span>
+      <p className="text-sm text-bm-text font-medium">{diagnosticLabel(diagnostic.reason)}</p>
+      <p className="font-mono text-[10px] text-bm-muted2">
+        null_reason: {diagnostic.reason}{diagnostic.detail ? ` (${diagnostic.detail})` : ""}
+      </p>
+      <p className="text-[10px] text-bm-muted2">No authoritative data to display — not a zero value.</p>
+    </div>
+  );
+}
+
 export default function WidgetRenderer({ widget, envId, businessId, quarter, entityNames, onConfigure, isEditing, queryManifest, dataAvailability }: Props) {
-  const { data, seriesLines, loading } = useWidgetData(widget, envId, businessId, quarter, entityNames);
+  const { data, seriesLines, loading, diagnostic } = useWidgetData(widget, envId, businessId, quarter, entityNames);
   const [showInfo, setShowInfo] = useState(false);
 
   return (
@@ -628,6 +724,8 @@ export default function WidgetRenderer({ widget, envId, businessId, quarter, ent
           <div className="flex items-center justify-center h-full">
             <p className="text-sm text-bm-muted2">Loading...</p>
           </div>
+        ) : diagnostic ? (
+          <DiagnosticEmptyState diagnostic={diagnostic} />
         ) : (
           <>
             {widget.type === "metrics_strip" && <MetricsStripWidget widget={widget} data={data} />}


### PR DESCRIPTION
Frontend follow-up to PR #203 (repe_fast_path fix). Implements ADO Story **#641** under Epic #210.

## Problem

REPE dashboard widgets fetched statement endpoints (`useWidgetData` in `WidgetRenderer.tsx`) and **ignored `null_reason` / `state_origin` / HTTP status**. A degraded or not-released authoritative read rendered a **blank or zeroed widget** with no explanation — so a demo could look broken even when the backend was behaving correctly (and #203 now makes the backend behave correctly).

## Fix (frontend-only, no fabricated numbers)

- `fetchStatementData` returns `{values, ok, diagnostic}` and **fails closed** on: non-2xx, an explicit `null_reason`, a non-authoritative `state_origin`, and a released-but-empty (zero lines) payload. It never coerces missing metrics to `0` for a degraded read.
- `useWidgetData` tracks a `diagnostic` across all three fetch shapes (single / multi-period / multi-entity) and surfaces it when no usable data came back.
- New `DiagnosticEmptyState` renders the reason (`null_reason` + detail) with an explicit "no authoritative data — not a zero value" note, instead of a blank widget.
- **Healthy released data renders unchanged.**

## Acceptance (ADO #641)

- ✅ widgets consult authoritative state / `null_reason` where applicable
- ✅ blank widgets → explicit diagnostic empty states
- ✅ no fabricated numbers (missing ≠ $0)
- ✅ existing healthy rendering preserved
- ✅ regression coverage for degraded/`null_reason` responses

## Verification

- `WidgetRenderer.degraded.test.tsx` (4): `null_reason` → diagnostic; HTTP error → diagnostic; released-empty → no-data diagnostic; healthy → normal render (no diagnostic).
- 39 dashboard/portfolio component tests pass; `tsc` typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)