### PR TITLE
feat(telemetry-copilot): scope expansion — freshness null_reason + in-scope aggregate counts (ADO #680)

### DIFF
--- a/backend/app/services/telemetry_copilot.py
+++ b/backend/app/services/telemetry_copilot.py
@@ -24,7 +24,7 @@ from app.services import telemetry_serving as svc
 from app.services import telemetry_copilot_policy as policy
 from app.services.telemetry_copilot_policy import (
     COPILOT_MODEL, SYSTEM_PROMPT_TEXT, INTENT_PLAN, REFUSAL_MESSAGE,
-    NULL_INSUFFICIENT,
+    NULL_INSUFFICIENT, NULL_LIVE_DATA_UNAVAILABLE,
 )
 
 # Canonical demo run (the flagship). Used when a free-form /ask carries no explicit run context.
@@ -39,7 +39,8 @@ _ARTIFACT_DIR = Path(__file__).resolve().parent.parent / "data" / "telemetry"
 
 # Prompt version: stable id over the policy that produces every answer.
 ALLOW_LIST = ["get_triggering_prediction", "get_prediction", "get_predictions_by_window",
-              "get_model_run_detail", "get_anomaly_events_in_window"]
+              "get_model_run_detail", "get_anomaly_events_in_window",
+              "get_inventory_counts", "get_stream_freshness"]
 PROMPT_VERSION = policy.compute_prompt_version_hash(
     SYSTEM_PROMPT_TEXT, COPILOT_MODEL, ALLOW_LIST, policy.refusal_rule_sources())
 
@@ -114,10 +115,39 @@ def _tool_get_anomaly_events_in_window(ctx: dict, state: dict):
     return res, "skipped", "no labeled anomaly in window"
 
 
+def _tool_get_inventory_counts(ctx: dict, state: dict):
+    # Aggregate counts from the same approved structured source the Overview uses (svc.summary).
+    res = svc.summary(env_id=ctx["env_id"], business_id=ctx["business_id"])
+    kpi = (res or {}).get("kpi") or {}
+    counts = {k: kpi.get(k) for k in
+              ("test_runs", "predictions", "anomaly_events", "promoted_models", "drift_monitors")}
+    counts = {k: int(v) for k, v in counts.items() if isinstance(v, (int, float))}
+    if counts:
+        state["counts"] = counts
+        return res, "success", "inventory " + " ".join(f"{k}={v}" for k, v in counts.items())
+    return res, "skipped", "no inventory counts available"
+
+
+def _tool_get_stream_freshness(ctx: dict, state: dict):
+    # In scope (platform telemetry state). Fresh -> evidence; stale/disabled/absent -> distinct
+    # fail-closed reason (NULL_LIVE_DATA_UNAVAILABLE), never a fabricated live value.
+    res = svc.monitoring(env_id=ctx["env_id"], business_id=ctx["business_id"])
+    stream = (res or {}).get("stream")
+    status = (stream or {}).get("status")
+    if stream and status in ("fresh", "ok", "live"):
+        state["stream_freshness"] = stream
+        return res, "success", f"stream {status} as_of={stream.get('as_of_ts')}"
+    state["null_reason_override"] = NULL_LIVE_DATA_UNAVAILABLE
+    reason = (stream or {}).get("reason") or "stream worker disabled or no live frames"
+    return res, "skipped", f"live stream unavailable: {status or 'no_stream'} ({reason})"
+
+
 ALLOWED_TOOLS: dict[str, Callable[[dict, dict], tuple]] = {
     "get_triggering_prediction": _tool_get_triggering_prediction,
     "get_model_run_detail": _tool_get_model_run_detail,
     "get_anomaly_events_in_window": _tool_get_anomaly_events_in_window,
+    "get_inventory_counts": _tool_get_inventory_counts,
+    "get_stream_freshness": _tool_get_stream_freshness,
 }
 
 
@@ -168,6 +198,16 @@ def _assemble_evidence(state: dict) -> list[dict]:
                    "metadata": {"channel_name": e.get("channel_name"),
                                 "start_t": e.get("start_t"), "end_t": e.get("end_t"),
                                 "source": e.get("source")}})
+    for entity, n in (state.get("counts") or {}).items():
+        ev.append({"type": "inventory", "id": None, "label": entity.replace("_", " "),
+                   "value": n, "metadata": {"entity": entity, "source": "recorded tel_ summary"}})
+    sf = state.get("stream_freshness")
+    if sf:
+        ev.append({"type": "stream_status", "id": None, "label": "live stream freshness",
+                   "value": sf.get("status"),
+                   "metadata": {"as_of_ts": str(sf.get("as_of_ts")),
+                                "last_frame_at": str(sf.get("last_frame_at")),
+                                "rows_per_min": sf.get("rows_per_min"), "reason": sf.get("reason")}})
     return ev
 
 
@@ -304,6 +344,17 @@ def _fallback_template_answer(intent: str, state: dict, evidence: list[dict]) ->
                 f"{model.get('mlflow_run_id')}. Metrics: F1 {m.get('f1')}, precision "
                 f"{m.get('precision')}, recall {m.get('recall')}.\n\n"
                 "**Human review:** assistant-generated draft from recorded model metadata.")
+    counts = state.get("counts")
+    if counts:
+        parts = ", ".join(f"{v} {k.replace('_', ' ')}" for k, v in counts.items())
+        return (f"**Inventory.** Recorded on the platform: {parts}. These are counts from the "
+                "platform record.\n\n**Human review:** assistant-generated from recorded inventory counts.")
+    sf = state.get("stream_freshness")
+    if sf:
+        return (f"**Live stream.** Status {sf.get('status')} as of {sf.get('as_of_ts')}; last frame "
+                f"{sf.get('last_frame_at')}, {sf.get('rows_per_min')} rows/min. The copilot reports "
+                "recorded predictions and stream freshness, not raw live sensor values.\n\n"
+                "**Human review:** assistant-generated from recorded pipeline status.")
     return "Insufficient evidence to answer from the platform record."
 
 
@@ -356,12 +407,16 @@ async def answer(*, env_id: str, business_id, question: str | None = None,
 
     # 6. fail closed if nothing to cite
     if not evidence:
-        nr = NULL_INSUFFICIENT
+        nr = state.get("null_reason_override") or NULL_INSUFFICIENT
         for t in tool_trace:
             if t["status"] == "error" and "missing_run" in t["result_summary"]:
                 nr = policy.NULL_MISSING_RUN
-        result = {**base, "answer": "No grounded evidence is available for this question on the "
-                  "current run, so the copilot cannot answer.", "is_refusal": False,
+        msg = ("Live telemetry is not currently available for this environment, so the copilot "
+               "cannot report a live value (the recorded record is still queryable)."
+               if nr == NULL_LIVE_DATA_UNAVAILABLE else
+               "No grounded evidence is available for this question on the current run, so the "
+               "copilot cannot answer.")
+        result = {**base, "answer": msg, "is_refusal": False,
                   "intent": intent, "null_reason": nr, "answer_source": "fallback_template"}
         _log(env_id, business_id, question, result, t0)
         return result

--- a/backend/app/services/telemetry_copilot_policy.py
+++ b/backend/app/services/telemetry_copilot_policy.py
@@ -28,6 +28,9 @@ NULL_MISSING_RUN = "missing_run"
 NULL_NO_PREDICTIONS = "no_prediction_rows"
 NULL_CHANNEL_NOT_SCORED = "channel_not_scored"
 NULL_MODEL_NOT_PROMOTED = "model_not_promoted"
+# Distinct from unsupported_question: the question is IN scope (live stream state) but the live
+# source is stale/unavailable right now. Fails closed with this reason rather than a generic refusal.
+NULL_LIVE_DATA_UNAVAILABLE = "live_data_not_available"
 
 # ── Refusals (checked first; all map to unsupported_question) ──────────────────
 # These are deliberately specific so that supported phrasings ("why did this flip to NO-GO",
@@ -95,6 +98,30 @@ INTENT_PLAN: dict[str, dict] = {
         "patterns": [r"\bwhat\s+should\b.*\b(review|inspect|check|look)\b", r"\bnext\s+steps?\b",
                      r"\bhuman\b.*\b(review|follow)\b", r"\bfollow[\s-]?up\b"],
     },
+    # Aggregate inventory counts — answered from approved structured evidence (svc.summary), scoped to
+    # KNOWN platform entities only so arbitrary "how many X" still falls through to refuse.
+    "inventory_counts": {
+        "tools": ["get_inventory_counts"],
+        "patterns": [
+            r"\bhow\s+many\b.*\b(test\s+runs?|runs?|predictions?|models?|champions?|"
+            r"drift\s+monitors?|monitors?|anomaly\s+events?|events?|channels?)\b",
+            r"\b(count|number|total)\s+of\b.*\b(runs?|predictions?|models?|monitors?|"
+            r"anomaly\s+events?|events?|channels?)\b",
+            r"\binventory\b.*\b(runs?|models?|predictions?|telemetry)\b",
+        ],
+    },
+    # Live stream freshness/availability — IN scope (platform telemetry state). Answers from
+    # tel_pipeline_status; when stale/disabled it fails closed with NULL_LIVE_DATA_UNAVAILABLE (a
+    # distinct reason), never a fabricated live value.
+    "live_status": {
+        "tools": ["get_stream_freshness"],
+        "patterns": [
+            r"\b(live|current|currently|right\s+now|now|real[\s-]?time)\b.*\b(pressure|temperature|"
+            r"temp|reading|readings|value|values|telemetry|stream|feed|sensor|chamber|channel)\b",
+            r"\b(stream|feed|pipeline)\b.*\b(fresh|stale|status|health|live|up|running|flowing)\b",
+            r"\bis\s+(the\s+)?(stream|feed|data)\b.*\b(live|fresh|stale|current|up|flowing)\b",
+        ],
+    },
     # Reserved for Phase 7 — not active in Phase 6 (see ACTIVE_INTENTS).
     "draft_report": {
         "tools": ["get_triggering_prediction", "get_model_run_detail", "get_anomaly_events_in_window"],
@@ -102,10 +129,12 @@ INTENT_PLAN: dict[str, dict] = {
     },
 }
 
-# Phase 6 ships intents 1–7; draft_report is enabled in Phase 7.
+# Phase 6 ships intents 1–7; draft_report is enabled in Phase 7. inventory_counts + live_status
+# (scope expansion, ADO #680) are appended LAST so the specific verdict/model intents win on overlap.
 ACTIVE_INTENTS: tuple[str, ...] = (
     "why_no_go", "which_channel", "what_model", "model_performance",
     "point_vs_contextual", "evidence", "human_followup",
+    "inventory_counts", "live_status",
 )
 
 _COMPILED_INTENTS = {

--- a/backend/tests/test_copilot_telemetry.py
+++ b/backend/tests/test_copilot_telemetry.py
@@ -240,6 +240,73 @@ def test_governance_summary_aggregates(fake_cursor):
     assert g["active_prompt_version"] == "e1d3a0daab52"
 
 
+# ── Scope expansion (ADO #680): inventory counts + live-status freshness ───────
+def test_inventory_count_questions_classify_in_scope():
+    for q in ["How many test runs are in this environment?",
+              "How many predictions and promoted models exist?",
+              "What is the count of drift monitors?"]:
+        intent, refusal = policy.classify(q)
+        assert intent == "inventory_counts" and refusal is None, q
+
+
+def test_unsupported_aggregates_still_refuse():
+    # Not a known platform entity -> falls through to refuse; never a fabricated count.
+    for q in ["How many launches happened this year?",
+              "How many customers do we have?",
+              "How many engines are there?"]:
+        intent, refusal = policy.classify(q)
+        assert intent is None and refusal == policy.NULL_UNSUPPORTED, q
+
+
+def test_live_status_questions_classify_in_scope():
+    for q in ["What is the live chamber pressure right now?",
+              "Is the stream fresh?",
+              "What is the current sensor reading now?"]:
+        intent, refusal = policy.classify(q)
+        assert intent == "live_status" and refusal is None, q
+
+
+def test_inventory_counts_tool_grounds_counts(monkeypatch):
+    monkeypatch.setattr(tc.svc, "summary", lambda **k: {
+        "kpi": {"test_runs": 42, "predictions": 364, "anomaly_events": 102,
+                "promoted_models": 2, "drift_monitors": 104}})
+    state: dict = {}
+    _res, status, _summary = tc._tool_get_inventory_counts({"env_id": ENV, "business_id": BIZ}, state)
+    assert status == "success"
+    assert state["counts"] == {"test_runs": 42, "predictions": 364, "anomaly_events": 102,
+                               "promoted_models": 2, "drift_monitors": 104}
+    vals = {e["value"] for e in tc._assemble_evidence(state) if e["type"] == "inventory"}
+    assert {42, 364, 102, 2, 104} <= vals   # each count is a citable evidence value
+
+
+def test_stream_freshness_fresh_grounds_evidence(monkeypatch):
+    monkeypatch.setattr(tc.svc, "monitoring", lambda **k: {
+        "stream": {"status": "fresh", "as_of_ts": "2026-06-18T12:00:00Z",
+                   "last_frame_at": "2026-06-18T11:59:59Z", "rows_per_min": 60, "reason": None}})
+    state: dict = {}
+    _res, status, _ = tc._tool_get_stream_freshness({"env_id": ENV, "business_id": BIZ}, state)
+    assert status == "success" and state.get("stream_freshness")
+    assert "null_reason_override" not in state
+    assert any(e["type"] == "stream_status" for e in tc._assemble_evidence(state))
+
+
+def test_stream_freshness_stale_sets_distinct_null_reason(monkeypatch):
+    monkeypatch.setattr(tc.svc, "monitoring", lambda **k: {
+        "stream": {"status": "stale", "as_of_ts": None, "reason": "stream worker disabled"}})
+    state: dict = {}
+    _res, status, _ = tc._tool_get_stream_freshness({"env_id": ENV, "business_id": BIZ}, state)
+    assert status == "skipped"
+    assert state["null_reason_override"] == policy.NULL_LIVE_DATA_UNAVAILABLE
+    assert tc._assemble_evidence(state) == []   # no fabricated live value
+
+
+def test_stream_freshness_absent_sets_distinct_null_reason(monkeypatch):
+    monkeypatch.setattr(tc.svc, "monitoring", lambda **k: {"stream": None})
+    state: dict = {}
+    _res, status, _ = tc._tool_get_stream_freshness({"env_id": ENV, "business_id": BIZ}, state)
+    assert status == "skipped" and state["null_reason_override"] == policy.NULL_LIVE_DATA_UNAVAILABLE
+
+
 # ── Track B: operator usefulness (disposition capture + measurement) ────────────
 REPORT_ID = str(uuid4())
 


### PR DESCRIPTION
ADO #680. The verification-driven fix #675 surfaced: the copilot **refused aggregate-count questions** and folded **stale-live** into a generic `unsupported_question`. This widens scope along exactly those two lines — and nothing else. The deterministic control plane (classify → fixed tool list → grounded evidence → post-validator) is preserved.

## Acceptance (from the Session Brief)
- ✅ **Distinct freshness reason:** stale/missing live telemetry → `null_reason: live_data_not_available` (not `unsupported_question`).
- ✅ **Aggregate counts in-scope:** "how many runs / predictions / promoted models / drift monitors / anomaly events" answered from approved structured evidence (`svc.summary` — the same counts the Overview uses).
- ✅ **Unsupported aggregates still refuse:** "how many launches/customers/engines" → no known-entity match → `unsupported_question`.
- ✅ **Governance reflects it automatically** (rates/null_reason breakdown derive from `tel_copilot_interactions`).
- ⏳ **How This Works row stays honest:** unchanged in this PR — updated only after deploy + prod re-verify (see below).

## Changes (backend only)
- `telemetry_copilot_policy.py`: `NULL_LIVE_DATA_UNAVAILABLE`; intents `inventory_counts` (entity-scoped patterns) + `live_status`; appended LAST in `ACTIVE_INTENTS` so verdict/model intents win on overlap.
- `telemetry_copilot.py`: tools `get_inventory_counts` (counts as citable evidence values — post-validator safe) and `get_stream_freshness` (fresh → evidence; stale/absent → `null_reason_override`, never a fabricated live value); step-6 fail-closed honors the override; fallback templates; `ALLOW_LIST` extended (prompt-version hash updates).
- Anti-fabrication, genuine refusals, and the out-of-scope wall are unchanged.

## Tests
+7 in `test_copilot_telemetry.py` (classify in-scope; unsupported-still-refuse; live-status; tool units: counts grounded, freshness fresh/stale/absent). **37 passed; ruff clean.**

## ⚠️ Not deployed / not prod-verified yet
Per the plan, this is **implement + test, paused before deploy**. The behavior change needs a **Railway backend deploy** (`authentic-sparkle`, not the Vercel path) + a prod re-verify (re-run the #675 scripted set: counts now answer, live→distinct reason, unsupported still refuses). The How-This-Works copilot row is **intentionally not updated** until that passes — it stays `Partial · Production verified` from the grounding pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)