### PR TITLE
Phase 6 PR 16c: Morning-brief manual runner + schedule runbook (cron deferred)

### DIFF
--- a/backend/tests/test_morning_brief_runner.py
+++ b/backend/tests/test_morning_brief_runner.py
@@ -1,0 +1,68 @@
+"""Tests for the manual morning-brief runner (plan PR 16c).
+
+The runner is a thin wrapper over app.services.morning_brief.generate (the same path the POST
+route uses), so idempotency/determinism are covered by test_morning_brief.py. Here we prove
+the runner threads its args through and fails closed (non-zero exit + null_reason) when the
+brief can't be produced.
+
+Run: cd backend && python -m pytest tests/test_morning_brief_runner.py -x -q
+"""
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("BM_MCP_DRY_RUN", "1")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+os.environ.setdefault("MCP_API_TOKEN", "test-token")
+
+_SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "generate_morning_brief.py"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("generate_morning_brief", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_runner_threads_args_and_succeeds(monkeypatch, capsys):
+    runner = _load_runner()
+    from app.services import morning_brief
+    seen = {}
+    monkeypatch.setattr(morning_brief, "generate",
+                        lambda env, biz, **kw: seen.update(env=env, biz=biz, date=kw.get("brief_date"))
+                        or {"card_id": "c1", "brief": {"brief_date": "2026-06-16"}, "null_reason": None})
+    monkeypatch.setattr(sys, "argv",
+                        ["generate_morning_brief.py", "--env", "env-A", "--business", "biz-1",
+                         "--date", "2026-06-16"])
+    rc = runner.main()
+    assert rc == 0
+    assert seen == {"env": "env-A", "biz": "biz-1", "date": "2026-06-16"}
+    out = capsys.readouterr().out
+    assert '"ok": true' in out and '"card_id": "c1"' in out
+
+
+def test_runner_fails_closed_on_null_reason(monkeypatch, capsys):
+    runner = _load_runner()
+    from app.services import morning_brief
+    monkeypatch.setattr(morning_brief, "generate",
+                        lambda env, biz, **kw: {"card_id": None, "brief": None,
+                                                "null_reason": "morning_brief_unavailable"})
+    monkeypatch.setattr(sys, "argv",
+                        ["generate_morning_brief.py", "--env", "env-A", "--business", "biz-1"])
+    rc = runner.main()
+    assert rc == 1                                    # non-zero exit when no card produced
+    assert "morning_brief_unavailable" in capsys.readouterr().out
+
+
+def test_runner_reports_error_on_exception(monkeypatch, capsys):
+    runner = _load_runner()
+    from app.services import morning_brief
+    monkeypatch.setattr(morning_brief, "generate",
+                        lambda env, biz, **kw: (_ for _ in ()).throw(RuntimeError("db down")))
+    monkeypatch.setattr(sys, "argv",
+                        ["generate_morning_brief.py", "--env", "env-A", "--business", "biz-1"])
+    rc = runner.main()
+    assert rc == 1
+    assert "db down" in capsys.readouterr().err

--- a/docs/runbooks/morning-brief-schedule.md
+++ b/docs/runbooks/morning-brief-schedule.md
@@ -1,0 +1,49 @@
+# Executive Morning Brief — schedule runbook
+
+The deterministic executive morning brief (Phase 6, PRs 16a/16b) is generated **on demand**.
+The on-demand route is the source of truth:
+
+- `POST /api/ade/intel/morning-brief/generate` (env-scoped, idempotent per env/date)
+- `GET /api/ade/intel/morning-brief?env_id=...` (today's brief or honest null)
+- Manual runner: `python scripts/generate_morning_brief.py --env <env_id> --business <business_id>`
+
+The runner calls the **same service** (`app.services.morning_brief.generate`) as the route, so
+scheduled and manual runs are identical. Generation is idempotent — one `story` card per
+`(env, brief_date)`; re-running the same day updates the card in place (it never duplicates).
+
+## Intended schedule
+
+Daily **07:00 (after the overnight analyzer / reel / agent runs)**, one brief per active
+environment.
+
+## Why the live cron is deferred (not wired in PR 16c)
+
+A live GitHub Actions cron is intentionally **not** added yet. Wiring it safely requires two
+things the repo does not provide in a scoped, secret-safe way today:
+
+1. **Production write credentials in CI.** Writing a real brief card means the scheduled job
+   needs the production `DATABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` (the existing
+   `winston-eval-nightly` cron uses these). Adding a job that writes to production on a timer
+   is a larger security decision than this PR should make unilaterally.
+2. **Safe environment discovery / fanout.** "One brief per active environment" needs an
+   env-discovery step. Fanning out across all environments from a timer — without a vetted,
+   scoped discovery query — risks cross-env work and unbounded fanout. The established
+   daily-brief scripts in this repo (`hr_daily_decision.py`, `generate_reels.py`,
+   `pod_daily_brief.py`) follow the same posture: a runnable script with a documented schedule,
+   **no** live cron registration.
+
+So PR 16c ships the **manual runner above** and this runbook. The cron is a follow-up that
+should decide explicitly: which secrets the job may use, how active environments are
+discovered (a single scoped query, not a broad scan), and per-env isolation.
+
+## When wiring the cron later
+
+- Mirror `.github/workflows/winston-eval-nightly.yml`: a `schedule:` cron (e.g. `0 7 * * *`)
+  plus `workflow_dispatch` for manual runs.
+- Pass each env explicitly (a secret-backed allowlist or a single scoped discovery query) —
+  do **not** scan all environments unscoped.
+- Call `scripts/generate_morning_brief.py --env … --business …` per env so the scheduled path
+  is the same service the route uses.
+- Keep it idempotent (it already is): a re-run on the same day updates, never duplicates.
+- The optional LLM narration (16b) stays off unless `MORNING_BRIEF_SUMMARY_ENABLED=true` and a
+  provider key is present; the deterministic brief works without it.

--- a/scripts/generate_morning_brief.py
+++ b/scripts/generate_morning_brief.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Generate the deterministic executive morning brief for an environment, on demand.
+
+Calls the same service path as POST /api/ade/intel/morning-brief/generate
+(app.services.morning_brief.generate) — the on-demand route is the source of truth and this
+script is a thin wrapper around it, so behaviour is identical. Idempotent: one story card per
+(env, brief_date); re-running the same day updates in place. Deterministic; the optional LLM
+narration only runs when MORNING_BRIEF_SUMMARY_ENABLED is set and a provider key is present
+(fail-closed otherwise).
+
+Usage:
+    python scripts/generate_morning_brief.py --env <env_id> --business <business_id>
+    python scripts/generate_morning_brief.py --env <env_id> --business <business_id> --date 2026-06-16
+
+Schedule (planned, NOT yet wired): daily 7:00 AM, after the overnight analyzer/reel/agent
+runs. A live GitHub Actions cron is a deferred follow-up because it would require production
+secrets in CI and an environment-discovery/fanout step; see
+docs/runbooks/morning-brief-schedule.md. This script is the runnable, env-scoped entry point.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate the morning brief for an environment.")
+    parser.add_argument("--env", required=True, help="env_id to generate the brief for")
+    parser.add_argument("--business", required=True, help="business_id (tenant) for the env")
+    parser.add_argument("--date", default=None, help="brief_date YYYY-MM-DD (defaults to server today)")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    backend_dir = repo_root / "backend"
+    if str(backend_dir) not in sys.path:
+        sys.path.insert(0, str(backend_dir))
+
+    from dotenv import load_dotenv
+    load_dotenv(backend_dir / ".env", override=True)
+
+    from app.services import morning_brief
+
+    try:
+        result = morning_brief.generate(args.env, args.business, brief_date=args.date)
+    except Exception as exc:  # noqa: BLE001 — surface a clear failure, exit non-zero
+        print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr)
+        return 1
+
+    # Fail closed visibly: a null_reason means the brief could not be produced from real data.
+    ok = result.get("card_id") is not None
+    print(json.dumps({"ok": ok, "card_id": result.get("card_id"),
+                      "null_reason": result.get("null_reason"),
+                      "brief_date": (result.get("brief") or {}).get("brief_date")}, default=str))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Phase 6 / PR 16c — wires the morning brief into a **runnable scheduled-path entry point**, and **defers the live cron** as a documented follow-up (the safe choice).

## Why no live cron

A live GitHub Actions cron that writes real brief cards would require:
1. **Production secrets in CI** (`DATABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`) — the only cron precedent (`winston-eval-nightly`) uses these.
2. **An environment-discovery / fanout step** — "one brief per env" needs scoped env discovery; an unscoped scan risks cross-env work and unbounded fanout.

Both are explicit **hard-stop conditions**. The repo's existing daily-brief scripts (`hr_daily_decision.py`, `generate_reels.py`, `pod_daily_brief.py`) already follow the safe posture: a runnable env-scoped script + documented schedule, **cron deferred**. PR 16c ships exactly that.

## Changes (3 files)

- `scripts/generate_morning_brief.py` — thin manual runner over `app.services.morning_brief.generate` (the **same** service the POST route uses), so scheduled and manual runs are identical and the one-card-per-(env,date) idempotency is already proven. Env-scoped (`--env/--business/--date`); fails closed (non-zero exit + null_reason) when no card is produced.
- `docs/runbooks/morning-brief-schedule.md` — the intended 7AM schedule, why the live cron is deferred, and exactly what a future cron must decide (which secrets, scoped env discovery, per-env isolation) — and that it must call the same script/service so the path stays proven.
- `backend/tests/test_morning_brief_runner.py` — 3 tests: runner threads args to the service, fails closed (rc=1) on null_reason, reports errors on exception.

## Honesty / exclusions

No new cron, no new secrets, no env fanout, no service/route changes. `ruff` clean; idempotency inherited from `morning_brief.generate` (covered by `test_morning_brief.py`).

> Review Gate 16c: scheduling is a thin wrapper around the already-proven generation path. No broad infra, no new credential assumptions, no untested environment fanout. The live cron is deferred with documented rationale rather than wired unsafely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
