### PR TITLE
CI: auto-deploy backend to Railway on backend changes (path-filtered)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,71 @@
+name: Deploy Backend (Railway)
+
+# Ships the FastAPI backend to Railway. Runs automatically on a push to main ONLY when backend
+# code (or its Railway/Docker config) changed — non-backend merges (frontend, docs, plans) are
+# skipped by the path filter and never start this workflow. Also exposes a manual trigger so a
+# deploy can be kicked on demand (e.g. to ship an already-merged backend change).
+#
+# Setup required once: add a repo secret RAILWAY_TOKEN = a Railway *project token* scoped to the
+# production environment of the project that owns the `authentic-sparkle` service. Until the secret
+# exists the job runs but no-ops with a warning (it does not fail the commit).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - "railway.json"
+      - ".github/workflows/deploy-backend.yml"
+  workflow_dispatch:
+    inputs:
+      service:
+        description: "Railway service to deploy"
+        required: false
+        default: "authentic-sparkle"
+
+concurrency:
+  group: deploy-backend-railway
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      # Project token — empty when the secret is unset, which the guard step detects.
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      SERVICE: ${{ github.event.inputs.service || 'authentic-sparkle' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Guard — require RAILWAY_TOKEN
+        id: guard
+        run: |
+          if [ -z "${RAILWAY_TOKEN}" ]; then
+            echo "::warning::RAILWAY_TOKEN secret is not set — skipping backend deploy. Add it to enable Railway auto-deploy."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Node
+        if: steps.guard.outputs.enabled == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Railway CLI
+        if: steps.guard.outputs.enabled == 'true'
+        run: npm i -g @railway/cli
+
+      - name: Stamp git SHA for /version
+        if: steps.guard.outputs.enabled == 'true'
+        # Mirrors scripts/deploy_backend.sh: the backend reads this at startup and serves it on
+        # GET /version, so a deploy is traceable to a commit.
+        run: echo "${GITHUB_SHA}" > backend/app/_git_sha.txt
+
+      - name: Deploy to Railway
+        if: steps.guard.outputs.enabled == 'true'
+        working-directory: backend
+        run: railway up --service "${SERVICE}" --ci


### PR DESCRIPTION
## Why
Backend routes were 404ing in production after merge: the frontend auto-deploys via Vercel, but the Railway backend is deployed manually (`railway up`), so a merge that adds a backend route ships the caller before the route exists. The Telemetry Spike Inspector's new `GET /api/telemetry/findings` hit exactly this — confirmed live: `/health` and `/monitoring` return 200, `/api/telemetry/findings` returns `404 {"detail":"Not Found"}`.

## What
New workflow `.github/workflows/deploy-backend.yml` that deploys the backend to Railway:

- **Conditional (skips when no backend change):** `on.push.paths` is limited to `backend/**`, `railway.json`, and the workflow file itself. A merge that only touches frontend/docs/plans never starts the workflow.
- **Token-guarded (safe to merge before setup):** if the `RAILWAY_TOKEN` secret is unset, the job runs but **no-ops with a warning** instead of failing the commit.
- **Manual trigger:** `workflow_dispatch` to deploy on demand (e.g. ship an already-merged backend change without a local `railway up`).
- **Traceable:** stamps `GITHUB_SHA` into `backend/app/_git_sha.txt` (mirrors `scripts/deploy_backend.sh`) so `GET /version` reports the deployed commit.
- **Fails loudly:** `railway up --service authentic-sparkle --ci` waits for the build and fails the workflow if the deploy fails.

## One-time setup
Add a repo secret **`RAILWAY_TOKEN`** = a Railway **project token** scoped to the **production** environment of the project that owns the `authentic-sparkle` service (Railway → project → Settings → Tokens). Until it's set, the workflow safely no-ops.

## Bonus: this can fix the current 404
Because the workflow file is in the path filter, **merging this PR with the secret already set will trigger a deploy of current `main`** — which includes the pending `/api/telemetry/findings` route — clearing the production 404 without a local `railway up`. If you'd rather, after merge I can also fire the `workflow_dispatch` manually via the GitHub API to ship it.

## Notes
- Verified `railway up` supports `--ci` and `--service` (CLI 5.18.0) and the YAML parses.
- This touches CI/deploy governance; per `WINSTON_CODING_SESSION_INSTRUCTIONS.md` it nominally wants an ADO work item first — no `az` CLI is available in this environment, so flagging ADO intake as a follow-up rather than skipping silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2pzMu5Lpd51YJEQGMkEHR

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2pzMu5Lpd51YJEQGMkEHR)_