### PR TITLE
Phase 5 PR 13: Agent Personalities (deterministic, LLM-free)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -88,6 +88,7 @@ from app.routes import analysis_sessions
 from app.routes import telemetry_analyzer
 from app.routes import data_platform_analyzer
 from app.routes import business_analyzer
+from app.routes import agent_personalities
 from app.routes import re_uw_reports, re_uw_links, re_pipeline, re_geography, re_intelligence
 from app.routes import re_opportunities
 from app.routes import (
@@ -467,6 +468,7 @@ app.include_router(analysis_sessions.router)
 app.include_router(telemetry_analyzer.router)
 app.include_router(data_platform_analyzer.router)
 app.include_router(business_analyzer.router)
+app.include_router(agent_personalities.router)
 app.include_router(tracking.router)
 app.include_router(email_integrations.router)
 app.include_router(nv_discovery.router)

--- a/backend/app/routes/agent_personalities.py
+++ b/backend/app/routes/agent_personalities.py
@@ -1,0 +1,47 @@
+"""Agent Personalities API (plan PR 13) — deterministic role agents, NO LLM.
+
+Read-only registry + run-now. An agent run filters the env's existing intelligence cards
+by its role and upserts one role-tagged rollup card; it never invents findings and never
+calls a model. Env-scoped, fail-closed.
+
+Paths:
+    GET  /api/ade/agents               list the fixed agent registry (cfo/operations/...)
+    POST /api/ade/agents/run           run one agent (agent_type) or all (omit), persist rollups
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from app.auth.platform import require_environment_access
+from app.observability.logger import emit_log
+from app.services import agent_personalities as svc
+
+router = APIRouter(prefix="/api/ade/agents", tags=["ade"])
+
+
+class RunBody(BaseModel):
+    env_id: str
+    business_id: UUID
+    agent_type: str | None = None  # one agent; omit to run all four
+
+
+@router.get("")
+def list_agents():
+    return {"agents": svc.list_agents(), "null_reason": None}
+
+
+@router.post("/run")
+def run(body: RunBody, request: Request):
+    require_environment_access(request, env_id=body.env_id)
+    try:
+        if body.agent_type:
+            result = svc.run_agent(body.agent_type, body.env_id, body.business_id)
+            return {"results": [result],
+                    "cards_upserted": 1 if result.get("card_id") else 0, "null_reason": None}
+        return {**svc.run_all(body.env_id, body.business_id), "null_reason": None}
+    except Exception as exc:  # noqa: BLE001 — fail closed, never 500 with fabricated data
+        emit_log(level="error", service="agent_personalities", action="run_failed", message=str(exc), error=exc)
+        return {"results": [], "cards_upserted": 0, "null_reason": "agents_run_unavailable"}

--- a/backend/app/services/agent_personalities.py
+++ b/backend/app/services/agent_personalities.py
@@ -1,0 +1,177 @@
+"""Agent Personalities (plan PR 13) — deterministic role lenses over existing cards.
+
+Four fixed role agents (CFO, Operations, Data Quality, Risk). Each is a DETERMINISTIC
+filter over the intelligence cards the analyzers/reels already persisted: it selects the
+cards relevant to its role (by the card's real source_ref signals + severity + anomaly
+flag), and upserts ONE role-tagged rollup card that references the matched source cards.
+
+NO LLM, NO model call anywhere in this module — agents are role lenses, not narrators. An
+agent never invents a finding; it only reads existing cards and restates which ones matter
+to its role. The single-call executive summary is a deliberately separate later PR (13b).
+
+Honest + fail closed: an agent with no matching cards writes nothing and reports an empty
+result with a reason (never a fabricated card). Idempotent: the rollup card's source_ref
+carries the sorted matched card ids, so re-running an agent updates its card in place.
+Env-scoped throughout (no cross-env reads).
+"""
+from __future__ import annotations
+
+import time
+from uuid import UUID
+
+from app.services import intelligence_cards
+
+# Agent type -> created_by tag on the cards it produces.
+AGENT_TYPES = ("cfo", "operations", "data_quality", "risk")
+_CREATED_BY = {a: f"agent:{a}" for a in AGENT_TYPES}
+_LABEL = {"cfo": "CFO", "operations": "Operations", "data_quality": "Data Quality", "risk": "Risk"}
+
+
+def _haystack(card: dict) -> str:
+    """Lowercased blob of the card's real provenance signals, for substring matching.
+
+    Pulls only fields the analyzers/reels actually emit into source_ref (source, field,
+    signal_type, analyzer_type) plus the title — never invents a signal.
+    """
+    ref = card.get("source_ref") or {}
+    parts = [str(ref.get(k, "")) for k in ("source", "field", "signal_type", "analyzer_type", "type")]
+    parts.append(str(card.get("title") or ""))
+    return " ".join(parts).lower()
+
+
+# Deterministic per-role predicates over REAL card signals (see the analyzers' source_ref
+# vocabulary: cash_balance/calls_per_day/overdue_count/today_count/success_rate; signal_type
+# bottleneck/leading_indicator/risk; sources accounting/cost/pipeline/stream/dq_assertions/
+# error_rate; severity + anomaly_flag).
+_CFO_TERMS = ("cash", "margin", "forecast", "cost", "budget", "burn", "accounting",
+              "calls_per_day", "leading_indicator")
+_OPS_TERMS = ("throughput", "bottleneck", "utilization", "workflow", "overdue", "today_count",
+              "board_summary", "pipeline", "stream", "telemetry", "anomaly_rate", "psi")
+_DQ_TERMS = ("dq_assertion", "dq_assertions", "schema_drift", "schema drift", "stale", "feed_stale",
+             "lineage", "missing_source", "stream_health", "pipeline_status", "success_rate", "error_rate")
+
+
+def _is_cfo(card: dict) -> bool:
+    return any(t in _haystack(card) for t in _CFO_TERMS)
+
+
+def _is_ops(card: dict) -> bool:
+    return any(t in _haystack(card) for t in _OPS_TERMS)
+
+
+def _is_dq(card: dict) -> bool:
+    return any(t in _haystack(card) for t in _DQ_TERMS)
+
+
+def _is_risk(card: dict) -> bool:
+    # Risk is severity/anomaly driven, not vocabulary driven: an alert card, an anomaly
+    # flag, or a 'risk' signal_type. (card_type 'alert' == critical severity from to_intel_card.)
+    ref = card.get("source_ref") or {}
+    return bool(
+        card.get("anomaly_flag")
+        or card.get("card_type") == "alert"
+        or str(ref.get("signal_type")) == "risk"
+        or any(t in _haystack(card) for t in ("exposure", "audit", "worsening"))
+    )
+
+
+_PREDICATES = {"cfo": _is_cfo, "operations": _is_ops, "data_quality": _is_dq, "risk": _is_risk}
+
+# Cards an agent rolls up — the findings/alerts/reels, never another agent's card (avoids
+# agents rolling up each other and never converging).
+_SOURCE_CARD_TYPES = ("alert", "finding", "story")
+
+
+def list_agents() -> list[dict]:
+    """The fixed agent registry (code-defined; no table). Static metadata only."""
+    return [{"agent_type": a, "label": _LABEL[a], "created_by": _CREATED_BY[a]} for a in AGENT_TYPES]
+
+
+def _source_cards(env_id: str, business_id: str | UUID) -> list[dict]:
+    """All non-dismissed finding/alert/reel cards for the env — the agent's input pool.
+
+    Excludes agent-authored cards so agents never roll up each other.
+    """
+    cards: list[dict] = []
+    for ct in _SOURCE_CARD_TYPES:
+        cards.extend(intelligence_cards.list_cards(env_id, business_id, card_type=ct, limit=100))
+    return [c for c in cards if not str(c.get("created_by") or "").startswith("agent:")]
+
+
+def _compose_agent_card(agent_type: str, matched: list[dict]) -> dict:
+    """Build the role-tagged rollup card. Pure function — counts + the top matched card."""
+    label = _LABEL[agent_type]
+    ids = sorted(str(m["id"]) for m in matched)
+    anomalies = [m for m in matched if m.get("anomaly_flag")]
+    top = matched[0]  # list_cards order: anomaly, priority, recency
+    n = len(matched)
+    crit = len(anomalies)
+    lead = (top.get("title") or "").strip()
+
+    title = f"{label}: {n} relevant signal{'' if n == 1 else 's'}"
+    if crit:
+        title += f" ({crit} critical)"
+    summary = (
+        f"{n} card{'' if n == 1 else 's'} match the {label} lens"
+        + (f", {crit} flagged as anomalies" if crit else "")
+        + (f". Top: {lead}" if lead else ".")
+    )
+    priority = round(max((m.get("priority_score") or 0.0) for m in matched), 4)
+    return {
+        "card_type": "alert" if anomalies else "finding",
+        "title": title[:200],
+        "summary": summary,
+        "source_ref": {
+            "type": "agent_rollup",
+            "agent_type": agent_type,
+            "member_card_ids": ids,
+            "member_count": n,
+            "anomaly_count": crit,
+        },
+        "priority_score": priority,
+        "anomaly_flag": bool(anomalies),
+        "created_by": _CREATED_BY[agent_type],
+    }
+
+
+def run_agent(agent_type: str, env_id: str, business_id: str | UUID) -> dict:
+    """Run one role agent: filter existing cards, upsert a role-tagged rollup. No LLM.
+
+    Fail closed: unknown agent -> error dict; no matches -> empty result + reason; an
+    upsert failure is reported, not raised.
+    """
+    started = time.monotonic()
+    if agent_type not in AGENT_TYPES:
+        return {"agent_type": agent_type, "matched": 0, "card_id": None,
+                "null_reason": "unknown_agent_type", "latency_ms": 0}
+
+    biz = business_id if isinstance(business_id, UUID) else UUID(str(business_id))
+    pool = _source_cards(env_id, biz)
+    matched = [c for c in pool if _PREDICATES[agent_type](c)]
+
+    if not matched:
+        return {"agent_type": agent_type, "matched": 0, "card_id": None,
+                "null_reason": "no_cards_match_role" if pool else "no_source_cards",
+                "latency_ms": int((time.monotonic() - started) * 1000)}
+
+    card_id = None
+    null_reason = None
+    try:
+        card = intelligence_cards.upsert_card(env_id, biz, **_compose_agent_card(agent_type, matched))
+        card_id = card.get("id")
+    except Exception:  # noqa: BLE001 — report, never raise; nothing fabricated
+        null_reason = "agent_card_upsert_failed"
+
+    return {
+        "agent_type": agent_type,
+        "matched": len(matched),
+        "card_id": card_id,
+        "null_reason": null_reason,
+        "latency_ms": int((time.monotonic() - started) * 1000),
+    }
+
+
+def run_all(env_id: str, business_id: str | UUID) -> dict:
+    """Run every agent over the env's cards. Deterministic, no LLM."""
+    results = [run_agent(a, env_id, business_id) for a in AGENT_TYPES]
+    return {"results": results, "cards_upserted": sum(1 for r in results if r.get("card_id"))}

--- a/backend/tests/test_agent_personalities.py
+++ b/backend/tests/test_agent_personalities.py
@@ -1,0 +1,198 @@
+"""Tests for Agent Personalities (plan PR 13) — deterministic role lenses, NO LLM.
+
+Run: cd backend && python -m pytest tests/test_agent_personalities.py -x -q
+
+Proves: each agent filters existing cards by its role deterministically; agents read only
+existing cards (never invent); produced cards are role-tagged (created_by 'agent:<type>')
+and reference their source cards; re-running is idempotent (sorted member ids); empty
+results are honest (reason, no card); and NO LLM/model-call path exists in the module.
+"""
+import os
+
+os.environ.setdefault("BM_MCP_DRY_RUN", "1")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+os.environ.setdefault("MCP_API_TOKEN", "test-token")
+
+from app.services import agent_personalities as svc  # noqa: E402
+
+ENV = "test-env"
+BIZ = "00000000-0000-0000-0000-000000000001"
+
+
+def _card(cid, *, ctype="finding", anomaly=False, priority=0.6, title="A signal",
+          source=None, field=None, signal_type=None, analyzer="business", created_by="analyzer:business"):
+    ref = {"analyzer_type": analyzer}
+    if source:
+        ref["source"] = source
+    if field:
+        ref["field"] = field
+    if signal_type:
+        ref["signal_type"] = signal_type
+    return {"id": cid, "card_type": ctype, "title": title, "summary": title,
+            "source_ref": ref, "priority_score": priority, "anomaly_flag": anomaly,
+            "created_by": created_by, "is_dismissed": False}
+
+
+# Real-shaped cards spanning the analyzer vocabularies.
+_CASH = _card("cash", field="cash_balance", signal_type="leading_indicator", title="Cash balance $120k")
+_OVERDUE = _card("od", field="overdue_count", signal_type="bottleneck", title="5 tasks overdue")
+_DQ = _card("dq", source="dq_assertions", analyzer="data_platform", title="DQ assertion failed")
+_PSI = _card("psi", ctype="alert", anomaly=True, priority=1.0, analyzer="telemetry",
+             field="psi", signal_type="risk", title="PSI drift 0.34")
+
+
+def _patch_pool(monkeypatch, by_type):
+    from app.services import intelligence_cards
+    monkeypatch.setattr(intelligence_cards, "list_cards",
+                        lambda env, biz, *, card_type=None, **kw: list(by_type.get(card_type, [])))
+    calls = []
+    monkeypatch.setattr(intelligence_cards, "upsert_card",
+                        lambda env, biz, **kw: calls.append(kw) or {"id": f"agent-card-{len(calls)}"})
+    return calls
+
+
+# ── deterministic role predicates ─────────────────────────────────────────────
+def test_predicates_route_cards_to_the_right_agent():
+    assert svc._is_cfo(_CASH) and not svc._is_cfo(_DQ)
+    assert svc._is_ops(_OVERDUE) and svc._is_ops(_PSI)        # psi/telemetry is operational
+    assert svc._is_dq(_DQ) and not svc._is_dq(_CASH)
+    assert svc._is_risk(_PSI) and not svc._is_risk(_CASH)     # risk = anomaly/alert/risk signal
+
+
+def test_registry_is_the_four_fixed_agents():
+    assert [a["agent_type"] for a in svc.list_agents()] == ["cfo", "operations", "data_quality", "risk"]
+    assert svc.list_agents()[0]["created_by"] == "agent:cfo"
+
+
+# ── run_agent: tag + reference + idempotency ──────────────────────────────────
+def test_run_agent_tags_card_and_references_sources(monkeypatch):
+    calls = _patch_pool(monkeypatch, {"finding": [_CASH, _OVERDUE], "alert": [], "story": []})
+    out = svc.run_agent("cfo", ENV, BIZ)
+    assert out["matched"] == 1                                # only the cash card matches CFO
+    assert len(calls) == 1
+    kw = calls[0]
+    assert kw["created_by"] == "agent:cfo"
+    assert kw["source_ref"]["type"] == "agent_rollup"
+    assert kw["source_ref"]["agent_type"] == "cfo"
+    assert kw["source_ref"]["member_card_ids"] == ["cash"]
+
+
+def test_run_agent_idempotent_sorted_member_ids(monkeypatch):
+    pool = {"finding": [_OVERDUE, _card("od2", field="overdue_count", signal_type="bottleneck")],
+            "alert": [], "story": []}
+    calls = _patch_pool(monkeypatch, pool)
+    svc.run_agent("operations", ENV, BIZ)
+    svc.run_agent("operations", ENV, BIZ)
+    assert calls[0]["source_ref"]["member_card_ids"] == calls[1]["source_ref"]["member_card_ids"] == ["od", "od2"]
+
+
+def test_risk_agent_flags_anomaly_card_as_alert(monkeypatch):
+    calls = _patch_pool(monkeypatch, {"finding": [], "alert": [_PSI], "story": []})
+    out = svc.run_agent("risk", ENV, BIZ)
+    assert out["matched"] == 1
+    assert calls[0]["card_type"] == "alert"
+    assert calls[0]["anomaly_flag"] is True
+
+
+def test_agents_do_not_roll_up_other_agents(monkeypatch):
+    # an agent-authored card in the pool must be excluded from the source set
+    agent_card = _card("a1", field="cash_balance", created_by="agent:cfo")
+    calls = _patch_pool(monkeypatch, {"finding": [agent_card], "alert": [], "story": []})
+    out = svc.run_agent("cfo", ENV, BIZ)
+    assert out["matched"] == 0
+    assert out["null_reason"] == "no_source_cards"
+    assert calls == []
+
+
+# ── honest empty / fail closed ────────────────────────────────────────────────
+def test_no_matching_cards_is_honest_empty(monkeypatch):
+    calls = _patch_pool(monkeypatch, {"finding": [_DQ], "alert": [], "story": []})  # DQ-only pool
+    out = svc.run_agent("cfo", ENV, BIZ)
+    assert out["matched"] == 0 and out["card_id"] is None
+    assert out["null_reason"] == "no_cards_match_role"
+    assert calls == []
+
+
+def test_unknown_agent_type_fails_closed(monkeypatch):
+    _patch_pool(monkeypatch, {"finding": [_CASH], "alert": [], "story": []})
+    out = svc.run_agent("ceo", ENV, BIZ)
+    assert out["null_reason"] == "unknown_agent_type"
+
+
+def test_upsert_failure_is_reported_not_raised(monkeypatch):
+    from app.services import intelligence_cards
+    monkeypatch.setattr(intelligence_cards, "list_cards",
+                        lambda env, biz, *, card_type=None, **kw: [_CASH] if card_type == "finding" else [])
+    monkeypatch.setattr(intelligence_cards, "upsert_card",
+                        lambda env, biz, **kw: (_ for _ in ()).throw(RuntimeError("db")))
+    out = svc.run_agent("cfo", ENV, BIZ)
+    assert out["null_reason"] == "agent_card_upsert_failed"
+    assert out["card_id"] is None
+
+
+def test_run_all_runs_four_agents(monkeypatch):
+    _patch_pool(monkeypatch, {"finding": [_CASH, _OVERDUE, _DQ], "alert": [_PSI], "story": []})
+    out = svc.run_all(ENV, BIZ)
+    assert len(out["results"]) == 4
+    # cfo(cash), operations(overdue+psi), data_quality(dq), risk(psi) all match -> 4 cards
+    assert out["cards_upserted"] == 4
+
+
+# ── NO LLM path (the load-bearing invariant of this PR) ───────────────────────
+def test_module_has_no_llm_import():
+    # Inspect IMPORTS via AST, not raw text — the "NO LLM" docstring legitimately mentions
+    # the word. The invariant is that the module pulls in no model/gateway SDK.
+    import ast
+    import inspect
+    banned = ("openai", "anthropic", "ai_gateway", "ai_conversations", "litellm", "ai_copilot")
+    tree = ast.parse(inspect.getsource(svc))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported += [a.name for a in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            imported.append(node.module or "")
+    for name in imported:
+        assert not any(b in name for b in banned), f"agent_personalities must not import {name!r}"
+
+
+def test_run_agent_calls_no_model(monkeypatch):
+    # The only external write an agent makes is upsert_card; nothing else is invoked. We
+    # prove it by making upsert_card the sole side effect and asserting it's the one call.
+    from app.services import intelligence_cards
+    monkeypatch.setattr(intelligence_cards, "list_cards",
+                        lambda env, biz, *, card_type=None, **kw: [_CASH] if card_type == "finding" else [])
+    seen = []
+    monkeypatch.setattr(intelligence_cards, "upsert_card",
+                        lambda env, biz, **kw: seen.append("upsert") or {"id": "x"})
+    svc.run_agent("cfo", ENV, BIZ)
+    assert seen == ["upsert"]  # exactly one write, no model call interleaved
+
+
+# ── route ─────────────────────────────────────────────────────────────────────
+def test_route_list_agents(client):
+    resp = client.get("/api/ade/agents")
+    assert resp.status_code == 200
+    assert [a["agent_type"] for a in resp.json()["agents"]] == ["cfo", "operations", "data_quality", "risk"]
+
+
+def test_route_run_fails_closed(client, monkeypatch):
+    from app.routes import agent_personalities as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    monkeypatch.setattr(svc, "run_all", lambda env, biz: (_ for _ in ()).throw(RuntimeError("x")))
+    resp = client.post("/api/ade/agents/run", json={"env_id": ENV, "business_id": BIZ})
+    assert resp.status_code == 200
+    assert resp.json()["null_reason"] == "agents_run_unavailable"
+
+
+def test_route_run_single_agent(client, monkeypatch):
+    from app.routes import agent_personalities as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    monkeypatch.setattr(svc, "run_agent",
+                        lambda at, env, biz: {"agent_type": at, "matched": 2, "card_id": "c1",
+                                              "null_reason": None, "latency_ms": 3})
+    resp = client.post("/api/ade/agents/run", json={"env_id": ENV, "business_id": BIZ, "agent_type": "risk"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cards_upserted"] == 1
+    assert body["results"][0]["agent_type"] == "risk"

--- a/repo-b/src/app/app/page.tsx
+++ b/repo-b/src/app/app/page.tsx
@@ -16,7 +16,10 @@ import {
   dismissCard,
   runAnalyzers,
   generateReels,
+  runAgent,
+  agentCreatedBy,
   type IntelCard,
+  type AgentType,
 } from "@/lib/intelligence/cards";
 import { cn } from "@/lib/cn";
 import {
@@ -66,32 +69,55 @@ function dashboardSourceRef(envId: string) {
   return { type: "app_home_dashboard", env_id: envId };
 }
 
-// ── Agent pills: VISUAL-ONLY scaffold (PR 5). No logic, no handlers, no routing. ──
+// ── Agent pills: deterministic role lenses (PR 13). Click to filter the feed to that
+// agent's cards; the count is the agent's cards already in the feed. Run-now lives in the
+// header "Run agents" button. Disabled (no handler) until an env+tenant is resolved.
 const AGENT_PILLS = [
-  { label: "CFO", glow: ACTION_TEAL },
-  { label: "Operations", glow: "107, 174, 127" },
-  { label: "Data Quality", glow: "176, 64, 255" },
-  { label: "Risk", glow: "209, 161, 91" },
-] as const;
+  { type: "cfo", label: "CFO", glow: ACTION_TEAL },
+  { type: "operations", label: "Operations", glow: "107, 174, 127" },
+  { type: "data_quality", label: "Data Quality", glow: "176, 64, 255" },
+  { type: "risk", label: "Risk", glow: "209, 161, 91" },
+] as const satisfies ReadonlyArray<{ type: AgentType; label: string; glow: string }>;
 
-function AgentPills() {
+function AgentPills({
+  activeFilter,
+  counts,
+  onToggle,
+}: {
+  activeFilter: AgentType | null;
+  counts: Record<AgentType, number>;
+  onToggle: ((agent: AgentType) => void) | null; // null => disabled (no env/tenant)
+}) {
   return (
-    <div className="flex flex-wrap items-center gap-2" aria-label="Agents (preview)">
+    <div className="flex flex-wrap items-center gap-2" aria-label="Agents">
       <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/35">
         Agents
       </span>
-      {AGENT_PILLS.map((agent) => (
-        <span
-          key={agent.label}
-          aria-disabled
-          title="Coming soon"
-          className="inline-flex shrink-0 items-center gap-2 rounded-full border px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] text-white/55"
-          style={{ borderColor: `rgba(${agent.glow}, 0.22)`, background: `rgba(${agent.glow}, 0.06)` }}
-        >
-          <span className="h-1.5 w-1.5 rounded-full" style={{ background: `rgba(${agent.glow}, 0.8)` }} />
-          {agent.label}
-        </span>
-      ))}
+      {AGENT_PILLS.map((agent) => {
+        const active = activeFilter === agent.type;
+        const count = counts[agent.type] ?? 0;
+        const disabled = !onToggle;
+        return (
+          <button
+            key={agent.type}
+            type="button"
+            aria-pressed={active}
+            disabled={disabled}
+            title={disabled ? "Select an environment to run agents" : `Filter the feed to ${agent.label} cards`}
+            onClick={() => onToggle?.(agent.type)}
+            className="inline-flex shrink-0 items-center gap-2 rounded-full border px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] transition-colors disabled:cursor-default disabled:opacity-50"
+            style={{
+              borderColor: `rgba(${agent.glow}, ${active ? 0.55 : 0.22})`,
+              background: `rgba(${agent.glow}, ${active ? 0.16 : 0.06})`,
+              color: active ? "#fff" : "rgba(255,255,255,0.55)",
+            }}
+          >
+            <span className="h-1.5 w-1.5 rounded-full" style={{ background: `rgba(${agent.glow}, 0.8)` }} />
+            {agent.label}
+            {count > 0 ? <span className="text-white/70">{count}</span> : null}
+          </button>
+        );
+      })}
     </div>
   );
 }
@@ -549,6 +575,8 @@ function AppIndexPageInner() {
   const [showPreview, setShowPreview] = useState(false);
   const [analyzing, setAnalyzing] = useState(false);
   const [buildingReels, setBuildingReels] = useState(false);
+  const [runningAgents, setRunningAgents] = useState(false);
+  const [agentFilter, setAgentFilter] = useState<AgentType | null>(null);
 
   const deniedTarget = searchParams.get("denied");
   const selectedEnvironment = useMemo(
@@ -576,6 +604,31 @@ function AppIndexPageInner() {
     () => deriveEnvironmentStatus(selectedEnvironment, anomalyCount, bizId),
     [selectedEnvironment, anomalyCount, bizId],
   );
+
+  // Per-agent card counts (cards an agent has already produced, by created_by tag).
+  const agentCounts = useMemo(() => {
+    const counts: Record<AgentType, number> = { cfo: 0, operations: 0, data_quality: 0, risk: 0 };
+    for (const card of feed.cards) {
+      for (const t of ["cfo", "operations", "data_quality", "risk"] as AgentType[]) {
+        if (card.created_by === agentCreatedBy(t)) counts[t] += 1;
+      }
+    }
+    return counts;
+  }, [feed.cards]);
+
+  // Feed filtered to the active agent's cards (null => all cards).
+  const visibleCards = useMemo(
+    () =>
+      agentFilter
+        ? feed.cards.filter((c) => c.created_by === agentCreatedBy(agentFilter))
+        : feed.cards,
+    [feed.cards, agentFilter],
+  );
+
+  // Reset the agent filter when the selected env changes (its cards differ).
+  useEffect(() => {
+    setAgentFilter(null);
+  }, [selectedEnvironment?.env_id]);
 
   // Reset the preview toggle when the selected env changes.
   useEffect(() => {
@@ -684,6 +737,26 @@ function AppIndexPageInner() {
     }
   }, [selectedEnvironment, bizId, buildingReels, feed]);
 
+  // Run all role agents (deterministic role lenses, NO LLM), then refetch the feed.
+  // Fail-closed: no-op without a real env/tenant.
+  const handleRunAgents = useCallback(async () => {
+    if (!selectedEnvironment || !bizId || runningAgents) return;
+    setRunningAgents(true);
+    try {
+      await runAgent(selectedEnvironment.env_id, bizId); // omit type => run all four
+      await feed.refetch();
+    } catch {
+      // Agents fail closed server-side; nothing fabricated on error.
+    } finally {
+      setRunningAgents(false);
+    }
+  }, [selectedEnvironment, bizId, runningAgents, feed]);
+
+  // Toggle the feed filter to one agent's cards (click again to clear).
+  const handleToggleAgentFilter = useCallback((agent: AgentType) => {
+    setAgentFilter((cur) => (cur === agent ? null : agent));
+  }, []);
+
   useEffect(() => {
     if (loading || environments.length !== 1 || isPlatformAdmin || deniedTarget) {
       return;
@@ -707,7 +780,7 @@ function AppIndexPageInner() {
       }}
     >
       <IntelligenceCardFeed
-        cards={feed.cards}
+        cards={visibleCards}
         loading={feed.loading}
         error={feed.error}
         nullReason={feed.nullReason}
@@ -717,6 +790,13 @@ function AppIndexPageInner() {
       />
     </section>
   );
+
+  // Agent pill props — disabled (null onToggle) until a real env + tenant resolves.
+  const agentPillProps = {
+    activeFilter: agentFilter,
+    counts: agentCounts,
+    onToggle: selectedEnvironment && bizId ? handleToggleAgentFilter : null,
+  };
 
   return (
     <div className="min-h-screen bg-[#03070e] text-white">
@@ -800,8 +880,8 @@ function AppIndexPageInner() {
             ) : null}
           </section>
 
-          {/* Agent pills (visual-only) */}
-          <AgentPills />
+          {/* Agent pills — filter the feed to a role lens */}
+          <AgentPills {...agentPillProps} />
 
           {/* Intelligence feed — the core of the home, kept near the top on mobile too */}
           {feedSection}
@@ -1081,7 +1161,7 @@ function AppIndexPageInner() {
                 ) : null}
 
                 <div className="flex items-center justify-between gap-4">
-                  <AgentPills />
+                  <AgentPills {...agentPillProps} />
                   <div className="flex shrink-0 items-center gap-3">
                     {selectedEnvironment && bizId ? (
                       <button
@@ -1108,6 +1188,17 @@ function AppIndexPageInner() {
                         className="inline-flex items-center gap-2 rounded-md border border-white/15 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.2em] text-white/55 transition-colors hover:text-white/80 disabled:cursor-default disabled:opacity-60"
                       >
                         {buildingReels ? "Building…" : "Stories"}
+                      </button>
+                    ) : null}
+                    {selectedEnvironment && bizId ? (
+                      <button
+                        type="button"
+                        onClick={() => void handleRunAgents()}
+                        disabled={runningAgents}
+                        title="Run the role agents over the current findings"
+                        className="inline-flex items-center gap-2 rounded-md border border-white/15 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.2em] text-white/55 transition-colors hover:text-white/80 disabled:cursor-default disabled:opacity-60"
+                      >
+                        {runningAgents ? "Running…" : "Run agents"}
                       </button>
                     ) : null}
                     {selectedEnvironment ? (

--- a/repo-b/src/lib/intelligence/cards.ts
+++ b/repo-b/src/lib/intelligence/cards.ts
@@ -151,6 +151,49 @@ export async function generateReels(env: string, biz: string): Promise<GenerateR
   }
 }
 
+// ── Agent personalities (deterministic role lenses) ───────────────────────────
+// Run a role agent (or all) to filter existing cards into role-tagged rollup cards.
+// Deterministic, NO LLM. created_by on produced cards is 'agent:<type>'.
+export type AgentType = "cfo" | "operations" | "data_quality" | "risk";
+
+export const AGENT_LABELS: Record<AgentType, string> = {
+  cfo: "CFO",
+  operations: "Operations",
+  data_quality: "Data Quality",
+  risk: "Risk",
+};
+
+// The created_by tag an agent stamps on its cards — used to filter the feed by agent.
+export const agentCreatedBy = (a: AgentType): string => `agent:${a}`;
+
+interface AgentRunResponse {
+  results?: { agent_type: string; matched: number; card_id: string | null; null_reason: string | null }[];
+  cards_upserted?: number;
+  null_reason?: string | null;
+}
+
+export interface RunAgentResult {
+  cardsUpserted: number;
+  ok: boolean;
+}
+
+// Run one agent (agentType) or all four (omit). Persists role-tagged rollup cards.
+export async function runAgent(
+  env: string,
+  biz: string,
+  agentType?: AgentType,
+): Promise<RunAgentResult> {
+  try {
+    const res = await apiFetch<AgentRunResponse>("/api/ade/agents/run", {
+      method: "POST",
+      body: JSON.stringify({ env_id: env, business_id: biz, agent_type: agentType ?? null }),
+    });
+    return { cardsUpserted: res?.cards_upserted ?? 0, ok: true };
+  } catch {
+    return { cardsUpserted: 0, ok: false };
+  }
+}
+
 export const CARD_TYPE_LABELS: Record<CardType, string> = {
   dashboard: "Dashboard",
   report: "Report",


### PR DESCRIPTION
## Summary

Phase 5 / PR 13 — **Agent Personalities**: four fixed role agents (CFO, Operations, Data Quality, Risk) as **deterministic role lenses** over the intelligence cards the analyzers/reels already persisted. **LLM-free by decision** — agents prove they can create trustworthy role-based intelligence before they're eloquent. The single-call executive summary is a deliberately separate later PR (13b).

## Key design call: no table

The agents are a **fixed, code-defined registry**; their only state is the role-tagged cards they produce, which already live in `nv_intel_cards`. So **no migration, no `nv_agent_definitions` table** — the plan said "if needed," and it isn't.

## Changes (6 files)

- `services/agent_personalities.py` — each agent has a deterministic predicate over a card's **real** provenance signals (`source_ref` source/field/signal_type/analyzer_type + severity + anomaly_flag), never an invented category. `run_agent()` reads existing finding/alert/reel cards (excluding agent-authored ones, so agents don't roll up each other), filters by role, and upserts **one** role-tagged rollup card (`created_by: agent:<type>`) whose `source_ref` carries the **sorted** matched card ids → idempotent re-runs. Honest empty (reason, no card); fail-closed on upsert failure. **No LLM import or call path.**
- `routes/agent_personalities.py` + `main.py` — `GET /api/ade/agents` (registry), `POST /api/ade/agents/run` (one agent or all), env-scoped, fail-closed.
- `repo-b` `cards.ts` — `runAgent()` + `agentCreatedBy()` helper.
- `page.tsx` — **AgentPills now functional**: click a pill to filter the feed to that agent's cards (per-agent counts shown); a **Run agents** header button runs all four then refetches. Disabled fail-closed without a real env+tenant.

## Category → real-signal mapping

CFO: cash/margin/forecast/cost/budget/leading-indicator · Operations: throughput/bottleneck/utilization/workflow/telemetry-operational · Data Quality: dq-failure/schema-drift/stale-feed/lineage/missing-source/error-rate · Risk: critical severity / anomaly / `signal_type=risk` / audit-exposure.

## Rules honored

Agents read existing cards only (never invent); produced cards reference their source cards; idempotent by `source_ref`; env-scoped, no cross-env; **no LLM**; no analyzer execution; no reels/mission-control/memory changes.

## Tests & checks

**89 passed** (incl. no-regression across analyzers/reels/cards). Coverage: per-role predicate routing, role-tagged + source-referencing cards, idempotent sorted ids, agents-don't-roll-up-agents, honest empty, unknown-agent + upsert-failure fail-closed, `run_all`=4, route list/run, and the **load-bearing NO-LLM proof** (AST import scan + single-write assertion). `ruff` + `tsc` + `eslint` clean; `app.main` 1498 routes.

> CI note: the Frontend job has a known suite-order flake (`oidcPkce > rejects tampered payloads`) unrelated to this diff; will re-run/rebase if it appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
