### PR TITLE
feat(history-rhymes): feature API + ML-lab shared-dataset swap (A2)

### DIFF
--- a/backend/app/routes/hr_ml_demo.py
+++ b/backend/app/routes/hr_ml_demo.py
@@ -113,6 +113,63 @@ def cloud_config() -> dict[str, Any]:
         return {"provider": "none", "available_link_types": []}
 
 
+# ── Feature Foundry (feature store) ───────────────────────────────────────────
+# Static routes are declared BEFORE the dynamic `by-id/{feature_id}` so a literal
+# segment (quality-board / pipeline-map / importance) can never be parsed as an id.
+
+
+@router.get("/features")
+def features_overview() -> dict[str, Any]:
+    try:
+        from app.services.hr_feature_store import build_feature_overview
+
+        return build_feature_overview()
+    except Exception:  # noqa: BLE001 — fail closed
+        logger.exception("feature-store overview failed")
+        return {"title": "Feature Foundry", "features": [], "error": True}
+
+
+@router.get("/features/quality-board")
+def features_quality_board() -> dict[str, Any]:
+    try:
+        from app.services.hr_feature_store import build_quality_board
+
+        return build_quality_board()
+    except Exception:  # noqa: BLE001
+        logger.exception("feature-store quality board failed")
+        return {"dimensions": [], "features": [], "grid": {}}
+
+
+@router.get("/features/pipeline-map")
+def features_pipeline_map() -> dict[str, Any]:
+    try:
+        from app.services.hr_feature_store import build_pipeline_map
+
+        return build_pipeline_map()
+    except Exception:  # noqa: BLE001
+        logger.exception("feature-store pipeline map failed")
+        return {"nodes": []}
+
+
+@router.get("/features/importance")
+def features_importance() -> dict[str, Any]:
+    try:
+        from app.services.hr_feature_store import build_importance
+
+        return build_importance()
+    except Exception:  # noqa: BLE001
+        logger.exception("feature-store importance failed")
+        return {"importance": {}}
+
+
+@router.get("/features/by-id/{feature_id}")
+def feature_detail(feature_id: str) -> dict[str, Any]:
+    """Single feature detail. Unknown id ⇒ 200 + null_reason='unknown_feature_id'."""
+    from app.services.hr_feature_store import run_feature
+
+    return run_feature(feature_id)
+
+
 @router.post("/run")
 async def run(request: Request) -> dict[str, Any]:
     """Run one algorithm under an optional Reality Mode scenario.

--- a/backend/app/services/hr_feature_store/__init__.py
+++ b/backend/app/services/hr_feature_store/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from .contract import MODEL_OBS_COLUMNS, MODEL_OBS_VERSION, QUANT_FEATURE_ORDER, FeatureObservation, encode_quant_block
 from .enrich import FEATURE_FAMILIES, SIGNATURE_FEATURE_IDS, enrich_observation, latest_signatures, signature_series
+from .lab_dataset import lab_model_dataset
 from .macro_dataset import generate_macro_panel
 from .registry import FEATURE_REGISTRY, get_feature
 from .runner import (
@@ -39,6 +40,7 @@ __all__ = [
     "enrich_observation",
     "generate_macro_panel",
     "get_feature",
+    "lab_model_dataset",
     "latest_signatures",
     "prepare_model_dataset",
     "run_feature",

--- a/backend/app/services/hr_feature_store/lab_dataset.py
+++ b/backend/app/services/hr_feature_store/lab_dataset.py
@@ -1,0 +1,89 @@
+"""Lab-schema adapter — renders the shared canonical macro panel into the exact
+column schema the ML lab's trainers + curveballs expect.
+
+This is the "one shared dataset" bridge: the feature store owns the canonical
+`QUANT_FEATURE_ORDER` panel (for the spine), and this adapter derives the lab's
+`NUMERIC_FEATURES` + targets + metadata from it so `hr_ml_demo` can train on the
+same underlying data without changing any trainer. Deterministic (seed 42).
+"""
+
+from __future__ import annotations
+
+import functools
+
+import numpy as np
+import pandas as pd
+
+from .macro_dataset import _THEME_TOKENS, THEMES, generate_macro_panel
+
+_ASSET_CLASSES = ["equity", "credit", "rates", "crypto", "commodity"]
+
+
+def _std(s: pd.Series) -> pd.Series:
+    return (s - s.mean()) / (s.std() + 1e-9)
+
+
+def _balanced_theme_and_narrative(p: pd.DataFrame, seed: int) -> tuple[np.ndarray, np.ndarray]:
+    """Balanced 5-class theme (quantile buckets of a stress composite) + matching
+    narrative text. Balance guarantees the lab's stratified text split has ≥2 per
+    class; narrative is generated FROM the theme so Naive Bayes has real signal.
+    The panel's own theme stays untouched (A1 golden depends only on signatures).
+    """
+    composite = (
+        _std(p["hy_credit_spread"]) + _std(p["vix_spot"]) - _std(p["yield_curve_10y2y"])
+        + _std(p["libor_ois_spread"]) - _std(p["sp500_return_1m"])
+    )
+    theme = pd.qcut(composite.rank(method="first"), q=len(THEMES), labels=THEMES).astype(object).to_numpy()
+    rng = np.random.default_rng(seed + 7)
+    narrative = np.empty(len(p), dtype=object)
+    for i in range(len(p)):
+        tokens = _THEME_TOKENS[theme[i]]
+        k = int(rng.integers(4, 7))
+        idx = rng.choice(len(tokens), size=min(k, len(tokens)), replace=False)
+        narrative[i] = "market note: " + " ".join(tokens[j] for j in sorted(idx.tolist()))
+    return theme, narrative
+
+
+@functools.lru_cache(maxsize=4)
+def lab_model_dataset(seed: int = 42) -> pd.DataFrame:
+    """Return the shared panel in the ML lab's exact column schema (no NaN)."""
+    p = generate_macro_panel(seed)
+    n = len(p)
+
+    yc_vel = (p["yield_curve_10y2y"] - p["yield_curve_10y2y"].shift(30)).fillna(0.0)
+    theme, narrative = _balanced_theme_and_narrative(p, seed)
+
+    out = pd.DataFrame({
+        # identity / metadata (lab schema)
+        "observation_id": p["observation_id"].to_numpy(),
+        "as_of_date": p["as_of_date"].to_numpy(),
+        "asset_class": [_ASSET_CLASSES[i % len(_ASSET_CLASSES)] for i in range(n)],
+        "episode_id": p["anchor_name"].to_numpy(),
+        "episode_name": p["anchor_name"].to_numpy(),
+        "regime_label": p["regime_label"].to_numpy(),
+        "is_crisis_anchor": p["is_crisis_anchor"].to_numpy(),
+        "is_non_event": p["is_non_event"].to_numpy(),
+        "has_anchor": (p["is_crisis_anchor"] | p["is_non_event"]).to_numpy(),
+        # NUMERIC_FEATURES (lab names) derived from canonical panel
+        "vix_level": p["vix_spot"].to_numpy(),
+        "yield_curve_10y2y": p["yield_curve_10y2y"].to_numpy(),
+        "yield_curve_velocity": yc_vel.to_numpy(),
+        "credit_spread_hy": p["hy_credit_spread"].to_numpy(),
+        "btc_mvrv_zscore": p["btc_mvrv_zscore"].to_numpy(),
+        "crypto_fear_greed": p["crypto_fear_greed"].to_numpy(),
+        "liquidity_index": (-_std(p["libor_ois_spread"])).to_numpy(),
+        "momentum_63d": p["sp500_return_3m"].to_numpy(),
+        "breadth": np.clip(0.55 + 2.0 * p["sp500_return_1m"], 0.02, 0.98),
+        "term_premium": p["term_premium"].to_numpy(),
+        "housing_starts_yoy": p["case_shiller_yoy"].to_numpy(),
+        "cmbs_delinquency_rate": np.clip(0.04 + 0.01 * _std(p["hy_credit_spread"]), 0.005, 0.30),
+        "aaii_bull_bear_spread": p["aaii_bull_bear_spread"].to_numpy(),
+        "put_call_ratio": p["put_call_ratio"].to_numpy(),
+        # targets
+        "forward_return_30d": p["forward_return_30d"].to_numpy(),
+        "risk_event_30d": p["risk_event_30d"].to_numpy(),
+        "theme": theme,
+        "narrative_text": narrative,
+        "source_quality": p["source_quality"].to_numpy(),
+    })
+    return out

--- a/backend/app/services/hr_feature_store/schema.py
+++ b/backend/app/services/hr_feature_store/schema.py
@@ -36,14 +36,16 @@ def evidence_block(extra: dict[str, Any] | None = None) -> dict[str, Any]:
 
 
 def _static(feature: dict[str, Any]) -> dict[str, Any]:
-    """The registry fields that survive a compute failure."""
+    """The registry fields that survive a compute failure (registry key is `id`)."""
     keep = (
-        "feature_id", "name", "family", "definition", "formula",
+        "name", "family", "definition", "formula",
         "source_dependencies", "cadence", "availability_at_prediction_time",
         "leakage_risk", "imputation_policy", "models_using", "demo_explanation",
         "quant_slot",
     )
-    return {k: feature.get(k) for k in keep}
+    out = {k: feature.get(k) for k in keep}
+    out["feature_id"] = feature.get("id") or feature.get("feature_id")
+    return out
 
 
 def ok_feature_response(feature: dict[str, Any], computed: dict[str, Any]) -> dict[str, Any]:

--- a/backend/app/services/hr_ml_demo/runner.py
+++ b/backend/app/services/hr_ml_demo/runner.py
@@ -59,18 +59,55 @@ DEMO_SCRIPT: dict[str, list[str]] = {
 }
 
 
+# Shared dataset provenance (computed once). The lab now trains on the feature
+# store's shared deterministic frame; if that package is unavailable we FALL BACK
+# to the lab's own generator and badge it LOUDLY so a degraded run is never
+# mistaken for the one-shared-dataset path.
+_SHARED: tuple[Any, dict[str, Any]] | None = None
+
+
+def _shared_base() -> tuple[Any, dict[str, Any]]:
+    global _SHARED
+    if _SHARED is None:
+        try:
+            from app.services.hr_feature_store import lab_model_dataset  # noqa: PLC0415
+
+            _SHARED = (
+                lab_model_dataset(SEED),
+                {"source_quality": "synthetic", "dataset_provenance": "hr_feature_store", "fallback_reason": None},
+            )
+        except Exception:  # noqa: BLE001 — loud fallback, never break the lab
+            logger.exception("hr_feature_store unavailable; falling back to lab generate_dataset")
+            _SHARED = (
+                generate_dataset(SEED),
+                {"source_quality": "synthetic_fallback", "dataset_provenance": "lab_generate_dataset",
+                 "fallback_reason": "hr_feature_store_unavailable"},
+            )
+    return _SHARED
+
+
+def dataset_provenance() -> dict[str, Any]:
+    return dict(_shared_base()[1])
+
+
+def reset_dataset_cache() -> None:
+    """Test hook: drop the memoized shared dataset so provenance re-resolves."""
+    global _SHARED
+    _SHARED = None
+
+
 def _prepare_dataset(scenario: dict[str, Any] | None):
     """Return the dataset for a run; Reality Mode mutations are applied here.
 
-    PR1 uses the base dataset. The curveball engine (PR2) hooks in by importing
-    `apply_scenario` lazily so this module stays importable before it exists.
+    Consumes the feature store's shared deterministic frame (fail-soft to the
+    lab's own generator). Curveballs are applied to a copy.
     """
-    base = generate_dataset(SEED)
+    base = _shared_base()[0]
     if not scenario:
         return base
     try:
         from .curveballs import apply_scenario  # noqa: PLC0415
-    except Exception:  # curveball engine not present yet
+    except Exception:  # curveball engine not present
         return base
     return apply_scenario(base.copy(), scenario)
 
@@ -89,6 +126,12 @@ def run_algorithm(algorithm_id: str, scenario: dict[str, Any] | None = None) -> 
             _augment_with_scenario(result, demo, df, scenario)
         envelope = ok_response(demo, result)
         _attach_cloud(envelope, algorithm_id)
+        # Badge dataset provenance inside evidence (keeps top-level envelope keys stable).
+        prov = dataset_provenance()
+        envelope["evidence"]["source_quality"] = prov["source_quality"]
+        envelope["evidence"]["dataset_provenance"] = prov["dataset_provenance"]
+        if prov.get("fallback_reason"):
+            envelope["evidence"]["fallback_reason"] = prov["fallback_reason"]
         return envelope
     except Exception as exc:  # noqa: BLE001 — per-algorithm fail-closed
         logger.exception("ml-demo algorithm %s failed", algorithm_id)

--- a/backend/tests/test_hr_feature_store_routes.py
+++ b/backend/tests/test_hr_feature_store_routes.py
@@ -1,0 +1,94 @@
+"""A2 route tests for the Feature Foundry endpoints + the ML-lab dataset swap.
+
+All endpoints fail-closed (HTTP 200). Route-safety: static segments are not
+parsed as a feature id. Dataset-swap: the lab trains on the feature-store frame
+and badges provenance; a loud fallback is exposed when the store is unavailable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ── Feature routes ────────────────────────────────────────────────────────────
+
+def test_features_overview(client):
+    r = client.get("/api/hr/v1/ml-demo/features")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["feature_count"] == len(body["features"]) == 20
+    assert body["family_count"] == 20
+
+
+def test_features_quality_board_is_static_not_id(client):
+    r = client.get("/api/hr/v1/ml-demo/features/quality-board")
+    assert r.status_code == 200
+    body = r.json()
+    # Must be the board, NOT a feature detail parsed from "quality-board".
+    assert "grid" in body and "features" in body
+    assert "null_reason" not in body
+    assert len(body["features"]) == 20
+
+
+def test_features_pipeline_map(client):
+    r = client.get("/api/hr/v1/ml-demo/features/pipeline-map")
+    assert r.status_code == 200
+    assert [n["layer"] for n in r.json()["nodes"]] == ["bronze", "silver", "gold", "vector", "algorithm"]
+
+
+def test_features_importance(client):
+    r = client.get("/api/hr/v1/ml-demo/features/importance")
+    assert r.status_code == 200
+    assert "importance" in r.json()
+
+
+def test_feature_detail_by_id(client):
+    r = client.get("/api/hr/v1/ml-demo/features/by-id/credit_complacency_gap")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["feature_id"] == "credit_complacency_gap"
+    assert body["family"] == "cross_signal_divergence"
+
+
+def test_feature_detail_unknown_id_visible(client):
+    r = client.get("/api/hr/v1/ml-demo/features/by-id/totally_made_up")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "not_available"
+    assert body["null_reason"] == "unknown_feature_id"
+
+
+# ── ML-lab dataset swap + loud fallback ───────────────────────────────────────
+
+def test_lab_trains_on_feature_store_frame():
+    from app.services.hr_ml_demo import run_algorithm
+    from app.services.hr_ml_demo.runner import reset_dataset_cache
+
+    reset_dataset_cache()
+    res = run_algorithm("linear_regression")
+    ev = res["evidence"]
+    assert ev["source_quality"] == "synthetic"
+    assert ev["dataset_provenance"] == "hr_feature_store"
+    assert "fallback_reason" not in ev
+
+
+def test_loud_fallback_when_feature_store_unavailable(monkeypatch):
+    import app.services.hr_feature_store as fs
+    from app.services.hr_ml_demo import run_all_algorithms
+    from app.services.hr_ml_demo.runner import reset_dataset_cache
+
+    def _boom(*a, **k):
+        raise RuntimeError("synthetic outage")
+
+    try:
+        monkeypatch.setattr(fs, "lab_model_dataset", _boom)
+        reset_dataset_cache()
+        out = run_all_algorithms()
+        ev = out["algorithms"][0]["evidence"]
+        assert ev["source_quality"] == "synthetic_fallback"
+        assert ev["fallback_reason"] == "hr_feature_store_unavailable"
+        # A degraded dataset must not break the lab — all algorithms still run.
+        assert all(a["status"] == "ok" for a in out["algorithms"])
+    finally:
+        reset_dataset_cache()  # restore clean state for other tests


### PR DESCRIPTION
## Summary
Phase **A2** of the feature-store + Feature Foundry roadmap (stacked on **A1 #206**). Exposes the Feature Foundry through the ML-lab API and makes the ML lab train on the feature store's shared deterministic frame — backend only (frontend is A3).

- **Routes** (`backend/app/routes/hr_ml_demo.py`): `GET /api/hr/v1/ml-demo/features`, `/features/quality-board`, `/features/pipeline-map`, `/features/importance` (static), then `/features/by-id/{feature_id}`. Static declared **before** the dynamic segment so a literal (`quality-board`/…) is never parsed as an id; all fail-closed; unknown id ⇒ `null_reason="unknown_feature_id"`.
- **Shared dataset swap** (`hr_ml_demo/runner.py`): `_prepare_dataset` now consumes the feature store's frame, **fail-soft** to the lab generator. Provenance is badged in `evidence` (`source_quality`, `dataset_provenance`); a **loud fallback** (`source_quality="synthetic_fallback"` + `fallback_reason="hr_feature_store_unavailable"`) fires if the store is unavailable — so a degraded run is never mistaken for the one-shared-dataset path.
- **Adapter** (`hr_feature_store/lab_dataset.py`): renders the canonical `QUANT_FEATURE_ORDER` panel into the lab's exact `NUMERIC_FEATURES` + targets schema, with a **balanced 5-class theme** so the text classifier's stratified split is valid. A1's `macro_dataset` + golden fixture stay frozen (signatures don't depend on theme).
- **Fix**: feature envelope `feature_id` mapping (registry key is `id`).

## Tests
- `pytest` over feature-store (service+routes) + full `hr_ml_demo` (service, routes, curveballs, cloud-links) — **82 passed**.
- Route safety (static not shadowed), unknown-id visible, **fallback badged**, and the full lab regression (incl. all-15 curveballs) green on the swapped dataset. No external network.

## Scope / stacking
- 6 files, +294/−7. Parent is `de43cf58` (A1). **Depends on #206**; base = `feat/hr-feature-store-a1`.

## Next (separate PRs)
- A3: Feature Foundry frontend (route + subnav + `featureStore.ts` + components + contract test + Playwright).
- B1: schema 10018 + gold materializer. B2+: one connector per PR. C: gated `episode_embeddings` backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
