### PR TITLE
feat(history-rhymes): FRED feature-store connector (B2)

### DIFF
--- a/backend/app/services/hr_feature_store/connectors/__init__.py
+++ b/backend/app/services/hr_feature_store/connectors/__init__.py
@@ -1,0 +1,8 @@
+"""History Rhymes Feature Store connectors (Phase B).
+
+Each connector follows the polymarket triad: a strict live `client` (raises, no
+fixture fallback), a pure `normalizer` (raw → canonical readings), and an
+inspectable `series_registry` (source contract). Connectors write the SILVER
+layer (`hr_fs_readings`) idempotently; tests run on committed fixtures only,
+never the network.
+"""

--- a/backend/app/services/hr_feature_store/connectors/fred/__init__.py
+++ b/backend/app/services/hr_feature_store/connectors/fred/__init__.py
@@ -1,0 +1,1 @@
+"""FRED connector — Treasury/rates/credit series into canonical readings."""

--- a/backend/app/services/hr_feature_store/connectors/fred/client.py
+++ b/backend/app/services/hr_feature_store/connectors/fred/client.py
@@ -1,0 +1,54 @@
+"""Strict live FRED client. Raises on missing key / HTTP error — NO fixture
+fallback in live mode (fixtures are used only by tests, never here). Never called
+in unit/CI tests; the network import (httpx) is lazy.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .config import FredSettings, fred_api_key
+
+
+class FredConfigError(RuntimeError):
+    """FRED key/config is missing — caller must handle (no silent fallback)."""
+
+
+class FredFetchError(RuntimeError):
+    """FRED API returned a non-success response or unparseable body."""
+
+
+def fetch_observations(
+    series_id: str,
+    *,
+    observation_start: str | None = None,
+    limit: int | None = None,
+    settings: FredSettings | None = None,
+) -> dict[str, Any]:
+    """Fetch raw FRED observations JSON for a series. Live only; raises on error."""
+    key = fred_api_key()
+    if not key:
+        raise FredConfigError("FRED_API_KEY not configured (set FRED_API_KEY or FRED_API_KEY_FILE)")
+
+    settings = settings or FredSettings.from_env()
+    params: dict[str, Any] = {"series_id": series_id, "api_key": key, "file_type": "json"}
+    if observation_start:
+        params["observation_start"] = observation_start
+    if limit:
+        params["limit"] = int(limit)
+
+    import httpx  # noqa: PLC0415 — lazy; only the live path needs it
+
+    try:
+        resp = httpx.get(f"{settings.base_url}/series/observations", params=params, timeout=settings.timeout_seconds)
+    except Exception as exc:  # network error
+        raise FredFetchError(f"FRED request failed for {series_id}: {exc}") from exc
+    if resp.status_code != 200:
+        raise FredFetchError(f"FRED {series_id} → HTTP {resp.status_code}")
+    try:
+        body = resp.json()
+    except Exception as exc:
+        raise FredFetchError(f"FRED {series_id} returned unparseable JSON") from exc
+    if "observations" not in body:
+        raise FredFetchError(f"FRED {series_id} response missing 'observations'")
+    return body

--- a/backend/app/services/hr_feature_store/connectors/fred/config.py
+++ b/backend/app/services/hr_feature_store/connectors/fred/config.py
@@ -1,0 +1,41 @@
+"""FRED connector config (self-contained, flat env reads + _FILE secrets)."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _clean(value: str | None) -> str:
+    return value.strip() if value else ""
+
+
+def _read_secret_file(env_name: str) -> str:
+    path = _clean(os.getenv(env_name))
+    if not path:
+        return ""
+    try:
+        return Path(path).read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def fred_api_key() -> str:
+    """Live FRED key: env var first, then the GCP Secret Manager _FILE mount."""
+    return _clean(os.getenv("FRED_API_KEY")) or _read_secret_file("FRED_API_KEY_FILE")
+
+
+@dataclass(frozen=True)
+class FredSettings:
+    base_url: str = "https://api.stlouisfed.org/fred"
+    enabled: bool = False
+    timeout_seconds: float = 20.0
+
+    @classmethod
+    def from_env(cls) -> "FredSettings":
+        return cls(
+            base_url=_clean(os.getenv("FS_FRED_BASE_URL")) or "https://api.stlouisfed.org/fred",
+            enabled=(os.getenv("FS_FRED_ENABLED", "false").lower() == "true"),
+            timeout_seconds=float(os.getenv("FS_FRED_TIMEOUT_SECONDS", "20") or "20"),
+        )

--- a/backend/app/services/hr_feature_store/connectors/fred/normalizer.py
+++ b/backend/app/services/hr_feature_store/connectors/fred/normalizer.py
@@ -1,0 +1,50 @@
+"""Pure FRED normalizer: raw observations JSON → canonical silver readings.
+
+FRED encodes a missing observation as the string '.', which becomes
+value=None + null_reason='fred_missing_value' — NEVER zero-imputed. Deterministic;
+no network. `source_quality` is 'fixture' in tests, 'live' from the ingest script.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .series_registry import CONNECTOR, FRED_SERIES
+
+
+def normalize_observations(
+    canonical_name: str,
+    fred_json: dict[str, Any],
+    *,
+    source_quality: str = "live",
+) -> list[dict[str, Any]]:
+    meta = FRED_SERIES.get(canonical_name)
+    if meta is None:
+        raise ValueError(f"unknown canonical FRED series: {canonical_name}")
+    series_id = meta["series_id"]
+    rows: list[dict[str, Any]] = []
+    for obs in fred_json.get("observations", []):
+        date = obs.get("date")
+        raw = obs.get("value")
+        if not date:
+            continue
+        value: float | None
+        null_reason: str | None
+        if raw is None or raw == ".":
+            value, null_reason = None, "fred_missing_value"  # never 0
+        else:
+            try:
+                value, null_reason = float(raw), None
+            except (TypeError, ValueError):
+                value, null_reason = None, "fred_unparseable_value"
+        rows.append({
+            "connector": CONNECTOR,
+            "series_key": canonical_name,
+            "ts_source": f"{date}T00:00:00+00:00",
+            "value": value,
+            "quality_flag": "ok" if null_reason is None else "missing",
+            "null_reason": null_reason,
+            "source_quality": source_quality,
+            "provenance": {"series_id": series_id, "cadence": meta["cadence"], "units": meta.get("units")},
+        })
+    return rows

--- a/backend/app/services/hr_feature_store/connectors/fred/series_registry.py
+++ b/backend/app/services/hr_feature_store/connectors/fred/series_registry.py
@@ -1,0 +1,48 @@
+"""FRED series contract — pinned series IDs mapped to canonical feature names.
+
+Inspectable + auditable: each entry pins the FRED `series_id`, the cadence (drives
+cadence-aware staleness), and the canonical `QUANT_FEATURE_ORDER` slot it fills.
+Some series are revisable (e.g. the term-premium estimate) — pinning the id here
+makes the source contract explicit. Every key MUST be a canonical quant name so
+gold/spine consumption stays aligned.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.hr_feature_store.contract import QUANT_FEATURE_ORDER
+
+# canonical_name -> {series_id, cadence, units, note}
+FRED_SERIES: dict[str, dict[str, Any]] = {
+    "yield_curve_10y2y": {"series_id": "T10Y2Y", "cadence": "daily", "units": "percent",
+                          "note": "10Y minus 2Y Treasury constant-maturity spread."},
+    "fed_funds_rate": {"series_id": "DFF", "cadence": "daily", "units": "percent",
+                       "note": "Effective federal funds rate (daily)."},
+    "term_premium": {"series_id": "ACMTP10", "cadence": "daily", "units": "percent",
+                     "note": "ACM 10Y term premium estimate (revisable)."},
+    "mortgage_rate_30y": {"series_id": "MORTGAGE30US", "cadence": "weekly", "units": "percent",
+                          "note": "30Y fixed mortgage rate (Freddie Mac PMMS)."},
+    "hy_credit_spread": {"series_id": "BAMLH0A0HYM2", "cadence": "daily", "units": "percent",
+                         "note": "ICE BofA US High Yield OAS."},
+    "ig_credit_spread": {"series_id": "BAMLC0A0CM", "cadence": "daily", "units": "percent",
+                         "note": "ICE BofA US Corporate (IG) OAS."},
+}
+
+CONNECTOR = "fred"
+
+
+def canonical_for_series_id(series_id: str) -> str | None:
+    for name, meta in FRED_SERIES.items():
+        if meta["series_id"] == series_id:
+            return name
+    return None
+
+
+def registered_canonical_names() -> list[str]:
+    return list(FRED_SERIES.keys())
+
+
+# Validation at import: every key is a real canonical quant slot.
+_unknown = [n for n in FRED_SERIES if n not in QUANT_FEATURE_ORDER]
+assert not _unknown, f"FRED_SERIES keys must be canonical QUANT_FEATURE_ORDER names; unknown: {_unknown}"

--- a/backend/app/services/hr_feature_store/freshness.py
+++ b/backend/app/services/hr_feature_store/freshness.py
@@ -1,0 +1,32 @@
+"""Cadence-aware staleness for feature-store pipeline status.
+
+A daily series stale != a minute series stale, so freshness thresholds are keyed
+by the source's expected cadence. Pure + clock-injected (no implicit now()) so it
+is deterministic and testable.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+# Max acceptable lag before a surface is considered stale, per cadence (seconds).
+CADENCE_MAX_LAG_SECONDS: dict[str, int] = {
+    "daily": 3 * 86400,    # weekends + a release-day grace
+    "weekly": 10 * 86400,
+    "monthly": 40 * 86400,
+    "event": 7 * 86400,
+}
+_DEFAULT_MAX_LAG = 3 * 86400
+
+
+def compute_status(
+    as_of: datetime | None,
+    now: datetime,
+    cadence: str,
+) -> tuple[str, float | None]:
+    """Return (status, lag_seconds). as_of=None ⇒ ('unavailable', None)."""
+    if as_of is None:
+        return "unavailable", None
+    lag = (now - as_of).total_seconds()
+    max_lag = CADENCE_MAX_LAG_SECONDS.get(cadence, _DEFAULT_MAX_LAG)
+    return ("fresh" if lag <= max_lag else "stale"), lag

--- a/backend/app/services/hr_feature_store/loader.py
+++ b/backend/app/services/hr_feature_store/loader.py
@@ -106,6 +106,105 @@ def model_obs_to_params(obs: dict[str, Any]) -> dict[str, Any]:
     return params
 
 
+SILVER_UPSERT_SQL = """
+INSERT INTO public.hr_fs_readings (
+    connector, series_key, ts_source, value, quality_flag, null_reason, source_quality, provenance
+) VALUES (
+    %(connector)s, %(series_key)s, %(ts_source)s, %(value)s, %(quality_flag)s,
+    %(null_reason)s, %(source_quality)s, %(provenance)s::jsonb
+)
+ON CONFLICT (connector, series_key, ts_source) DO UPDATE SET
+    value = EXCLUDED.value,
+    quality_flag = EXCLUDED.quality_flag,
+    null_reason = EXCLUDED.null_reason,
+    source_quality = EXCLUDED.source_quality,
+    provenance = EXCLUDED.provenance,
+    updated_at = now()
+RETURNING (xmax = 0) AS inserted;
+"""
+
+_STATUS_UPSERT_SQL = """
+INSERT INTO public.hr_fs_pipeline_status (
+    connector, surface, status, expected_cadence, as_of_ts, lag_seconds, reason, updated_at
+) VALUES (
+    %(connector)s, %(surface)s, %(status)s, %(expected_cadence)s, %(as_of_ts)s, %(lag_seconds)s, %(reason)s, now()
+)
+ON CONFLICT (connector, surface) DO UPDATE SET
+    status = EXCLUDED.status,
+    expected_cadence = EXCLUDED.expected_cadence,
+    as_of_ts = EXCLUDED.as_of_ts,
+    lag_seconds = EXCLUDED.lag_seconds,
+    reason = EXCLUDED.reason,
+    updated_at = now();
+"""
+
+
+def silver_reading_to_params(reading: dict[str, Any]) -> dict[str, Any]:
+    """Map a normalized reading → silver SQL params. Missing value stays None (never 0)."""
+    return {
+        "connector": reading.get("connector"),
+        "series_key": reading.get("series_key"),
+        "ts_source": reading.get("ts_source"),
+        "value": reading.get("value"),
+        "quality_flag": reading.get("quality_flag", "ok"),
+        "null_reason": reading.get("null_reason"),
+        "source_quality": reading.get("source_quality", "fixture"),
+        "provenance": json.dumps(reading.get("provenance", {})),
+    }
+
+
+def upsert_silver_readings(rows: list[dict[str, Any]]) -> dict[str, int]:
+    """Idempotent UPSERT of normalized readings into SILVER. Never raises on DB issues."""
+    counts = {"inserted": 0, "updated": 0, "skipped": 0, "unavailable": 0}
+    valid: list[dict[str, Any]] = []
+    for r in rows:
+        if not r.get("connector") or not r.get("series_key") or not r.get("ts_source"):
+            counts["skipped"] += 1
+        else:
+            valid.append(r)
+    if not valid:
+        return counts
+    try:
+        from app.db import get_cursor  # lazy so tests can patch app.db.get_cursor
+
+        with get_cursor() as cur:
+            for r in valid:
+                cur.execute(SILVER_UPSERT_SQL, silver_reading_to_params(r))
+                row = cur.fetchone()
+                inserted = bool(row["inserted"]) if row and "inserted" in row else True
+                counts["inserted" if inserted else "updated"] += 1
+    except Exception as exc:  # noqa: BLE001 — surface unavailable, never raise
+        logger.warning("hr_feature_store silver upsert unavailable: %s", exc)
+        counts["unavailable"] = len(valid) - (counts["inserted"] + counts["updated"])
+    return counts
+
+
+def update_pipeline_status(
+    connector: str,
+    surface: str,
+    status: str,
+    *,
+    expected_cadence: str | None = None,
+    as_of_ts: str | None = None,
+    lag_seconds: float | None = None,
+    reason: str | None = None,
+) -> bool:
+    """Fail-closed freshness write. Returns False if the DB is unavailable."""
+    try:
+        from app.db import get_cursor  # lazy
+
+        with get_cursor() as cur:
+            cur.execute(_STATUS_UPSERT_SQL, {
+                "connector": connector, "surface": surface, "status": status,
+                "expected_cadence": expected_cadence, "as_of_ts": as_of_ts,
+                "lag_seconds": lag_seconds, "reason": reason,
+            })
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("hr_feature_store pipeline status update unavailable: %s", exc)
+        return False
+
+
 def upsert_model_observations(rows: list[dict[str, Any]]) -> dict[str, int]:
     """Idempotent UPSERT of gold rows. Returns counts; never raises on DB issues."""
     counts = {"inserted": 0, "updated": 0, "skipped": 0, "unavailable": 0}

--- a/backend/tests/fixtures/hr_feature_store/fred/T10Y2Y.json
+++ b/backend/tests/fixtures/hr_feature_store/fred/T10Y2Y.json
@@ -1,0 +1,17 @@
+{
+  "realtime_start": "2026-06-16",
+  "realtime_end": "2026-06-16",
+  "observation_start": "2026-06-01",
+  "observation_end": "9999-12-31",
+  "units": "lin",
+  "output_type": 1,
+  "file_type": "json",
+  "count": 5,
+  "observations": [
+    { "realtime_start": "2026-06-16", "realtime_end": "2026-06-16", "date": "2026-06-08", "value": "0.52" },
+    { "realtime_start": "2026-06-16", "realtime_end": "2026-06-16", "date": "2026-06-09", "value": "0.49" },
+    { "realtime_start": "2026-06-16", "realtime_end": "2026-06-16", "date": "2026-06-10", "value": "." },
+    { "realtime_start": "2026-06-16", "realtime_end": "2026-06-16", "date": "2026-06-11", "value": "0.55" },
+    { "realtime_start": "2026-06-16", "realtime_end": "2026-06-16", "date": "2026-06-12", "value": "0.58" }
+  ]
+}

--- a/backend/tests/test_hr_feature_store_fred.py
+++ b/backend/tests/test_hr_feature_store_fred.py
@@ -1,0 +1,141 @@
+"""B2 tests: FRED connector (registry / client key-gating / normalizer) + the
+silver loader + cadence-aware freshness. Fixtures only — NO network in any test.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from app.services.hr_feature_store.connectors.fred import client as fred_client
+from app.services.hr_feature_store.connectors.fred import normalizer as fred_norm
+from app.services.hr_feature_store.connectors.fred import series_registry as reg
+from app.services.hr_feature_store.contract import QUANT_FEATURE_ORDER
+from app.services.hr_feature_store.freshness import compute_status
+from app.services.hr_feature_store import loader as fs_loader
+from app.services.hr_feature_store.loader import (
+    SILVER_UPSERT_SQL,
+    silver_reading_to_params,
+    update_pipeline_status,
+    upsert_silver_readings,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "hr_feature_store" / "fred" / "T10Y2Y.json"
+FRED_JSON = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+# ── Series registry ───────────────────────────────────────────────────────────
+
+def test_registry_keys_are_canonical_quant_names():
+    for name, meta in reg.FRED_SERIES.items():
+        assert name in QUANT_FEATURE_ORDER, f"{name} is not a canonical quant slot"
+        assert meta["series_id"]
+        assert meta["cadence"] in ("daily", "weekly", "monthly", "event")
+
+
+def test_canonical_for_series_id_roundtrip():
+    assert reg.canonical_for_series_id("T10Y2Y") == "yield_curve_10y2y"
+    assert reg.canonical_for_series_id("NOPE") is None
+
+
+# ── Client key-gating (no network) ────────────────────────────────────────────
+
+def test_client_raises_without_key(monkeypatch):
+    monkeypatch.delenv("FRED_API_KEY", raising=False)
+    monkeypatch.delenv("FRED_API_KEY_FILE", raising=False)
+    with pytest.raises(fred_client.FredConfigError):
+        fred_client.fetch_observations("T10Y2Y")  # raises before any HTTP
+
+
+# ── Normalizer (pure) ─────────────────────────────────────────────────────────
+
+def test_normalizer_maps_and_preserves_missing_as_null():
+    rows = fred_norm.normalize_observations("yield_curve_10y2y", FRED_JSON, source_quality="fixture")
+    assert len(rows) == 5
+    by_date = {r["ts_source"][:10]: r for r in rows}
+    # numeric obs
+    good = by_date["2026-06-08"]
+    assert good["value"] == 0.52
+    assert good["null_reason"] is None
+    assert good["connector"] == "fred"
+    assert good["series_key"] == "yield_curve_10y2y"
+    assert good["source_quality"] == "fixture"
+    assert good["provenance"]["series_id"] == "T10Y2Y"
+    # missing obs ('.') → None, NOT zero
+    missing = by_date["2026-06-10"]
+    assert missing["value"] is None
+    assert missing["value"] != 0
+    assert missing["null_reason"] == "fred_missing_value"
+    assert missing["quality_flag"] == "missing"
+
+
+# ── Silver loader ─────────────────────────────────────────────────────────────
+
+def test_silver_upsert_sql_idempotent_shape():
+    assert "ON CONFLICT (connector, series_key, ts_source) DO UPDATE" in SILVER_UPSERT_SQL
+    assert "RETURNING (xmax = 0) AS inserted" in SILVER_UPSERT_SQL
+
+
+def test_silver_params_preserve_null_and_provenance():
+    rows = fred_norm.normalize_observations("yield_curve_10y2y", FRED_JSON, source_quality="fixture")
+    missing = next(r for r in rows if r["ts_source"].startswith("2026-06-10"))
+    p = silver_reading_to_params(missing)
+    assert p["value"] is None  # never coerced to 0
+    assert p["null_reason"] == "fred_missing_value"
+    assert p["source_quality"] == "fixture"
+    assert json.loads(p["provenance"])["series_id"] == "T10Y2Y"
+
+
+def test_silver_upsert_tally(fake_cursor):
+    fake_cursor.push_result([{"inserted": True}])
+    fake_cursor.push_result([{"inserted": False}])
+    rows = fred_norm.normalize_observations("yield_curve_10y2y", FRED_JSON)[:2]
+    counts = upsert_silver_readings(rows)
+    assert counts["inserted"] == 1 and counts["updated"] == 1 and counts["unavailable"] == 0
+
+
+def test_silver_upsert_unavailable(monkeypatch):
+    import app.db as appdb
+
+    monkeypatch.setattr(appdb, "get_cursor", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no db")))
+    rows = fred_norm.normalize_observations("yield_curve_10y2y", FRED_JSON)
+    counts = upsert_silver_readings(rows)
+    assert counts["unavailable"] == len(rows)
+
+
+def test_silver_upsert_skips_incomplete_rows():
+    counts = upsert_silver_readings([{"connector": "fred", "series_key": "x"}])  # no ts_source
+    assert counts["skipped"] == 1
+
+
+def test_update_pipeline_status_unavailable(monkeypatch):
+    import app.db as appdb
+
+    monkeypatch.setattr(appdb, "get_cursor", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no db")))
+    assert update_pipeline_status("fred", "yield_curve_10y2y", "fresh") is False
+
+
+# ── Cadence-aware freshness ───────────────────────────────────────────────────
+
+def test_compute_status_fresh_vs_stale_vs_unavailable():
+    now = datetime(2026, 6, 16, tzinfo=timezone.utc)
+    fresh_as_of = datetime(2026, 6, 15, tzinfo=timezone.utc)
+    stale_as_of = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    assert compute_status(fresh_as_of, now, "daily")[0] == "fresh"
+    assert compute_status(stale_as_of, now, "daily")[0] == "stale"
+    # weekly cadence tolerates a longer lag
+    assert compute_status(datetime(2026, 6, 10, tzinfo=timezone.utc), now, "weekly")[0] == "fresh"
+    assert compute_status(None, now, "daily") == ("unavailable", None)
+
+
+# ── Scope guards ──────────────────────────────────────────────────────────────
+
+def test_no_episode_embeddings_or_ade_in_fred_sources():
+    for mod in (fred_client, fred_norm, reg, fs_loader):
+        src = Path(mod.__file__).read_text(encoding="utf-8")
+        assert "episode_embeddings" not in src
+        assert "ade_connectors" not in src
+        assert "cre_source_registry" not in src

--- a/scripts/streaming/feature_store/fred_ingest.py
+++ b/scripts/streaming/feature_store/fred_ingest.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""Ingest FRED series into the History Rhymes feature store SILVER layer.
+
+DRY-RUN BY DEFAULT and rate-limit guarded (--limit) so a first live attempt never
+pulls a huge history by accident. Live behind the provisioned FRED key
+(FRED_API_KEY / FRED_API_KEY_FILE). A live failure prints and exits 0 — this is
+ops/evidence tooling, never a CI requirement.
+
+Usage:
+    python scripts/streaming/feature_store/fred_ingest.py --dry-run --limit 50
+    python scripts/streaming/feature_store/fred_ingest.py --write --limit 50
+    python scripts/streaming/feature_store/fred_ingest.py --write --series yield_curve_10y2y,hy_credit_spread
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "backend"))
+
+from app.services.hr_feature_store.connectors.fred import client, normalizer  # noqa: E402
+from app.services.hr_feature_store.connectors.fred.series_registry import (  # noqa: E402
+    CONNECTOR,
+    FRED_SERIES,
+    registered_canonical_names,
+)
+from app.services.hr_feature_store.freshness import compute_status  # noqa: E402
+from app.services.hr_feature_store.loader import (  # noqa: E402
+    update_pipeline_status,
+    upsert_silver_readings,
+)
+
+
+def _latest_as_of(rows: list[dict]) -> datetime | None:
+    stamps = [r["ts_source"] for r in rows if r.get("ts_source")]
+    if not stamps:
+        return None
+    try:
+        return max(datetime.fromisoformat(s.replace("Z", "+00:00")) for s in stamps)
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Ingest FRED series into feature-store silver")
+    parser.add_argument("--series", default="", help="csv of canonical names (default: all registered)")
+    parser.add_argument("--limit", type=int, default=50, help="max observations per series (rate-limit guard)")
+    parser.add_argument("--observation-start", default=None, help="YYYY-MM-DD")
+    parser.add_argument("--dry-run", action="store_true", help="default; build the plan, write nothing")
+    parser.add_argument("--write", action="store_true", help="actually UPSERT (default is dry-run)")
+    parser.add_argument("--source-quality", default="live", choices=["live", "fixture"])
+    args = parser.parse_args()
+
+    names = [s.strip() for s in args.series.split(",") if s.strip()] or registered_canonical_names()
+    now = datetime.now(timezone.utc)
+    summary: list[dict] = []
+
+    for name in names:
+        meta = FRED_SERIES.get(name)
+        if meta is None:
+            summary.append({"series": name, "status": "unknown_series"})
+            continue
+        try:
+            body = client.fetch_observations(
+                meta["series_id"], observation_start=args.observation_start, limit=args.limit,
+            )
+            rows = normalizer.normalize_observations(name, body, source_quality=args.source_quality)
+        except Exception as exc:  # noqa: BLE001 — live failure must not crash the run
+            summary.append({"series": name, "status": "fetch_failed", "reason": str(exc)})
+            continue
+
+        as_of = _latest_as_of(rows)
+        status, lag = compute_status(as_of, now, meta["cadence"])
+        item = {"series": name, "series_id": meta["series_id"], "rows": len(rows),
+                "freshness": status, "lag_seconds": lag}
+        if args.write:
+            counts = upsert_silver_readings(rows)
+            update_pipeline_status(
+                CONNECTOR, name, status,
+                expected_cadence=meta["cadence"],
+                as_of_ts=as_of.isoformat() if as_of else None,
+                lag_seconds=lag,
+                reason=None if status == "fresh" else f"lag {lag}s exceeds {meta['cadence']} cadence",
+            )
+            item["counts"] = counts
+        summary.append(item)
+
+    print(json.dumps({"connector": CONNECTOR, "mode": "write" if args.write else "dry-run",
+                      "limit": args.limit, "series": summary}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
B2 of the History Rhymes Feature Store: the **FRED connector** (Treasury / rates / credit series → canonical silver readings) + the silver loader, cadence-aware freshness, and a guarded ingest script. One connector per PR.

## Scope
- `connectors/fred/series_registry.py` — pinned FRED ids → canonical `QUANT_FEATURE_ORDER` names (`T10Y2Y`→yield_curve_10y2y, `DFF`→fed_funds_rate, `ACMTP10`→term_premium, `MORTGAGE30US`→mortgage_rate_30y, `BAMLH0A0HYM2`→hy_credit_spread, `BAMLC0A0CM`→ig_credit_spread); import-time guard that every key is canonical.
- `connectors/fred/client.py` — strict live `httpx` client; raises `FredConfigError` without a key (no fixture fallback in live mode); httpx imported lazily.
- `connectors/fred/normalizer.py` — pure; FRED `.` → `value=None` + `null_reason='fred_missing_value'` (never zero-imputed).
- `loader.py` — silver upsert (`ON CONFLICT(connector,series_key,ts_source) DO UPDATE … RETURNING xmax=0`) + `update_pipeline_status` (fail-soft); preserves value/null_reason/provenance.
- `freshness.py` — cadence-aware staleness (daily ≠ weekly ≠ monthly).
- `scripts/streaming/feature_store/fred_ingest.py` — `--dry-run` default, `--limit` guard, `--write`; live failure prints + exits 0.

## Explicitly out of scope
- Census/VIX/FOMC/DefiLlama connectors (one per PR)
- k8s/GKE/Confluent/BigQuery sink
- production migration apply / live ingestion in CI
- `episode_embeddings` backfill

## Tests
```
cd backend && pytest tests/test_hr_feature_store_*.py tests/test_hr_ml_demo_*.py
→ 108 passed  (12 new B2)
```
Fixtures only — **no network in any test**. Covers: registry canonicality, client key-gating (raises without a key, before any HTTP), normalizer missing→null (not 0), silver UPSERT idempotency shape + tally + unavailable + skip, `update_pipeline_status` fail-soft, and cadence-aware fresh/stale/unavailable.

## Evidence
- **Ingest dry-run (no key)** is graceful + network-free:
  ```
  $ python scripts/streaming/feature_store/fred_ingest.py --dry-run --limit 5 --series yield_curve_10y2y
  {"connector":"fred","mode":"dry-run","limit":5,"series":[
     {"series":"yield_curve_10y2y","status":"fetch_failed",
      "reason":"FRED_API_KEY not configured (set FRED_API_KEY or FRED_API_KEY_FILE)"}]}   # exit 0
  ```
- **Live**: behind the already-provisioned `winston-fred-api-key`; run `--write --limit 50` against a non-prod DB to populate `hr_fs_readings` + `hr_fs_pipeline_status`. Not run here (no live key/DB in this environment).

## Scope / stacking
- 11 files, +589/−0. Parent is `67a58f28` (B1). **Depends on #213**; base = `feat/hr-feature-store-b1-schema-materializer`.

## Next recommended ticket
**B3 — Census connector** (housing starts/permits; public, no key), same shape. Then VIX (`vix_term` nullable), FOMC text (fetch-only), DefiLlama.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
