### PR TITLE
feat(history-rhymes): Feature Foundry frontend (A3)

### DIFF
--- a/repo-b/src/app/lab/env/[envId]/historyrhymes/ml-algorithms/features/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/historyrhymes/ml-algorithms/features/page.tsx
@@ -1,0 +1,10 @@
+import { FeatureFoundryClient } from "@/components/historyrhymes/FeatureFoundryClient";
+
+export default async function FeatureFoundryPage({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  return <FeatureFoundryClient envId={envId} />;
+}

--- a/repo-b/src/components/historyrhymes/FeatureFamilyGrid.tsx
+++ b/repo-b/src/components/historyrhymes/FeatureFamilyGrid.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { FeatureOverview } from "@/lib/historyrhymes/featureStore";
+
+function label(family: string): string {
+  return family.replace(/_/g, " ");
+}
+
+/** 20 feature-family cards; clicking one filters the feature list (null = all). */
+export function FeatureFamilyGrid({
+  overview,
+  selected,
+  onSelect,
+}: {
+  overview: FeatureOverview;
+  selected: string | null;
+  onSelect: (family: string | null) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2">
+      <button
+        type="button"
+        onClick={() => onSelect(null)}
+        className={`text-left rounded-md border p-2 transition-colors ${
+          selected === null
+            ? "border-sky-500/60 bg-sky-500/10"
+            : "border-neutral-800 bg-neutral-900 hover:border-neutral-600"
+        }`}
+      >
+        <div className="text-xs font-medium text-neutral-100">All families</div>
+        <div className="text-[10px] text-neutral-500">{overview.feature_count} features</div>
+      </button>
+      {overview.families.map((f) => (
+        <button
+          key={f.family}
+          type="button"
+          data-testid="hr-feature-family-card"
+          onClick={() => onSelect(f.family)}
+          className={`text-left rounded-md border p-2 transition-colors ${
+            selected === f.family
+              ? "border-sky-500/60 bg-sky-500/10"
+              : "border-neutral-800 bg-neutral-900 hover:border-neutral-600"
+          }`}
+        >
+          <div className="text-xs font-medium text-neutral-100 capitalize">{label(f.family)}</div>
+          <div className="text-[10px] text-neutral-500">{f.feature_count} feature{f.feature_count === 1 ? "" : "s"}</div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/repo-b/src/components/historyrhymes/FeatureFoundry.test.tsx
+++ b/repo-b/src/components/historyrhymes/FeatureFoundry.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FeatureReadinessBadge } from "./FeatureReadinessBadge";
+import { FeatureQualityBoard } from "./FeatureQualityBoard";
+import type { QualityBoard } from "@/lib/historyrhymes/featureStore";
+
+describe("FeatureReadinessBadge", () => {
+  it("shows a blocked/red badge with the leakage reason when score is 0", () => {
+    render(
+      <FeatureReadinessBadge readiness={{ score: 0, degrade_reasons: ["leakage_blocked:not_available_at_prediction_time"] }} />,
+    );
+    const badge = screen.getByTestId("hr-feature-readiness");
+    expect(badge.textContent).toContain("blocked");
+    expect(badge.textContent).toContain("leakage_blocked");
+  });
+
+  it("shows a healthy score without degrade reasons", () => {
+    render(<FeatureReadinessBadge readiness={{ score: 1, degrade_reasons: [] }} />);
+    expect(screen.getByTestId("hr-feature-readiness").textContent).toContain("1.00");
+  });
+});
+
+describe("FeatureQualityBoard", () => {
+  const board: QualityBoard = {
+    dimensions: ["freshness"],
+    families: ["leakage_guard", "missingness_as_signal"],
+    grid: {},
+    features: [
+      {
+        feature_id: "resolved_trap_label", family: "leakage_guard", freshness_status: "fresh",
+        missingness_rate: 0, drift_status: "normal", leakage_risk: "high", leakage_blocked: true,
+        lineage_present: true, models_using_count: 0, readiness_score: 0, readiness_degrade_reasons: [],
+      },
+      {
+        feature_id: "btc_mvrv_missing_flag", family: "missingness_as_signal", freshness_status: "fresh",
+        missingness_rate: 0.02, drift_status: "normal", leakage_risk: "low", leakage_blocked: false,
+        lineage_present: true, models_using_count: 2, readiness_score: 1, readiness_degrade_reasons: [],
+      },
+    ],
+  };
+
+  it("renders rows and surfaces leakage-blocked + missingness states", () => {
+    render(<FeatureQualityBoard board={board} />);
+    const table = screen.getByTestId("hr-feature-quality-board");
+    expect(table.textContent).toContain("resolved_trap_label");
+    expect(table.textContent).toContain("blocked");
+    expect(table.textContent).toContain("btc_mvrv_missing_flag");
+    expect(table.textContent).toContain("0.02");
+  });
+});

--- a/repo-b/src/components/historyrhymes/FeatureFoundryClient.tsx
+++ b/repo-b/src/components/historyrhymes/FeatureFoundryClient.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import * as React from "react";
+import {
+  fetchFeatureDetail,
+  fetchFeatureOverview,
+  fetchFeaturePipelineMap,
+  fetchFeatureQualityBoard,
+  type FeatureDetail,
+  type FeatureOverview,
+  type PipelineMap,
+  type QualityBoard,
+} from "@/lib/historyrhymes/featureStore";
+import { fetchCloudConfig, type CloudConfig } from "@/lib/historyrhymes/mlDemo";
+import { CloudProviderBadge } from "./CloudProviderBadge";
+import { FeatureFamilyGrid } from "./FeatureFamilyGrid";
+import { FeatureImportanceAcrossModels } from "./FeatureImportanceAcrossModels";
+import { FeaturePipelineMap } from "./FeaturePipelineMap";
+import { FeatureQualityBoard } from "./FeatureQualityBoard";
+import { FeatureReadinessBadge } from "./FeatureReadinessBadge";
+import { FeatureTransformationExample } from "./FeatureTransformationExample";
+import { HrSubNav } from "./HrSubNav";
+import { MLDetailDrawer, type DrawerPayload } from "./MLDetailDrawer";
+import { ErrorState, Loading, Panel, Tag, fmt } from "./mlUi";
+
+function featureDrawerPayload(d: FeatureDetail): DrawerPayload {
+  const readiness = (d.readiness as { score?: number }) ?? {};
+  return {
+    mode: "feature",
+    title: d.name,
+    subtitle: d.family ? d.family.replace(/_/g, " ") : undefined,
+    whyItMatters: d.demo_explanation ?? undefined,
+    rows: [
+      { label: "Definition", value: d.definition ?? "—" },
+      { label: "Formula", value: <code className="text-[11px]">{d.formula ?? "—"}</code> },
+      { label: "Source", value: d.source_dependencies.join(", ") || "—" },
+      { label: "Cadence", value: d.cadence ?? "—" },
+      { label: "Freshness", value: "fresh (synthetic, seed 42)" },
+      { label: "Available at prediction time", value: String(d.availability_at_prediction_time) },
+      { label: "Leakage risk", value: d.leakage_risk ?? "—" },
+      { label: "Imputation policy", value: d.imputation_policy ?? "—" },
+      { label: "Current value", value: fmt(d.current_value) },
+      { label: "Models using", value: d.models_using.join(", ") || "—" },
+      { label: "Readiness", value: fmt(typeof readiness.score === "number" ? readiness.score : null, 2) },
+    ],
+    links: d.external_links,
+    lineage: d.lineage,
+    warning:
+      d.leakage_risk === "high"
+        ? "Leakage risk HIGH — readiness forced to 0; the score is invalid until this feature is removed."
+        : undefined,
+  };
+}
+
+export function FeatureFoundryClient({ envId }: { envId: string }) {
+  const [overview, setOverview] = React.useState<FeatureOverview | null>(null);
+  const [board, setBoard] = React.useState<QualityBoard | null>(null);
+  const [pipeline, setPipeline] = React.useState<PipelineMap | null>(null);
+  const [cloud, setCloud] = React.useState<CloudConfig | null>(null);
+  const [family, setFamily] = React.useState<string | null>(null);
+  const [detail, setDetail] = React.useState<FeatureDetail | null>(null);
+  const [drawer, setDrawer] = React.useState<DrawerPayload | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const [ov, qb, pm, cc] = await Promise.all([
+        fetchFeatureOverview(),
+        fetchFeatureQualityBoard(),
+        fetchFeaturePipelineMap(),
+        fetchCloudConfig(),
+      ]);
+      if (cancelled) return;
+      if (!ov) setError("Could not load the Feature Foundry overview.");
+      setOverview(ov);
+      setBoard(qb);
+      setPipeline(pm);
+      setCloud(cc);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const openFeature = React.useCallback(async (featureId: string) => {
+    const d = await fetchFeatureDetail(featureId);
+    if (!d) return;
+    setDetail(d);
+    setDrawer(featureDrawerPayload(d));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-neutral-950 text-neutral-200 p-6" data-testid="hr-feature-foundry-page">
+        <HrSubNav envId={envId} />
+        <Loading label="Loading Feature Foundry…" />
+      </div>
+    );
+  }
+  if (error || !overview) {
+    return (
+      <div className="min-h-screen bg-neutral-950 text-neutral-200 p-6" data-testid="hr-feature-foundry-page">
+        <HrSubNav envId={envId} />
+        <ErrorState message={error ?? "Overview unavailable."} />
+      </div>
+    );
+  }
+
+  const features = family ? overview.features.filter((f) => f.family === family) : overview.features;
+
+  return (
+    <div className="min-h-screen bg-neutral-950 text-neutral-200 p-6" data-testid="hr-feature-foundry-page">
+      <div className="max-w-6xl mx-auto">
+        <HrSubNav envId={envId} />
+
+        <header className="mb-6">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div>
+              <h1 className="text-2xl font-semibold text-neutral-50">{overview.title}</h1>
+              <p className="text-sm text-neutral-400 mt-1">{overview.subtitle}</p>
+            </div>
+            <CloudProviderBadge config={cloud} />
+          </div>
+          <p className="text-xs text-neutral-400 mt-3 max-w-3xl border-l-2 border-neutral-700 pl-3">{overview.lesson}</p>
+        </header>
+
+        <div className="mb-4">
+          <FeaturePipelineMap map={pipeline} />
+        </div>
+
+        <div className="mb-4">
+          <Panel title={`Feature families (${overview.family_count})`}>
+            <FeatureFamilyGrid overview={overview} selected={family} onSelect={setFamily} />
+          </Panel>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+          <Panel title={`Features${family ? ` — ${family.replace(/_/g, " ")}` : ""}`}>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {features.map((f) => (
+                <button
+                  key={f.feature_id}
+                  type="button"
+                  data-testid="hr-feature-card"
+                  onClick={() => openFeature(f.feature_id)}
+                  className={`text-left rounded-md border p-2 transition-colors ${
+                    detail?.feature_id === f.feature_id
+                      ? "border-sky-500/60"
+                      : "border-neutral-800 bg-neutral-900 hover:border-neutral-600"
+                  }`}
+                >
+                  <div className="text-xs font-mono text-neutral-100">{f.feature_id}</div>
+                  <div className="flex items-center gap-1.5 mt-1">
+                    <span className="text-[10px] text-neutral-500 capitalize">{f.family.replace(/_/g, " ")}</span>
+                    {f.leakage_risk === "high" ? <Tag tone="red">leaky</Tag> : null}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </Panel>
+
+          <div>
+            {detail ? (
+              <Panel
+                title={detail.name}
+                right={
+                  <button
+                    type="button"
+                    onClick={() => setDrawer(featureDrawerPayload(detail))}
+                    className="text-[10px] text-sky-300 hover:text-sky-200 underline"
+                  >
+                    Open detail
+                  </button>
+                }
+              >
+                <div className="space-y-3">
+                  <FeatureReadinessBadge readiness={detail.readiness} />
+                  <p className="text-xs text-neutral-300">{detail.demo_explanation}</p>
+                  <div className="text-[11px] text-neutral-500">
+                    <span className="text-neutral-400">Formula:</span>{" "}
+                    <code className="text-neutral-300">{detail.formula}</code>
+                  </div>
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wide text-neutral-500 mb-1">Transformation</div>
+                    <FeatureTransformationExample detail={detail} />
+                  </div>
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wide text-neutral-500 mb-1">Importance across models</div>
+                    <FeatureImportanceAcrossModels entries={detail.importance_across_models} />
+                  </div>
+                </div>
+              </Panel>
+            ) : (
+              <Panel title="Feature detail">
+                <div className="text-sm text-neutral-500">Select a feature to see its formula, transformation, readiness, and per-model importance.</div>
+              </Panel>
+            )}
+          </div>
+        </div>
+
+        <div className="mb-4">
+          <FeatureQualityBoard board={board} onSelect={openFeature} />
+        </div>
+
+        <p className="text-xs text-neutral-500 mb-10 border-l-2 border-neutral-700 pl-3">{overview.closer}</p>
+      </div>
+
+      <MLDetailDrawer payload={drawer} onClose={() => setDrawer(null)} />
+    </div>
+  );
+}

--- a/repo-b/src/components/historyrhymes/FeatureImportanceAcrossModels.tsx
+++ b/repo-b/src/components/historyrhymes/FeatureImportanceAcrossModels.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { ImportanceEntry } from "@/lib/historyrhymes/featureStore";
+import { fmt } from "./mlUi";
+
+function magnitude(e: ImportanceEntry): { kind: string; value: number } {
+  if (typeof e.importance === "number") return { kind: "importance", value: e.importance };
+  if (typeof e.coefficient_abs === "number") return { kind: "|coef|", value: e.coefficient_abs };
+  if (typeof e.coefficient === "number") return { kind: "coefficient", value: e.coefficient };
+  return { kind: "—", value: 0 };
+}
+
+/** Per-model importance/coefficient — proves features behave differently per model. */
+export function FeatureImportanceAcrossModels({ entries }: { entries: ImportanceEntry[] }) {
+  if (!entries || entries.length === 0) {
+    return <div className="text-[11px] text-neutral-500">Not used by the supervised models in this demo.</div>;
+  }
+  const maxMag = Math.max(...entries.map((e) => Math.abs(magnitude(e).value)), 1e-9);
+  return (
+    <div className="space-y-1.5" data-testid="hr-feature-importance">
+      {entries.map((e) => {
+        const m = magnitude(e);
+        const pct = Math.min(100, (Math.abs(m.value) / maxMag) * 100);
+        const neg = m.value < 0;
+        return (
+          <div key={e.model} className="flex items-center gap-2 text-xs">
+            <span className="w-40 shrink-0 text-neutral-300">{e.model.replace(/_/g, " ")}</span>
+            <span className="flex-1 h-2 bg-neutral-800 rounded">
+              <span
+                className={`block h-2 rounded ${neg ? "bg-red-400/70" : "bg-emerald-400/70"}`}
+                style={{ width: `${pct}%` }}
+              />
+            </span>
+            <span className="w-24 shrink-0 text-right text-neutral-400">
+              {fmt(m.value)} <span className="text-neutral-600">{m.kind}</span>
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/repo-b/src/components/historyrhymes/FeaturePipelineMap.tsx
+++ b/repo-b/src/components/historyrhymes/FeaturePipelineMap.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ArrowRight } from "lucide-react";
+import type { PipelineMap } from "@/lib/historyrhymes/featureStore";
+import { Panel } from "./mlUi";
+
+/** Bronze → silver → gold → vector → algorithm pipeline ladder. */
+export function FeaturePipelineMap({ map }: { map: PipelineMap | null }) {
+  if (!map || !map.nodes?.length) {
+    return null;
+  }
+  return (
+    <Panel title="Pipeline">
+      <div className="flex flex-wrap items-stretch gap-2">
+        {map.nodes.map((n, i) => (
+          <div key={n.layer} className="flex items-stretch gap-2">
+            <div className="rounded-md border border-neutral-800 bg-neutral-950/60 p-3 min-w-[150px]">
+              <div className="text-[10px] uppercase tracking-wide text-sky-300">{n.layer}</div>
+              <div className="text-xs text-neutral-100 font-medium">{n.label}</div>
+              <div className="text-[10px] text-neutral-500 mt-0.5 font-mono break-all">{n.detail}</div>
+            </div>
+            {i < map.nodes.length - 1 ? (
+              <ArrowRight size={16} className="self-center text-neutral-600 shrink-0" />
+            ) : null}
+          </div>
+        ))}
+      </div>
+      <div className="text-[10px] text-neutral-600 mt-2">{map.note}</div>
+    </Panel>
+  );
+}

--- a/repo-b/src/components/historyrhymes/FeatureQualityBoard.tsx
+++ b/repo-b/src/components/historyrhymes/FeatureQualityBoard.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import type { QualityBoard } from "@/lib/historyrhymes/featureStore";
+import { Panel, Tag, fmt } from "./mlUi";
+
+/** Per-feature quality flags: freshness / missingness / drift / leakage / readiness. */
+export function FeatureQualityBoard({
+  board,
+  onSelect,
+}: {
+  board: QualityBoard | null;
+  onSelect?: (featureId: string) => void;
+}) {
+  if (!board || !board.features?.length) {
+    return null;
+  }
+  return (
+    <Panel title="Feature Quality Board">
+      <p className="text-[11px] text-neutral-500 mb-3">
+        A stale, missing, drifting, or leaky feature is not neutral — it changes model trust.
+      </p>
+      <div className="overflow-x-auto" data-testid="hr-feature-quality-board">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-neutral-500 text-left">
+              <th className="font-medium px-2 py-1.5 border-b border-neutral-800">Feature</th>
+              <th className="font-medium px-2 py-1.5 border-b border-neutral-800">Family</th>
+              <th className="font-medium px-2 py-1.5 border-b border-neutral-800">Freshness</th>
+              <th className="font-medium px-2 py-1.5 border-b border-neutral-800">Missingness</th>
+              <th className="font-medium px-2 py-1.5 border-b border-neutral-800">Drift</th>
+              <th className="font-medium px-2 py-1.5 border-b border-neutral-800">Leakage</th>
+              <th className="font-medium px-2 py-1.5 border-b border-neutral-800">Readiness</th>
+            </tr>
+          </thead>
+          <tbody>
+            {board.features.map((r) => (
+              <tr
+                key={r.feature_id}
+                onClick={() => onSelect?.(r.feature_id)}
+                data-testid="hr-feature-quality-row"
+                className={`border-b border-neutral-900 ${onSelect ? "cursor-pointer hover:bg-neutral-800/50" : ""}`}
+              >
+                <td className="px-2 py-1.5 text-neutral-100 font-mono">{r.feature_id}</td>
+                <td className="px-2 py-1.5 text-neutral-400">{r.family.replace(/_/g, " ")}</td>
+                <td className="px-2 py-1.5">{r.freshness_status}</td>
+                <td className={`px-2 py-1.5 ${r.missingness_rate > 0 ? "text-amber-300" : "text-neutral-400"}`}>
+                  {fmt(r.missingness_rate, 2)}
+                </td>
+                <td className="px-2 py-1.5">{r.drift_status}</td>
+                <td className="px-2 py-1.5">
+                  {r.leakage_blocked ? (
+                    <Tag tone="red">blocked</Tag>
+                  ) : r.leakage_risk === "medium" ? (
+                    <Tag tone="amber">medium</Tag>
+                  ) : (
+                    <span className="text-neutral-500">low</span>
+                  )}
+                </td>
+                <td className={`px-2 py-1.5 ${r.readiness_score === 0 ? "text-red-300" : "text-emerald-300"}`}>
+                  {fmt(r.readiness_score, 2)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Panel>
+  );
+}

--- a/repo-b/src/components/historyrhymes/FeatureReadinessBadge.tsx
+++ b/repo-b/src/components/historyrhymes/FeatureReadinessBadge.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import type { Readiness } from "@/lib/historyrhymes/featureStore";
+import { Tag, fmt } from "./mlUi";
+
+/** Model-readiness score + degrade reasons. Red when blocked (leakage/score 0). */
+export function FeatureReadinessBadge({ readiness }: { readiness: Readiness | Record<string, never> }) {
+  const r = readiness as Readiness;
+  if (!r || typeof r.score !== "number") {
+    return <Tag tone="neutral">readiness —</Tag>;
+  }
+  const blocked = r.score === 0;
+  const tone = blocked ? "red" : r.score >= 0.8 ? "emerald" : "amber";
+  return (
+    <span className="inline-flex flex-col gap-1" data-testid="hr-feature-readiness">
+      <Tag tone={tone}>Model readiness: {fmt(r.score, 2)}{blocked ? " · blocked" : ""}</Tag>
+      {r.degrade_reasons && r.degrade_reasons.length > 0 ? (
+        <span className="text-[10px] text-amber-300/90">
+          {blocked ? "blocked: " : "downgrade: "}{r.degrade_reasons.join(", ")}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/repo-b/src/components/historyrhymes/FeatureTransformationExample.tsx
+++ b/repo-b/src/components/historyrhymes/FeatureTransformationExample.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import type { FeatureDetail } from "@/lib/historyrhymes/featureStore";
+import { fmt } from "./mlUi";
+
+/** Before (raw input) → after (engineered output) tail slice. */
+export function FeatureTransformationExample({ detail }: { detail: FeatureDetail }) {
+  const ex = detail.transformation_example;
+  if (!ex || !ex.before?.length || !ex.after?.length) {
+    return <div className="text-[11px] text-neutral-500">No before/after example for this feature.</div>;
+  }
+  const rows = ex.before.map((b, i) => ({
+    as_of: b.as_of,
+    before: b.value,
+    after: ex.after?.[i]?.value ?? null,
+  }));
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="text-neutral-500 text-left">
+            <th className="font-medium px-2 py-1 border-b border-neutral-800">As of</th>
+            <th className="font-medium px-2 py-1 border-b border-neutral-800">Raw input</th>
+            <th className="font-medium px-2 py-1 border-b border-neutral-800">Engineered</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.as_of} className="border-b border-neutral-900">
+              <td className="px-2 py-1 text-neutral-400">{r.as_of}</td>
+              <td className="px-2 py-1 text-neutral-300">{fmt(r.before)}</td>
+              <td className="px-2 py-1 text-sky-300">{fmt(r.after)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/repo-b/src/components/historyrhymes/HrSubNav.tsx
+++ b/repo-b/src/components/historyrhymes/HrSubNav.tsx
@@ -8,17 +8,26 @@ const TABS = [
   { slug: "morning-book", label: "Morning Book" },
   { slug: "planning", label: "Planning" },
   { slug: "ml-algorithms", label: "ML Algorithm Lab" },
+  { slug: "ml-algorithms/features", label: "Feature Foundry" },
 ];
 
 /** Minimal tab strip linking the History Rhymes sub-pages for an env. */
 export function HrSubNav({ envId }: { envId: string }) {
   const pathname = usePathname() || "";
   const base = `/lab/env/${envId}/historyrhymes`;
+  // The active tab is the one whose href is the LONGEST prefix of the path, so a
+  // nested route (…/ml-algorithms/features) highlights Feature Foundry, not both.
+  const activeSlug = TABS.map((t) => t.slug)
+    .filter((slug) => {
+      const href = `${base}/${slug}`;
+      return pathname === href || pathname.startsWith(`${href}/`);
+    })
+    .sort((a, b) => b.length - a.length)[0];
   return (
     <nav className="flex flex-wrap gap-1 mb-4" aria-label="History Rhymes sections">
       {TABS.map((t) => {
         const href = `${base}/${t.slug}`;
-        const active = pathname.startsWith(href);
+        const active = t.slug === activeSlug;
         return (
           <Link
             key={t.slug}

--- a/repo-b/src/components/historyrhymes/featureStoreClientContract.test.ts
+++ b/repo-b/src/components/historyrhymes/featureStoreClientContract.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Contract test: the Feature Foundry client must call /api/hr/v1/ml-demo/features*
+ * (single lookup via /features/by-id/{id}) and never the forbidden
+ * /api/historyrhymes/* namespace. Guards against silent path drift.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  fetchFeatureOverview,
+  fetchFeatureQualityBoard,
+  fetchFeaturePipelineMap,
+  fetchFeatureImportance,
+  fetchFeatureDetail,
+} from "@/lib/historyrhymes/featureStore";
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  const fn = vi.fn(async () => ({ ok, status, json: async () => body }));
+  // @ts-expect-error - test stub for global fetch
+  global.fetch = fn;
+  return fn;
+}
+function calledUrl(fn: ReturnType<typeof vi.fn>): string {
+  return String(fn.mock.calls[0][0]);
+}
+
+describe("feature-store client contract", () => {
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("fetchFeatureOverview GETs /features", async () => {
+    const fn = mockFetch({ features: [] });
+    await fetchFeatureOverview();
+    expect(calledUrl(fn)).toBe("/api/hr/v1/ml-demo/features");
+  });
+
+  it("fetchFeatureQualityBoard / pipeline-map / importance hit their static paths", async () => {
+    const fn1 = mockFetch({ features: [] });
+    await fetchFeatureQualityBoard();
+    expect(calledUrl(fn1)).toBe("/api/hr/v1/ml-demo/features/quality-board");
+
+    const fn2 = mockFetch({ nodes: [] });
+    await fetchFeaturePipelineMap();
+    expect(calledUrl(fn2)).toBe("/api/hr/v1/ml-demo/features/pipeline-map");
+
+    const fn3 = mockFetch({ importance: {} });
+    await fetchFeatureImportance();
+    expect(calledUrl(fn3)).toBe("/api/hr/v1/ml-demo/features/importance");
+  });
+
+  it("fetchFeatureDetail uses /features/by-id/{id} (never a bare dynamic segment)", async () => {
+    const fn = mockFetch({ feature_id: "credit_complacency_gap", status: "ok" });
+    await fetchFeatureDetail("credit_complacency_gap");
+    expect(calledUrl(fn)).toBe("/api/hr/v1/ml-demo/features/by-id/credit_complacency_gap");
+  });
+
+  it("never uses the drifted /api/historyrhymes/* namespace", async () => {
+    const fn = mockFetch({ features: [] });
+    await fetchFeatureOverview();
+    expect(calledUrl(fn)).not.toContain("/api/historyrhymes/");
+    expect(calledUrl(fn)).toContain("/api/hr/v1/ml-demo/features");
+  });
+});

--- a/repo-b/src/lib/historyrhymes/featureStore.ts
+++ b/repo-b/src/lib/historyrhymes/featureStore.ts
@@ -1,0 +1,149 @@
+/**
+ * Client for the Feature Foundry (feature store) API.
+ *
+ * Same direct-to-FastAPI convention as lib/historyrhymes/mlDemo.ts
+ * (NEXT_PUBLIC_API_BASE, no proxy). Paths are /api/hr/v1/ml-demo/features* —
+ * the /api/historyrhymes/* namespace is forbidden by the HR contract test.
+ * Single-feature lookup is /features/by-id/{feature_id} (never a bare dynamic
+ * segment). Reuses ExternalResourceLink / Lineage types from mlDemo.ts.
+ */
+
+import type { ExternalResourceLink, Lineage } from "@/lib/historyrhymes/mlDemo";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "";
+const ROOT = "/api/hr/v1/ml-demo";
+
+async function getJson<T>(path: string): Promise<T | null> {
+  try {
+    const res = await fetch(`${API_BASE}${path}`, { cache: "no-store" });
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`${path} → ${res.status}`);
+    return (await res.json()) as T;
+  } catch (err) {
+    console.error(`[feature-store] ${path} failed:`, err);
+    return null;
+  }
+}
+
+/* ── Types ─────────────────────────────────────────────────────────────────── */
+
+export type LeakageRisk = "low" | "medium" | "high";
+
+export interface FeatureSummary {
+  feature_id: string;
+  name: string;
+  family: string;
+  leakage_risk: LeakageRisk | null;
+  models_using: string[];
+}
+
+export interface FeatureOverview {
+  title: string;
+  subtitle: string;
+  lesson: string;
+  closer: string;
+  feature_count: number;
+  family_count: number;
+  families: Array<{ family: string; feature_count: number }>;
+  signature_features: string[];
+  features: FeatureSummary[];
+  cloud_provider: string;
+  evidence: { seed: number; model_obs_version: string; source: string };
+}
+
+export interface Readiness {
+  score: number;
+  degrade_reasons: string[];
+}
+
+export interface ImportanceEntry {
+  model: string;
+  importance?: number;
+  coefficient?: number;
+  coefficient_abs?: number;
+}
+
+export interface TransformationPoint {
+  as_of: string;
+  value: number | null;
+}
+
+export interface FeatureDetail {
+  feature_id: string;
+  name: string;
+  status: "ok" | "not_available";
+  null_reason: string | null;
+  family: string | null;
+  definition: string | null;
+  formula: string | null;
+  source_dependencies: string[];
+  cadence: string | null;
+  availability_at_prediction_time: boolean | null;
+  leakage_risk: LeakageRisk | null;
+  imputation_policy: string | null;
+  models_using: string[];
+  demo_explanation: string | null;
+  quant_slot: string | null;
+  current_value: number | null;
+  current_percentile: number | null;
+  transformation_example: { before?: TransformationPoint[]; after?: TransformationPoint[] };
+  readiness: Readiness | Record<string, never>;
+  missingness: { rate?: number; policy_visible?: boolean; imputation_policy?: string | null };
+  importance_across_models: ImportanceEntry[];
+  evidence: { seed: number; model_obs_version: string; source: string };
+  external_links: ExternalResourceLink[];
+  lineage: Lineage | Record<string, never>;
+}
+
+export interface QualityBoardRow {
+  feature_id: string;
+  family: string;
+  freshness_status: string;
+  missingness_rate: number;
+  drift_status: string;
+  leakage_risk: LeakageRisk;
+  leakage_blocked: boolean;
+  lineage_present: boolean;
+  models_using_count: number;
+  readiness_score: number;
+  readiness_degrade_reasons: string[];
+}
+
+export interface QualityBoard {
+  dimensions: string[];
+  families: string[];
+  features: QualityBoardRow[];
+  grid: Record<string, Record<string, unknown>>;
+}
+
+export interface PipelineMap {
+  nodes: Array<{ layer: string; label: string; detail: string }>;
+  model_obs_version: string;
+  note: string;
+}
+
+export interface ImportanceMap {
+  importance: Record<string, ImportanceEntry[]>;
+}
+
+/* ── Fetchers ─────────────────────────────────────────────────────────────── */
+
+export function fetchFeatureOverview(): Promise<FeatureOverview | null> {
+  return getJson<FeatureOverview>(`${ROOT}/features`);
+}
+
+export function fetchFeatureQualityBoard(): Promise<QualityBoard | null> {
+  return getJson<QualityBoard>(`${ROOT}/features/quality-board`);
+}
+
+export function fetchFeaturePipelineMap(): Promise<PipelineMap | null> {
+  return getJson<PipelineMap>(`${ROOT}/features/pipeline-map`);
+}
+
+export function fetchFeatureImportance(): Promise<ImportanceMap | null> {
+  return getJson<ImportanceMap>(`${ROOT}/features/importance`);
+}
+
+export function fetchFeatureDetail(featureId: string): Promise<FeatureDetail | null> {
+  return getJson<FeatureDetail>(`${ROOT}/features/by-id/${encodeURIComponent(featureId)}`);
+}

--- a/repo-b/tests/feature-foundry.spec.ts
+++ b/repo-b/tests/feature-foundry.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Best-effort smoke for the Feature Foundry (feature store) page.
+ *
+ * The data-driven flow (families, feature drawer, quality board) needs a live
+ * FastAPI backend, so it is gated behind HR_E2E=1 and otherwise skipped. The
+ * unconditional check verifies the page shell renders.
+ */
+
+const ENV = process.env.HR_E2E_ENV || "demo";
+const PAGE = `/lab/env/${ENV}/historyrhymes/ml-algorithms/features`;
+
+test("feature foundry page shell renders", async ({ page }) => {
+  const resp = await page.goto(PAGE, { waitUntil: "domcontentloaded" });
+  test.skip(
+    !resp || resp.status() >= 400,
+    "feature foundry not reachable without auth/backend in this run",
+  );
+  await expect(page.getByTestId("hr-feature-foundry-page")).toBeVisible();
+});
+
+test("feature drawer + quality board (requires live backend)", async ({ page }) => {
+  test.skip(process.env.HR_E2E !== "1", "set HR_E2E=1 with a live backend to run the data-driven flow");
+  await page.goto(PAGE, { waitUntil: "domcontentloaded" });
+
+  // Velocity feature → drawer shows formula / source / freshness / models.
+  await page.getByTestId("hr-feature-card").filter({ hasText: "yield_curve_10y2y_velocity_30d" }).click();
+  await expect(page.getByTestId("hr-ml-drawer")).toBeVisible();
+  await expect(page.getByText("Formula", { exact: false })).toBeVisible();
+  await expect(page.getByText("Freshness", { exact: false })).toBeVisible();
+  await expect(page.getByText("Models using", { exact: false })).toBeVisible();
+
+  // Divergence feature → disagreement explanation.
+  await page.getByTestId("hr-feature-card").filter({ hasText: "credit_complacency_gap" }).click();
+  await expect(page.getByText("disagreement", { exact: false })).toBeVisible();
+
+  // Quality board surfaces leakage-blocked + missingness states.
+  const board = page.getByTestId("hr-feature-quality-board");
+  await expect(board).toBeVisible();
+  await expect(board.getByText("resolved_trap_label")).toBeVisible();
+  await expect(board.getByText("blocked", { exact: false }).first()).toBeVisible();
+});


### PR DESCRIPTION
## Summary
Phase **A3** — the **Feature Foundry** frontend, completing Phase A (the demoable product). Stacked on **A2 #209**. Makes feature engineering visible and clickable: raw → engineered → readiness → lineage → per-model importance.

- **Route** `/lab/env/[envId]/historyrhymes/ml-algorithms/features` + a **Feature Foundry** tab in `HrSubNav` (longest-prefix active logic so the nested route doesn't double-highlight the ML-lab tab).
- **`featureStore.ts`** — typed client for `/api/hr/v1/ml-demo/features*` (single lookup via `/features/by-id/{id}`); reuses `ExternalResourceLink`/`Lineage` types from `mlDemo.ts`.
- **Components** — `FeatureFoundryClient`, `FeatureFamilyGrid` (20 families), `FeaturePipelineMap` (bronze→silver→gold→vector→algorithm), `FeatureQualityBoard` (freshness/missingness/drift/leakage/readiness), `FeatureTransformationExample` (raw→engineered), `FeatureImportanceAcrossModels`, `FeatureReadinessBadge` (red when leakage-blocked). The feature drawer **reuses `MLDetailDrawer` `mode:"feature"`** via a `featureDrawerPayload` builder (formula/source/freshness/models + links + lineage). Reuses `mlUi`/`CloudProviderBadge`.
- Hero/closer copy: *"Feature engineering is where raw data becomes judgment."* / *"The algorithm is the final mile. The feature system is the edge."*

## Tests
- `npm run typecheck` — clean (touched files).
- `npx vitest run src/components/historyrhymes/` — **42 passed** (incl. new `featureStoreClientContract` [bans `/api/historyrhymes/*`] + `FeatureFoundry` component tests).
- `tests/feature-foundry.spec.ts` — Playwright smoke (shell unconditional; deep flow — feature drawer shows formula/source/freshness/models, divergence explanation, quality board leakage/missingness — gated `HR_E2E=1`).

## Scope / stacking
- 13 files, +793/−1. Parent is `1ccb76bd` (A2). **Depends on #209**; base = `feat/hr-feature-store-a2`. No stray files.

## Phase A complete
ML lab (#200) → A1 engine (#206) → A2 API+swap (#209) → **A3 frontend (this)**. Next: **B1** schema 10018 + gold materializer, then one connector per PR, then the gated `episode_embeddings` backfill (C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
