### PR TITLE
feat(events): inline SA JSON creds for analytics dashboard BQ client

### DIFF
--- a/backend/app/services/events_analytics.py
+++ b/backend/app/services/events_analytics.py
@@ -74,8 +74,23 @@ def _view_fqn(view: str) -> str:
 
 
 def _get_bq_client():  # type: ignore[return]
-    """Lazy-import google-cloud-bigquery. Absent → ImportError (caught upstream)."""
+    """Lazy-import google-cloud-bigquery. Absent → ImportError (caught upstream).
+
+    Credential resolution, in order:
+      1. GOOGLE_APPLICATION_CREDENTIALS_JSON — inline service-account JSON. Used
+         on hosts without a persistent filesystem to drop a key file (Railway),
+         where the read-only dashboard reads the prod analytics views.
+      2. Application Default Credentials — GOOGLE_APPLICATION_CREDENTIALS file
+         path (local dev), or Workload Identity (GKE). Unchanged default.
+    """
     from google.cloud import bigquery  # noqa: PLC0415
+
+    inline = _clean(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", ""))
+    if inline:
+        import json  # noqa: PLC0415
+        from google.oauth2 import service_account  # noqa: PLC0415
+        creds = service_account.Credentials.from_service_account_info(json.loads(inline))
+        return bigquery.Client(project=BQ_PROJECT_ID, credentials=creds)
     return bigquery.Client(project=BQ_PROJECT_ID)
 
 

--- a/backend/tests/test_events_analytics.py
+++ b/backend/tests/test_events_analytics.py
@@ -7,6 +7,7 @@ the structural guarantee that this surface cannot read the raw events table.
 
 from __future__ import annotations
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -87,6 +88,68 @@ def test_view_fqn_rejects_raw_table():
         svc._view_fqn("events")  # the raw table name
     with pytest.raises(ValueError):
         svc._view_fqn("winston_events_raw.events")
+
+
+# ── credential resolution: inline JSON (Railway) vs ADC default ──────────────
+
+def test_bq_client_uses_inline_json_credentials_when_set():
+    """On a host without a key file (Railway), inline SA JSON builds the client."""
+    captured = {}
+
+    class _FakeCreds:
+        pass
+
+    class _FakeSAModule:
+        class Credentials:
+            @staticmethod
+            def from_service_account_info(info):
+                captured["info"] = info
+                return _FakeCreds()
+
+    class _FakeBQ:
+        class Client:
+            def __init__(self, project=None, credentials=None):
+                captured["project"] = project
+                captured["credentials"] = credentials
+
+    import sys
+    inline = '{"type":"service_account","project_id":"novendor-events-prod","client_email":"x@y.iam"}'
+    with patch.object(svc, "BQ_PROJECT_ID", "novendor-events-prod"), \
+         patch.dict(os.environ, {"GOOGLE_APPLICATION_CREDENTIALS_JSON": inline}), \
+         patch.dict(sys.modules, {
+             "google.cloud": type(sys)("google.cloud"),
+             "google.oauth2": type(sys)("google.oauth2"),
+         }):
+        sys.modules["google.cloud"].bigquery = _FakeBQ  # type: ignore[attr-defined]
+        sys.modules["google.oauth2"].service_account = _FakeSAModule  # type: ignore[attr-defined]
+        svc._get_bq_client()
+
+    assert captured["project"] == "novendor-events-prod"
+    assert isinstance(captured["credentials"], _FakeCreds)
+    assert captured["info"]["project_id"] == "novendor-events-prod"
+
+
+def test_bq_client_falls_back_to_adc_without_inline_json():
+    """No inline JSON → plain Client(project=...) (ADC / key-file / Workload Identity)."""
+    captured = {}
+
+    class _FakeBQ:
+        class Client:
+            def __init__(self, project=None, credentials=None):
+                captured["project"] = project
+                captured["credentials"] = credentials
+
+    import sys
+    env = dict(os.environ)
+    env.pop("GOOGLE_APPLICATION_CREDENTIALS_JSON", None)
+    with patch.object(svc, "BQ_PROJECT_ID", "p"), \
+         patch.dict(os.environ, env, clear=True), \
+         patch.dict(sys.modules, {"google.cloud": type(sys)("google.cloud")}):
+        sys.modules["google.cloud"].bigquery = _FakeBQ  # type: ignore[attr-defined]
+        svc._get_bq_client()
+
+    assert captured["project"] == "p"
+    assert captured["credentials"] is None  # ADC path, no explicit creds
 
 
 def test_happy_path_payload_shape_with_mocked_client():


### PR DESCRIPTION
## Summary

Lets the Event Analytics dashboard service authenticate to BigQuery on a host without a key file on disk (Railway — where the prod backend serves the read-only dashboard from `novendor-events-prod`). Resolves credentials from inline `GOOGLE_APPLICATION_CREDENTIALS_JSON` via `service_account.Credentials.from_service_account_info`, falling back to ADC (file path / Workload Identity) unchanged when absent.

Needed because the prod backend (Railway) has no persistent filesystem to drop a service-account key, and the dashboard's `bigquery.Client()` otherwise relies on a `GOOGLE_APPLICATION_CREDENTIALS` file path.

- Read-only; no new BQ views; still reads only allowlisted analytics views (the `_view_fqn` guard is untouched).
- ADC default unchanged — local dev + GKE Workload Identity behave exactly as before.

## Tests

- 10 `test_events_analytics.py` pass (8 prior + 2 new: inline-JSON builds client with explicit creds; absent → plain ADC client).
- `ruff` clean.

## Context

Part of wiring `novendor.ai/app/event-analytics` to serve real data from the prod analytics project `novendor-events-prod` (which now holds real HR-signal events via the prod sink path). This PR is the one code change needed; the rest is prod env/deploy config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)