### PR TITLE
Phase 5 PR 12b: forward PATCH through the ADE proxy (fixes card dismiss/prioritize)

### DIFF
--- a/repo-b/src/app/api/ade/[...path]/route.ts
+++ b/repo-b/src/app/api/ade/[...path]/route.ts
@@ -68,10 +68,26 @@ async function forward(request: NextRequest, context: { params: { path: string[]
   }
 }
 
+// Next.js App Router only routes methods that have a named export. `forward` already
+// handles every method (it reads a body for non-GET/HEAD and passes request.method
+// through), so the proxy supports the full CRUD surface its backend exposes — including
+// PATCH, which the card dismiss/prioritize clients in cards.ts rely on.
 export async function GET(request: NextRequest, context: { params: { path: string[] } }) {
   return forward(request, context);
 }
 
 export async function POST(request: NextRequest, context: { params: { path: string[] } }) {
+  return forward(request, context);
+}
+
+export async function PATCH(request: NextRequest, context: { params: { path: string[] } }) {
+  return forward(request, context);
+}
+
+export async function PUT(request: NextRequest, context: { params: { path: string[] } }) {
+  return forward(request, context);
+}
+
+export async function DELETE(request: NextRequest, context: { params: { path: string[] } }) {
   return forward(request, context);
 }


### PR DESCRIPTION
## Summary

Tiny cleanup before PR 13. The ADE catch-all proxy (`repo-b/src/app/api/ade/[...path]/route.ts`) had a method-agnostic `forward()` but exported only `GET` + `POST`. Next.js App Router only routes methods that have a **named export**, so browser `PATCH /api/ade/intel/cards/{id}` returned 405 before reaching `forward()` — **card dismiss (`dismissCard`) and prioritize (`bumpCardPriority`) in `cards.ts` were silently broken from the browser.**

## Fix

Additive: export `PATCH` (the real bug) plus `PUT`/`DELETE` for completeness. `forward()` already handles every method (reads a body for non-GET/HEAD, passes `request.method` through), so **no logic change**. This matches the sibling `psychrag` and `tasks` catch-all proxies, which already export the full GET/POST/PATCH/PUT/DELETE set — `ade` was the outlier.

## Scope

- Add PATCH/PUT/DELETE forwarding. GET/POST behavior unchanged (same `forward`).
- No UI redesign, no agents, no reels changes, no backend changes.

## Verification (acceptance)

- ✅ PATCH `/api/ade/intel/cards/{id}` now forwards (export added; `forward` reaches `@router.patch("/cards/{card_id}")`).
- ✅ Card dismiss/prioritize browser path unblocked — verified the `cards.ts` PATCH bodies (`{env_id, business_id, dismiss}` / `{…, priority_delta}`) match the backend `PatchCardBody`.
- ✅ `tsc` 0 errors in the file · ✅ `eslint` clean.
- No ADE proxy tests exist, so none to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
