### PR TITLE
feat(history-rhymes): ship episode feature store phase 0

### DIFF
--- a/backend/app/connectors/cre/fred_rates/fetch.py
+++ b/backend/app/connectors/cre/fred_rates/fetch.py
@@ -51,3 +51,105 @@ def fetch(context: ConnectorContext) -> dict:
 
     log.info("FRED fetch: %d rows", len(rows))
     return {"period": date.today().isoformat(), "rows": rows}
+
+
+# ── Historical series fetch (History Rhymes Episode Feature Store, ticket 0.2) ──
+# The connector `fetch()` above pulls a fixed recent window for the CRE pipeline.
+# The episode builder needs arbitrary historical windows for specific series, so
+# this helper exposes a date-windowed, multi-series pull. It is best-effort: with
+# no FRED_API_KEY it returns {} (the builder then fails closed per feature/target).
+
+# Series the episode feature store can request. FRED has deep history for the
+# treasury/macro series; SP500 (price index) only goes back ~10y on FRED, so
+# targets for older episodes fail closed live and are exercised via fixtures.
+HR_FRED_SERIES = (
+    "DGS10", "DGS2", "FEDFUNDS", "BAMLC0A0CM",
+    "UNRATE", "HOUST", "USREC", "SP500",
+)
+
+
+def fetch_series_history(
+    series_ids,
+    observation_start,
+    observation_end=None,
+    api_key: str | None = None,
+) -> dict[str, list[tuple[str, float]]]:
+    """Pull raw FRED observations per series over [start, end].
+
+    Returns {series_id: [(date_iso, value), ...]} sorted ascending by date, with
+    FRED's missing-value sentinel '.' dropped. Best-effort: returns {} when no API
+    key is available, and omits any series that errors (logged, never raised)."""
+    key = api_key or os.environ.get("FRED_API_KEY", "")
+    if not key:
+        log.warning("FRED_API_KEY not set — fetch_series_history returning {}")
+        return {}
+
+    start = observation_start.isoformat() if hasattr(observation_start, "isoformat") else str(observation_start)
+    out: dict[str, list[tuple[str, float]]] = {}
+    for series_id in series_ids:
+        params = {
+            "series_id": series_id, "api_key": key,
+            "file_type": "json", "observation_start": start,
+        }
+        if observation_end is not None:
+            params["observation_end"] = (
+                observation_end.isoformat() if hasattr(observation_end, "isoformat") else str(observation_end)
+            )
+        try:
+            resp = httpx.get(FRED_API_BASE, params=params, timeout=30)
+            resp.raise_for_status()
+            pts: list[tuple[str, float]] = []
+            for obs in resp.json().get("observations", []):
+                val = obs.get("value")
+                if val in (".", None, ""):
+                    continue
+                try:
+                    pts.append((obs["date"], float(val)))
+                except (TypeError, ValueError):
+                    continue
+            pts.sort(key=lambda p: p[0])
+            out[series_id] = pts
+        except Exception as exc:  # noqa: BLE001 — best-effort, fail closed
+            log.warning("FRED history %s error: %s", series_id, exc)
+    return out
+
+
+FREDGRAPH_CSV = "https://fred.stlouisfed.org/graph/fredgraph.csv"
+
+
+def fetch_series_history_csv(
+    series_ids, observation_start, observation_end=None,
+) -> dict[str, list[tuple[str, float]]]:
+    """Pull FRED observations per series over [start, end] via the KEYLESS
+    fredgraph CSV endpoint — no FRED_API_KEY required.
+
+    Returns {series_id: [(date_iso, value), ...]} ascending, with FRED's '.'
+    missing sentinel dropped. Best-effort: omits any series that errors (logged)."""
+    cosd = observation_start.isoformat() if hasattr(observation_start, "isoformat") else str(observation_start)
+    out: dict[str, list[tuple[str, float]]] = {}
+    for series_id in series_ids:
+        params = {"id": series_id, "cosd": cosd}
+        if observation_end is not None:
+            params["coed"] = (
+                observation_end.isoformat() if hasattr(observation_end, "isoformat") else str(observation_end)
+            )
+        try:
+            resp = httpx.get(FREDGRAPH_CSV, params=params, timeout=30)
+            resp.raise_for_status()
+            pts: list[tuple[str, float]] = []
+            for line in resp.text.splitlines()[1:]:  # skip header
+                parts = line.split(",")
+                if len(parts) != 2:
+                    continue
+                d, val = parts[0].strip(), parts[1].strip()
+                if val in (".", "", None):
+                    continue
+                try:
+                    pts.append((d, float(val)))
+                except ValueError:
+                    continue
+            pts.sort(key=lambda p: p[0])
+            out[series_id] = pts
+        except Exception as exc:  # noqa: BLE001 — best-effort, fail closed
+            log.warning("FRED CSV %s error: %s", series_id, exc)
+    return out

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -120,6 +120,7 @@ from app.routes import hr_polymarket as hr_polymarket_routes
 from app.routes import hr_research as hr_research_routes
 from app.routes import hr_morning_book as hr_morning_book_routes
 from app.routes import hr_ml_demo as hr_ml_demo_routes
+from app.routes import hr_feature_store as hr_feature_store_routes
 from app.routes import altered_mind as altered_mind_routes
 from app.routes import hha as hha_routes
 from app.routes import ncf_grant_friction
@@ -544,6 +545,7 @@ app.include_router(hr_polymarket_routes.router)
 app.include_router(hr_research_routes.router)
 app.include_router(hr_morning_book_routes.router)
 app.include_router(hr_ml_demo_routes.router)
+app.include_router(hr_feature_store_routes.router)
 app.include_router(altered_mind_routes.router)
 app.include_router(hha_routes.router)
 app.include_router(ncf_grant_friction.router)

--- a/backend/app/routes/hr_feature_store.py
+++ b/backend/app/routes/hr_feature_store.py
@@ -1,0 +1,170 @@
+"""History Rhymes — Episode Feature Store / Feature Observatory API (Phase 0).
+
+Prefix: /api/hr/v1/features  (the /api/hr/v1 namespace is the only HR-compliant
+one; /api/historyrhymes/* is forbidden by the frontend contract test.)
+
+Single-tenant (no env_id/RLS — HR exemption; episode_* are shared dimensions).
+Fails closed: every handler returns HTTP 200 with a structured payload, never 5xx.
+
+Endpoints:
+    GET /api/hr/v1/features/episodes
+        — episodes that have feature-store rows (for the Observatory selector)
+    GET /api/hr/v1/features/episodes/{episode_id}/observatory
+        — the 5 Observatory bands for one episode
+
+The Observatory bands map to the build maturity:
+    raw_inputs / derived_features / model_outputs  -> live now (Phase 0)
+    analog_matches    -> planned (Phase 4: pgvector episode_embeddings)
+    forecast_performance -> planned (Phase 5: calibration)
+Planned bands return an honest not_available status, never fake numbers.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter
+
+from app.db import get_cursor
+from app.services.hr_features.model import run_smoke_model
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/hr/v1/features", tags=["history-rhymes-feature-store"])
+
+
+@router.get("/episodes")
+def list_episodes() -> dict[str, Any]:
+    """Episodes that currently have feature-store rows."""
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                """
+                SELECT e.id::text AS id, e.name AS name, e.is_non_event AS is_non_event,
+                       MIN(f.as_of_date)::text AS as_of,
+                       COUNT(DISTINCT f.feature_id) AS feature_count
+                FROM public.episode_features f
+                JOIN public.episodes e ON e.id = f.entity_id
+                GROUP BY e.id, e.name, e.is_non_event
+                ORDER BY e.name;
+                """
+            )
+            episodes = [dict(r) for r in cur.fetchall()]
+        return {"status": "ok", "episodes": episodes, "null_reason": None}
+    except Exception:  # noqa: BLE001 — fail closed
+        logger.exception("feature-store list_episodes failed")
+        return {"status": "not_available", "episodes": [], "null_reason": "query_failed"}
+
+
+@router.get("/episodes/{episode_id}/observatory")
+def observatory(episode_id: str) -> dict[str, Any]:
+    """The five Feature Observatory bands for one episode (fail-closed)."""
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                "SELECT id::text AS id, name, start_date::text AS as_of, is_non_event "
+                "FROM public.episodes WHERE id = %s;",
+                (episode_id,),
+            )
+            ep = cur.fetchone()
+            if ep is None:
+                return {"status": "not_available", "null_reason": "episode_not_found",
+                        "episode_id": episode_id}
+
+            cur.execute(
+                """
+                SELECT f.feature_id, r.feature_name, r.family, r.transform, r.unit,
+                       r.raw_sources, f.value, f.value_label, f.null_reason,
+                       f.data_provenance
+                FROM public.episode_features f
+                JOIN public.feature_registry r ON r.feature_id = f.feature_id
+                WHERE f.entity_id = %s
+                ORDER BY r.family, f.feature_id;
+                """,
+                (episode_id,),
+            )
+            feats = [dict(r) for r in cur.fetchall()]
+
+            cur.execute(
+                "SELECT target_name, horizon_days, value, null_reason, source_lineage "
+                "FROM public.episode_targets WHERE entity_id = %s ORDER BY target_name;",
+                (episode_id,),
+            )
+            targets = [dict(r) for r in cur.fetchall()]
+
+            model = run_smoke_model(cur)
+
+        if not feats:
+            return {"status": "not_available", "null_reason": "no_features_for_episode",
+                    "episode": ep, "episode_id": episode_id}
+
+        provenance = sorted({f["data_provenance"] for f in feats})
+
+        # Band 1: raw inputs — the source series behind the features, by family.
+        raw_by_family: dict[str, set] = {}
+        for f in feats:
+            raw_by_family.setdefault(f["family"], set()).update(f.get("raw_sources") or [])
+        raw_inputs = [{"family": fam, "raw_sources": sorted(src)}
+                      for fam, src in sorted(raw_by_family.items())]
+
+        # Band 3: model outputs — this episode's slice of the smoke model.
+        ep_pred = next((e for e in model.get("episodes", [])
+                        if e["episode_id"] == episode_id), None)
+        model_outputs = {
+            "status": model.get("status"),
+            "status_label": model.get("status_label", "pipeline smoke model"),
+            "training_basis": model.get("training_basis"),
+            "purpose": model.get("purpose"),
+            "calibrated": model.get("calibrated", False),
+            "model": model.get("model"),
+            "target": model.get("target"),
+            "features_used": model.get("features", []),
+            "features_dropped": model.get("features_dropped", []),
+            "note": model.get("note"),
+            "recession_flag": ep_pred["recession_flag"] if ep_pred else None,
+            "recession_probability": ep_pred["recession_probability"] if ep_pred else None,
+            "null_reason": None if ep_pred else model.get("null_reason", "no_prediction"),
+        }
+
+        # Band 0: data coverage — turn missing data into a visible trust signal.
+        feat_unavailable = [
+            {"kind": "feature", "id": f["feature_id"], "reason": f["null_reason"]}
+            for f in feats if f["null_reason"] is not None
+        ]
+        tgt_unavailable = [
+            {"kind": "target", "id": t["target_name"], "reason": t["null_reason"]}
+            for t in targets if t["null_reason"] is not None
+        ]
+        coverage = {
+            "features_available": sum(1 for f in feats if f["null_reason"] is None),
+            "features_total": len(feats),
+            "targets_available": sum(1 for t in targets if t["null_reason"] is None),
+            "targets_total": len(targets),
+            "unavailable": feat_unavailable + tgt_unavailable,
+        }
+
+        return {
+            "status": "ok",
+            "model_status": "experimental",  # Phase 0: pipeline smoke, not calibrated
+            "data_provenance": provenance,
+            "episode": ep,
+            "coverage": coverage,
+            "bands": {
+                "raw_inputs": raw_inputs,
+                "derived_features": feats,
+                "model_outputs": model_outputs,
+                "analog_matches": {"status": "not_available",
+                                   "null_reason": "planned_phase_4_pgvector_embeddings",
+                                   "items": []},
+                "forecast_performance": {"status": "not_available",
+                                         "null_reason": "planned_phase_5_calibration",
+                                         "metrics": {}},
+            },
+            "targets": targets,
+            "null_reason": None,
+        }
+    except Exception:  # noqa: BLE001 — fail closed
+        logger.exception("feature-store observatory failed for %s", episode_id)
+        return {"status": "not_available", "null_reason": "query_failed",
+                "episode_id": episode_id}

--- a/backend/app/services/hr_features/__init__.py
+++ b/backend/app/services/hr_features/__init__.py
@@ -1,0 +1,39 @@
+"""History Rhymes Episode Feature Store (the learning layer).
+
+Phase 0 ships the pure transform library that turns a raw signal series into a
+derived feature value. The episode builder (0.4) prepares per-`as_of` series from
+`episode_signals` / FRED and calls these transforms; nothing here touches the DB,
+the network, or the clock — so every transform is deterministic and unit-testable.
+
+See docs/plans (Episode Feature Store + Model Lab) and ADO Feature #623 / Story #624.
+"""
+
+from .transforms import (
+    FeatureValue,
+    TRANSFORMS,
+    acceleration,
+    compute,
+    level,
+    percentile_rank,
+    regime_label,
+    shock_frequency,
+    slope,
+    trend_persistence,
+    velocity,
+    zscore,
+)
+
+__all__ = [
+    "FeatureValue",
+    "TRANSFORMS",
+    "acceleration",
+    "compute",
+    "level",
+    "percentile_rank",
+    "regime_label",
+    "shock_frequency",
+    "slope",
+    "trend_persistence",
+    "velocity",
+    "zscore",
+]

--- a/backend/app/services/hr_features/episode_builder.py
+++ b/backend/app/services/hr_features/episode_builder.py
@@ -1,0 +1,370 @@
+"""Episode feature builder (History Rhymes Episode Feature Store, Phase 0).
+
+Turns each seeded episode into a labeled training example at one `as_of` window:
+derived features (from data <= as_of) + forward-looking targets (from data > as_of),
+written to public.episode_features / public.episode_targets with the governed
+definitions in public.feature_registry.
+
+Design:
+- PURE compute (`compute_episode_rows`) takes a `series_provider` callable and an
+  episode descriptor and returns feature/target rows — no DB, no network, no clock —
+  so the no-lookahead contract and every value is golden-testable with fixtures.
+- PERSISTENCE (`persist_rows`) does the idempotent upsert.
+- ORCHESTRATION (`build_phase0`) resolves the 3 seeded episodes from the DB
+  (de-duplicating the repeated `episodes` rows by earliest id), pulls FRED history
+  via the default provider, computes, and persists.
+
+NO-LOOKAHEAD: features use only observations with date <= as_of; targets use only
+observations with date > as_of. Enforced here, not in the transforms.
+
+CADENCE: raw daily/monthly FRED series are resampled to month-end last-observation
+so velocity/zscore windows are uniform months across treasury/credit/housing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Callable, Sequence
+
+from . import transforms
+
+# Series provider: (series_ids, start, end) -> {series_id: [(date, value), ...]}
+SeriesProvider = Callable[[Sequence[str], date, date], dict[str, list[tuple[date, float]]]]
+
+MODEL_VERSION = "fs-v0"
+
+# The 3 Phase-0 episodes (exact names as seeded in 435_history_rhymes_seed.sql).
+PHASE0_EPISODE_NAMES = (
+    "2007-2009 Global Financial Crisis",
+    "2016 Brexit Shock (Non-Event)",
+    "2020 COVID Crash and V-Shaped Recovery",
+)
+
+# ── Governed feature catalog (seeds public.feature_registry) ────────────────────
+# Each spec names how to build its input series and which transform to apply.
+# `series` is the FRED series id(s); the yield-curve family uses the 10y-2y spread.
+FEATURE_SPECS = [
+    {"feature_id": "yc_slope", "feature_name": "Yield curve slope (10y-2y)",
+     "family": "yield_curve", "transform": "level", "params": {},
+     "raw_sources": ["FRED:DGS10", "FRED:DGS2"], "window_days": None,
+     "value_kind": "numeric", "unit": "pct_points",
+     "series": "yc_spread", "description": "10y minus 2y Treasury yield (latest, month-end)."},
+    {"feature_id": "yc_velocity", "feature_name": "Yield curve velocity (1m)",
+     "family": "yield_curve", "transform": "velocity", "params": {"periods": 1},
+     "raw_sources": ["FRED:DGS10", "FRED:DGS2"], "window_days": 30,
+     "value_kind": "numeric", "unit": "pct_points_per_month",
+     "series": "yc_spread", "description": "1-month change in the 10y-2y spread."},
+    {"feature_id": "yc_acceleration", "feature_name": "Yield curve acceleration",
+     "family": "yield_curve", "transform": "acceleration", "params": {"periods": 1},
+     "raw_sources": ["FRED:DGS10", "FRED:DGS2"], "window_days": 60,
+     "value_kind": "numeric", "unit": "pct_points_per_month2",
+     "series": "yc_spread", "description": "Change in yield-curve velocity (2nd difference)."},
+    {"feature_id": "yc_zscore", "feature_name": "Yield curve z-score (2y)",
+     "family": "yield_curve", "transform": "zscore", "params": {"window": 24},
+     "raw_sources": ["FRED:DGS10", "FRED:DGS2"], "window_days": 730,
+     "value_kind": "numeric", "unit": "sigma",
+     "series": "yc_spread", "description": "Standardized 10y-2y spread over a trailing 24 months."},
+    {"feature_id": "yc_regime", "feature_name": "Yield curve regime",
+     "family": "yield_curve", "transform": "regime",
+     "params": {"thresholds": [0.0, 0.5], "labels": ["inverted", "flat", "steep"]},
+     "raw_sources": ["FRED:DGS10", "FRED:DGS2"], "window_days": None,
+     "value_kind": "categorical", "unit": None,
+     "series": "yc_spread", "description": "inverted (<0) | flat (0-0.5) | steep (>=0.5)."},
+    {"feature_id": "credit_spread_velocity", "feature_name": "HY credit spread velocity (1m)",
+     "family": "credit", "transform": "velocity", "params": {"periods": 1},
+     "raw_sources": ["FRED:BAMLC0A0CM"], "window_days": 30,
+     "value_kind": "numeric", "unit": "pct_points_per_month",
+     "series": "BAMLC0A0CM", "description": "1-month change in HY OAS credit spread."},
+    {"feature_id": "housing_velocity", "feature_name": "Housing starts velocity (1m)",
+     "family": "housing", "transform": "velocity", "params": {"periods": 1},
+     "raw_sources": ["FRED:HOUST"], "window_days": 30,
+     "value_kind": "numeric", "unit": "thousands_per_month",
+     "series": "HOUST", "description": "1-month change in housing starts (SAAR, thousands)."},
+]
+
+# All FRED series the builder needs (features + targets).
+FEATURE_SERIES_IDS = ("DGS10", "DGS2", "BAMLC0A0CM", "HOUST")
+TARGET_SERIES_IDS = ("SP500", "USREC")
+ALL_SERIES_IDS = tuple(dict.fromkeys(FEATURE_SERIES_IDS + TARGET_SERIES_IDS))
+
+# Features need trailing history; targets need ~13 months forward.
+FEATURE_LOOKBACK_DAYS = 800   # ~26 months, covers the 24-month z-score window
+TARGET_HORIZON_DAYS = 365
+
+
+@dataclass(frozen=True)
+class FeatureRow:
+    feature_id: str
+    value: float | None
+    value_label: str | None
+    null_reason: str | None
+    inputs_hash: str
+    data_provenance: str
+
+
+@dataclass(frozen=True)
+class TargetRow:
+    target_name: str
+    horizon_days: int
+    value: float | None
+    null_reason: str | None
+    source_lineage: str
+    data_provenance: str
+
+
+@dataclass(frozen=True)
+class EpisodeDescriptor:
+    episode_id: str
+    name: str
+    as_of: date
+
+
+# ── series helpers ──────────────────────────────────────────────────────────────
+
+def _to_monthly(points: list[tuple[date, float]]) -> list[tuple[date, float]]:
+    """Resample to one value per calendar month: the last observation in the month.
+    Returns [(month_key_date, value)] ascending, month_key = first of month."""
+    by_month: dict[tuple[int, int], tuple[date, float]] = {}
+    for d, v in sorted(points, key=lambda p: p[0]):
+        key = (d.year, d.month)
+        prev = by_month.get(key)
+        if prev is None or d >= prev[0]:
+            by_month[key] = (d, v)
+    return [(date(y, m, 1), val) for (y, m), (_, val) in sorted(by_month.items())]
+
+
+def _spread_monthly(
+    dgs10: list[tuple[date, float]], dgs2: list[tuple[date, float]]
+) -> list[tuple[date, float]]:
+    """Monthly 10y-2y spread, aligned on the months present in both series."""
+    m10 = dict(_to_monthly(dgs10))
+    m2 = dict(_to_monthly(dgs2))
+    common = sorted(set(m10) & set(m2))
+    return [(k, m10[k] - m2[k]) for k in common]
+
+
+def _values_upto(monthly: list[tuple[date, float]], as_of: date) -> list[float]:
+    return [v for d, v in monthly if d <= as_of]
+
+
+def _coerce_date(d) -> date:
+    return d if isinstance(d, date) else date.fromisoformat(str(d)[:10])
+
+
+def _hash_inputs(series: dict[str, list[tuple[date, float]]]) -> str:
+    payload = {sid: [(d.isoformat(), round(v, 6)) for d, v in pts]
+               for sid, pts in sorted(series.items())}
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()[:32]
+
+
+# ── pure compute ────────────────────────────────────────────────────────────────
+
+def compute_episode_rows(
+    episode: EpisodeDescriptor,
+    series_provider: SeriesProvider,
+    provenance: str = "public_fred",
+) -> dict[str, list]:
+    """Compute feature + target rows for one episode at its as_of window. Pure."""
+    as_of = episode.as_of
+    win_start = as_of - timedelta(days=FEATURE_LOOKBACK_DAYS)
+    win_end = as_of + timedelta(days=TARGET_HORIZON_DAYS + 31)
+    raw = series_provider(list(ALL_SERIES_IDS), win_start, win_end)
+    # normalize dates AND clip to the requested window. The keyless fredgraph CSV
+    # endpoint ignores the date range for some series (e.g. BAMLC0A0CM, SP500) and
+    # returns recent data instead — clipping prevents wrong-era contamination
+    # (a 2007 as_of must never borrow 2016 values) and yields an honest null when a
+    # series has no data in-window.
+    raw = {
+        sid: [(_coerce_date(d), float(v)) for d, v in pts
+              if win_start <= _coerce_date(d) <= win_end]
+        for sid, pts in raw.items()
+    }
+
+    # Prepare the named input series (monthly), including the derived yc_spread.
+    prepared: dict[str, list[tuple[date, float]]] = {
+        sid: _to_monthly(raw.get(sid, [])) for sid in FEATURE_SERIES_IDS
+    }
+    prepared["yc_spread"] = _spread_monthly(raw.get("DGS10", []), raw.get("DGS2", []))
+    inputs_hash = _hash_inputs({k: prepared[k] for k in sorted(prepared)})
+
+    features: list[FeatureRow] = []
+    for spec in FEATURE_SPECS:
+        series = _values_upto(prepared.get(spec["series"], []), as_of)  # no-lookahead
+        res = transforms.compute(spec["transform"], series, **spec["params"])
+        features.append(FeatureRow(
+            feature_id=spec["feature_id"],
+            value=res.value,
+            value_label=res.label,
+            null_reason=res.null_reason,
+            inputs_hash=inputs_hash,
+            data_provenance=provenance,
+        ))
+
+    targets = _compute_targets(raw, as_of, provenance)
+    return {"features": features, "targets": targets}
+
+
+def _forward(points: list[tuple[date, float]], as_of: date) -> list[tuple[date, float]]:
+    """Observations strictly after as_of (the no-lookahead target window)."""
+    return [(d, v) for d, v in sorted(points) if d > as_of]
+
+
+def _value_at_or_after(points: list[tuple[date, float]], target: date) -> float | None:
+    for d, v in points:
+        if d >= target:
+            return v
+    return None
+
+
+def _compute_targets(
+    raw: dict[str, list[tuple[date, float]]], as_of: date, provenance: str
+) -> list[TargetRow]:
+    spx_all = sorted(raw.get("SP500", []))
+    usrec_fwd = _forward(raw.get("USREC", []), as_of)
+    spx_fwd = _forward(spx_all, as_of)
+    base = _value_at_or_after(sorted(spx_all), as_of)  # baseline at/after as_of
+
+    rows: list[TargetRow] = []
+
+    # outcome_3m: SP500 forward total return as_of -> as_of+90d
+    end_val = _value_at_or_after(spx_fwd, as_of + timedelta(days=90))
+    if base and end_val is not None:
+        rows.append(TargetRow("outcome_3m", 90, end_val / base - 1.0, None,
+                              "FRED:SP500 forward return as_of+90d", provenance))
+    else:
+        rows.append(TargetRow("outcome_3m", 90, None, "source_unavailable",
+                              "FRED:SP500 forward return as_of+90d", provenance))
+
+    # drawdown: worst peak-to-trough decline within (as_of, as_of+365d]
+    horizon = [(d, v) for d, v in spx_fwd if d <= as_of + timedelta(days=TARGET_HORIZON_DAYS)]
+    if base and horizon:
+        peak = base
+        worst = 0.0
+        for _, v in horizon:
+            peak = max(peak, v)
+            worst = min(worst, v / peak - 1.0)
+        rows.append(TargetRow("drawdown", TARGET_HORIZON_DAYS, worst, None,
+                              "FRED:SP500 max peak-to-trough within 365d", provenance))
+    else:
+        rows.append(TargetRow("drawdown", TARGET_HORIZON_DAYS, None, "source_unavailable",
+                              "FRED:SP500 max peak-to-trough within 365d", provenance))
+
+    # recession_flag: USREC max within (as_of, as_of+365d]
+    rec_window = [v for d, v in usrec_fwd if d <= as_of + timedelta(days=TARGET_HORIZON_DAYS)]
+    if rec_window:
+        rows.append(TargetRow("recession_flag", TARGET_HORIZON_DAYS,
+                              1.0 if max(rec_window) >= 1.0 else 0.0, None,
+                              "FRED:USREC max within 365d", provenance))
+    else:
+        rows.append(TargetRow("recession_flag", TARGET_HORIZON_DAYS, None, "source_unavailable",
+                              "FRED:USREC max within 365d", provenance))
+
+    return rows
+
+
+# ── persistence + orchestration (DB) ─────────────────────────────────────────────
+
+def seed_feature_registry(cur) -> None:
+    """Upsert the governed feature definitions (episode_features FKs this)."""
+    for s in FEATURE_SPECS:
+        cur.execute(
+            """
+            INSERT INTO public.feature_registry
+                (feature_id, feature_name, family, transform, raw_sources,
+                 window_days, value_kind, unit, description, owner)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,'history-rhymes')
+            ON CONFLICT (feature_id) DO UPDATE SET
+                feature_name=EXCLUDED.feature_name, family=EXCLUDED.family,
+                transform=EXCLUDED.transform, raw_sources=EXCLUDED.raw_sources,
+                window_days=EXCLUDED.window_days, value_kind=EXCLUDED.value_kind,
+                unit=EXCLUDED.unit, description=EXCLUDED.description, updated_at=NOW();
+            """,
+            (s["feature_id"], s["feature_name"], s["family"], s["transform"],
+             s["raw_sources"], s["window_days"], s["value_kind"], s["unit"], s["description"]),
+        )
+
+
+def persist_rows(cur, episode_id: str, as_of: date, rows: dict[str, list]) -> tuple[int, int]:
+    """Idempotent upsert of computed feature/target rows for one episode."""
+    fcount = 0
+    for r in rows["features"]:
+        cur.execute(
+            """
+            INSERT INTO public.episode_features
+                (entity_type, entity_id, episode_id, as_of_date, feature_id,
+                 value, value_label, null_reason, inputs_hash, freshness_hours,
+                 model_version, data_provenance)
+            VALUES ('hr_episode',%s,%s,%s,%s,%s,%s,%s,%s,NULL,%s,%s)
+            ON CONFLICT (entity_type, entity_id, as_of_date, feature_id, model_version)
+            DO UPDATE SET value=EXCLUDED.value, value_label=EXCLUDED.value_label,
+                null_reason=EXCLUDED.null_reason, inputs_hash=EXCLUDED.inputs_hash,
+                data_provenance=EXCLUDED.data_provenance, computed_at=NOW();
+            """,
+            (episode_id, episode_id, as_of, r.feature_id, r.value, r.value_label,
+             r.null_reason, r.inputs_hash, MODEL_VERSION, r.data_provenance),
+        )
+        fcount += 1
+    tcount = 0
+    for t in rows["targets"]:
+        cur.execute(
+            """
+            INSERT INTO public.episode_targets
+                (entity_type, entity_id, episode_id, as_of_date, target_name,
+                 horizon_days, value, null_reason, source_lineage, data_provenance)
+            VALUES ('hr_episode',%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            ON CONFLICT (entity_type, entity_id, as_of_date, target_name, horizon_days)
+            DO UPDATE SET value=EXCLUDED.value, null_reason=EXCLUDED.null_reason,
+                source_lineage=EXCLUDED.source_lineage,
+                data_provenance=EXCLUDED.data_provenance, computed_at=NOW();
+            """,
+            (episode_id, episode_id, as_of, t.target_name, t.horizon_days,
+             t.value, t.null_reason, t.source_lineage, t.data_provenance),
+        )
+        tcount += 1
+    return fcount, tcount
+
+
+def _default_fred_provider(series_ids, start, end):
+    # Lazy import so the pure path / tests never require the connector deps.
+    # Uses the KEYLESS fredgraph CSV endpoint — real FRED data, no FRED_API_KEY.
+    from app.connectors.cre.fred_rates.fetch import fetch_series_history_csv
+    hist = fetch_series_history_csv(series_ids, start, end)
+    return {sid: [(date.fromisoformat(d), v) for d, v in pts] for sid, pts in hist.items()}
+
+
+def resolve_phase0_episodes(cur) -> list[EpisodeDescriptor]:
+    """Resolve the 3 Phase-0 episodes, de-duplicating repeated rows by earliest id."""
+    out: list[EpisodeDescriptor] = []
+    for name in PHASE0_EPISODE_NAMES:
+        cur.execute(
+            """
+            SELECT id::text AS id, start_date
+            FROM public.episodes WHERE name = %s
+            ORDER BY created_at NULLS FIRST, id LIMIT 1;
+            """,
+            (name,),
+        )
+        row = cur.fetchone()
+        if row:
+            out.append(EpisodeDescriptor(row["id"], name, _coerce_date(row["start_date"])))
+    return out
+
+
+def build_phase0(cur, series_provider: SeriesProvider | None = None) -> dict:
+    """Resolve episodes, compute features+targets at each as_of, persist. Idempotent."""
+    provider = series_provider or _default_fred_provider
+    provenance = "public_fred" if series_provider is None else "fixture"
+    seed_feature_registry(cur)
+    episodes = resolve_phase0_episodes(cur)
+    summary = {"episodes": [], "features_written": 0, "targets_written": 0}
+    for ep in episodes:
+        rows = compute_episode_rows(ep, provider, provenance)
+        f, t = persist_rows(cur, ep.episode_id, ep.as_of, rows)
+        summary["episodes"].append({"name": ep.name, "as_of": ep.as_of.isoformat(),
+                                    "features": f, "targets": t})
+        summary["features_written"] += f
+        summary["targets_written"] += t
+    return summary

--- a/backend/app/services/hr_features/model.py
+++ b/backend/app/services/hr_features/model.py
@@ -1,0 +1,142 @@
+"""Phase 0 pipeline smoke model (History Rhymes Episode Feature Store).
+
+Proves the feature -> target -> train -> score -> display loop end to end on REAL
+episode rows. It is deliberately a **smoke model, NOT a production-calibrated
+forecaster**: 3 episodes is not a trainable population, so it fits in-sample and
+reports `status='experimental'`, `calibrated=False`. Real predictive value comes
+only after the episode/as_of population is expanded (Phase 1+).
+
+Same estimator family the synthetic ML lab uses (RandomForestClassifier, fixed
+seed). `train_smoke(frame)` is pure (no DB) so it is unit-testable; `run_smoke_model`
+loads the frame from the feature store.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.db import get_cursor
+
+# Numeric features the smoke classifier uses (deterministic order). yc_regime is
+# categorical (its numeric value duplicates yc_slope) so it is excluded here.
+SMOKE_FEATURES = [
+    "yc_slope", "yc_velocity", "yc_acceleration", "yc_zscore",
+    "credit_spread_velocity", "housing_velocity",
+]
+TARGET = "recession_flag"
+SEED = 42
+
+
+def load_episode_frame(cur) -> list[dict[str, Any]]:
+    """Wide frame: one row per episode with the numeric features + recession_flag.
+
+    Only episodes whose features are all present (non-null) and that have a
+    recession_flag target are returned — fail closed on incomplete rows."""
+    cur.execute(
+        """
+        SELECT f.entity_id::text AS episode_id, e.name AS name,
+               f.feature_id, f.value
+        FROM public.episode_features f
+        JOIN public.episodes e ON e.id = f.entity_id
+        WHERE f.feature_id = ANY(%s) AND f.value IS NOT NULL;
+        """,
+        (SMOKE_FEATURES,),
+    )
+    by_ep: dict[str, dict[str, Any]] = {}
+    for row in cur.fetchall():
+        rec = by_ep.setdefault(row["episode_id"], {"episode_id": row["episode_id"],
+                                                    "name": row["name"], "features": {}})
+        # Only non-null feature values land in the frame; missing ones are simply
+        # absent (the trainer uses the features common to all episodes).
+        if row["value"] is not None:
+            rec["features"][row["feature_id"]] = float(row["value"])
+
+    cur.execute(
+        """
+        SELECT entity_id::text AS episode_id, value
+        FROM public.episode_targets WHERE target_name = %s AND value IS NOT NULL;
+        """,
+        (TARGET,),
+    )
+    targets = {r["episode_id"]: float(r["value"]) for r in cur.fetchall()}
+
+    # Include every episode that has the target and at least one numeric feature;
+    # train_smoke picks the features common (non-null) across the included episodes.
+    frame: list[dict[str, Any]] = []
+    for ep_id, rec in by_ep.items():
+        if ep_id in targets and rec["features"]:
+            rec[TARGET] = targets[ep_id]
+            frame.append(rec)
+    frame.sort(key=lambda r: r["name"])
+    return frame
+
+
+def _not_available(reason: str, n: int = 0) -> dict[str, Any]:
+    return {"status": "not_available", "calibrated": False, "null_reason": reason,
+            "n_train": n, "features": SMOKE_FEATURES, "importances": [], "episodes": []}
+
+
+def train_smoke(frame: list[dict[str, Any]]) -> dict[str, Any]:
+    """Fit the in-sample smoke classifier on a feature frame. Pure (no DB).
+
+    Fails closed (returns a not_available envelope) when there are too few rows or
+    fewer than two classes — never raises."""
+    if len(frame) < 2:
+        return _not_available("insufficient_episodes", len(frame))
+    ys = [r[TARGET] for r in frame]
+    if len(set(ys)) < 2:
+        return _not_available("single_class", len(frame))
+
+    # Use the features that are present (non-null) across EVERY included episode,
+    # in the canonical order. Real data may leave a feature unavailable for some
+    # episodes (e.g. no in-window credit history) — drop it rather than collapse.
+    common = [f for f in SMOKE_FEATURES if all(f in r["features"] for r in frame)]
+    if not common:
+        return _not_available("no_common_features", len(frame))
+    dropped = [f for f in SMOKE_FEATURES if f not in common]
+
+    # Imported here so the pure import path / non-ML callers don't pull sklearn.
+    from sklearn.ensemble import RandomForestClassifier
+
+    X = [[r["features"][f] for f in common] for r in frame]
+    clf = RandomForestClassifier(n_estimators=200, random_state=SEED)
+    clf.fit(X, ys)
+    pos_idx = list(clf.classes_).index(1.0) if 1.0 in clf.classes_ else len(clf.classes_) - 1
+    probs = clf.predict_proba(X)
+    importances = [
+        {"feature": f, "importance": round(float(imp), 6)}
+        for f, imp in sorted(zip(common, clf.feature_importances_),
+                             key=lambda t: t[1], reverse=True)
+    ]
+    episodes = [
+        {"episode_id": r["episode_id"], "name": r["name"],
+         "recession_flag": r[TARGET],
+         "recession_probability": round(float(probs[i][pos_idx]), 6)}
+        for i, r in enumerate(frame)
+    ]
+    return {
+        "status": "experimental",
+        "status_label": "pipeline smoke model",
+        "training_basis": f"{len(frame)} historical episodes",
+        "purpose": "validate feature -> target -> train -> score flow",
+        "calibrated": False,
+        "model": "random_forest",
+        "target": TARGET,
+        "n_train": len(frame),
+        "evaluation": "in_sample",
+        "note": "Pipeline smoke model — proves the loop, NOT production-calibrated. "
+                "Expand the episode/as_of population (Phase 1+) before trusting predictions.",
+        "features": common,
+        "features_dropped": dropped,
+        "importances": importances,
+        "episodes": episodes,
+        "null_reason": None,
+    }
+
+
+def run_smoke_model(cur=None) -> dict[str, Any]:
+    """Load the feature frame from the store and fit the smoke model. Fail-closed."""
+    if cur is not None:
+        return train_smoke(load_episode_frame(cur))
+    with get_cursor() as c:
+        return train_smoke(load_episode_frame(c))

--- a/backend/app/services/hr_features/phase0_fixture.py
+++ b/backend/app/services/hr_features/phase0_fixture.py
@@ -1,0 +1,59 @@
+"""Deterministic, clearly-labeled fixture series for the Phase 0 backfill.
+
+Used ONLY when a live FRED key is not available. It lets the full loop
+(builder -> transforms -> store -> API -> Observatory) run on concrete data today;
+rows land with data_provenance='fixture' and the UI shows status=experimental.
+
+Honesty:
+- The macro series (yields, credit, housing, SP500) are SYNTHETIC and labeled as
+  such — they are NOT presented as real FRED observations.
+- USREC uses FACTUAL NBER recession months, so `recession_flag` is genuinely
+  correct per episode (GFC=1, Brexit=0, COVID=1) — the target the smoke model uses.
+
+Swap to real data with: `build_phase0(cur)` (no provider) once FRED_API_KEY is set.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date
+
+# Factual NBER recession months (inclusive). Source: NBER business-cycle dating.
+_RECESSION_MONTHS: set[tuple[int, int]] = set()
+for _y, _m0, _m1 in [(2007, 12, 12), (2008, 1, 12), (2009, 1, 6)]:
+    for _m in range(_m0, _m1 + 1):
+        _RECESSION_MONTHS.add((_y, _m))
+for _m in range(2, 5):  # COVID recession Feb-Apr 2020
+    _RECESSION_MONTHS.add((2020, _m))
+
+
+def _months(start: date, end: date):
+    y, m = start.year, start.month
+    while (y, m) <= (end.year, end.month):
+        yield date(y, m, 1)
+        m += 1
+        if m > 12:
+            m, y = 1, y + 1
+
+
+def _idx(d: date) -> int:
+    return (d.year - 2004) * 12 + (d.month - 1)
+
+
+def fixture_series_provider(series_ids, start, end):
+    """Deterministic synthetic monthly series across [start, end]. No randomness."""
+    out: dict[str, list[tuple[date, float]]] = {sid: [] for sid in series_ids}
+    for d in _months(start, end):
+        b = _idx(d)
+        vals = {
+            "DGS10": 3.5 + 0.3 * math.sin(b / 6.0),
+            "DGS2": 2.5 + 0.5 * math.sin(b / 6.0 + 0.5),
+            "BAMLC0A0CM": 4.0 + 1.0 * math.sin(b / 9.0),
+            "HOUST": 1400.0 + 100.0 * math.sin(b / 8.0),
+            "SP500": 1000.0 * (1.004 ** b),
+            "USREC": 1.0 if (d.year, d.month) in _RECESSION_MONTHS else 0.0,
+        }
+        for sid in series_ids:
+            if sid in vals:
+                out[sid].append((d, round(vals[sid], 4)))
+    return out

--- a/backend/app/services/hr_features/transforms.py
+++ b/backend/app/services/hr_features/transforms.py
@@ -1,0 +1,206 @@
+"""Pure derived-feature transforms for the History Rhymes Episode Feature Store.
+
+Each transform takes a **chronologically ordered** series (oldest -> newest) of
+floats that the builder has already filtered to observations on or before the
+`as_of_date` (the no-lookahead contract lives in the builder, not here). Every
+transform returns a `FeatureValue` and **fails closed**: when there is not enough
+history (or no variance) it returns `value=None` with a `null_reason` rather than a
+silent zero, mirroring the fail-closed discipline used across the HR services.
+
+Numeric transforms populate `value`; categorical transforms (`regime_label`)
+populate `label` (and echo the raw level into `value`). These are the reusable
+primitives the registry's feature definitions compose; the builder maps a
+`feature_registry.transform` string + params onto `compute(...)`.
+
+No DB, no network, no clock — deterministic and golden-testable.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+
+@dataclass(frozen=True)
+class FeatureValue:
+    """Result of a transform. Exactly one of (value/label) is meaningful per call;
+    `null_reason` is set (and value/label None) when the feature is not computable."""
+
+    value: float | None = None
+    label: str | None = None
+    null_reason: str | None = None
+
+
+def _clean(series: Sequence[float]) -> list[float]:
+    """Drop None / NaN holes; the builder passes raw pulls that may have gaps."""
+    out: list[float] = []
+    for x in series:
+        if x is None:
+            continue
+        try:
+            fx = float(x)
+        except (TypeError, ValueError):
+            continue
+        if math.isnan(fx) or math.isinf(fx):
+            continue
+        out.append(fx)
+    return out
+
+
+def _insufficient(need: int, have: int) -> FeatureValue:
+    return FeatureValue(null_reason=f"insufficient_history(need>={need},have={have})")
+
+
+def level(series: Sequence[float]) -> FeatureValue:
+    """Most recent value (point-in-time level)."""
+    s = _clean(series)
+    if not s:
+        return _insufficient(1, len(s))
+    return FeatureValue(value=s[-1])
+
+
+def velocity(series: Sequence[float], periods: int = 1) -> FeatureValue:
+    """Average change per period over the last `periods` steps: (s[-1]-s[-1-p])/p."""
+    s = _clean(series)
+    if len(s) <= periods:
+        return _insufficient(periods + 1, len(s))
+    return FeatureValue(value=(s[-1] - s[-1 - periods]) / periods)
+
+
+def acceleration(series: Sequence[float], periods: int = 1) -> FeatureValue:
+    """Change in velocity: vel_now - vel_prev. With periods=1 this is the second
+    difference s[-1] - 2*s[-2] + s[-3]."""
+    s = _clean(series)
+    if len(s) <= 2 * periods:
+        return _insufficient(2 * periods + 1, len(s))
+    vel_now = (s[-1] - s[-1 - periods]) / periods
+    vel_prev = (s[-1 - periods] - s[-1 - 2 * periods]) / periods
+    return FeatureValue(value=vel_now - vel_prev)
+
+
+def zscore(series: Sequence[float], window: int) -> FeatureValue:
+    """Standardized latest value over the trailing `window` (sample std)."""
+    s = _clean(series)
+    if window < 2 or len(s) < 2:
+        return _insufficient(2, len(s))
+    w = s[-window:]
+    if len(w) < 2:
+        return _insufficient(2, len(w))
+    sd = statistics.stdev(w)
+    if sd == 0:
+        return FeatureValue(null_reason="no_variance")
+    return FeatureValue(value=(w[-1] - statistics.fmean(w)) / sd)
+
+
+def percentile_rank(series: Sequence[float], window: int) -> FeatureValue:
+    """Fraction of the trailing `window` strictly below the latest value, in [0,1]."""
+    s = _clean(series)
+    if len(s) < 2:
+        return _insufficient(2, len(s))
+    w = s[-window:] if window > 0 else s
+    if len(w) < 2:
+        return _insufficient(2, len(w))
+    below = sum(1 for v in w if v < w[-1])
+    return FeatureValue(value=below / (len(w) - 1))
+
+
+def slope(series: Sequence[float], window: int) -> FeatureValue:
+    """OLS slope (per step) of the last `window` points against index 0..n-1."""
+    s = _clean(series)
+    if len(s) < 2:
+        return _insufficient(2, len(s))
+    w = s[-window:] if window > 0 else s
+    n = len(w)
+    if n < 2:
+        return _insufficient(2, n)
+    xs = list(range(n))
+    mx = (n - 1) / 2.0
+    my = statistics.fmean(w)
+    var_x = sum((x - mx) ** 2 for x in xs)
+    if var_x == 0:
+        return FeatureValue(null_reason="no_variance")
+    cov = sum((xs[i] - mx) * (w[i] - my) for i in range(n))
+    return FeatureValue(value=cov / var_x)
+
+
+def trend_persistence(series: Sequence[float], ma_window: int) -> FeatureValue:
+    """Count of trailing consecutive points above the trailing moving average."""
+    s = _clean(series)
+    if len(s) < 1 or ma_window < 1:
+        return _insufficient(1, len(s))
+    ma = statistics.fmean(s[-ma_window:])
+    count = 0
+    for v in reversed(s):
+        if v > ma:
+            count += 1
+        else:
+            break
+    return FeatureValue(value=float(count))
+
+
+def shock_frequency(series: Sequence[float], window: int, k: float = 2.0) -> FeatureValue:
+    """Count of first-differences in the trailing `window` whose magnitude exceeds
+    k * std(diffs). Detects clustered shocks; needs window+1 observations."""
+    s = _clean(series)
+    if len(s) < window + 1 or window < 2:
+        return _insufficient(window + 1, len(s))
+    w = s[-(window + 1):]
+    diffs = [w[i] - w[i - 1] for i in range(1, len(w))]
+    sd = statistics.stdev(diffs)
+    if sd == 0:
+        return FeatureValue(value=0.0)
+    thresh = k * sd
+    return FeatureValue(value=float(sum(1 for d in diffs if abs(d) > thresh)))
+
+
+def regime_label(
+    series: Sequence[float],
+    thresholds: Sequence[float],
+    labels: Sequence[str],
+) -> FeatureValue:
+    """Categorical regime of the latest value. `labels` has len(thresholds)+1 entries;
+    the latest value picks the bucket it falls into (thresholds ascending)."""
+    s = _clean(series)
+    if not s:
+        return _insufficient(1, len(s))
+    if len(labels) != len(thresholds) + 1:
+        return FeatureValue(null_reason="bad_regime_config")
+    x = s[-1]
+    idx = len(thresholds)
+    for i, t in enumerate(thresholds):
+        if x < t:
+            idx = i
+            break
+    return FeatureValue(value=x, label=labels[idx])
+
+
+# Dispatch table: feature_registry.transform string -> callable.
+TRANSFORMS: dict[str, Callable[..., FeatureValue]] = {
+    "level": level,
+    "velocity": velocity,
+    "acceleration": acceleration,
+    "zscore": zscore,
+    "percentile": percentile_rank,
+    "percentile_rank": percentile_rank,
+    "slope": slope,
+    "trend_persistence": trend_persistence,
+    "shock_frequency": shock_frequency,
+    "regime": regime_label,
+    "regime_label": regime_label,
+}
+
+
+def compute(transform: str, series: Sequence[float], **params) -> FeatureValue:
+    """Map a registry `transform` name + params onto the right primitive.
+
+    Unknown transforms fail closed (never raise) so a bad registry row degrades to
+    a null feature with a reason instead of crashing the builder."""
+    fn = TRANSFORMS.get(transform)
+    if fn is None:
+        return FeatureValue(null_reason=f"unknown_transform:{transform}")
+    try:
+        return fn(series, **params)
+    except TypeError as exc:  # bad params for this transform
+        return FeatureValue(null_reason=f"bad_params:{exc}")

--- a/backend/tests/test_hr_episode_builder.py
+++ b/backend/tests/test_hr_episode_builder.py
@@ -1,0 +1,120 @@
+"""Pure-compute tests for the episode feature builder (no DB, no network).
+
+Uses a deterministic fixture series_provider so every feature/target is exact and
+the no-lookahead contract is asserted directly. Run from backend/:
+    pytest --noconftest tests/test_hr_episode_builder.py
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.services.hr_features.episode_builder import (
+    EpisodeDescriptor,
+    compute_episode_rows,
+)
+
+AS_OF = date(2007, 6, 1)
+
+
+def _monthly(start_year, start_month, n, fn):
+    """n monthly points (first-of-month) ascending, value = fn(i)."""
+    pts = []
+    y, m = start_year, start_month
+    for i in range(n):
+        pts.append((date(y, m, 1), float(fn(i))))
+        m += 1
+        if m > 12:
+            m = 1
+            y += 1
+    return pts
+
+
+def fixture_provider(series_ids, start, end):
+    """Crafted series. Feature inputs span 30 months ending at AS_OF; target inputs
+    span forward from AS_OF. A wild post-AS_OF spread point is included to prove
+    features ignore the future (no-lookahead)."""
+    # 30 monthly points 2005-01 .. 2007-06 (i=29 -> 2007-06)
+    dgs2 = _monthly(2005, 1, 30, lambda i: 4.0 + 0.02 * i)
+    dgs10 = _monthly(2005, 1, 30, lambda i: 4.5 + 0.01 * i)
+    # Leak trap: a post-as_of month with a huge spread; features must ignore it.
+    dgs10.append((date(2007, 7, 1), 99.0))
+    dgs2.append((date(2007, 7, 1), 0.0))
+
+    credit = _monthly(2005, 1, 30, lambda i: 3.0 + 0.05 * i)   # velocity +0.05
+    houst = _monthly(2005, 1, 30, lambda i: 1500 - 10 * i)     # velocity -10
+
+    # SP500 forward from AS_OF: dip to 1200 then recover (drawdown ~ -0.2105)
+    spx_vals = [1500, 1520, 1480, 1440, 1300, 1200, 1350, 1450, 1500, 1550, 1560, 1570, 1580, 1590]
+    spx = _monthly(2007, 6, len(spx_vals), lambda i: spx_vals[i])
+    # USREC forward: recession starts 2007-12
+    usrec = _monthly(2007, 6, 14, lambda i: 1.0 if i >= 6 else 0.0)
+
+    return {"DGS10": dgs10, "DGS2": dgs2, "BAMLC0A0CM": credit,
+            "HOUST": houst, "SP500": spx, "USREC": usrec}
+
+
+@pytest.fixture
+def rows():
+    ep = EpisodeDescriptor(episode_id="00000000-0000-0000-0000-000000000001",
+                           name="Fixture GFC", as_of=AS_OF)
+    return compute_episode_rows(ep, fixture_provider, provenance="fixture")
+
+
+def _feat(rows, fid):
+    return next(r for r in rows["features"] if r.feature_id == fid)
+
+
+def _tgt(rows, name):
+    return next(r for r in rows["targets"] if r.target_name == name)
+
+
+def test_all_features_non_null(rows):
+    for r in rows["features"]:
+        assert r.null_reason is None, f"{r.feature_id} unexpectedly null: {r.null_reason}"
+
+
+def test_yield_curve_family_values(rows):
+    # spread at i=29: dgs10=4.79, dgs2=4.58 -> 0.21
+    assert _feat(rows, "yc_slope").value == pytest.approx(0.21, abs=1e-9)
+    assert _feat(rows, "yc_velocity").value == pytest.approx(-0.01, abs=1e-9)  # linear, -0.01/mo
+    assert _feat(rows, "yc_acceleration").value == pytest.approx(0.0, abs=1e-9)
+    assert _feat(rows, "yc_regime").value_label == "flat"   # 0 <= 0.21 < 0.5
+    assert _feat(rows, "yc_zscore").value is not None
+
+
+def test_no_lookahead_ignores_future_spread(rows):
+    # The 2007-07 leak point (spread 99) is after AS_OF; yc_slope must stay 0.21.
+    assert _feat(rows, "yc_slope").value == pytest.approx(0.21, abs=1e-9)
+
+
+def test_credit_and_housing_velocity(rows):
+    assert _feat(rows, "credit_spread_velocity").value == pytest.approx(0.05, abs=1e-9)
+    assert _feat(rows, "housing_velocity").value == pytest.approx(-10.0, abs=1e-9)
+
+
+def test_targets(rows):
+    # base 1500 (2007-06), end at/after as_of+90d (2007-09) = 1440 -> -0.04
+    assert _tgt(rows, "outcome_3m").value == pytest.approx(1440 / 1500 - 1, abs=1e-9)
+    # worst drawdown: peak 1520 -> trough 1200 = -0.210526...
+    assert _tgt(rows, "drawdown").value == pytest.approx(1200 / 1520 - 1, abs=1e-9)
+    # USREC hits 1 within 365d
+    assert _tgt(rows, "recession_flag").value == 1.0
+
+
+def test_deterministic_inputs_hash():
+    ep = EpisodeDescriptor("id", "Fixture GFC", AS_OF)
+    a = compute_episode_rows(ep, fixture_provider, "fixture")
+    b = compute_episode_rows(ep, fixture_provider, "fixture")
+    assert a["features"][0].inputs_hash == b["features"][0].inputs_hash
+    assert a["features"][0].inputs_hash != ""
+
+
+def test_fail_closed_when_series_missing():
+    ep = EpisodeDescriptor("id", "Empty", AS_OF)
+    empty = compute_episode_rows(ep, lambda ids, s, e: {}, "fixture")
+    # every feature null with a reason, every target null with a reason — no crash
+    assert all(r.value is None and r.null_reason for r in empty["features"])
+    assert all(t.value is None and t.null_reason for t in empty["targets"])

--- a/backend/tests/test_hr_features_model.py
+++ b/backend/tests/test_hr_features_model.py
@@ -1,0 +1,36 @@
+"""Tests for the Phase 0 pipeline smoke model (pure train_smoke, no DB)."""
+
+from __future__ import annotations
+
+from app.services.hr_features.model import SMOKE_FEATURES, TARGET, train_smoke
+
+
+def _row(name, target, base):
+    return {"episode_id": name, "name": name, TARGET: target,
+            "features": {f: base + i * 0.1 for i, f in enumerate(SMOKE_FEATURES)}}
+
+
+def test_smoke_model_trains_and_scores():
+    frame = [_row("GFC", 1.0, 0.9), _row("Brexit", 0.0, 0.1), _row("COVID", 1.0, 1.2)]
+    res = train_smoke(frame)
+    assert res["status"] == "experimental"
+    assert res["calibrated"] is False           # never claims calibration
+    assert res["evaluation"] == "in_sample"
+    assert res["n_train"] == 3
+    assert len(res["importances"]) == len(SMOKE_FEATURES)
+    assert len(res["episodes"]) == 3
+    for ep in res["episodes"]:
+        assert 0.0 <= ep["recession_probability"] <= 1.0
+
+
+def test_fail_closed_single_class():
+    frame = [_row("a", 0.0, 0.1), _row("b", 0.0, 0.2)]
+    res = train_smoke(frame)
+    assert res["status"] == "not_available"
+    assert res["null_reason"] == "single_class"
+
+
+def test_fail_closed_too_few():
+    res = train_smoke([_row("only", 1.0, 0.5)])
+    assert res["status"] == "not_available"
+    assert res["null_reason"] == "insufficient_episodes"

--- a/backend/tests/test_hr_features_transforms.py
+++ b/backend/tests/test_hr_features_transforms.py
@@ -1,0 +1,110 @@
+"""Golden-value + fail-closed tests for the Episode Feature Store transforms (no DB).
+
+The series [1, 2, 4, 7, 11] (first-differences 1,2,3,4) is hand-computed so every
+expected value below is exact / closed-form. Run from backend/:
+    pytest --noconftest tests/test_hr_features_transforms.py
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from app.services.hr_features import compute
+from app.services.hr_features.transforms import (
+    FeatureValue,
+    acceleration,
+    level,
+    percentile_rank,
+    regime_label,
+    shock_frequency,
+    slope,
+    trend_persistence,
+    velocity,
+    zscore,
+)
+
+S = [1.0, 2.0, 4.0, 7.0, 11.0]
+
+
+def test_level():
+    assert level(S).value == 11.0
+
+
+def test_velocity():
+    assert velocity(S, periods=1).value == 4.0          # 11 - 7
+    assert velocity(S, periods=2).value == 3.5          # (11 - 4) / 2
+
+
+def test_acceleration():
+    # second difference: 11 - 2*7 + 4 = 1.0
+    assert acceleration(S, periods=1).value == 1.0
+
+
+def test_zscore():
+    # mean=5, sample std=sqrt(16.5); z=(11-5)/sqrt(16.5)
+    expected = 6.0 / math.sqrt(16.5)
+    assert zscore(S, window=5).value == pytest.approx(expected)
+
+
+def test_slope():
+    # OLS slope of y vs x=0..4 -> cov/var = 25/10
+    assert slope(S, window=5).value == pytest.approx(2.5)
+
+
+def test_percentile_rank():
+    # latest (11) is the max -> all 4 others below -> 4/4 = 1.0
+    assert percentile_rank(S, window=5).value == pytest.approx(1.0)
+
+
+def test_trend_persistence():
+    # ma = 5.0; trailing points above ma: 11, 7 (then 4 < 5 stops) -> 2
+    assert trend_persistence(S, ma_window=5).value == 2.0
+
+
+def test_shock_frequency():
+    # diffs [1,2,3,4]; mean 2.5; sample std sqrt(5/3)~1.291; k=1 -> 2,3,4 exceed -> 3
+    assert shock_frequency(S, window=4, k=1.0).value == 3.0
+
+
+def test_regime_label_yield_curve():
+    thresholds = [0.0, 0.5]
+    labels = ["inverted", "flat", "steep"]
+    assert regime_label([0.8], thresholds, labels).label == "steep"
+    assert regime_label([-0.2], thresholds, labels).label == "inverted"
+    assert regime_label([0.3], thresholds, labels).label == "flat"
+    # value is echoed for downstream storage
+    assert regime_label([-0.2], thresholds, labels).value == -0.2
+
+
+# ---- fail-closed paths (no exceptions, null_reason set) -------------------------
+
+def test_insufficient_history_fails_closed():
+    assert velocity([5.0], periods=1).null_reason is not None
+    assert velocity([5.0], periods=1).value is None
+    assert acceleration([1.0, 2.0], periods=1).null_reason is not None
+
+
+def test_no_variance_fails_closed():
+    z = zscore([5.0, 5.0, 5.0], window=3)
+    assert z.value is None
+    assert z.null_reason == "no_variance"
+
+
+def test_nan_and_none_holes_are_dropped():
+    assert level([1.0, None, float("nan"), 9.0]).value == 9.0
+
+
+def test_compute_dispatch_and_unknown_transform():
+    assert compute("velocity", S, periods=1).value == 4.0
+    bad = compute("does_not_exist", S)
+    assert bad.value is None
+    assert bad.null_reason.startswith("unknown_transform")
+
+
+def test_compute_bad_params_fails_closed():
+    # 'level' takes no params; passing one must not raise
+    res = compute("level", S, window=3)
+    assert isinstance(res, FeatureValue)
+    assert res.null_reason is not None and res.null_reason.startswith("bad_params")

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -3271,6 +3271,26 @@ validates the whole trust thesis in ~½ day, training nothing — using the exis
 the shipped RUL predictions. Train the SupCon encoder only on a weak-but-real result; a dead ρ kills the
 project before a dollar of build.
 
+### FRED `fredgraph.csv` ignores the date window for some series — clip in the builder (2026-06-16)
+
+Building the History Rhymes Episode Feature Store Phase 0, I used FRED's **keyless**
+`https://fred.stlouisfed.org/graph/fredgraph.csv?id=<SERIES>&cosd=<start>&coed=<end>` endpoint to avoid
+provisioning a `FRED_API_KEY` (none existed in `.env`, Vercel, or Railway). It works and is reproducible,
+**but it silently ignores `cosd`/`coed` for some series** (`BAMLC0A0CM`, `SP500`) and returns recent data
+instead, while honoring the window for others (`DGS10`, `DGS2`, `HOUST`, `USREC`). A 2007 `as_of` was
+quietly borrowing **2016 SP500 values** and reporting `outcome_3m=0` — wrong-era data masquerading as a
+real zero, not a fetch error.
+
+Fix: **clip every provider series to the requested `[start, end]` window inside the builder**, never trust
+the source to honor it. Out-of-window data then becomes an honest `null` (`source_unavailable`) instead of
+contamination. Two principles this reinforces: (1) a missing feature/target must fail closed with a
+`null_reason`, never a silent fallback or a fabricated proxy — dropping `credit_spread_velocity` and
+nulling GFC's pre-2015 SP500 targets is *more* credible than faking them; (2) a model trained on few rows
+must train on the features **common (non-null) across all rows** rather than collapsing when one is
+unavailable, and must be labeled a pipeline smoke model (not production-calibrated). The keyed FRED API
+(`series/observations`) honors the window reliably if a key is later provisioned — the keyless path is the
+secret-free default.
+
 **Reusable lessons go to canonical `docs/tips.md` (~380 KB), never the root `tips.md` duplicate.**
 The root file is do-not-write; this file is the one loaded for situational awareness.
 

--- a/repo-b/db/schema/10019_episode_feature_store.sql
+++ b/repo-b/db/schema/10019_episode_feature_store.sql
@@ -1,0 +1,199 @@
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 10019_episode_feature_store.sql
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- History Rhymes — Episode Feature Store (Phase 0 slice).
+--
+-- The learning layer that turns episodes from research documents into trainable
+-- examples: derived features (episode_features), forward-looking labels
+-- (episode_targets), and the governed catalog that names them (feature_registry).
+--
+-- Phase 0 ships only these three tables (the minimal vertical slice). The rest of
+-- the warehouse — episode_clusters / episode_forecasts / episode_calibration and a
+-- wide view for trainers — lands in a later migration (Phase 1). See ADO Story #624 / Feature #623.
+--
+-- LINEAGE (linear, by design):
+--   FRED raw pull -> episode_signals (raw normalized panel, 434)
+--                 -> episode_features (derived, this file)
+--                 -> episode_targets  (future-outcome labels, this file)
+--                 -> episode_forecasts -> episode_calibration (10019, later)
+--
+-- NO-LOOKAHEAD CONTRACT: an episode emits one or more `as_of_date` windows.
+--   episode_features hold values computed ONLY from observations <= as_of_date.
+--   episode_targets  hold outcomes  computed ONLY from observations >  as_of_date.
+--
+-- ENTITY-GENERIC SEAM: tables carry (entity_type, entity_id) so RS booster-flight
+--   "episodes" can reuse this warehouse later with no migration. For History Rhymes
+--   v1: entity_type='hr_episode', entity_id = episodes.id, and episode_id is a real
+--   FK to episodes(id). For a future entity: entity_type='rs_flight',
+--   entity_id = <flight id>, episode_id = NULL.
+--
+-- TENANT ISOLATION: these are SHARED DIMENSION tables in the History Rhymes module
+--   (single-tenant analytics), exactly like public.episodes / public.episode_signals
+--   / public.episode_embeddings (434/503). They intentionally carry NO env_id /
+--   business_id; RLS is enabled with read-for-all + service_role-write, mirroring
+--   public.episode_embeddings in 503_history_rhymes_structural.sql.
+--
+-- Requires: public.episodes (434_history_rhymes_wss.sql).
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- ───────────────────────────────────────────────────────────────────────────────
+-- 1. feature_registry — the governed catalog (one row per named feature)
+-- ───────────────────────────────────────────────────────────────────────────────
+-- Naming + versioning + lineage layer. episode_features.feature_id FKs here, so a
+-- feature value cannot exist without a declared definition (registry<->impl parity
+-- is asserted in tests). raw_sources records provenance (e.g. ARRAY['FRED:DGS10']).
+
+CREATE TABLE IF NOT EXISTS public.feature_registry (
+    feature_id            TEXT PRIMARY KEY,
+        -- stable slug, e.g. 'yc_slope', 'yc_velocity', 'credit_spread_velocity'
+    feature_name          TEXT NOT NULL,
+    family                TEXT NOT NULL,
+        -- 'yield_curve' | 'vix' | 'credit' | 'housing' | 'labor' | 'liquidity' | 'equity'
+    transform             TEXT NOT NULL,
+        -- 'level' | 'slope' | 'velocity' | 'acceleration' | 'zscore' | 'percentile'
+        -- | 'regime' | 'surprise' | 'trend_persistence' | 'contango' | 'shock_frequency'
+    raw_sources           TEXT[] NOT NULL DEFAULT '{}',
+        -- e.g. ARRAY['FRED:DGS10','FRED:DGS2']
+    window_days           INTEGER,
+        -- lookback window for the transform; NULL for point-in-time levels
+    stale_threshold_hours INTEGER,
+    value_kind            TEXT NOT NULL DEFAULT 'numeric',
+        -- 'numeric' | 'categorical' (regime labels live in episode_features.value_label)
+    unit                  TEXT,
+    description           TEXT,
+    owner                 TEXT NOT NULL DEFAULT 'history-rhymes',
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (value_kind IN ('numeric', 'categorical'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_registry_family
+    ON public.feature_registry(family);
+
+ALTER TABLE public.feature_registry ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS feature_registry_read ON public.feature_registry;
+CREATE POLICY feature_registry_read ON public.feature_registry
+    FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS feature_registry_service_write ON public.feature_registry;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+        EXECUTE 'CREATE POLICY feature_registry_service_write ON public.feature_registry FOR ALL TO service_role USING (true) WITH CHECK (true)';
+    END IF;
+END $$;
+
+COMMENT ON TABLE public.feature_registry IS
+    'Governed catalog of History Rhymes derived features (name, family, transform, raw sources, lineage). '
+    'episode_features.feature_id references this table. Shared dimension (no env_id), mirrors the '
+    'episode_embeddings tenancy stance. Owning module: skills/historyrhymes (Episode Feature Store, ADO #623).';
+
+-- ───────────────────────────────────────────────────────────────────────────────
+-- 2. episode_features — derived feature values (long/tall) at an as_of window
+-- ───────────────────────────────────────────────────────────────────────────────
+-- One row per (entity, as_of_date, feature, model_version). Long form matches the
+-- registry; a wide view for trainers is added in 10019. Numeric values in `value`;
+-- categorical (regime) labels in `value_label`. Fail-closed: a missing value carries
+-- a `null_reason` rather than a silent zero.
+
+CREATE TABLE IF NOT EXISTS public.episode_features (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type     TEXT NOT NULL DEFAULT 'hr_episode',
+        -- 'hr_episode' now; 'rs_flight' etc. later (entity-generic seam)
+    entity_id       UUID NOT NULL,
+        -- for hr_episode this equals episodes.id
+    episode_id      UUID REFERENCES public.episodes(id) ON DELETE CASCADE,
+        -- real FK for History Rhymes; NULL for non-episode entities
+    as_of_date      DATE NOT NULL,
+    feature_id      TEXT NOT NULL REFERENCES public.feature_registry(feature_id),
+    value           DOUBLE PRECISION,
+        -- numeric value; NULL when not computable (see null_reason)
+    value_label     TEXT,
+        -- categorical/regime label, e.g. 'inverted' | 'flat' | 'steep'
+    null_reason     TEXT,
+        -- e.g. 'insufficient_history' | 'source_unavailable' (fail-closed)
+    inputs_hash     TEXT NOT NULL,
+        -- hash of the raw inputs used; powers idempotent re-computation
+    freshness_hours NUMERIC(10,2),
+    model_version   TEXT NOT NULL DEFAULT 'fs-v0',
+    data_provenance TEXT NOT NULL DEFAULT 'public_fred',
+        -- 'public_fred' | 'public_treasury' | 'derived' | 'synthetic_seed'
+    computed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (entity_type, entity_id, as_of_date, feature_id, model_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_episode_features_episode
+    ON public.episode_features(episode_id);
+CREATE INDEX IF NOT EXISTS idx_episode_features_lookup
+    ON public.episode_features(entity_type, entity_id, as_of_date);
+
+ALTER TABLE public.episode_features ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS episode_features_read ON public.episode_features;
+CREATE POLICY episode_features_read ON public.episode_features
+    FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS episode_features_service_write ON public.episode_features;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+        EXECUTE 'CREATE POLICY episode_features_service_write ON public.episode_features FOR ALL TO service_role USING (true) WITH CHECK (true)';
+    END IF;
+END $$;
+
+COMMENT ON TABLE public.episode_features IS
+    'Derived History Rhymes features at point-in-time as_of windows (long form). Values computed only '
+    'from data <= as_of_date (no-lookahead). feature_id references feature_registry. Shared dimension '
+    '(no env_id), mirrors episode_embeddings tenancy. Owning module: skills/historyrhymes (ADO #624).';
+
+-- ───────────────────────────────────────────────────────────────────────────────
+-- 3. episode_targets — forward-looking training labels at an as_of window
+-- ───────────────────────────────────────────────────────────────────────────────
+-- Outcomes computed ONLY from data strictly after as_of_date. horizon_days is part
+-- of the key (NOT NULL, 0 for non-horizon targets like recovery_days) so upserts
+-- stay idempotent (Postgres treats NULL as distinct in UNIQUE).
+
+CREATE TABLE IF NOT EXISTS public.episode_targets (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type     TEXT NOT NULL DEFAULT 'hr_episode',
+    entity_id       UUID NOT NULL,
+    episode_id      UUID REFERENCES public.episodes(id) ON DELETE CASCADE,
+    as_of_date      DATE NOT NULL,
+    target_name     TEXT NOT NULL,
+        -- 'outcome_3m' | 'outcome_6m' | 'outcome_12m' | 'drawdown'
+        -- | 'recovery_days' | 'recession_flag'
+    horizon_days    INTEGER NOT NULL DEFAULT 0,
+        -- 90/180/365 for outcome_*; 365 for recession_flag/drawdown; 0 for recovery_days
+    value           DOUBLE PRECISION,
+    null_reason     TEXT,
+    source_lineage  TEXT,
+        -- e.g. 'FRED:SP500 forward total return as_of+90d'
+    data_provenance TEXT NOT NULL DEFAULT 'public_fred',
+    computed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (entity_type, entity_id, as_of_date, target_name, horizon_days)
+);
+
+CREATE INDEX IF NOT EXISTS idx_episode_targets_episode
+    ON public.episode_targets(episode_id);
+CREATE INDEX IF NOT EXISTS idx_episode_targets_lookup
+    ON public.episode_targets(entity_type, entity_id, as_of_date);
+
+ALTER TABLE public.episode_targets ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS episode_targets_read ON public.episode_targets;
+CREATE POLICY episode_targets_read ON public.episode_targets
+    FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS episode_targets_service_write ON public.episode_targets;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+        EXECUTE 'CREATE POLICY episode_targets_service_write ON public.episode_targets FOR ALL TO service_role USING (true) WITH CHECK (true)';
+    END IF;
+END $$;
+
+COMMENT ON TABLE public.episode_targets IS
+    'Forward-looking training labels for History Rhymes episodes (outcome_3m/6m/12m, drawdown, '
+    'recovery_days, recession_flag) at as_of windows. Computed only from data > as_of_date '
+    '(no-lookahead). Shared dimension (no env_id). Owning module: skills/historyrhymes (ADO #624).';

--- a/repo-b/src/app/lab/env/[envId]/historyrhymes/observatory/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/historyrhymes/observatory/page.tsx
@@ -1,0 +1,10 @@
+import { FeatureObservatoryClient } from "@/components/historyrhymes/FeatureObservatoryClient";
+
+export default async function FeatureObservatoryPage({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  return <FeatureObservatoryClient envId={envId} />;
+}

--- a/repo-b/src/components/historyrhymes/FeatureObservatoryClient.tsx
+++ b/repo-b/src/components/historyrhymes/FeatureObservatoryClient.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+/**
+ * Feature Observatory (History Rhymes Episode Feature Store, Phase 0).
+ *
+ * Flagship learning-layer surface. For a selected episode, shows the five bands:
+ *   Raw Inputs -> Derived Features -> Model Outputs -> Analog Matches -> Forecast Performance
+ * proving data engineering + feature engineering + (smoke) forecasting + the
+ * honest "not yet" placeholders for analog/calibration (Phases 4-5).
+ *
+ * Standalone full-bleed dark surface (no app shell), Tailwind neutral palette,
+ * reusing mlUi primitives. Phase 0 displays an explicit model status badge and
+ * never implies calibration that has not been measured.
+ */
+
+import * as React from "react";
+
+import { HrSubNav } from "@/components/historyrhymes/HrSubNav";
+import { ErrorState, Loading, Panel, StatTile, Tag, fmt } from "@/components/historyrhymes/mlUi";
+import {
+  fetchObservatory,
+  fetchObservatoryEpisodes,
+  type EpisodeListItem,
+  type ObservatoryResponse,
+} from "@/lib/historyrhymes/episodeObservatory";
+
+function StatusBadge({ status }: { status?: string }) {
+  const tone =
+    status === "calibrated" ? "emerald" : status === "experimental" ? "amber" : "neutral";
+  const label =
+    status === "experimental"
+      ? "EXPERIMENTAL · not calibrated"
+      : status === "calibrated"
+        ? "CALIBRATED"
+        : (status || "unknown").toUpperCase();
+  return <Tag tone={tone as "amber" | "emerald" | "neutral"}>{label}</Tag>;
+}
+
+function ProvenanceBadge({ provenance }: { provenance?: string[] }) {
+  if (!provenance || provenance.length === 0) return null;
+  const isFixture = provenance.includes("fixture");
+  return (
+    <Tag tone={isFixture ? "violet" : "sky"}>
+      {isFixture ? "SYNTHETIC FIXTURE" : provenance.join(", ").toUpperCase()}
+    </Tag>
+  );
+}
+
+function PlannedBand({ title, reason }: { title: string; reason: string }) {
+  const phase = reason.includes("phase_4") ? "Phase 4" : reason.includes("phase_5") ? "Phase 5" : "later";
+  const what = reason.includes("phase_4") ? "pgvector analog retrieval" : "calibration (Brier / MAE / hit-rate)";
+  return (
+    <Panel title={title} right={<Tag tone="neutral">PLANNED · {phase}</Tag>}>
+      <div className="text-sm text-neutral-500">
+        Not available yet — {what} lands in {phase}. Shown as a placeholder rather than fabricated numbers.
+      </div>
+    </Panel>
+  );
+}
+
+export function FeatureObservatoryClient({ envId }: { envId: string }) {
+  const [episodes, setEpisodes] = React.useState<EpisodeListItem[] | null>(null);
+  const [selected, setSelected] = React.useState<string | null>(null);
+  const [data, setData] = React.useState<ObservatoryResponse | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let alive = true;
+    (async () => {
+      const res = await fetchObservatoryEpisodes();
+      if (!alive) return;
+      if (!res || res.status !== "ok" || res.episodes.length === 0) {
+        setError("No episodes have feature-store data yet. Run the Phase 0 backfill.");
+        setLoading(false);
+        return;
+      }
+      setEpisodes(res.episodes);
+      // Default to the GFC episode if present, else the first.
+      const gfc = res.episodes.find((e) => e.name.includes("Global Financial"));
+      setSelected((gfc || res.episodes[0]).id);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (!selected) return;
+    let alive = true;
+    setLoading(true);
+    (async () => {
+      const res = await fetchObservatory(selected);
+      if (!alive) return;
+      if (!res || res.status !== "ok" || !res.bands) {
+        setError(`Observatory unavailable (${res?.null_reason ?? "fetch failed"}).`);
+        setData(null);
+      } else {
+        setError(null);
+        setData(res);
+      }
+      setLoading(false);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [selected]);
+
+  return (
+    <div className="min-h-screen bg-neutral-950 text-neutral-100 px-4 py-5 lg:px-7">
+      <HrSubNav envId={envId} />
+
+      <header className="mb-4">
+        <h1 className="text-lg font-semibold">Feature Observatory</h1>
+        <p className="text-xs text-neutral-500 mt-1">
+          Every historical episode as a training example: raw inputs → derived features → model
+          outputs → analog matches → forecast performance. Phase 0 vertical slice.
+        </p>
+      </header>
+
+      {episodes && (
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          {episodes.map((e) => (
+            <button
+              key={e.id}
+              type="button"
+              onClick={() => setSelected(e.id)}
+              className={`text-xs px-3 py-1.5 rounded border transition-colors ${
+                e.id === selected
+                  ? "bg-sky-500/20 text-sky-200 border-sky-500/40"
+                  : "bg-neutral-900 text-neutral-400 border-neutral-800 hover:text-neutral-200"
+              }`}
+            >
+              {e.name}
+              {e.is_non_event ? " · non-event" : ""}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {loading && <Loading label="Loading observatory…" />}
+      {!loading && error && <ErrorState message={error} />}
+
+      {!loading && data && data.bands && (
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium text-neutral-200">{data.episode?.name}</span>
+            <Tag tone="neutral">as of {data.episode?.as_of}</Tag>
+            <StatusBadge status={data.model_status} />
+            <ProvenanceBadge provenance={data.data_provenance} />
+          </div>
+
+          {/* Band 0 — Data Coverage (missing data as a trust signal) */}
+          {data.coverage ? (
+            <Panel
+              title="Data Coverage"
+              right={
+                <span className="text-[11px] text-neutral-500">
+                  features {data.coverage.features_available}/{data.coverage.features_total} · targets{" "}
+                  {data.coverage.targets_available}/{data.coverage.targets_total}
+                </span>
+              }
+            >
+              {data.coverage.unavailable.length === 0 ? (
+                <div className="text-sm text-emerald-300">All features and targets available.</div>
+              ) : (
+                <ul className="space-y-1">
+                  {data.coverage.unavailable.map((u) => (
+                    <li key={`${u.kind}-${u.id}`} className="text-xs text-neutral-400 flex items-center gap-2">
+                      <Tag tone="amber">{u.kind}</Tag>
+                      <span className="text-neutral-200">{u.id}</span>
+                      <span className="text-neutral-500">— {u.reason}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <p className="text-[11px] text-neutral-600 mt-2">
+                Unavailable fields fail closed with a reason — never filled with a fabricated proxy.
+              </p>
+            </Panel>
+          ) : null}
+
+          {/* Band 1 — Raw Inputs */}
+          <Panel title="1 · Raw Inputs">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              {data.bands.raw_inputs.map((ri) => (
+                <div key={ri.family} className="bg-neutral-950/60 border border-neutral-800 rounded-md p-3">
+                  <div className="text-[10px] uppercase tracking-wide text-neutral-500">{ri.family}</div>
+                  <div className="text-xs text-neutral-300 mt-1">{ri.raw_sources.join(", ")}</div>
+                </div>
+              ))}
+            </div>
+          </Panel>
+
+          {/* Band 2 — Derived Features */}
+          <Panel title="2 · Derived Features">
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead className="text-neutral-500">
+                  <tr className="text-left">
+                    <th className="py-1 pr-3 font-medium">Feature</th>
+                    <th className="py-1 pr-3 font-medium">Family</th>
+                    <th className="py-1 pr-3 font-medium">Transform</th>
+                    <th className="py-1 pr-3 font-medium text-right">Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.bands.derived_features.map((f) => (
+                    <tr key={f.feature_id} className="border-t border-neutral-800/60">
+                      <td className="py-1.5 pr-3 text-neutral-200">{f.feature_name}</td>
+                      <td className="py-1.5 pr-3 text-neutral-500">{f.family}</td>
+                      <td className="py-1.5 pr-3 text-neutral-500">{f.transform}</td>
+                      <td className="py-1.5 pr-3 text-right font-mono text-neutral-100">
+                        {f.null_reason ? (
+                          <span className="text-amber-300">{f.null_reason}</span>
+                        ) : f.value_label ? (
+                          <Tag tone="sky">{f.value_label}</Tag>
+                        ) : (
+                          fmt(f.value)
+                        )}
+                        {f.unit && !f.null_reason && !f.value_label ? (
+                          <span className="text-neutral-600 ml-1">{f.unit}</span>
+                        ) : null}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Panel>
+
+          {/* Band 3 — Model Outputs (with explicit pipeline-smoke-model framing) */}
+          <Panel
+            title="3 · Model Outputs"
+            right={<StatusBadge status={data.bands.model_outputs.status ?? undefined} />}
+          >
+            {/* Honesty header: this is a pipeline smoke model, not a calibrated forecaster. */}
+            <div className="mb-3 rounded-md border border-amber-500/30 bg-amber-500/5 p-2.5">
+              <div className="flex flex-wrap items-center gap-2">
+                <Tag tone="amber">{(data.bands.model_outputs.status_label ?? "pipeline smoke model").toUpperCase()}</Tag>
+                <span className="text-[11px] text-neutral-400">
+                  basis: {data.bands.model_outputs.training_basis ?? "—"} · calibration:{" "}
+                  {data.bands.model_outputs.calibrated ? "calibrated" : "not production-calibrated"}
+                </span>
+              </div>
+              <div className="text-[11px] text-neutral-500 mt-1">
+                Purpose: {data.bands.model_outputs.purpose ?? "validate the loop"}.
+              </div>
+              {data.bands.model_outputs.features_dropped.length > 0 ? (
+                <div className="text-[11px] text-neutral-500 mt-1">
+                  Trained on {data.bands.model_outputs.features_used.length} features; dropped{" "}
+                  {data.bands.model_outputs.features_dropped.join(", ")} (unavailable).
+                </div>
+              ) : null}
+            </div>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+              <StatTile
+                label="Recession probability"
+                value={
+                  data.bands.model_outputs.recession_probability != null
+                    ? `${(data.bands.model_outputs.recession_probability * 100).toFixed(1)}%`
+                    : "—"
+                }
+                sub={`actual flag: ${data.bands.model_outputs.recession_flag ?? "—"}`}
+              />
+              <StatTile label="Model" value={data.bands.model_outputs.model ?? "—"} sub={data.bands.model_outputs.target ?? ""} />
+              <StatTile label="Calibrated" value={data.bands.model_outputs.calibrated ? "yes" : "no"} sub="in-sample" />
+            </div>
+            {data.bands.model_outputs.note ? (
+              <p className="text-[11px] text-neutral-500 mt-3">{data.bands.model_outputs.note}</p>
+            ) : null}
+          </Panel>
+
+          {/* Band 4 — Analog Matches (planned) */}
+          <PlannedBand title="4 · Analog Matches" reason={data.bands.analog_matches.null_reason} />
+
+          {/* Band 5 — Forecast Performance (planned) */}
+          <PlannedBand title="5 · Forecast Performance" reason={data.bands.forecast_performance.null_reason} />
+
+          {/* Targets footnote */}
+          {data.targets && data.targets.length > 0 ? (
+            <Panel title="Training labels (targets)">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+                {data.targets.map((t) => (
+                  <StatTile
+                    key={`${t.target_name}-${t.horizon_days}`}
+                    label={`${t.target_name} (${t.horizon_days}d)`}
+                    value={t.null_reason ? <span className="text-amber-300 text-sm">{t.null_reason}</span> : fmt(t.value)}
+                    sub={t.source_lineage ?? ""}
+                  />
+                ))}
+              </div>
+            </Panel>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/repo-b/src/components/historyrhymes/HrSubNav.tsx
+++ b/repo-b/src/components/historyrhymes/HrSubNav.tsx
@@ -8,6 +8,7 @@ const TABS = [
   { slug: "morning-book", label: "Morning Book" },
   { slug: "planning", label: "Planning" },
   { slug: "ml-algorithms", label: "ML Algorithm Lab" },
+  { slug: "observatory", label: "Feature Observatory" },
 ];
 
 /** Minimal tab strip linking the History Rhymes sub-pages for an env. */

--- a/repo-b/src/lib/historyrhymes/episodeObservatory.ts
+++ b/repo-b/src/lib/historyrhymes/episodeObservatory.ts
@@ -1,0 +1,113 @@
+/**
+ * Client for the Episode Feature Store / Feature Observatory API (Phase 0).
+ *
+ * Same direct-to-FastAPI convention as the other HR clients (NEXT_PUBLIC_API_BASE,
+ * no Next.js proxy). Paths are /api/hr/v1/features/* — the /api/historyrhymes/*
+ * namespace is forbidden by the HR contract test. Distinct from featureStore.ts
+ * (the ml-demo "Feature Foundry" surface); this drives the episode Observatory.
+ */
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "";
+
+async function getJson<T>(path: string): Promise<T | null> {
+  try {
+    const res = await fetch(`${API_BASE}${path}`, { cache: "no-store" });
+    if (!res.ok) throw new Error(`${path} → ${res.status}`);
+    return (await res.json()) as T;
+  } catch (err) {
+    console.error(`[episode-observatory] ${path} failed:`, err);
+    return null;
+  }
+}
+
+export type EpisodeListItem = {
+  id: string;
+  name: string;
+  is_non_event: boolean;
+  as_of: string | null;
+  feature_count: number;
+};
+
+export type EpisodesResponse = {
+  status: "ok" | "not_available";
+  episodes: EpisodeListItem[];
+  null_reason: string | null;
+};
+
+export type DerivedFeature = {
+  feature_id: string;
+  feature_name: string;
+  family: string;
+  transform: string;
+  unit: string | null;
+  raw_sources: string[];
+  value: number | null;
+  value_label: string | null;
+  null_reason: string | null;
+  data_provenance: string;
+};
+
+export type RawInput = { family: string; raw_sources: string[] };
+
+export type ModelOutputs = {
+  status: string | null;
+  status_label: string | null;
+  training_basis: string | null;
+  purpose: string | null;
+  calibrated: boolean;
+  model: string | null;
+  target: string | null;
+  features_used: string[];
+  features_dropped: string[];
+  note: string | null;
+  recession_flag: number | null;
+  recession_probability: number | null;
+  null_reason: string | null;
+};
+
+export type CoverageItem = { kind: "feature" | "target"; id: string; reason: string };
+
+export type Coverage = {
+  features_available: number;
+  features_total: number;
+  targets_available: number;
+  targets_total: number;
+  unavailable: CoverageItem[];
+};
+
+export type PlannedBand = { status: "not_available"; null_reason: string };
+
+export type ObservatoryTarget = {
+  target_name: string;
+  horizon_days: number;
+  value: number | null;
+  null_reason: string | null;
+  source_lineage: string | null;
+};
+
+export type ObservatoryResponse = {
+  status: "ok" | "not_available";
+  null_reason: string | null;
+  model_status?: string;
+  data_provenance?: string[];
+  episode?: { id: string; name: string; as_of: string; is_non_event: boolean };
+  coverage?: Coverage;
+  bands?: {
+    raw_inputs: RawInput[];
+    derived_features: DerivedFeature[];
+    model_outputs: ModelOutputs;
+    analog_matches: PlannedBand & { items: unknown[] };
+    forecast_performance: PlannedBand & { metrics: Record<string, unknown> };
+  };
+  targets?: ObservatoryTarget[];
+};
+
+export function fetchObservatoryEpisodes(): Promise<EpisodesResponse | null> {
+  return getJson<EpisodesResponse>("/api/hr/v1/features/episodes");
+}
+
+export function fetchObservatory(episodeId: string): Promise<ObservatoryResponse | null> {
+  return getJson<ObservatoryResponse>(
+    `/api/hr/v1/features/episodes/${encodeURIComponent(episodeId)}/observatory`,
+  );
+}


### PR DESCRIPTION
## History Rhymes — Episode Feature Store + Model Lab (Phase 0)

The learning layer: every historical episode becomes a labeled training example, end to end on **real keyless-FRED data**. ADO **#624** (Feature #623, Epic #213).

> **Stacked PR.** Base is `feat/hr-ml-algorithm-decision-lab`, not `main`, because Phase 0 depends on `hr_ml_demo` / `HrSubNav` which are not yet on `main`. The 159-line ADE-removal in that branch's working tree is intentionally **not** included here.

### What's in it
- **Real keyless FRED-backed Phase 0 slice** — `fredgraph.csv` (no `FRED_API_KEY`); `provenance=public_fred`.
- **Feature/target coverage panel** (Band 0) — `features X/Y · targets X/Y` + each unavailable field with its `null_reason`. Missing data as a trust signal.
- **Pipeline smoke-model honesty card** — amber badge, `training_basis=3 episodes`, *not production-calibrated*, dropped-feature note.
- **Fail-closed null reasons** — credit + GFC pre-2015 SP500 targets fail closed with reasons, never fabricated proxies.
- **Leakage fix** — clip `fredgraph.csv` responses to the requested window (it ignores the date range for some series; a 2007 `as_of` was borrowing 2016 SP500). Out-of-window → honest null.

### Behavior (real data)
- Features 6/7 real for all 3 episodes (`credit_spread_velocity` honestly null).
- `recession_flag` real for all 3 (GFC=1, Brexit=0, COVID=1); SP500 targets real for Brexit (−5.3%) / COVID (−33.9%), null for GFC (pre-2015).
- Smoke model: GFC 0.935 / COVID 0.96 / Brexit 0.29 (5 features; credit dropped).

### Receipts
- `pytest --noconftest tests/test_hr_features_*.py tests/test_hr_episode_builder.py` → **24 passed**
- `npm run typecheck` → **exit 0**
- Live API: `provenance=['public_fred']`, coverage 6/7 + 1/3, 5 Observatory bands
- **Remaining: Vercel preview screenshot** of the GFC Observatory (Band 0 coverage + amber smoke-model card) → attach to PR + ADO #624 before Close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
