### PR TITLE
Phase 5 PR 12: Analytics Reels (deterministic story cards)

### DIFF
--- a/backend/app/routes/intelligence_cards.py
+++ b/backend/app/routes/intelligence_cards.py
@@ -15,9 +15,10 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
+from app.auth.platform import require_environment_access
 from app.observability.logger import emit_log
 from app.services import intelligence_cards as svc
 
@@ -100,3 +101,26 @@ def patch_card(card_id: UUID, body: PatchCardBody):
     except Exception as exc:  # noqa: BLE001
         emit_log(level="error", service="intelligence_cards", action="patch_failed", message=str(exc), error=exc)
         raise HTTPException(500, {"error_code": "INTERNAL_ERROR", "message": "intel_cards_write_unavailable"})
+
+
+# ── Analytics reels (plan PR 12) ──────────────────────────────────────────────
+class GenerateReelsBody(BaseModel):
+    env_id: str
+    business_id: UUID
+
+
+@router.post("/reels/generate")
+def generate_reels(body: GenerateReelsBody, request: Request):
+    """Roll up the env's finding/alert cards into story (reel) cards. Deterministic, no LLM.
+
+    Env-scoped + fail-closed: returns reels_upserted=0 with a null_reason rather than 500
+    when there are no findings to roll up or the rollup is unavailable.
+    """
+    require_environment_access(request, env_id=body.env_id)
+    try:
+        from app.services import analytics_reels
+        return {**analytics_reels.generate_reels(body.env_id, body.business_id), "null_reason": None}
+    except Exception as exc:  # noqa: BLE001 — fail closed, never 500 with fabricated data
+        emit_log(level="error", service="analytics_reels", action="generate_failed", message=str(exc), error=exc)
+        return {"env_id": body.env_id, "reels_upserted": 0, "groups": 0,
+                "null_reasons": [], "latency_ms": None, "null_reason": "reels_generate_unavailable"}

--- a/backend/app/services/analytics_reels.py
+++ b/backend/app/services/analytics_reels.py
@@ -1,0 +1,135 @@
+"""Analytics Reels (plan PR 12) — deterministic story cards from persisted findings.
+
+A "reel" is a higher-level rollup card (card_type='story') that summarizes a group of
+already-persisted analyzer finding/alert cards into one narrative tile. It reads the cards
+that the analyzers wrote (intelligence_cards), groups them deterministically by analyzer
+type, and composes one story card per group — every reel traces to the real underlying
+cards via source_ref.member_card_ids.
+
+Deterministic-first, NO LLM: title/summary are built from counts and the highest-priority
+member finding; severity/priority are derived from the members, never invented. Fail
+closed: no finding cards -> zero reels + a recorded reason, never a fabricated story.
+
+The story card's `summary` IS the cached hover trailer text (no hover-time call). Idempotent
+by source_ref (sorted member ids + analyzer_type), so re-running updates a reel in place.
+"""
+from __future__ import annotations
+
+import time
+from uuid import UUID
+
+from app.services import intelligence_cards
+
+# Cards the analyzers produce that a reel rolls up (not other reels/dashboards).
+_FINDING_CARD_TYPES = ("alert", "finding")
+# How many member findings a reel may cite in its title math (display only; all are linked).
+MAX_REELS_PER_RUN = 8
+
+
+def _analyzer_of(card: dict) -> str:
+    ref = card.get("source_ref") or {}
+    return str(ref.get("analyzer_type") or "general")
+
+
+def _label(analyzer_type: str) -> str:
+    return {
+        "telemetry": "Telemetry",
+        "data_platform": "Data platform",
+        "business": "Business",
+    }.get(analyzer_type, analyzer_type.replace("_", " ").title() or "General")
+
+
+def _compose_reel(analyzer_type: str, members: list[dict]) -> dict:
+    """Build one story-card upsert dict from a group of finding cards. Pure function."""
+    # Members arrive already sorted by the feed order (anomaly, priority, recency).
+    top = members[0]
+    anomalies = [m for m in members if m.get("anomaly_flag")]
+    member_ids = sorted(str(m["id"]) for m in members)
+    label = _label(analyzer_type)
+    n = len(members)
+    crit = len(anomalies)
+
+    if crit:
+        title = f"{label}: {crit} critical signal{'' if crit == 1 else 's'} across {n} finding{'' if n == 1 else 's'}"
+    else:
+        title = f"{label}: {n} open finding{'' if n == 1 else 's'} to review"
+
+    # Summary doubles as the cached hover trailer — grounded in the top finding, no LLM.
+    lead = (top.get("title") or "").strip()
+    summary = (
+        f"{n} {label.lower()} finding{'' if n == 1 else 's'} in the feed"
+        + (f", {crit} flagged as anomalies" if crit else "")
+        + (f". Leading signal: {lead}" if lead else ".")
+    )
+
+    # Priority = the group's strongest member (already in [0,1]); reels never out-rank a
+    # live critical card. anomaly_flag only when a member is an anomaly.
+    priority = round(max((m.get("priority_score") or 0.0) for m in members), 4)
+
+    return {
+        "card_type": "story",
+        "title": title[:200],
+        "summary": summary,
+        "source_ref": {
+            "type": "reel",
+            "analyzer_type": analyzer_type,
+            "member_card_ids": member_ids,
+            "member_count": n,
+            "anomaly_count": crit,
+        },
+        "priority_score": priority,
+        "anomaly_flag": bool(anomalies),
+        "created_by": "system:reels",
+    }
+
+
+def generate_reels(env_id: str, business_id: str | UUID) -> dict:
+    """Roll up an env's finding/alert cards into story (reel) cards. Returns a summary.
+
+    Reads only persisted cards (no analyzer run here — run the analyzers first). Fails
+    closed: when there are no finding cards, writes nothing and records a reason.
+    """
+    started = time.monotonic()
+    null_reasons: list[dict] = []
+
+    # Pull current finding + alert cards (non-dismissed). Two reads keep the type filter
+    # in the indexed query rather than filtering a mixed list in Python.
+    findings: list[dict] = []
+    for ct in _FINDING_CARD_TYPES:
+        try:
+            findings.extend(intelligence_cards.list_cards(env_id, business_id, card_type=ct, limit=100))
+        except Exception:  # noqa: BLE001 — fail closed per source, never fabricate
+            null_reasons.append({"source": f"list_cards:{ct}", "reason": f"list_{ct}_unavailable"})
+
+    if not findings:
+        null_reasons.append({"source": "reels", "reason": "no_finding_cards_to_roll_up"})
+        return {"env_id": env_id, "reels_upserted": 0, "groups": 0,
+                "null_reasons": null_reasons, "latency_ms": int((time.monotonic() - started) * 1000)}
+
+    # Group deterministically by analyzer type, preserving the list_cards ordering within
+    # each group (anomaly, priority, recency).
+    groups: dict[str, list[dict]] = {}
+    for card in findings:
+        groups.setdefault(_analyzer_of(card), []).append(card)
+
+    # Stable group order: most-anomalous then largest, then name — so MAX cap is deterministic.
+    ordered = sorted(
+        groups.items(),
+        key=lambda kv: (-sum(1 for c in kv[1] if c.get("anomaly_flag")), -len(kv[1]), kv[0]),
+    )[:MAX_REELS_PER_RUN]
+
+    upserted = 0
+    for analyzer_type, members in ordered:
+        try:
+            intelligence_cards.upsert_card(env_id, business_id, **_compose_reel(analyzer_type, members))
+            upserted += 1
+        except Exception:  # noqa: BLE001 — skip the one reel, keep going
+            null_reasons.append({"source": f"reel:{analyzer_type}", "reason": "reel_upsert_failed"})
+
+    return {
+        "env_id": env_id,
+        "reels_upserted": upserted,
+        "groups": len(ordered),
+        "null_reasons": null_reasons,
+        "latency_ms": int((time.monotonic() - started) * 1000),
+    }

--- a/backend/tests/test_analytics_reels.py
+++ b/backend/tests/test_analytics_reels.py
@@ -1,0 +1,149 @@
+"""Tests for Analytics Reels (plan PR 12) — deterministic story cards from findings.
+
+Run: cd backend && python -m pytest tests/test_analytics_reels.py -x -q
+
+Proves: reels roll up real finding/alert cards (monkeypatched) into story cards; the
+composition is deterministic with sorted member ids (idempotent); no findings -> zero
+reels + a recorded reason (never a fabricated story); grouping is by analyzer type with a
+stable MAX cap; and the route is env-scoped + fails closed.
+"""
+import os
+
+os.environ.setdefault("BM_MCP_DRY_RUN", "1")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+os.environ.setdefault("MCP_API_TOKEN", "test-token")
+
+from app.services import analytics_reels as svc  # noqa: E402
+
+ENV = "test-env"
+BIZ = "00000000-0000-0000-0000-000000000001"
+
+
+def _card(cid, analyzer="telemetry", anomaly=False, priority=0.6, title="A signal", ctype="finding"):
+    return {"id": cid, "card_type": ctype, "title": title, "summary": title,
+            "source_ref": {"type": "analyzer_finding", "analyzer_type": analyzer},
+            "priority_score": priority, "anomaly_flag": anomaly}
+
+
+def _patch_cards(monkeypatch, by_type):
+    """by_type: {'finding': [...], 'alert': [...]}. Captures upsert calls."""
+    from app.services import intelligence_cards
+    monkeypatch.setattr(intelligence_cards, "list_cards",
+                        lambda env, biz, *, card_type=None, **kw: list(by_type.get(card_type, [])))
+    calls = []
+    monkeypatch.setattr(intelligence_cards, "upsert_card",
+                        lambda env, biz, **kw: calls.append(kw) or {"id": f"reel-{len(calls)}"})
+    return calls
+
+
+# ── pure composition ──────────────────────────────────────────────────────────
+def test_compose_is_deterministic_and_sorts_member_ids():
+    members = [_card("c2", anomaly=True, priority=0.9, title="PSI drift"),
+               _card("c1", anomaly=False, priority=0.6, title="Anomaly rate")]
+    reel = svc._compose_reel("telemetry", members)
+    assert reel["card_type"] == "story"
+    assert reel["anomaly_flag"] is True
+    assert reel["priority_score"] == 0.9                       # strongest member
+    assert reel["source_ref"]["type"] == "reel"
+    assert reel["source_ref"]["member_card_ids"] == ["c1", "c2"]  # sorted -> idempotent
+    assert reel["source_ref"]["analyzer_type"] == "telemetry"
+    assert reel["created_by"] == "system:reels"
+    # title/summary grounded in the members, no fabricated numbers
+    assert "2 finding" in reel["title"] and "1 critical" in reel["title"]
+    assert "PSI drift" in reel["summary"]
+
+
+def test_no_anomaly_group_is_not_flagged():
+    reel = svc._compose_reel("business", [_card("b1", analyzer="business", priority=0.3)])
+    assert reel["anomaly_flag"] is False
+    assert "open finding" in reel["title"]
+
+
+# ── service: grouping + idempotency carrier ───────────────────────────────────
+def test_one_reel_per_analyzer_group(monkeypatch):
+    calls = _patch_cards(monkeypatch, {
+        "finding": [_card("t1", "telemetry"), _card("b1", "business")],
+        "alert": [_card("t2", "telemetry", anomaly=True, priority=1.0, ctype="alert")],
+    })
+    out = svc.generate_reels(ENV, BIZ)
+    assert out["reels_upserted"] == 2          # telemetry + business
+    assert out["groups"] == 2
+    by_type = {c["source_ref"]["analyzer_type"] for c in calls}
+    assert by_type == {"telemetry", "business"}
+    tel = next(c for c in calls if c["source_ref"]["analyzer_type"] == "telemetry")
+    assert tel["source_ref"]["member_card_ids"] == ["t1", "t2"]  # both telemetry cards, sorted
+    assert tel["anomaly_flag"] is True
+
+
+def test_rerun_uses_stable_source_ref(monkeypatch):
+    cards = {"finding": [_card("t1", "telemetry"), _card("t0", "telemetry")], "alert": []}
+    calls = _patch_cards(monkeypatch, cards)
+    svc.generate_reels(ENV, BIZ)
+    svc.generate_reels(ENV, BIZ)
+    # both runs produce identical member id lists -> upsert idempotency key is stable
+    assert calls[0]["source_ref"]["member_card_ids"] == calls[1]["source_ref"]["member_card_ids"] == ["t0", "t1"]
+
+
+# ── fail closed ───────────────────────────────────────────────────────────────
+def test_no_findings_yields_zero_reels_with_reason(monkeypatch):
+    _patch_cards(monkeypatch, {"finding": [], "alert": []})
+    out = svc.generate_reels(ENV, BIZ)
+    assert out["reels_upserted"] == 0
+    assert any(r["reason"] == "no_finding_cards_to_roll_up" for r in out["null_reasons"])
+
+
+def test_list_cards_failure_is_recorded_not_raised(monkeypatch):
+    from app.services import intelligence_cards
+    def boom(env, biz, *, card_type=None, **kw):
+        raise RuntimeError("db")
+    monkeypatch.setattr(intelligence_cards, "list_cards", boom)
+    out = svc.generate_reels(ENV, BIZ)
+    assert out["reels_upserted"] == 0
+    assert any("unavailable" in r["reason"] for r in out["null_reasons"])
+
+
+def test_reel_upsert_failure_skips_not_raises(monkeypatch):
+    from app.services import intelligence_cards
+    monkeypatch.setattr(intelligence_cards, "list_cards",
+                        lambda env, biz, *, card_type=None, **kw: [_card("t1", "telemetry")] if card_type == "finding" else [])
+    def boom(env, biz, **kw):
+        raise RuntimeError("write")
+    monkeypatch.setattr(intelligence_cards, "upsert_card", boom)
+    out = svc.generate_reels(ENV, BIZ)
+    assert out["reels_upserted"] == 0
+    assert any(r["reason"] == "reel_upsert_failed" for r in out["null_reasons"])
+
+
+def test_max_reels_per_run_caps_groups(monkeypatch):
+    # 10 analyzer types -> only MAX_REELS_PER_RUN reels written
+    findings = [_card(f"c{i}", analyzer=f"type{i}") for i in range(10)]
+    calls = _patch_cards(monkeypatch, {"finding": findings, "alert": []})
+    out = svc.generate_reels(ENV, BIZ)
+    assert out["reels_upserted"] == svc.MAX_REELS_PER_RUN
+    assert len(calls) == svc.MAX_REELS_PER_RUN
+
+
+# ── route ─────────────────────────────────────────────────────────────────────
+def test_route_generate_fails_closed(client, monkeypatch):
+    from app.routes import intelligence_cards as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    import app.services.analytics_reels as reels_svc
+    monkeypatch.setattr(reels_svc, "generate_reels",
+                        lambda env, biz: (_ for _ in ()).throw(RuntimeError("x")))
+    resp = client.post("/api/ade/intel/reels/generate", json={"env_id": ENV, "business_id": BIZ})
+    assert resp.status_code == 200
+    assert resp.json()["null_reason"] == "reels_generate_unavailable"
+
+
+def test_route_generate_success(client, monkeypatch):
+    from app.routes import intelligence_cards as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    import app.services.analytics_reels as reels_svc
+    monkeypatch.setattr(reels_svc, "generate_reels",
+                        lambda env, biz: {"env_id": env, "reels_upserted": 3, "groups": 3,
+                                          "null_reasons": [], "latency_ms": 5})
+    resp = client.post("/api/ade/intel/reels/generate", json={"env_id": ENV, "business_id": BIZ})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["reels_upserted"] == 3
+    assert body["null_reason"] is None

--- a/repo-b/src/app/app/page.tsx
+++ b/repo-b/src/app/app/page.tsx
@@ -15,6 +15,7 @@ import {
   upsertCard,
   dismissCard,
   runAnalyzers,
+  generateReels,
   type IntelCard,
 } from "@/lib/intelligence/cards";
 import { cn } from "@/lib/cn";
@@ -547,6 +548,7 @@ function AppIndexPageInner() {
   const [error, setError] = useState<string | null>(null);
   const [showPreview, setShowPreview] = useState(false);
   const [analyzing, setAnalyzing] = useState(false);
+  const [buildingReels, setBuildingReels] = useState(false);
 
   const deniedTarget = searchParams.get("denied");
   const selectedEnvironment = useMemo(
@@ -666,6 +668,21 @@ function AppIndexPageInner() {
       setAnalyzing(false);
     }
   }, [selectedEnvironment, bizId, analyzing, feed]);
+
+  // Roll up the env's finding cards into story (reel) cards, then refetch the feed.
+  // Deterministic, no LLM. Fail-closed: no-op without a real env/tenant.
+  const handleBuildReels = useCallback(async () => {
+    if (!selectedEnvironment || !bizId || buildingReels) return;
+    setBuildingReels(true);
+    try {
+      await generateReels(selectedEnvironment.env_id, bizId);
+      await feed.refetch();
+    } catch {
+      // Reels generation fails closed server-side; nothing fabricated on error.
+    } finally {
+      setBuildingReels(false);
+    }
+  }, [selectedEnvironment, bizId, buildingReels, feed]);
 
   useEffect(() => {
     if (loading || environments.length !== 1 || isPlatformAdmin || deniedTarget) {
@@ -1080,6 +1097,17 @@ function AppIndexPageInner() {
                         }}
                       >
                         {analyzing ? "Analyzing…" : "Analyze"}
+                      </button>
+                    ) : null}
+                    {selectedEnvironment && bizId ? (
+                      <button
+                        type="button"
+                        onClick={() => void handleBuildReels()}
+                        disabled={buildingReels}
+                        title="Roll up the current findings into story cards"
+                        className="inline-flex items-center gap-2 rounded-md border border-white/15 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.2em] text-white/55 transition-colors hover:text-white/80 disabled:cursor-default disabled:opacity-60"
+                      >
+                        {buildingReels ? "Building…" : "Stories"}
                       </button>
                     ) : null}
                     {selectedEnvironment ? (

--- a/repo-b/src/lib/intelligence/cards.ts
+++ b/repo-b/src/lib/intelligence/cards.ts
@@ -123,6 +123,34 @@ export async function runAnalyzers(
   return { ran, failed, cardsUpserted };
 }
 
+// ── Analytics reels (connective trigger) ──────────────────────────────────────
+// Roll up the env's persisted finding/alert cards into story (reel) cards. Deterministic,
+// no LLM — reads existing cards and composes narrative tiles. Run the analyzers first so
+// there are findings to roll up.
+interface ReelsResponse {
+  reels_upserted?: number;
+  groups?: number;
+  null_reasons?: unknown[];
+  null_reason?: string | null;
+}
+
+export interface GenerateReelsResult {
+  reelsUpserted: number;
+  ok: boolean; // false when the request itself rejected
+}
+
+export async function generateReels(env: string, biz: string): Promise<GenerateReelsResult> {
+  try {
+    const res = await apiFetch<ReelsResponse>("/api/ade/intel/reels/generate", {
+      method: "POST",
+      body: JSON.stringify({ env_id: env, business_id: biz }),
+    });
+    return { reelsUpserted: res?.reels_upserted ?? 0, ok: true };
+  } catch {
+    return { reelsUpserted: 0, ok: false };
+  }
+}
+
 export const CARD_TYPE_LABELS: Record<CardType, string> = {
   dashboard: "Dashboard",
   report: "Report",

--- a/scripts/generate_reels.py
+++ b/scripts/generate_reels.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Generate analytics reels (story cards) for an environment, on demand.
+
+Rolls up an environment's persisted analyzer finding/alert cards into story-type "reel"
+cards via app.services.analytics_reels. Deterministic, no LLM. Run the analyzers first so
+there are findings to roll up.
+
+Usage:
+    python scripts/generate_reels.py --env <env_id> --business <business_id>
+
+Schedule (planned, NOT yet wired): daily 7:00 AM, after the overnight analyzer runs.
+This script is the on-demand runner; cron registration is a deferred follow-up.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate analytics reels for an environment.")
+    parser.add_argument("--env", required=True, help="env_id to generate reels for")
+    parser.add_argument("--business", required=True, help="business_id (tenant) for the env")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    backend_dir = repo_root / "backend"
+    if str(backend_dir) not in sys.path:
+        sys.path.insert(0, str(backend_dir))
+
+    from dotenv import load_dotenv
+    load_dotenv(backend_dir / ".env", override=True)
+
+    from app.services import analytics_reels
+
+    try:
+        result = analytics_reels.generate_reels(args.env, args.business)
+    except Exception as exc:  # noqa: BLE001 — surface a clear failure, exit non-zero
+        print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr)
+        return 1
+
+    print(json.dumps({"ok": True, **result}, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Phase 5 / PR 12 — **Analytics Reels**, the first slice of the Experience Layer. A "reel" is a `story`-type card that rolls up an environment's persisted analyzer finding/alert cards into one narrative tile, giving Phase 4 findings a higher-level executive surface. **Deterministic, no LLM** — every reel traces to the real underlying cards.

## Scope (as decided)

- **Reels:** on-demand script + POST route generate story cards from current findings; they render in the **existing** home feed. No dedicated `/stories` viewer this PR; **7AM cron deferred** (no scheduled-batch infra is wired for this surface yet — honest follow-up).
- **Trailers:** `card_type='story'` + the existing `nv_intel_cards.summary` **is** the cached hover text — no new column/table, no hover-time call (honors the no-hover-query rule).

## Changes (6 files)

- `services/analytics_reels.py` — `generate_reels()` reads finding+alert cards, groups by analyzer type, upserts one reel per group via `_compose_reel` (pure): title/summary from counts + top member, priority = strongest member, anomaly_flag only if a member is an anomaly. `source_ref.member_card_ids` (sorted) → **idempotent re-runs**. Fail-closed throughout (no findings → 0 reels + null_reason; per-source/per-reel failures recorded, never raised, never fabricated).
- `routes/intelligence_cards.py` — `POST /api/ade/intel/reels/generate`, env-scoped (`require_environment_access`), fail-closed.
- `scripts/generate_reels.py` — on-demand runner (mirrors the `pod_daily_brief` bootstrap).
- `repo-b` `cards.ts` `generateReels()` + a tool-like **Stories** button beside Analyze in the feed header (fail-closed on env+tenant) → run → `feed.refetch()`.

## Honesty / exclusions

No LLM, no migration, no new component, no app-shell change, no dedicated viewer, no cron. REPE quarter-gated KPIs untouched.

## Tests & checks

- `test_analytics_reels.py` (new): pure-compose determinism + sorted member ids, grouping, idempotent re-run, fail-closed (empty / list-failure / upsert-failure), MAX cap, route success + fail-closed.
- **29 passed** (reels + intel cards + analyzer persist, no regression); `ruff` clean; `tsc` + `eslint` clean on both frontend files; `app.main` imports (1496 routes, reels mounted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
