### PR TITLE
Phase 5 PR 14: Mission Control (full-bleed ops wall, pure composition)

### DIFF
--- a/repo-b/src/app/app/page.tsx
+++ b/repo-b/src/app/app/page.tsx
@@ -21,6 +21,12 @@ import {
   type IntelCard,
   type AgentType,
 } from "@/lib/intelligence/cards";
+import {
+  deriveEnvironmentStatus,
+  statusToneColor,
+  type EnvStatus,
+} from "@/lib/intelligence/envStatus";
+import { AgentPills, AGENT_PILL_TYPES } from "@/components/intelligence/AgentPills";
 import { cn } from "@/lib/cn";
 import {
   environmentCatalog,
@@ -72,109 +78,6 @@ function dashboardSourceRef(envId: string) {
 // ── Agent pills: deterministic role lenses (PR 13). Click to filter the feed to that
 // agent's cards; the count is the agent's cards already in the feed. Run-now lives in the
 // header "Run agents" button. Disabled (no handler) until an env+tenant is resolved.
-const AGENT_PILLS = [
-  { type: "cfo", label: "CFO", glow: ACTION_TEAL },
-  { type: "operations", label: "Operations", glow: "107, 174, 127" },
-  { type: "data_quality", label: "Data Quality", glow: "176, 64, 255" },
-  { type: "risk", label: "Risk", glow: "209, 161, 91" },
-] as const satisfies ReadonlyArray<{ type: AgentType; label: string; glow: string }>;
-
-function AgentPills({
-  activeFilter,
-  counts,
-  onToggle,
-}: {
-  activeFilter: AgentType | null;
-  counts: Record<AgentType, number>;
-  onToggle: ((agent: AgentType) => void) | null; // null => disabled (no env/tenant)
-}) {
-  return (
-    <div className="flex flex-wrap items-center gap-2" aria-label="Agents">
-      <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/35">
-        Agents
-      </span>
-      {AGENT_PILLS.map((agent) => {
-        const active = activeFilter === agent.type;
-        const count = counts[agent.type] ?? 0;
-        const disabled = !onToggle;
-        return (
-          <button
-            key={agent.type}
-            type="button"
-            aria-pressed={active}
-            disabled={disabled}
-            title={disabled ? "Select an environment to run agents" : `Filter the feed to ${agent.label} cards`}
-            onClick={() => onToggle?.(agent.type)}
-            className="inline-flex shrink-0 items-center gap-2 rounded-full border px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] transition-colors disabled:cursor-default disabled:opacity-50"
-            style={{
-              borderColor: `rgba(${agent.glow}, ${active ? 0.55 : 0.22})`,
-              background: `rgba(${agent.glow}, ${active ? 0.16 : 0.06})`,
-              color: active ? "#fff" : "rgba(255,255,255,0.55)",
-            }}
-          >
-            <span className="h-1.5 w-1.5 rounded-full" style={{ background: `rgba(${agent.glow}, 0.8)` }} />
-            {agent.label}
-            {count > 0 ? <span className="text-white/70">{count}</span> : null}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-// ── Derived environment status (PR 5) ─────────────────────────────────────────
-// Honest, derived from KNOWN client-side fields only. No invented health_score,
-// no numeric percentage. promotion_state is NOT available on the client Environment
-// type, so its branches are forward-compat and unreachable this PR — we never fetch it.
-type EnvStatusTone = "teal" | "amber" | "muted";
-type EnvStatus = { label: string; tone: EnvStatusTone; reason: string | null };
-
-const PROMO_DEGRADED = new Set(["degraded", "blocked", "failed", "error", "broken"]);
-const PROMO_PENDING = new Set(["pending", "draft", "in_progress", "provisioning", "queued"]);
-
-function deriveEnvironmentStatus(
-  env: Environment | null,
-  anomalyCount: number,
-  bizId: string | null,
-  promotionState?: string | null, // omitted by callers — forward-compat only
-): EnvStatus {
-  if (!env) {
-    return { label: "Status unavailable", tone: "muted", reason: "No environment selected." };
-  }
-  if (typeof env.is_active !== "boolean" || !env.env_id) {
-    return { label: "Status unavailable", tone: "muted", reason: "Required environment fields not loaded." };
-  }
-  // Inactive wins: a dead env's signals are moot.
-  if (env.is_active === false) {
-    return { label: "Inactive", tone: "amber", reason: null };
-  }
-  // Forward-compat (unreachable now — promotionState is always undefined).
-  const ps = promotionState?.toLowerCase();
-  if (ps && PROMO_DEGRADED.has(ps)) {
-    return { label: "Needs attention", tone: "amber", reason: `Promotion state: ${promotionState}` };
-  }
-  // No tenant → intelligence cannot be scoped → fail closed (never use the default tenant).
-  if (!bizId) {
-    return {
-      label: "Status unavailable",
-      tone: "muted",
-      reason: "No tenant (business_id) resolved; intelligence cannot be scoped.",
-    };
-  }
-  // The real signal this PR ships: open anomaly cards for the scoped env.
-  if (anomalyCount > 0) {
-    return {
-      label: "Needs attention",
-      tone: "amber",
-      reason: `${anomalyCount} open anomaly card${anomalyCount === 1 ? "" : "s"}.`,
-    };
-  }
-  if (ps && PROMO_PENDING.has(ps)) {
-    return { label: "In progress", tone: "teal", reason: `Promotion state: ${promotionState}` };
-  }
-  return { label: "Healthy", tone: "teal", reason: "Derived from active state and open cards. Promotion state not loaded." };
-}
-
 // ── Intelligence feed hook (PR 5) ─────────────────────────────────────────────
 // Binds to the SELECTED environment (never hover). Fails closed when there is no
 // real business_id — never falls back to the cards.ts default tenant.
@@ -527,12 +430,6 @@ function EnvironmentStatusPanel({
   );
 }
 
-function statusToneColor(tone: EnvStatusTone): string {
-  if (tone === "amber") return "rgba(209, 161, 91, 0.95)";
-  if (tone === "teal") return "rgba(140, 200, 158, 0.95)";
-  return "rgba(255,255,255,0.55)";
-}
-
 function SidePanelRow({
   label,
   value,
@@ -609,7 +506,7 @@ function AppIndexPageInner() {
   const agentCounts = useMemo(() => {
     const counts: Record<AgentType, number> = { cfo: 0, operations: 0, data_quality: 0, risk: 0 };
     for (const card of feed.cards) {
-      for (const t of ["cfo", "operations", "data_quality", "risk"] as AgentType[]) {
+      for (const t of AGENT_PILL_TYPES) {
         if (card.created_by === agentCreatedBy(t)) counts[t] += 1;
       }
     }

--- a/repo-b/src/app/lab/env/[envId]/mission-control/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/mission-control/page.tsx
@@ -1,0 +1,13 @@
+// Full-bleed Mission Control wall. The lab shell yields full-bleed for /mission-control
+// (added to isDomainRoute), and MissionControlWall carries the RS dark palette inline, so
+// no theme pinning is needed here. Composition only — no new backend.
+import MissionControlWall from "@/components/mission-control/MissionControlWall";
+
+export default async function MissionControlPage({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  return <MissionControlWall envId={envId} />;
+}

--- a/repo-b/src/components/intelligence/AgentPills.tsx
+++ b/repo-b/src/components/intelligence/AgentPills.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+// Agent pills (PR 13; extracted in PR 14 for reuse on the Mission Control wall).
+// Deterministic role lenses: click a pill to filter the feed to that agent's cards; the
+// count is the agent's cards already in the feed. Disabled (no handler) until an env+tenant
+// resolves. Pure presentational — no run logic here (run-now lives in the home header).
+import type { AgentType } from "@/lib/intelligence/cards";
+
+// Action teal kept local so this component carries no cross-file constant dependency.
+const ACTION_TEAL = "92, 213, 204";
+
+export const AGENT_PILLS = [
+  { type: "cfo", label: "CFO", glow: ACTION_TEAL },
+  { type: "operations", label: "Operations", glow: "107, 174, 127" },
+  { type: "data_quality", label: "Data Quality", glow: "176, 64, 255" },
+  { type: "risk", label: "Risk", glow: "209, 161, 91" },
+] as const satisfies ReadonlyArray<{ type: AgentType; label: string; glow: string }>;
+
+// The agent types in display order — for deriving per-agent counts from card.created_by.
+export const AGENT_PILL_TYPES: AgentType[] = AGENT_PILLS.map((a) => a.type);
+
+export function AgentPills({
+  activeFilter,
+  counts,
+  onToggle,
+}: {
+  activeFilter: AgentType | null;
+  counts: Record<AgentType, number>;
+  onToggle: ((agent: AgentType) => void) | null; // null => disabled (no env/tenant)
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2" aria-label="Agents">
+      <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/35">
+        Agents
+      </span>
+      {AGENT_PILLS.map((agent) => {
+        const active = activeFilter === agent.type;
+        const count = counts[agent.type] ?? 0;
+        const disabled = !onToggle;
+        return (
+          <button
+            key={agent.type}
+            type="button"
+            aria-pressed={active}
+            disabled={disabled}
+            title={disabled ? "Select an environment to run agents" : `Filter the feed to ${agent.label} cards`}
+            onClick={() => onToggle?.(agent.type)}
+            className="inline-flex shrink-0 items-center gap-2 rounded-full border px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] transition-colors disabled:cursor-default disabled:opacity-50"
+            style={{
+              borderColor: `rgba(${agent.glow}, ${active ? 0.55 : 0.22})`,
+              background: `rgba(${agent.glow}, ${active ? 0.16 : 0.06})`,
+              color: active ? "#fff" : "rgba(255,255,255,0.55)",
+            }}
+          >
+            <span className="h-1.5 w-1.5 rounded-full" style={{ background: `rgba(${agent.glow}, 0.8)` }} />
+            {agent.label}
+            {count > 0 ? <span className="text-white/70">{count}</span> : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/repo-b/src/components/lab/LabEnvironmentShell.tsx
+++ b/repo-b/src/components/lab/LabEnvironmentShell.tsx
@@ -164,7 +164,7 @@ export default function LabEnvironmentShell({ envId, children }: Props) {
     };
   }, [mobileSidebarOpen]);
 
-  const isDomainRoute = new RegExp(`^/lab/env/${envId}/(re|pds|credit|legal|medical|consulting|operator|opportunity-engine|ecc|demo|documents|definitions|resume|markets|trading|ncf|supply-chain|investment-engine|altered-mind|telemetry|healthcare-subscription|automated-data-engineering|historyrhymes)(/|$)`).test(pathname);
+  const isDomainRoute = new RegExp(`^/lab/env/${envId}/(re|pds|credit|legal|medical|consulting|operator|opportunity-engine|ecc|demo|documents|definitions|resume|markets|trading|ncf|supply-chain|investment-engine|altered-mind|telemetry|healthcare-subscription|automated-data-engineering|historyrhymes|mission-control)(/|$)`).test(pathname);
   const homeHref = `/lab/env/${envId}`;
   if (isDomainRoute) {
     return <div className="min-h-screen bg-bm-bg">{children}</div>;

--- a/repo-b/src/components/mission-control/MissionControlWall.test.ts
+++ b/repo-b/src/components/mission-control/MissionControlWall.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from "vitest";
+
+import { isDemoTelemetryEnv } from "./MissionControlWall";
+import { deriveEnvironmentStatus } from "@/lib/intelligence/envStatus";
+import type { Environment } from "@/components/EnvProvider";
+
+// Mission Control composes existing state and FAILS CLOSED. Two load-bearing decisions are
+// pure and testable: the live-telemetry gate (only the demo env gets a real feed) and the
+// status wall's categorical derivation (no fabricated "Needs attention" off un-fetched data).
+
+function env(partial: Partial<Environment>): Environment {
+  return {
+    env_id: "e1",
+    client_name: "Env One",
+    industry: "general",
+    is_active: true,
+    business_id: "biz-1",
+    ...partial,
+  } as Environment;
+}
+
+describe("isDemoTelemetryEnv (live-telemetry gate)", () => {
+  test("true only for the telemetry demo env (by slug)", () => {
+    expect(isDemoTelemetryEnv(env({ industry: "telemetry", slug: "telemetry-demo" }))).toBe(true);
+  });
+
+  test("false for a telemetry env that is not the demo env", () => {
+    expect(isDemoTelemetryEnv(env({ industry: "telemetry", slug: "some-other-env" }))).toBe(false);
+  });
+
+  test("false for a non-telemetry env, and for null", () => {
+    expect(isDemoTelemetryEnv(env({ industry: "consulting" }))).toBe(false);
+    expect(isDemoTelemetryEnv(null)).toBe(false);
+  });
+});
+
+describe("deriveEnvironmentStatus (status wall, extracted from home)", () => {
+  test("route env with open anomalies => Needs attention", () => {
+    const s = deriveEnvironmentStatus(env({}), 2, "biz-1");
+    expect(s.label).toBe("Needs attention");
+    expect(s.tone).toBe("amber");
+  });
+
+  test("active env with zero anomalies => Healthy (non-route envs pass 0, never fabricated)", () => {
+    const s = deriveEnvironmentStatus(env({}), 0, "biz-1");
+    expect(s.label).toBe("Healthy");
+  });
+
+  test("inactive env => Inactive", () => {
+    expect(deriveEnvironmentStatus(env({ is_active: false }), 0, "biz-1").label).toBe("Inactive");
+  });
+
+  test("no tenant => Status unavailable (never scoped to the default tenant)", () => {
+    expect(deriveEnvironmentStatus(env({}), 0, null).label).toBe("Status unavailable");
+  });
+
+  test("null env => Status unavailable", () => {
+    expect(deriveEnvironmentStatus(null, 0, "biz-1").label).toBe("Status unavailable");
+  });
+});

--- a/repo-b/src/components/mission-control/MissionControlWall.tsx
+++ b/repo-b/src/components/mission-control/MissionControlWall.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+// Mission Control — a full-bleed operational wall that COMPOSES existing platform state
+// (live telemetry, intelligence cards/findings/reels, role agents, environment status) for
+// one environment. It adds NO new intelligence: no analyzers, no agent runs, no LLM, no
+// warehouse, no fabricated telemetry or health scores. Every column fails closed with a
+// stated reason when its source is unavailable.
+//
+// Visual language: the telemetry cockpit's RS palette (rsTokens) — not designed from scratch.
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+
+import { useEnv, type Environment } from "@/components/EnvProvider";
+import MissionControlStream from "@/components/telemetry/MissionControlStream";
+import { RS, RS_MONO, RS_SANS, RsChip, RsPanel } from "@/components/telemetry/rsTokens";
+import IntelligenceCardFeed from "@/components/intelligence/IntelligenceCardFeed";
+import { AgentPills, AGENT_PILL_TYPES } from "@/components/intelligence/AgentPills";
+import { getCards, agentCreatedBy, type AgentType, type IntelCard } from "@/lib/intelligence/cards";
+import { deriveEnvironmentStatus, statusToneColor } from "@/lib/intelligence/envStatus";
+import { isTelemetryEnvironment } from "@/components/lab/environments/constants";
+import { TELEMETRY_DEMO_ENV_ID } from "@/lib/telemetry/api";
+
+// The live stream source is bound to the telemetry demo env only (MissionControlStream
+// hardcodes TELEMETRY_DEMO_ENV_ID). For any other env we fail closed rather than fake a feed.
+export function isDemoTelemetryEnv(env: Environment | null): boolean {
+  if (!env) return false;
+  return (
+    isTelemetryEnvironment(env.industry) &&
+    (env.slug === TELEMETRY_DEMO_ENV_ID || env.env_id === TELEMETRY_DEMO_ENV_ID)
+  );
+}
+
+type FeedState = {
+  cards: IntelCard[];
+  loading: boolean;
+  error: string | null;
+  nullReason: string | null;
+};
+
+const EMPTY_COUNTS: Record<AgentType, number> = { cfo: 0, operations: 0, data_quality: 0, risk: 0 };
+
+export default function MissionControlWall({ envId }: { envId: string }) {
+  const { environments } = useEnv();
+  const routeEnv = useMemo(
+    () => environments.find((e) => e.env_id === envId || e.slug === envId) ?? null,
+    [environments, envId],
+  );
+  const bizId = routeEnv?.business_id ?? null;
+
+  // ── Intelligence Center: the route env's cards (read-only; never the default tenant) ──
+  const [feed, setFeed] = useState<FeedState>({ cards: [], loading: false, error: null, nullReason: null });
+  const [agentFilter, setAgentFilter] = useState<AgentType | null>(null);
+
+  useEffect(() => {
+    if (!routeEnv || !bizId) {
+      setFeed({ cards: [], loading: false, error: null, nullReason: routeEnv ? "missing_business_id" : null });
+      return;
+    }
+    let cancelled = false;
+    setFeed((s) => ({ ...s, loading: true, error: null, nullReason: null }));
+    getCards(routeEnv.env_id, { biz: bizId, limit: 50 })
+      .then(({ cards, null_reason }) => {
+        if (!cancelled) setFeed({ cards, loading: false, error: null, nullReason: null_reason ?? null });
+      })
+      .catch((cause) => {
+        if (!cancelled) {
+          setFeed({
+            cards: [], loading: false,
+            error: cause instanceof Error ? cause.message : "Failed to load intelligence",
+            nullReason: null,
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [routeEnv, bizId]);
+
+  const anomalyCount = useMemo(
+    () => feed.cards.filter((c) => c.anomaly_flag && !c.is_dismissed).length,
+    [feed.cards],
+  );
+
+  const agentCounts = useMemo(() => {
+    const counts: Record<AgentType, number> = { ...EMPTY_COUNTS };
+    for (const c of feed.cards) {
+      for (const t of AGENT_PILL_TYPES) if (c.created_by === agentCreatedBy(t)) counts[t] += 1;
+    }
+    return counts;
+  }, [feed.cards]);
+
+  const visibleCards = useMemo(
+    () => (agentFilter ? feed.cards.filter((c) => c.created_by === agentCreatedBy(agentFilter)) : feed.cards),
+    [feed.cards, agentFilter],
+  );
+
+  const onToggleAgent = useCallback((agent: AgentType) => {
+    setAgentFilter((cur) => (cur === agent ? null : agent));
+  }, []);
+
+  // ── Fullscreen toggle: Spacebar toggles, Escape exits — never while typing. ──
+  const [fullscreen, setFullscreen] = useState(false);
+  useEffect(() => {
+    function isTyping(): boolean {
+      const el = document.activeElement as HTMLElement | null;
+      if (!el) return false;
+      const tag = el.tagName;
+      return tag === "INPUT" || tag === "TEXTAREA" || el.isContentEditable;
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.code === "Space" && !isTyping()) {
+        e.preventDefault(); // stop page scroll
+        setFullscreen((v) => !v);
+      } else if (e.key === "Escape") {
+        setFullscreen(false);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  return (
+    <div
+      style={{
+        background: RS.bg,
+        color: RS.text,
+        fontFamily: RS_SANS,
+        minHeight: "100vh",
+        padding: 12,
+        position: fullscreen ? "fixed" : "relative",
+        inset: fullscreen ? 0 : undefined,
+        zIndex: fullscreen ? 60 : undefined,
+        overflow: fullscreen ? "auto" : undefined,
+      }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between" style={{ marginBottom: 12 }}>
+        <div className="flex items-baseline gap-3">
+          <span style={{ fontFamily: RS_MONO, fontSize: 13, letterSpacing: "0.18em", color: RS.text }}>
+            MISSION CONTROL
+          </span>
+          <span style={{ fontFamily: RS_MONO, fontSize: 11, color: RS.faint }}>
+            {routeEnv?.client_name || routeEnv?.env_id || envId}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <RsChip color={RS.dim}>{fullscreen ? "ESC TO EXIT" : "SPACE FOR WALL"}</RsChip>
+          <Link
+            href="/app"
+            style={{ fontFamily: RS_MONO, fontSize: 11, color: RS.dim, textDecoration: "none" }}
+          >
+            Open Home →
+          </Link>
+        </div>
+      </div>
+
+      {/* 3-column grid — stacks on small screens */}
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)_minmax(0,0.9fr)]">
+        {/* Column 1 — Live Telemetry */}
+        <div>
+          {isDemoTelemetryEnv(routeEnv) ? (
+            <MissionControlStream />
+          ) : (
+            <RsPanel title="LIVE TELEMETRY">
+              <div style={{ padding: 16 }}>
+                <div style={{ fontFamily: RS_MONO, fontSize: 13, color: RS.amber }}>
+                  Live telemetry unavailable for this environment
+                </div>
+                <div style={{ fontFamily: RS_SANS, fontSize: 12, color: RS.dim, marginTop: 6 }}>
+                  The live stream source is bound to the telemetry demo environment only. No
+                  synthetic feed is shown.
+                </div>
+              </div>
+            </RsPanel>
+          )}
+        </div>
+
+        {/* Column 2 — Intelligence Center */}
+        <div className="flex flex-col gap-3">
+          <RsPanel title="INTELLIGENCE CENTER">
+            <div style={{ padding: 12 }}>
+              <div style={{ marginBottom: 10 }}>
+                <AgentPills
+                  activeFilter={agentFilter}
+                  counts={agentCounts}
+                  onToggle={routeEnv && bizId ? onToggleAgent : null}
+                />
+              </div>
+              <IntelligenceCardFeed
+                cards={visibleCards}
+                loading={feed.loading}
+                error={feed.error}
+                nullReason={feed.nullReason}
+              />
+            </div>
+          </RsPanel>
+        </div>
+
+        {/* Column 3 — Environment Status Wall */}
+        <div>
+          <EnvironmentStatusWall
+            environments={environments}
+            routeEnvId={routeEnv?.env_id ?? null}
+            routeAnomalyCount={anomalyCount}
+          />
+        </div>
+      </div>
+
+      {/* Footer ticker — recent card/agent/reel/anomaly activity for this env */}
+      <ActivityTicker cards={feed.cards} loading={feed.loading} nullReason={feed.nullReason} />
+    </div>
+  );
+}
+
+// ── Environment Status Wall ───────────────────────────────────────────────────
+// Derived CATEGORICAL status only. For the route env we have real anomaly counts (from its
+// fetched cards); for other envs we derive from is_active/business_id presence — never a
+// fabricated "Needs attention" from data we didn't fetch. No health_score, no percentage.
+function EnvironmentStatusWall({
+  environments,
+  routeEnvId,
+  routeAnomalyCount,
+}: {
+  environments: Environment[];
+  routeEnvId: string | null;
+  routeAnomalyCount: number;
+}) {
+  return (
+    <RsPanel title="ENVIRONMENT STATUS">
+      <div style={{ padding: 10, display: "flex", flexDirection: "column", gap: 6 }}>
+        {environments.length === 0 ? (
+          <div style={{ fontFamily: RS_SANS, fontSize: 12, color: RS.dim, padding: 8 }}>
+            No environments resolved.
+          </div>
+        ) : (
+          environments.map((env) => {
+            const isRoute = env.env_id === routeEnvId;
+            // Only the route env carries a real anomaly count; others pass 0 (their cards
+            // were not fetched) so they never get a fabricated "Needs attention".
+            const status = deriveEnvironmentStatus(
+              env,
+              isRoute ? routeAnomalyCount : 0,
+              env.business_id ?? null,
+            );
+            const color = statusToneColor(status.tone);
+            return (
+              <div
+                key={env.env_id}
+                className="flex items-center justify-between gap-3"
+                style={{
+                  background: isRoute ? RS.panelAlt : RS.panel,
+                  border: `1px solid ${isRoute ? color : RS.line}`,
+                  borderRadius: 6,
+                  padding: "8px 10px",
+                }}
+              >
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ fontFamily: RS_SANS, fontSize: 12, color: RS.text }} className="truncate">
+                    {env.client_name || env.env_id}
+                  </div>
+                  {status.reason ? (
+                    <div style={{ fontFamily: RS_SANS, fontSize: 10, color: RS.faint }} className="truncate">
+                      {status.reason}
+                    </div>
+                  ) : null}
+                </div>
+                <span
+                  style={{
+                    fontFamily: RS_MONO, fontSize: 10, letterSpacing: "0.06em", whiteSpace: "nowrap",
+                    color, background: color.replace("0.95", "0.12").replace(")", ")"),
+                    border: `1px solid ${color}`, borderRadius: 4, padding: "2px 7px",
+                  }}
+                >
+                  {status.label}
+                </span>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </RsPanel>
+  );
+}
+
+// ── Footer activity ticker ────────────────────────────────────────────────────
+// Real platform activity from the env's cards (newest first). Fails closed to an explicit
+// "Activity feed unavailable" rather than a silently empty bar.
+function ActivityTicker({
+  cards,
+  loading,
+  nullReason,
+}: {
+  cards: IntelCard[];
+  loading: boolean;
+  nullReason: string | null;
+}) {
+  const items = useMemo(() => {
+    return [...cards]
+      .sort((a, b) => (b.last_updated_at || "").localeCompare(a.last_updated_at || ""))
+      .slice(0, 12);
+  }, [cards]);
+
+  const unavailable = !loading && items.length === 0;
+
+  return (
+    <div
+      style={{
+        marginTop: 12, background: RS.panel, border: `1px solid ${RS.line}`, borderRadius: 6,
+        padding: "8px 12px", display: "flex", alignItems: "center", gap: 14, overflowX: "auto",
+      }}
+    >
+      <span style={{ fontFamily: RS_MONO, fontSize: 10, letterSpacing: "0.12em", color: RS.faint, whiteSpace: "nowrap" }}>
+        ACTIVITY
+      </span>
+      {unavailable ? (
+        <span style={{ fontFamily: RS_SANS, fontSize: 12, color: RS.dim }}>
+          {nullReason ? `Activity feed unavailable — ${nullReason}` : "Activity feed unavailable"}
+        </span>
+      ) : (
+        items.map((c) => (
+          <span key={c.id} className="flex items-center gap-2" style={{ whiteSpace: "nowrap" }}>
+            <span
+              style={{
+                height: 6, width: 6, borderRadius: 9999,
+                background: c.anomaly_flag ? RS.red : RS.teal, display: "inline-block",
+              }}
+            />
+            <span style={{ fontFamily: RS_SANS, fontSize: 12, color: RS.dim }} className="truncate">
+              {c.title}
+            </span>
+          </span>
+        ))
+      )}
+    </div>
+  );
+}

--- a/repo-b/src/lib/intelligence/envStatus.ts
+++ b/repo-b/src/lib/intelligence/envStatus.ts
@@ -1,0 +1,60 @@
+// Derived environment status (PR 5; extracted in PR 14 for reuse on the Mission Control wall).
+// Honest, derived from KNOWN client-side fields only. No invented health_score, no numeric
+// percentage. promotion_state is NOT available on the client Environment type, so its branches
+// are forward-compat and unreachable today — we never fetch it.
+import type { Environment } from "@/components/EnvProvider";
+
+export type EnvStatusTone = "teal" | "amber" | "muted";
+export type EnvStatus = { label: string; tone: EnvStatusTone; reason: string | null };
+
+const PROMO_DEGRADED = new Set(["degraded", "blocked", "failed", "error", "broken"]);
+const PROMO_PENDING = new Set(["pending", "draft", "in_progress", "provisioning", "queued"]);
+
+export function deriveEnvironmentStatus(
+  env: Environment | null,
+  anomalyCount: number,
+  bizId: string | null,
+  promotionState?: string | null, // omitted by callers — forward-compat only
+): EnvStatus {
+  if (!env) {
+    return { label: "Status unavailable", tone: "muted", reason: "No environment selected." };
+  }
+  if (typeof env.is_active !== "boolean" || !env.env_id) {
+    return { label: "Status unavailable", tone: "muted", reason: "Required environment fields not loaded." };
+  }
+  // Inactive wins: a dead env's signals are moot.
+  if (env.is_active === false) {
+    return { label: "Inactive", tone: "amber", reason: null };
+  }
+  // Forward-compat (unreachable now — promotionState is always undefined).
+  const ps = promotionState?.toLowerCase();
+  if (ps && PROMO_DEGRADED.has(ps)) {
+    return { label: "Needs attention", tone: "amber", reason: `Promotion state: ${promotionState}` };
+  }
+  // No tenant → intelligence cannot be scoped → fail closed (never use the default tenant).
+  if (!bizId) {
+    return {
+      label: "Status unavailable",
+      tone: "muted",
+      reason: "No tenant (business_id) resolved; intelligence cannot be scoped.",
+    };
+  }
+  // The real signal this ships: open anomaly cards for the scoped env.
+  if (anomalyCount > 0) {
+    return {
+      label: "Needs attention",
+      tone: "amber",
+      reason: `${anomalyCount} open anomaly card${anomalyCount === 1 ? "" : "s"}.`,
+    };
+  }
+  if (ps && PROMO_PENDING.has(ps)) {
+    return { label: "In progress", tone: "teal", reason: `Promotion state: ${promotionState}` };
+  }
+  return { label: "Healthy", tone: "teal", reason: "Derived from active state and open cards. Promotion state not loaded." };
+}
+
+export function statusToneColor(tone: EnvStatusTone): string {
+  if (tone === "amber") return "rgba(209, 161, 91, 0.95)";
+  if (tone === "teal") return "rgba(140, 200, 158, 0.95)";
+  return "rgba(255,255,255,0.55)";
+}


### PR DESCRIPTION
## Summary

Phase 5 / PR 14 — **Mission Control**: a full-bleed operational wall that **composes existing platform state** for one environment. It adds **no new intelligence** — no analyzers, no agent runs, no LLM, no warehouse, no migration, **zero backend change**. Route: `/lab/env/[envId]/mission-control`. Visual language reuses the telemetry cockpit's RS palette (not designed from scratch).

## Layout (3 columns + ticker)

- **Col 1 — Live Telemetry:** reuses `MissionControlStream` **verbatim**, but **gated** — rendered only for the telemetry demo env (the stream source is hardcoded to it). Any other env shows *"Live telemetry unavailable for this environment"* — never a fake feed.
- **Col 2 — Intelligence Center:** the route env's cards (`getCards`) → `IntelligenceCardFeed`, with `AgentPills` as a **read-only feed filter** (no run buttons in MC). Agent status/counts derived from `created_by` tags.
- **Col 3 — Environment Status Wall:** derived **categorical** status only via the extracted `deriveEnvironmentStatus`. *"Needs attention"* is assigned **only to the route env** (whose anomaly cards were actually fetched); other envs show `is_active`-derived categories — never a fabricated alert. **No health_score, no percentage.**
- **Footer ticker:** the env's recent card activity, fail-closed to *"Activity feed unavailable"* (no silently empty bar).

## Controls

Spacebar toggles the fullscreen wall **only when not typing** (input/textarea/contenteditable guard, `preventDefault` to stop scroll); Escape exits. Local listener, scoped to the route.

## Extractions (shared, no behavior change)

- `lib/intelligence/envStatus.ts` — `deriveEnvironmentStatus` + types + `statusToneColor` (was private in `app/page.tsx`).
- `components/intelligence/AgentPills.tsx` — the pill strip (was inline). Home re-imports both; behavior identical.

## Honesty / exclusions

No new analyzer/agent/LLM/warehouse/migration. `bizId` from the route env's `business_id` (never the cards.ts default tenant). Fail-closed at every source: no tenant → feed unavailable; `getCards` null_reason/throw → empty/error state; non-demo env → live telemetry unavailable.

## Scope note

The footer ticker uses the env's **card activity** rather than a raw audit-events feed: the backend audit endpoint is `/api/audit/events?business_id=` (no existing frontend proxy, scoped by business_id not env). Building the ticker from cards I already fetch keeps PR 14 a **pure composition with zero backend/zero new proxy**, as scoped. A dedicated audit-events proxy can be a follow-up if desired.

## Tests & checks

8 tests: `isDemoTelemetryEnv` gate (demo-only by slug/env_id, fail-closed otherwise) + `deriveEnvironmentStatus` categories (proves the extraction preserved behavior). `tsc` 0; `eslint`/`next lint` clean (RS inline-style pattern matches the telemetry cockpit). No backend touched → no backend tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
