### PR TITLE
Phase 6 PR 15: Enterprise Memory Index (scoped retrieval, no LLM)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,6 +81,7 @@ from app.routes import telemetry
 from app.routes import telemetry_copilot
 from app.routes import automated_data_engineering
 from app.routes import intelligence_cards
+from app.routes import enterprise_memory
 from app.routes import events_analytics
 from app.routes import workflow_registry
 from app.routes import audit_dashboard
@@ -461,6 +462,7 @@ app.include_router(telemetry.router)
 app.include_router(telemetry_copilot.router)
 app.include_router(automated_data_engineering.router)
 app.include_router(intelligence_cards.router)
+app.include_router(enterprise_memory.router)
 app.include_router(events_analytics.router)
 app.include_router(workflow_registry.router)
 app.include_router(audit_dashboard.router)

--- a/backend/app/routes/enterprise_memory.py
+++ b/backend/app/routes/enterprise_memory.py
@@ -1,0 +1,87 @@
+"""Enterprise Memory API (plan PR 15) — scoped retrieval, NO LLM.
+
+Returns RECORDS WITH CITATIONS; never answers. Reads are env-scoped (and see org-global
+null-env rows read-only). Writing is admin-only; writing a GLOBAL (null-env) row requires
+admin and is the only way a global record is minted — a normal env actor cannot leak into
+the global pool. Embedding fill is deferred to a BackgroundTask; the request returns fast.
+Every handler fails closed to {..., null_reason} rather than a 500.
+
+Paths:
+    GET  /api/ade/memory/search                          scoped retrieval (records + citations)
+    POST /api/ade/memory/index                           admin-only; upsert + async embed
+    GET  /api/ade/memory/similar/{item_type}/{source_id} similar records by stored embedding
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, BackgroundTasks, Query, Request
+from pydantic import BaseModel
+
+from app.auth.platform import require_authenticated_request, require_environment_access
+from app.observability.logger import emit_log
+from app.services import enterprise_memory as svc
+
+router = APIRouter(prefix="/api/ade/memory", tags=["ade"])
+
+_ADMIN_ROLES = {"admin"}
+
+
+class IndexBody(BaseModel):
+    item_type: str
+    source_id: str
+    title: str
+    content_text: str
+    business_id: UUID
+    env_id: str | None = None  # null => org-global record (admin-only)
+    summary: str | None = None
+    source_ref: dict | None = None
+    metadata: dict | None = None
+
+
+@router.get("/search")
+def search(request: Request, env_id: str = Query(...), business_id: UUID = Query(...),
+           q: str = Query(...), item_type: str = Query(None), top_k: int = Query(5, ge=1, le=50)):
+    require_environment_access(request, env_id=env_id)
+    try:
+        return svc.search(env_id, business_id, q, item_type=item_type, top_k=top_k)
+    except Exception as exc:  # noqa: BLE001 — fail closed, never 500
+        emit_log(level="error", service="enterprise_memory", action="search_route_failed", message=str(exc), error=exc)
+        return {"items": [], "null_reason": "search_unavailable"}
+
+
+@router.post("/index")
+def index(body: IndexBody, request: Request, background_tasks: BackgroundTasks):
+    # Admin-only write. Env-scoped writes are gated against that env; a global (null-env)
+    # write requires an admin actor (no env to scope against) — this is the only mint path
+    # for a global record, so a normal env actor can never create one.
+    if body.env_id:
+        require_environment_access(request, env_id=body.env_id, allowed_app_roles=_ADMIN_ROLES, strict=True)
+    else:
+        auth = require_authenticated_request(request)
+        if getattr(auth, "app_role", None) not in _ADMIN_ROLES:
+            return {"item_id": None, "embedding_status": None, "null_reason": "global_write_requires_admin"}
+    try:
+        result = svc.index_item(
+            item_type=body.item_type, source_id=body.source_id, title=body.title,
+            content_text=body.content_text, business_id=body.business_id, env_id=body.env_id,
+            summary=body.summary, source_ref=body.source_ref, metadata=body.metadata,
+        )
+        # Defer embedding off the request path — returns fast with status 'pending'.
+        if result.get("item_id"):
+            background_tasks.add_task(svc.embed_pending_item, result["item_id"])
+        return result
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="enterprise_memory", action="index_route_failed", message=str(exc), error=exc)
+        return {"item_id": None, "embedding_status": None, "null_reason": "index_unavailable"}
+
+
+@router.get("/similar/{item_type}/{source_id}")
+def similar(item_type: str, source_id: str, request: Request,
+            env_id: str = Query(...), business_id: UUID = Query(...), top_k: int = Query(5, ge=1, le=50)):
+    require_environment_access(request, env_id=env_id)
+    try:
+        return svc.similar_items(item_type, source_id, env_id, business_id, top_k=top_k)
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="enterprise_memory", action="similar_route_failed", message=str(exc), error=exc)
+        return {"items": [], "null_reason": "similar_unavailable"}

--- a/backend/app/services/enterprise_memory.py
+++ b/backend/app/services/enterprise_memory.py
@@ -1,0 +1,273 @@
+"""Enterprise Memory Index (plan PR 15, Phase 6) — scoped retrieval, NO LLM.
+
+A retrieval/index layer, NOT an answerer. It returns RECORDS WITH CITATIONS (item_type,
+source_id, title, indexed_at); it never synthesizes an answer and makes no model call.
+
+Scoping: env_id NULL = org-global (e.g. ADRs), visible read-only to every env; non-null =
+env-scoped. Cross-env reads are blocked in BOTH the DB policy and the service WHERE clause.
+Writing a global (null-env) row is admin/system-only (enforced here, not relaxed at the DB).
+
+Embedding is ASYNCHRONOUS: index_item writes the row fast (embedding NULL, status 'pending')
+and never calls the provider on the request path; embed_pending_item fills it in the
+background. Missing provider FAILS CLOSED — embedding stays NULL with status 'no_provider';
+a zero/fake vector is NEVER stored (this module gates on OPENAI_API_KEY BEFORE calling the
+shared embedding code, which would otherwise return zero-vectors).
+"""
+from __future__ import annotations
+
+import json
+from uuid import UUID
+
+from app.config import OPENAI_EMBEDDING_MODEL
+from app.db import get_cursor
+from app.observability.logger import emit_log
+
+ITEM_TYPES = ("adr", "investigation", "card", "decision", "workflow")
+EMBED_DIM = 1536
+
+
+def _set_tenant(cur, env_id: str | None) -> None:
+    # Global (null-env) reads run with an empty scope; the RLS IS NULL branch still exposes
+    # global rows, and env rows are excluded because '' matches no real env.
+    cur.execute("SELECT set_config('app.env_id', %s, true)", (env_id or "",))
+
+
+def _has_provider() -> bool:
+    # Re-read at call time (tests/process may set it) rather than trusting an import-time copy.
+    from app import config
+    return bool(getattr(config, "OPENAI_API_KEY", ""))
+
+
+# ── index (fast, no provider call) ────────────────────────────────────────────
+def index_item(
+    *,
+    item_type: str,
+    source_id: str,
+    title: str,
+    content_text: str,
+    business_id: str | UUID,
+    env_id: str | None,
+    summary: str | None = None,
+    source_ref: dict | None = None,
+    metadata: dict | None = None,
+) -> dict:
+    """Upsert a memory row synchronously with embedding NULL + status 'pending', and return
+    fast. Idempotent by (item_type, source_id, business_id, env_id). Never calls the provider.
+    """
+    if item_type not in ITEM_TYPES:
+        return {"item_id": None, "embedding_status": None, "null_reason": "invalid_item_type"}
+    if not source_id or not title or not content_text:
+        return {"item_id": None, "embedding_status": None, "null_reason": "invalid_inputs"}
+    biz = business_id if isinstance(business_id, UUID) else UUID(str(business_id))
+
+    # The unique key spans (item_type, source_id, business_id, env_id) but env_id is nullable,
+    # so two partial unique indexes back it (env vs global). ON CONFLICT targets the matching
+    # one by its index predicate, which is fixed per call since env_id is known here.
+    conflict = (
+        "(item_type, source_id, business_id) WHERE env_id IS NULL" if env_id is None
+        else "(item_type, source_id, business_id, env_id) WHERE env_id IS NOT NULL"
+    )
+    with get_cursor() as cur:
+        _set_tenant(cur, env_id)
+        cur.execute(
+            f"""INSERT INTO nv_enterprise_memory_items
+                   (env_id, business_id, item_type, source_id, title, summary, content_text,
+                    embedding_status, source_ref, metadata)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, 'pending', %s, %s)
+               ON CONFLICT {conflict} DO UPDATE SET
+                   title = EXCLUDED.title,
+                   summary = EXCLUDED.summary,
+                   content_text = EXCLUDED.content_text,
+                   source_ref = EXCLUDED.source_ref,
+                   metadata = EXCLUDED.metadata,
+                   embedding = NULL,
+                   embedding_status = 'pending',
+                   embedding_model = NULL,
+                   null_reason = NULL,
+                   indexed_at = now(),
+                   updated_at = now()
+               RETURNING id::text""",
+            (env_id, str(biz), item_type, source_id, title, summary, content_text,
+             json.dumps(source_ref or {}), json.dumps(metadata or {})),
+        )
+        item_id = cur.fetchone()["id"]
+    return {"item_id": item_id, "embedding_status": "pending", "null_reason": None}
+
+
+# ── background embedding fill (provider fail-closed) ───────────────────────────
+def embed_pending_item(item_id: str) -> dict:
+    """Fill one row's embedding. Runs in the background (or via the backfill script). FAILS
+    CLOSED on a missing/erroring provider — never writes a zero/fake vector.
+    """
+    # Provider absent → mark no_provider, do NOT call the shared embedding code (it would
+    # return a zero-vector that poisons cosine ranking).
+    if not _has_provider():
+        _mark_status(item_id, status="no_provider", null_reason="embedding_provider_unavailable")
+        return {"item_id": item_id, "embedding_status": "no_provider"}
+
+    with get_cursor() as cur:
+        cur.execute(
+            "SELECT env_id, content_text FROM nv_enterprise_memory_items WHERE id = %s", (item_id,)
+        )
+        row = cur.fetchone()
+    if not row:
+        return {"item_id": item_id, "embedding_status": None, "null_reason": "item_not_found"}
+
+    try:
+        from app.services.rag_indexer import _embed_texts
+        vec = _embed_texts([row["content_text"]])[0]
+        if len(vec) != EMBED_DIM:
+            raise ValueError(f"embedding dim {len(vec)} != {EMBED_DIM}")
+        emb_str = "[" + ",".join(str(x) for x in vec) + "]"
+    except Exception as exc:  # noqa: BLE001 — fail closed; row stays unranked, never faked
+        emit_log(level="error", service="enterprise_memory", action="embed_failed",
+                 message=str(exc), error=exc)
+        _mark_status(item_id, status="error", null_reason="embedding_failed")
+        return {"item_id": item_id, "embedding_status": "error"}
+
+    with get_cursor() as cur:
+        cur.execute(
+            """UPDATE nv_enterprise_memory_items
+               SET embedding = %s::vector, embedding_status = 'indexed',
+                   embedding_model = %s, null_reason = NULL, updated_at = now()
+               WHERE id = %s""",
+            (emb_str, OPENAI_EMBEDDING_MODEL, item_id),
+        )
+    return {"item_id": item_id, "embedding_status": "indexed"}
+
+
+def _mark_status(item_id: str, *, status: str, null_reason: str | None) -> None:
+    with get_cursor() as cur:
+        cur.execute(
+            """UPDATE nv_enterprise_memory_items
+               SET embedding_status = %s, null_reason = %s, updated_at = now()
+               WHERE id = %s""",
+            (status, null_reason, item_id),
+        )
+
+
+def list_pending(limit: int = 200) -> list[str]:
+    """Ids of rows still awaiting an embedding (for the manual backfill sweep)."""
+    with get_cursor() as cur:
+        cur.execute(
+            "SELECT id::text FROM nv_enterprise_memory_items "
+            "WHERE embedding_status = 'pending' ORDER BY indexed_at LIMIT %s",
+            (limit,),
+        )
+        return [r["id"] for r in cur.fetchall()]
+
+
+# ── retrieval (records + citations only, NO answer, NO LLM) ────────────────────
+def _embed_query(query: str) -> str | None:
+    """Embed a search query. Fail closed (None) when no provider — search then returns an
+    honest empty rather than ranking against a fake vector."""
+    if not _has_provider():
+        return None
+    try:
+        from app.services.rag_indexer import _embed_texts
+        vec = _embed_texts([query])[0]
+        if len(vec) != EMBED_DIM:
+            return None
+        return "[" + ",".join(str(x) for x in vec) + "]"
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="enterprise_memory", action="query_embed_failed",
+                 message=str(exc), error=exc)
+        return None
+
+
+def _citation(row: dict) -> dict:
+    return {
+        "item_type": row["item_type"],
+        "source_id": row["source_id"],
+        "title": row["title"],
+        "summary": row.get("summary"),
+        "indexed_at": row["indexed_at"].isoformat() if row.get("indexed_at") else None,
+        "env_id": row.get("env_id"),
+        "scope": "global" if row.get("env_id") is None else "env",
+        "score": row.get("score"),
+    }
+
+
+def search(env_id: str, business_id: str | UUID, query: str, *,
+           item_type: str | None = None, top_k: int = 5) -> dict:
+    """Vector search over the env's records + org-global records. Returns RECORDS WITH
+    CITATIONS, never an answer. Fail closed on missing provider / empty / error."""
+    if not query or not query.strip():
+        return {"items": [], "null_reason": "empty_query"}
+    if item_type and item_type not in ITEM_TYPES:
+        return {"items": [], "null_reason": "invalid_item_type"}
+
+    emb = _embed_query(query)
+    if emb is None:
+        return {"items": [], "null_reason": "embedding_provider_unavailable"}
+
+    # Defense-in-depth: the explicit WHERE mirrors the RLS policy (env rows for THIS env, plus
+    # global null-env rows), so the contract holds even on a superuser connection.
+    conds = ["embedding IS NOT NULL", "(env_id IS NULL OR env_id = %s)"]
+    params: list = [emb, env_id]
+    if item_type:
+        conds.append("item_type = %s")
+        params.append(item_type)
+    where = " AND ".join(conds)
+    try:
+        with get_cursor() as cur:
+            _set_tenant(cur, env_id)
+            cur.execute(
+                f"""SELECT item_type, source_id, title, summary, env_id::text, indexed_at,
+                           1 - (embedding <=> %s::vector) AS score
+                    FROM nv_enterprise_memory_items
+                    WHERE {where}
+                    ORDER BY embedding <=> %s::vector
+                    LIMIT %s""",
+                [emb] + params[1:] + [emb, top_k],
+            )
+            rows = cur.fetchall()
+    except Exception as exc:  # noqa: BLE001 — fail closed, never 500, never unscoped rows
+        emit_log(level="error", service="enterprise_memory", action="search_failed",
+                 message=str(exc), error=exc)
+        return {"items": [], "null_reason": "search_unavailable"}
+
+    if not rows:
+        return {"items": [], "null_reason": "no_matching_records"}
+    return {"items": [_citation(r) for r in rows], "null_reason": None}
+
+
+def similar_items(item_type: str, source_id: str, env_id: str, business_id: str | UUID,
+                  *, top_k: int = 5) -> dict:
+    """Find records similar to an already-indexed item, by its STORED embedding (no re-embed).
+    If the seed isn't indexed yet, fail closed rather than embed-on-read (which would block)."""
+    if item_type not in ITEM_TYPES:
+        return {"items": [], "null_reason": "invalid_item_type"}
+    try:
+        with get_cursor() as cur:
+            _set_tenant(cur, env_id)
+            cur.execute(
+                """SELECT id::text, embedding IS NOT NULL AS has_emb
+                   FROM nv_enterprise_memory_items
+                   WHERE item_type = %s AND source_id = %s AND (env_id IS NULL OR env_id = %s)
+                   LIMIT 1""",
+                (item_type, source_id, env_id),
+            )
+            seed = cur.fetchone()
+            if not seed:
+                return {"items": [], "null_reason": "seed_not_found"}
+            if not seed["has_emb"]:
+                return {"items": [], "null_reason": "seed_not_indexed"}
+            cur.execute(
+                """SELECT item_type, source_id, title, summary, env_id::text, indexed_at,
+                          1 - (embedding <=> (SELECT embedding FROM nv_enterprise_memory_items WHERE id = %s)) AS score
+                   FROM nv_enterprise_memory_items
+                   WHERE embedding IS NOT NULL AND id <> %s AND (env_id IS NULL OR env_id = %s)
+                   ORDER BY embedding <=> (SELECT embedding FROM nv_enterprise_memory_items WHERE id = %s)
+                   LIMIT %s""",
+                (seed["id"], seed["id"], env_id, seed["id"], top_k),
+            )
+            rows = cur.fetchall()
+    except Exception as exc:  # noqa: BLE001
+        emit_log(level="error", service="enterprise_memory", action="similar_failed",
+                 message=str(exc), error=exc)
+        return {"items": [], "null_reason": "similar_unavailable"}
+
+    if not rows:
+        return {"items": [], "null_reason": "no_similar_records"}
+    return {"items": [_citation(r) for r in rows], "null_reason": None}

--- a/backend/tests/test_enterprise_memory.py
+++ b/backend/tests/test_enterprise_memory.py
@@ -1,0 +1,262 @@
+"""Tests for Enterprise Memory Index (plan PR 15) — scoped retrieval, NO LLM.
+
+No DB required: a fake cursor captures executed SQL + serves canned rows, so we can prove
+the env-boundary contract (global ∪ env, cross-env excluded), the provider-fail-closed path
+(no zero-vector ever, _embed_texts never called without a key), async non-blocking, citation
+shape, and the absence of any LLM/answer path. Route tests monkeypatch the service.
+
+Run: cd backend && python -m pytest tests/test_enterprise_memory.py -x -q
+"""
+import os
+from contextlib import contextmanager
+
+os.environ.setdefault("BM_MCP_DRY_RUN", "1")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+os.environ.setdefault("MCP_API_TOKEN", "test-token")
+
+import pytest  # noqa: E402
+
+from app.services import enterprise_memory as svc  # noqa: E402
+
+ENV_A = "env-A"
+ENV_B = "env-B"
+BIZ = "00000000-0000-0000-0000-000000000001"
+
+
+class FakeCursor:
+    """Records every (sql, params) and returns queued rows for fetchone/fetchall."""
+    def __init__(self, rows_queue):
+        self.executed = []
+        self._rows_queue = list(rows_queue)  # list of row-lists, popped per SELECT
+        self._last = None
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        s = sql.strip().lower()
+        # A statement that reads back rows (a SELECT, or an INSERT/UPDATE ... RETURNING)
+        # consumes the next queued row-set; set_config and plain writes return nothing.
+        reads_rows = (s.startswith("select") and "set_config" not in s) or "returning" in s
+        if reads_rows:
+            self._last = self._rows_queue.pop(0) if self._rows_queue else []
+        else:
+            self._last = []
+
+    def fetchone(self):
+        return self._last[0] if self._last else None
+
+    def fetchall(self):
+        return self._last
+
+    def all_sql(self):
+        return " || ".join(sql for sql, _ in self.executed).lower()
+
+
+def _patch_cursor(monkeypatch, rows_queue=()):
+    cur = FakeCursor(rows_queue)
+
+    @contextmanager
+    def fake_get_cursor():
+        yield cur
+
+    monkeypatch.setattr(svc, "get_cursor", fake_get_cursor)
+    return cur
+
+
+def _set_key(monkeypatch, value):
+    from app import config
+    monkeypatch.setattr(config, "OPENAI_API_KEY", value, raising=False)
+
+
+# ── async non-blocking index (no provider call on the request path) ───────────
+def test_index_returns_pending_without_calling_provider(monkeypatch):
+    cur = _patch_cursor(monkeypatch, rows_queue=[[{"id": "item-1"}]])
+    called = []
+    monkeypatch.setattr("app.services.rag_indexer._embed_texts", lambda t: called.append(t) or [[0.1] * 1536])
+    out = svc.index_item(item_type="card", source_id="c1", title="T", content_text="body",
+                         business_id=BIZ, env_id=ENV_A)
+    assert out["embedding_status"] == "pending"
+    assert out["item_id"] == "item-1"
+    assert called == []                       # provider NOT called during index
+    assert "insert into nv_enterprise_memory_items" in cur.all_sql()
+    assert "'pending'" in cur.all_sql()
+
+
+def test_index_rejects_bad_item_type(monkeypatch):
+    _patch_cursor(monkeypatch)
+    out = svc.index_item(item_type="bogus", source_id="x", title="T", content_text="b",
+                         business_id=BIZ, env_id=ENV_A)
+    assert out["null_reason"] == "invalid_item_type"
+
+
+# ── provider fail-closed (the landmine: never a zero-vector) ───────────────────
+def test_embed_no_provider_marks_no_provider_and_never_calls_embed(monkeypatch):
+    _set_key(monkeypatch, "")  # no provider
+    cur = _patch_cursor(monkeypatch)
+    called = []
+    monkeypatch.setattr("app.services.rag_indexer._embed_texts", lambda t: called.append(t) or [[0.0] * 1536])
+    out = svc.embed_pending_item("item-1")
+    assert out["embedding_status"] == "no_provider"
+    assert called == []                       # _embed_texts NEVER called without a key
+    # the UPDATE set status no_provider — and NO vector was written
+    sql = cur.all_sql()
+    assert "no_provider" in sql or "embedding_status = %s" in sql
+    assert "::vector" not in sql              # no embedding write at all
+
+
+def test_embed_with_provider_indexes_real_vector(monkeypatch):
+    _set_key(monkeypatch, "sk-test")
+    cur = _patch_cursor(monkeypatch, rows_queue=[[{"env_id": ENV_A, "content_text": "body"}]])
+    monkeypatch.setattr("app.services.rag_indexer._embed_texts", lambda t: [[0.2] * 1536])
+    out = svc.embed_pending_item("item-1")
+    assert out["embedding_status"] == "indexed"
+    assert "::vector" in cur.all_sql()        # a real vector was written
+    assert "'indexed'" in cur.all_sql()
+
+
+def test_embed_wrong_dim_fails_closed(monkeypatch):
+    _set_key(monkeypatch, "sk-test")
+    cur = _patch_cursor(monkeypatch, rows_queue=[[{"env_id": ENV_A, "content_text": "body"}]])
+    monkeypatch.setattr("app.services.rag_indexer._embed_texts", lambda t: [[0.2] * 10])  # wrong dim
+    out = svc.embed_pending_item("item-1")
+    assert out["embedding_status"] == "error"
+    assert "::vector" not in cur.all_sql()    # no fake/short vector stored
+
+
+# ── env boundary: global ∪ env, cross-env excluded (SQL contract) ─────────────
+def test_search_query_scopes_to_env_and_global_only(monkeypatch):
+    _set_key(monkeypatch, "sk-test")
+    cur = _patch_cursor(monkeypatch, rows_queue=[[
+        {"item_type": "card", "source_id": "c1", "title": "Env A card", "summary": None,
+         "env_id": ENV_A, "indexed_at": _Now(), "score": 0.9},
+        {"item_type": "adr", "source_id": "adr-1", "title": "Global ADR", "summary": None,
+         "env_id": None, "indexed_at": _Now(), "score": 0.8},
+    ]])
+    monkeypatch.setattr("app.services.rag_indexer._embed_texts", lambda t: [[0.2] * 1536])
+    out = svc.search(ENV_A, BIZ, "anything")
+    sql = cur.all_sql()
+    # The boundary contract is visible in the query (defense-in-depth beside RLS):
+    assert "env_id is null or env_id = %s" in sql
+    # set_config scopes the connection to env-A (RLS layer):
+    assert any("set_config" in s.lower() and (p == (ENV_A,) if p else False)
+               for s, p in cur.executed)
+    # results carry scope labels + citations
+    scopes = {i["scope"] for i in out["items"]}
+    assert scopes == {"env", "global"}
+    for i in out["items"]:
+        assert i["item_type"] and i["source_id"] and i["title"] and i["indexed_at"]
+
+
+def test_search_empty_is_honest(monkeypatch):
+    _set_key(monkeypatch, "sk-test")
+    _patch_cursor(monkeypatch, rows_queue=[[]])
+    monkeypatch.setattr("app.services.rag_indexer._embed_texts", lambda t: [[0.2] * 1536])
+    out = svc.search(ENV_A, BIZ, "nothing matches")
+    assert out["items"] == []
+    assert out["null_reason"] == "no_matching_records"
+
+
+def test_search_no_provider_fails_closed(monkeypatch):
+    _set_key(monkeypatch, "")  # no provider -> cannot embed the query
+    _patch_cursor(monkeypatch)
+    out = svc.search(ENV_A, BIZ, "query")
+    assert out["items"] == []
+    assert out["null_reason"] == "embedding_provider_unavailable"
+
+
+def test_search_empty_query_is_honest(monkeypatch):
+    _patch_cursor(monkeypatch)
+    assert svc.search(ENV_A, BIZ, "   ")["null_reason"] == "empty_query"
+
+
+# ── similar: no re-embed; seed-not-indexed fails closed ───────────────────────
+def test_similar_seed_not_indexed_fails_closed(monkeypatch):
+    cur = _patch_cursor(monkeypatch, rows_queue=[[{"id": "seed-1", "has_emb": False}]])
+    out = svc.similar_items("card", "c1", ENV_A, BIZ)
+    assert out["null_reason"] == "seed_not_indexed"
+    # we never embedded anything on read
+    assert "set_config" in cur.all_sql()
+
+
+def test_similar_seed_missing_fails_closed(monkeypatch):
+    _patch_cursor(monkeypatch, rows_queue=[[]])
+    out = svc.similar_items("card", "nope", ENV_A, BIZ)
+    assert out["null_reason"] == "seed_not_found"
+
+
+# ── NO LLM path (load-bearing invariant) ──────────────────────────────────────
+def test_module_imports_no_llm():
+    import ast
+    import inspect
+    banned = ("ai_gateway", "ai_conversations", "openai", "anthropic", "chat")
+    tree = ast.parse(inspect.getsource(svc))
+    imported = []
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Import):
+            imported += [a.name for a in n.names]
+        elif isinstance(n, ast.ImportFrom):
+            imported.append(n.module or "")
+    # rag_indexer is allowed (embeddings only) and is imported lazily inside functions; the
+    # top-level imports must contain no LLM/chat/gateway module.
+    for name in imported:
+        assert not any(b in name for b in banned), f"unexpected import {name!r}"
+
+
+def test_results_carry_citations_not_answers(monkeypatch):
+    _set_key(monkeypatch, "sk-test")
+    _patch_cursor(monkeypatch, rows_queue=[[
+        {"item_type": "investigation", "source_id": "s1", "title": "X", "summary": "sum",
+         "env_id": ENV_A, "indexed_at": _Now(), "score": 0.7},
+    ]])
+    monkeypatch.setattr("app.services.rag_indexer._embed_texts", lambda t: [[0.2] * 1536])
+    out = svc.search(ENV_A, BIZ, "q")
+    item = out["items"][0]
+    assert set(item.keys()) == {"item_type", "source_id", "title", "summary", "indexed_at", "env_id", "scope", "score"}
+    assert "answer" not in item and "response" not in item and "completion" not in item
+
+
+# ── routes ────────────────────────────────────────────────────────────────────
+def test_route_search_fails_closed(client, monkeypatch):
+    from app.routes import enterprise_memory as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    monkeypatch.setattr(svc, "search", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("x")))
+    resp = client.get("/api/ade/memory/search", params={"env_id": ENV_A, "business_id": BIZ, "q": "hi"})
+    assert resp.status_code == 200
+    assert resp.json()["null_reason"] == "search_unavailable"
+
+
+def test_route_index_schedules_embedding(client, monkeypatch):
+    from app.routes import enterprise_memory as route
+    monkeypatch.setattr(route, "require_environment_access", lambda req, **kw: None)
+    monkeypatch.setattr(svc, "index_item",
+                        lambda **kw: {"item_id": "i1", "embedding_status": "pending", "null_reason": None})
+    embedded = []
+    monkeypatch.setattr(svc, "embed_pending_item", lambda iid: embedded.append(iid))
+    resp = client.post("/api/ade/memory/index", json={
+        "item_type": "card", "source_id": "c1", "title": "T", "content_text": "b",
+        "business_id": BIZ, "env_id": ENV_A})
+    assert resp.status_code == 200
+    assert resp.json()["embedding_status"] == "pending"
+    assert embedded == ["i1"]                 # background embedding scheduled + ran (TestClient runs bg tasks)
+
+
+def test_route_global_write_requires_admin(client, monkeypatch):
+    from app.routes import enterprise_memory as route
+
+    class _NonAdmin:
+        app_role = "viewer"
+    monkeypatch.setattr(route, "require_authenticated_request", lambda req: _NonAdmin())
+    resp = client.post("/api/ade/memory/index", json={
+        "item_type": "adr", "source_id": "adr-1", "title": "Global", "content_text": "b",
+        "business_id": BIZ, "env_id": None})
+    assert resp.status_code == 200
+    assert resp.json()["null_reason"] == "global_write_requires_admin"
+
+
+class _Now:
+    """Minimal stand-in for a timestamptz row value with .isoformat()."""
+    def isoformat(self):
+        return "2026-06-16T00:00:00+00:00"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-x", "-q"]))

--- a/repo-b/db/schema/10021_nv_enterprise_memory_items.sql
+++ b/repo-b/db/schema/10021_nv_enterprise_memory_items.sql
@@ -1,0 +1,90 @@
+-- 10021_nv_enterprise_memory_items.sql
+-- Enterprise Memory Index (plan PR 15, Phase 6) — a scoped RETRIEVAL/INDEX layer.
+--
+-- This layer RETRIEVES RECORDS WITH CITATIONS (item_type, source_id, title, indexed_at).
+-- It NEVER answers questions and contains NO LLM. pgvector is the HOT similarity index;
+-- BigQuery / object storage is the FUTURE archive path (guardrail note only — no archive
+-- code ships in PR 15). Review the archive strategy when item count or query latency
+-- crosses a threshold; Postgres must not become a warehouse.
+--
+-- env_id is intentionally NULLABLE here (the ONE documented exception to the env_id NOT NULL
+-- house rule): a NULL env_id is an ORG-GLOBAL record (e.g. an ADR) visible read-only to every
+-- environment; a non-null env_id is env-scoped. business_id stays NOT NULL so tenancy is never
+-- fully open. Writing a global (null-env) row is admin/system-only, enforced in service code.
+--
+-- embedding is NULLABLE and filled ASYNCHRONOUSLY (the /index request never calls the provider).
+-- A NULL embedding is a valid state: 'pending' (queued), 'no_provider' (fail closed — key absent),
+-- or 'error'. A zero/fake vector is NEVER stored — rows without a real embedding are simply not
+-- rankable by the vector search and are surfaced honestly via embedding_status / null_reason.
+--
+-- Approved prefix: nv_. Owning module: backend/app/services/enterprise_memory.py.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector') THEN
+        CREATE EXTENSION IF NOT EXISTS vector;
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS nv_enterprise_memory_items (
+    id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id           text,                         -- NULLABLE: null = org-global (ADRs etc.)
+    business_id      uuid NOT NULL,
+    item_type        text NOT NULL
+                     CHECK (item_type IN ('adr', 'investigation', 'card', 'decision', 'workflow')),
+    source_id        text NOT NULL,                -- citation: the source record's id
+    title            text NOT NULL,                -- citation: human-readable title
+    summary          text,
+    content_text     text NOT NULL,                -- the indexed body (embedded)
+    embedding        vector(1536),                 -- NULL until embedded; never a fake vector
+    embedding_model  text,                         -- stamped when embedded (text-embedding-3-small)
+    embedding_status text NOT NULL DEFAULT 'pending'
+                     CHECK (embedding_status IN ('pending', 'indexed', 'no_provider', 'error')),
+    null_reason      text,                         -- why embedding is absent (fail-closed diagnostics)
+    source_ref       jsonb NOT NULL DEFAULT '{}',  -- provenance pointers
+    metadata         jsonb NOT NULL DEFAULT '{}',
+    indexed_at       timestamptz NOT NULL DEFAULT now(),
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- Idempotent re-index: one row per (item_type, source_id) within a scope. A table-level
+-- UNIQUE cannot hold an expression, so the nullable env_id is handled by two partial unique
+-- indexes — one for env-scoped rows, one for global (null-env) rows.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_nv_enterprise_memory_env
+    ON nv_enterprise_memory_items (item_type, source_id, business_id, env_id)
+    WHERE env_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_nv_enterprise_memory_global
+    ON nv_enterprise_memory_items (item_type, source_id, business_id)
+    WHERE env_id IS NULL;
+
+ALTER TABLE nv_enterprise_memory_items ENABLE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+    -- GLOBAL-AWARE tenant policy. The standard `env_id = current_setting(...)` form would hide
+    -- every global (null-env) row because `NULL = 'env-x'` is NULL/false. The IS NULL branch
+    -- makes org-global records visible to every env (read); env rows stay isolated to their env.
+    CREATE POLICY nv_enterprise_memory_items_tenant ON nv_enterprise_memory_items
+        USING (env_id IS NULL OR env_id = current_setting('app.env_id', true))
+        WITH CHECK (env_id IS NULL OR env_id = current_setting('app.env_id', true));
+EXCEPTION WHEN duplicate_object THEN
+    NULL;
+END $$;
+
+-- Workload: env-scoped (and global) list/filter by type.
+CREATE INDEX IF NOT EXISTS ix_nv_enterprise_memory_env_type
+    ON nv_enterprise_memory_items (env_id, item_type);
+-- Workload: the manual backfill sweep selects rows whose embedding is still pending.
+CREATE INDEX IF NOT EXISTS ix_nv_enterprise_memory_pending
+    ON nv_enterprise_memory_items (embedding_status) WHERE embedding_status = 'pending';
+-- Workload: approximate-nearest-neighbour vector search (cosine). Matches rag_chunks (316).
+CREATE INDEX IF NOT EXISTS ix_nv_enterprise_memory_embedding
+    ON nv_enterprise_memory_items USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);
+
+COMMENT ON TABLE nv_enterprise_memory_items IS
+    'Enterprise Memory hot index (plan PR 15). Scoped RETRIEVAL with citations; NEVER answers, '
+    'NO LLM. env_id NULL = org-global (ADRs etc.), non-null = env-scoped; global writes are '
+    'admin/system-only. embedding NULL = pending|no_provider|error (fail closed, never a fake '
+    'vector). pgvector = hot index; BigQuery/object-storage = future archive (note only). '
+    'Owning module: enterprise_memory.py.';

--- a/scripts/backfill_enterprise_memory_embeddings.py
+++ b/scripts/backfill_enterprise_memory_embeddings.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Backfill embeddings for enterprise-memory rows still marked 'pending'.
+
+The /index route fills embeddings via an in-process FastAPI BackgroundTask, which is lost if
+the backend restarts before it runs. The embedding_status='pending' column is the durable
+source of truth; this manual sweep finishes any rows the background path didn't. NOT
+scheduled — run it by hand (same doctrine as scripts/export_sessions_to_bq.py). Fails closed:
+if no embedding provider is configured, rows are marked 'no_provider', never given a fake
+vector.
+
+Usage:
+    python scripts/backfill_enterprise_memory_embeddings.py [--limit 200]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill pending enterprise-memory embeddings.")
+    parser.add_argument("--limit", type=int, default=200, help="max rows to process this run")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    backend_dir = repo_root / "backend"
+    if str(backend_dir) not in sys.path:
+        sys.path.insert(0, str(backend_dir))
+
+    from dotenv import load_dotenv
+    load_dotenv(backend_dir / ".env", override=True)
+
+    from app.services import enterprise_memory
+
+    pending = enterprise_memory.list_pending(limit=args.limit)
+    results = {"processed": 0, "indexed": 0, "no_provider": 0, "error": 0}
+    for item_id in pending:
+        out = enterprise_memory.embed_pending_item(item_id)
+        results["processed"] += 1
+        status = out.get("embedding_status")
+        if status in results:
+            results[status] += 1
+
+    print(json.dumps({"ok": True, "pending_seen": len(pending), **results}, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Phase 6 / PR 15 — **Enterprise Memory Index**: a scoped **retrieval/index** layer, **not** an answerer. It returns RECORDS WITH CITATIONS (`item_type, source_id, title, indexed_at`); it never synthesizes an answer and makes **no model call**.

## What it is / isn't

- **Retrieval, not RAG-answering**: search/similar return cited records + cosine score, never a generated answer (no `answer`/`response`/`completion` field anywhere).
- **No LLM** in PR 15 (the executive-summary layer is a later, separate decision).
- **Global vs env-scoped, explicitly separated**: `env_id NULL` = org-global (e.g. ADRs), visible read-only to every env; non-null = env-scoped. **Cross-env leakage is blocked in BOTH the RLS policy and the service WHERE clause.**

## Changes (6 files)

- `repo-b/db/schema/10021_nv_enterprise_memory_items.sql` — `vector(1536)` + HNSW `vector_cosine_ops` (matches `rag_chunks`/316, so `rag_indexer` embeddings reuse verbatim). **Global-aware RLS**: `USING (env_id IS NULL OR env_id = current_setting('app.env_id', true))` — the standard tenant policy would hide global rows. Two partial unique indexes (env vs global) for idempotent re-index.
- `services/enterprise_memory.py` — `index_item` writes fast (`embedding NULL`, status `pending`), **never calls the provider on the request path**. `embed_pending_item` fills async and **fails closed** on a missing provider: it gates on `OPENAI_API_KEY` **before** calling `rag_indexer._embed_texts` (which returns **zero-vectors** when the key is absent — the landmine this PR must not inherit). A zero/fake vector is **never** stored.
- `routes/enterprise_memory.py` + `main.py` — `GET /search`, `POST /index` (admin-only; global null-env write requires admin — the only mint path for a global row), `GET /similar/{item_type}/{source_id}`. `/index` schedules embedding via **FastAPI BackgroundTasks** and returns `pending` fast.
- `scripts/backfill_enterprise_memory_embeddings.py` — manual, NOT-scheduled, fail-closed sweep of `pending` rows (durable recovery if an in-process BackgroundTask is lost).

## Verified on the real DB (linked Supabase)

Migration applies cleanly (caught + fixed a table-level UNIQUE-can't-hold-an-expression error that CI would also catch). **Cross-env isolation proven**: env-B sees `[its own row, global ADR]` and **not** env-A's row; global rows visible to every env.

## Resource doctrine

pgvector = hot index; BigQuery/object-storage = future archive (note only, no code). Frontend deferred (backend-first per scope). ADR auto-indexing deferred until the write-gate is settled; cards/sessions index via the admin `/index` path.

## Tests & checks

**16 tests** (60 in the memory+cards+analyzer+agent+reel suite, no regression): async non-blocking index, **provider-fail-closed** (zero-vector never written; `_embed_texts` never called keyless), **env-boundary SQL contract** (global ∪ env, cross-env excluded), citation shape, similar seed-not-indexed fail-closed, **NO-LLM import proof**, route admin gate + fail-closed envelopes. `ruff` clean; `app.main` 1501 routes.

> Review Gate 15: scoped retrieval/index with citations + env safety. Not a chatbot, not a generic RAG answerer, not a cross-env pool, no hidden LLM summarizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
