### PR TITLE
Phase 6 PR 16b: Single-call LLM brief narration (optional, fail-closed)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -115,6 +115,10 @@ OPENAI_CHAT_MODEL_REASONING: str = os.getenv("OPENAI_CHAT_MODEL_REASONING", "gpt
 OPENAI_CHAT_MODEL_CODING: str = os.getenv("OPENAI_CHAT_MODEL_CODING", "gpt-5")
 OPENAI_CHAT_MODEL_AGENTIC: str = os.getenv("OPENAI_CHAT_MODEL_AGENTIC", "gpt-5")
 OPENAI_CHAT_MODEL_VERIFY: str = os.getenv("OPENAI_CHAT_MODEL_VERIFY", "gpt-5-mini")
+
+# ── Executive autopilot morning-brief narration (plan PR 16b) ─────
+# Opt-in: when false (default) the brief is deterministic-only, ZERO model calls.
+MORNING_BRIEF_SUMMARY_ENABLED: bool = os.getenv("MORNING_BRIEF_SUMMARY_ENABLED", "false").lower() == "true"
 OPENAI_CHAT_MODEL_FALLBACK: str = os.getenv("OPENAI_CHAT_MODEL_FALLBACK", "gpt-5-mini")
 OPENAI_CHAT_MODEL_DISPATCH: str = os.getenv("OPENAI_CHAT_MODEL_DISPATCH", OPENAI_CHAT_MODEL_FAST)
 OPENAI_DISPATCH_CONFIDENCE_THRESHOLD: float = float(os.getenv("OPENAI_DISPATCH_CONFIDENCE_THRESHOLD", "0.35"))

--- a/backend/app/services/morning_brief.py
+++ b/backend/app/services/morning_brief.py
@@ -170,6 +170,17 @@ def generate(env_id: str, business_id: str | UUID, *, brief_date: str | None = N
     priority = round(max((c.get("priority_score") or 0.0) for c in pool), 4) if pool else 0.0
     anomaly = any(c.get("anomaly_flag") for c in pool)
 
+    # Optional single-call LLM narration (PR 16b). Off by default → deterministic digest used,
+    # zero model calls. The wrapper validates the narration adds no uncited facts and falls
+    # back to the digest otherwise; it never raises into this path.
+    digest = _digest(brief)
+    from app.services import morning_brief_summary
+    summary_result = morning_brief_summary.summarize_brief(
+        brief, env_id=env_id, business_id=business_id, deterministic_digest=digest)
+    brief["summary"] = {"used_llm": summary_result["used_llm"], "model": summary_result["model"],
+                        "null_reason": summary_result["null_reason"]}
+    card_summary = summary_result["summary_text"]
+
     card_id = None
     try:
         card = intelligence_cards.upsert_card(
@@ -177,7 +188,7 @@ def generate(env_id: str, business_id: str | UUID, *, brief_date: str | None = N
             card_type="story",
             title=f"Morning brief — {date}: {brief['counts']['anomaly_count']} signal(s), "
                   f"{brief['counts']['watch_count']} to watch",
-            summary=_digest(brief),
+            summary=card_summary,
             source_ref=brief,
             dedup_ref={"type": BRIEF_TYPE, "env_id": env_id, "brief_date": date},
             priority_score=priority,

--- a/backend/app/services/morning_brief_summary.py
+++ b/backend/app/services/morning_brief_summary.py
@@ -1,0 +1,157 @@
+"""Optional single-call LLM narration over the deterministic MorningBrief (plan PR 16b).
+
+The model may write PROSE. It may not create facts. It receives only the structured brief
+(cards/findings/memory citations already gathered deterministically in PR 16a) — no tools,
+no data access, no new recommendations. The call is:
+
+  - OPT-IN: disabled by default (MORNING_BRIEF_SUMMARY_ENABLED=false) and skipped when no
+    provider key is configured → ZERO model calls, deterministic text used, null_reason set.
+  - AT MOST ONE model call per brief generation.
+  - FAIL-CLOSED: any error, or a validation failure (the narration introduces a number that
+    is not in the brief's evidence), discards the narration and keeps the deterministic digest.
+  - AUDITED: a receipt is written to ai_decision_audit_log via governance.record_decision.
+"""
+from __future__ import annotations
+
+import re
+import time
+from uuid import UUID
+
+from app.observability.logger import emit_log
+
+_SYSTEM_PROMPT = (
+    "You are narrating an executive morning brief. You will receive a STRUCTURED brief of "
+    "findings that were already computed deterministically. Write 2-4 sentences of plain prose "
+    "that summarize ONLY what the structured brief contains. Hard rules: do NOT invent any "
+    "number, metric, percentage, date, or fact that is not present in the brief. Do NOT add "
+    "recommendations beyond those listed. Do NOT call tools or claim to have queried data. If a "
+    "section is empty or has a null_reason, you may say it was not available — never fill it in. "
+    "Preserve any stated confidence and limitations. Output prose only."
+)
+
+# Tokens that look like numbers/percentages — used to verify the narration adds none.
+_NUM_RE = re.compile(r"\d+(?:[.,]\d+)?%?")
+
+
+def _evidence_numbers(brief: dict) -> set[str]:
+    """Every numeric token the narration is allowed to use — drawn from the brief's text."""
+    blob_parts: list[str] = []
+    for item in brief.get("what_changed", []):
+        blob_parts += [str(item.get("title", "")), str(item.get("priority_score", ""))]
+    for item in brief.get("why_it_matters", []):
+        blob_parts.append(str(item.get("reason", "")))
+    for item in brief.get("what_to_watch", []):
+        blob_parts += [str(item.get("title", "")), str(item.get("priority_score", ""))]
+    blob_parts += [str(a) for a in brief.get("recommended_actions", [])]
+    counts = brief.get("counts", {})
+    blob_parts += [str(v) for v in counts.values()]
+    blob_parts.append(str(brief.get("brief_date", "")))
+    nums: set[str] = set()
+    for part in blob_parts:
+        nums.update(_NUM_RE.findall(part))
+    return nums
+
+
+def _narration_is_supported(text: str, brief: dict) -> bool:
+    """Reject narration that introduces a numeric token absent from the brief's evidence."""
+    allowed = _evidence_numbers(brief)
+    for tok in _NUM_RE.findall(text or ""):
+        if tok not in allowed:
+            return False
+    return True
+
+
+def _brief_payload_for_model(brief: dict) -> dict:
+    """The structured slice the model sees — facts only, no instructions to act."""
+    return {
+        "brief_date": brief.get("brief_date"),
+        "confidence": brief.get("confidence"),
+        "counts": brief.get("counts"),
+        "what_changed": [{"title": i.get("title")} for i in brief.get("what_changed", [])],
+        "why_it_matters": [{"reason": i.get("reason")} for i in brief.get("why_it_matters", [])],
+        "what_to_watch": [{"title": i.get("title")} for i in brief.get("what_to_watch", [])],
+        "recommended_actions": list(brief.get("recommended_actions", [])),
+        "null_reasons": brief.get("null_reasons", []),
+    }
+
+
+def summarize_brief(brief: dict, *, env_id: str, business_id: str | UUID,
+                    deterministic_digest: str) -> dict:
+    """Return {summary_text, used_llm, model, null_reason}. At most one model call; never
+    raises. Falls back to deterministic_digest on disable/no-provider/error/invalid."""
+    from app import config
+
+    if not getattr(config, "MORNING_BRIEF_SUMMARY_ENABLED", False):
+        return {"summary_text": deterministic_digest, "used_llm": False,
+                "model": None, "null_reason": "summary_disabled"}
+    if not getattr(config, "OPENAI_API_KEY", ""):
+        return {"summary_text": deterministic_digest, "used_llm": False,
+                "model": None, "null_reason": "summary_provider_unavailable"}
+
+    model = getattr(config, "OPENAI_CHAT_MODEL_FAST", "gpt-5-mini")
+    started = time.monotonic()
+    text = None
+    prompt_tokens = completion_tokens = None
+    error = None
+    try:
+        import json as _json
+
+        import openai
+        client = openai.OpenAI(api_key=config.OPENAI_API_KEY)
+        resp = client.chat.completions.create(  # the ONE call
+            model=model,
+            messages=[
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": _json.dumps(_brief_payload_for_model(brief))},
+            ],
+        )
+        text = (resp.choices[0].message.content or "").strip()
+        usage = getattr(resp, "usage", None)
+        if usage:
+            prompt_tokens = getattr(usage, "prompt_tokens", None)
+            completion_tokens = getattr(usage, "completion_tokens", None)
+    except Exception as exc:  # noqa: BLE001 — model failure must not fail the brief
+        error = str(exc)
+        emit_log(level="warning", service="morning_brief_summary", action="model_call_failed",
+                 message=error, error=exc)
+
+    latency_ms = int((time.monotonic() - started) * 1000)
+
+    # Validate: discard a narration that invents numbers, or an empty/errored result.
+    used_text = deterministic_digest
+    used_llm = False
+    null_reason = None
+    if text and _narration_is_supported(text, brief):
+        used_text = text
+        used_llm = True
+    elif text:
+        null_reason = "summary_unsupported_claim"   # narration introduced an uncited number
+    elif error:
+        null_reason = "summary_failed"
+
+    # Audit receipt for the model call (best-effort, never raises). decision_type='response'
+    # is an allowed value of the ai_decision_audit_log CHECK constraint.
+    _record_receipt(env_id=env_id, business_id=business_id, model=model, used_llm=used_llm,
+                    prompt_tokens=prompt_tokens, completion_tokens=completion_tokens,
+                    latency_ms=latency_ms, null_reason=null_reason, error=error,
+                    brief_date=brief.get("brief_date"))
+
+    return {"summary_text": used_text, "used_llm": used_llm,
+            "model": model if used_llm else None, "null_reason": null_reason}
+
+
+def _record_receipt(*, env_id, business_id, model, used_llm, prompt_tokens, completion_tokens,
+                    latency_ms, null_reason, error, brief_date) -> None:
+    try:
+        from app.services import governance
+        governance.record_decision(
+            business_id=business_id, env_id=env_id,
+            actor="autopilot", decision_type="response", tool_name="morning_brief_summary",
+            input_summary={"brief_date": brief_date},
+            output_summary={"used_llm": used_llm, "null_reason": null_reason},
+            model_used=model, prompt_tokens=prompt_tokens, completion_tokens=completion_tokens,
+            latency_ms=latency_ms, success=(error is None), error_message=error,
+            tags=["morning_brief", "summary"],
+        )
+    except Exception:  # noqa: BLE001 — receipt is best-effort; never blocks the brief
+        pass

--- a/backend/tests/test_morning_brief_summary.py
+++ b/backend/tests/test_morning_brief_summary.py
@@ -1,0 +1,187 @@
+"""Tests for the optional single-call LLM brief narration (plan PR 16b).
+
+Proves: AT MOST one model call per generation; ZERO calls when disabled/unconfigured; a
+model failure does not fail the brief; a narration that invents a number is rejected and the
+deterministic text kept; an audit receipt is recorded; and the deterministic brief still
+works with the model disabled.
+
+Run: cd backend && python -m pytest tests/test_morning_brief_summary.py -x -q
+"""
+import os
+
+os.environ.setdefault("BM_MCP_DRY_RUN", "1")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+os.environ.setdefault("MCP_API_TOKEN", "test-token")
+
+from app.services import morning_brief_summary as sumsvc  # noqa: E402
+
+ENV = "env-A"
+BIZ = "00000000-0000-0000-0000-000000000001"
+
+_BRIEF = {
+    "brief_date": "2026-06-16",
+    "confidence": "high",
+    "counts": {"anomaly_count": 2, "watch_count": 1, "cards_scanned": 5},
+    "what_changed": [{"title": "PSI drift", "priority_score": 1.0}],
+    "why_it_matters": [{"reason": "drift erodes serving quality"}],
+    "what_to_watch": [{"title": "overdue tasks", "priority_score": 0.7}],
+    "recommended_actions": [],
+    "null_reasons": [],
+}
+_DIGEST = "Morning brief: 2 signals changed, 1 to watch. Lead: PSI drift"
+
+
+class _Resp:
+    def __init__(self, text):
+        self.choices = [type("C", (), {"message": type("M", (), {"content": text})()})()]
+        self.usage = type("U", (), {"prompt_tokens": 10, "completion_tokens": 8})()
+
+
+def _patch_config(monkeypatch, *, enabled, key="sk-test"):
+    from app import config
+    monkeypatch.setattr(config, "MORNING_BRIEF_SUMMARY_ENABLED", enabled, raising=False)
+    monkeypatch.setattr(config, "OPENAI_API_KEY", key, raising=False)
+
+
+def _patch_openai(monkeypatch, text="A short grounded summary of 2 signals."):
+    """Patch openai.OpenAI so .chat.completions.create returns _Resp(text). Counts calls."""
+    calls = {"n": 0}
+
+    class _Client:
+        def __init__(self, **kw):
+            pass
+
+        class chat:  # noqa: N801
+            class completions:  # noqa: N801
+                @staticmethod
+                def create(**kwargs):
+                    calls["n"] += 1
+                    return _Resp(text)
+
+    import openai
+    monkeypatch.setattr(openai, "OpenAI", _Client)
+    return calls
+
+
+def _patch_receipt(monkeypatch):
+    from app.services import governance
+    receipts = []
+    monkeypatch.setattr(governance, "record_decision", lambda **kw: receipts.append(kw) or "rid")
+    return receipts
+
+
+# ── zero calls when disabled / unconfigured ───────────────────────────────────
+def test_disabled_makes_no_model_call(monkeypatch):
+    _patch_config(monkeypatch, enabled=False)
+    calls = _patch_openai(monkeypatch)
+    out = sumsvc.summarize_brief(_BRIEF, env_id=ENV, business_id=BIZ, deterministic_digest=_DIGEST)
+    assert calls["n"] == 0
+    assert out["used_llm"] is False
+    assert out["summary_text"] == _DIGEST
+    assert out["null_reason"] == "summary_disabled"
+
+
+def test_no_provider_makes_no_model_call(monkeypatch):
+    _patch_config(monkeypatch, enabled=True, key="")  # enabled but no key
+    calls = _patch_openai(monkeypatch)
+    out = sumsvc.summarize_brief(_BRIEF, env_id=ENV, business_id=BIZ, deterministic_digest=_DIGEST)
+    assert calls["n"] == 0
+    assert out["used_llm"] is False
+    assert out["null_reason"] == "summary_provider_unavailable"
+
+
+# ── exactly one call when enabled ─────────────────────────────────────────────
+def test_enabled_makes_exactly_one_call_and_uses_narration(monkeypatch):
+    _patch_config(monkeypatch, enabled=True)
+    calls = _patch_openai(monkeypatch, text="Two signals changed today; one item to watch.")
+    receipts = _patch_receipt(monkeypatch)
+    out = sumsvc.summarize_brief(_BRIEF, env_id=ENV, business_id=BIZ, deterministic_digest=_DIGEST)
+    assert calls["n"] == 1                                   # AT MOST one — exactly one here
+    assert out["used_llm"] is True
+    assert out["summary_text"] == "Two signals changed today; one item to watch."
+    assert len(receipts) == 1                                # audit receipt recorded
+    assert receipts[0]["decision_type"] == "response"
+    assert receipts[0]["tool_name"] == "morning_brief_summary"
+    assert receipts[0]["model_used"]
+
+
+# ── validation: invented number rejected ──────────────────────────────────────
+def test_narration_with_uncited_number_is_rejected(monkeypatch):
+    _patch_config(monkeypatch, enabled=True)
+    # 2, 1, 5 (counts), 1.0/0.7 (priorities), 2026-06-16 are allowed; "47%" is invented.
+    calls = _patch_openai(monkeypatch, text="Anomalies rose 47% overnight.")
+    receipts = _patch_receipt(monkeypatch)
+    out = sumsvc.summarize_brief(_BRIEF, env_id=ENV, business_id=BIZ, deterministic_digest=_DIGEST)
+    assert calls["n"] == 1
+    assert out["used_llm"] is False                          # narration discarded
+    assert out["summary_text"] == _DIGEST                    # deterministic kept
+    assert out["null_reason"] == "summary_unsupported_claim"
+    assert receipts[0]["output_summary"]["used_llm"] is False
+
+
+def test_narration_reusing_brief_numbers_is_accepted(monkeypatch):
+    _patch_config(monkeypatch, enabled=True)
+    _patch_openai(monkeypatch, text="2 signals changed and 1 needs watching on 2026-06-16.")
+    _patch_receipt(monkeypatch)
+    out = sumsvc.summarize_brief(_BRIEF, env_id=ENV, business_id=BIZ, deterministic_digest=_DIGEST)
+    assert out["used_llm"] is True                           # all numbers are from the brief
+
+
+# ── model failure is non-fatal ────────────────────────────────────────────────
+def test_model_failure_falls_back_to_deterministic(monkeypatch):
+    _patch_config(monkeypatch, enabled=True)
+    import openai
+
+    class _Boom:
+        def __init__(self, **kw):
+            pass
+
+        class chat:  # noqa: N801
+            class completions:  # noqa: N801
+                @staticmethod
+                def create(**kwargs):
+                    raise RuntimeError("api down")
+
+    monkeypatch.setattr(openai, "OpenAI", _Boom)
+    receipts = _patch_receipt(monkeypatch)
+    out = sumsvc.summarize_brief(_BRIEF, env_id=ENV, business_id=BIZ, deterministic_digest=_DIGEST)
+    assert out["used_llm"] is False
+    assert out["summary_text"] == _DIGEST
+    assert out["null_reason"] == "summary_failed"
+    assert receipts[0]["success"] is False                  # receipt records the failure
+
+
+# ── integration: generate uses deterministic text when disabled ───────────────
+def test_generate_uses_deterministic_text_when_summary_disabled(monkeypatch):
+    from app.services import morning_brief as mb
+    from app import config
+    monkeypatch.setattr(config, "MORNING_BRIEF_SUMMARY_ENABLED", False, raising=False)
+    from app.services import intelligence_cards, enterprise_memory
+    alert = {"id": "al", "card_type": "alert", "title": "PSI drift", "summary": "drift",
+             "anomaly_flag": True, "priority_score": 1.0, "source_ref": {}, "is_dismissed": False}
+    monkeypatch.setattr(intelligence_cards, "list_cards",
+                        lambda env, biz, *, card_type=None, **kw: [alert] if card_type == "alert" else [])
+    captured = {}
+    monkeypatch.setattr(intelligence_cards, "upsert_card",
+                        lambda env, biz, **kw: captured.update(kw) or {"id": "c1"})
+    monkeypatch.setattr(enterprise_memory, "search", lambda *a, **k: {"items": [], "null_reason": None})
+    out = mb.generate(ENV, BIZ, brief_date="2026-06-16")
+    # summary metadata records the LLM was not used; card summary is the deterministic digest
+    assert out["brief"]["summary"]["used_llm"] is False
+    assert "Morning brief" in captured["summary"]
+
+
+# ── NO tools / no data access in the module ───────────────────────────────────
+def test_module_does_not_import_tools_or_registry():
+    import ast
+    import inspect
+    banned = ("mcp", "registry", "rag_indexer", "get_cursor")  # narration must not query data
+    tree = ast.parse(inspect.getsource(sumsvc))
+    imported = []
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Import):
+            imported += [a.name for a in n.names]
+        elif isinstance(n, ast.ImportFrom):
+            imported.append(n.module or "")
+    for name in imported:
+        assert not any(b in name for b in banned), f"narration must not import {name!r}"


### PR DESCRIPTION
## Summary

Phase 6 / PR 16b — an **optional, single-call LLM narration** over the deterministic MorningBrief from 16a. The model writes prose; **it may not create facts**. Thin, isolated wrapper — no new framework, no `ai_gateway` changes, no tools, no data access.

## Changes (4 files, backend-only)

- `services/morning_brief_summary.py` — `summarize_brief()` makes **at most one** `chat.completions.create` call (`OPENAI_CHAT_MODEL_FAST` = `gpt-5-mini`), passing **only** the structured brief. Fail-closed at every gate:
  - **disabled** (`MORNING_BRIEF_SUMMARY_ENABLED=false`, the default) → **zero calls**, deterministic digest, `summary_disabled`
  - **no key** → **zero calls**, `summary_provider_unavailable`
  - **model error** → deterministic digest kept, `summary_failed`
  - **validation**: a narration that introduces a numeric token **absent from the brief's evidence** is **discarded** (`summary_unsupported_claim`) and the deterministic text kept — the LLM cannot inject an uncited number.
  - Every attempt writes an **audit receipt** via `governance.record_decision` (`decision_type='response'` — an allowed value, no migration), best-effort.
- `config.py` — `MORNING_BRIEF_SUMMARY_ENABLED`, default **false** (LLM is opt-in).
- `services/morning_brief.py` — `generate()` routes its digest through `summarize_brief`; the returned text becomes the card summary, and `brief.summary` records `{used_llm, model, null_reason}`. **Flag off (default) → behaviour identical to 16a** (the 20 16a tests pass unchanged).

The system prompt forbids inventing numbers/dates/facts, adding recommendations, or claiming to query data; it must preserve stated confidence/limitations.

## Tests & checks

**8 tests** (67 in the brief+cards+reel+agent suite, no regression): zero-calls-when-disabled, zero-calls-no-provider, **exactly-one-call-when-enabled**, **invented-number-rejected**, brief-numbers-accepted, **model-failure-non-fatal**, generate-uses-deterministic-when-disabled, no-tools/registry/data-access import. `ruff` clean; `app.main` 1503 routes.

> Review Gate 16b: the LLM is a narration layer over deterministic evidence, not a fact generator. No broad AI-runtime changes (thin wrapper, no gateway edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
