### PR TITLE
docs(plans): reconcile zombie active plans (mark killed + shipped)

### DIFF
--- a/docs/plans/03-implementation-plans/active/0006-ade-ops-orchestrator-skeleton.md
+++ b/docs/plans/03-implementation-plans/active/0006-ade-ops-orchestrator-skeleton.md
@@ -1,6 +1,6 @@
 # 0006 — ADE Ops Orchestrator: read-only skeleton + 5 commands
 
-- **Status:** PR 1 implemented (branch `feat/ade-ops-skeleton`).
+- **Status:** PR 1–6 SHIPPED as of 2026-06-20 — skeleton + freshness/cloud adapters + recommendation engine + approval-gated execution (5A/5B/5C) + post-change watcher (6A, #259) + incident state machine (6B, #263) all merged to main. See `docs/plans/ade-ops-orchestrator/roadmap.md` for the full PR ledger; this skeleton doc is historical.
 - **Source vision:** `AUTO_ENGINEERING_2.md` (Agentic Data Engineering Operations).
 - **Plan folder:** `docs/plans/ade-ops-orchestrator/`.
 - **ADO:** Epic "ADE Operations Platform" → Feature "PR 1 skeleton + 5 read-only commands" (created via azure-devops-intake; import file at `docs/plans/ade-ops-orchestrator/ado/ado-backlog.json`).

--- a/docs/plans/03-implementation-plans/active/telemetry-calibration-layer.md
+++ b/docs/plans/03-implementation-plans/active/telemetry-calibration-layer.md
@@ -1,7 +1,9 @@
 # Telemetry Calibration Layer — Implementation Plan
 
 **Created:** 2026-06-13
-**Status:** ACTIVE — **Tickets 1 & 2 DONE 2026-06-13.** Ticket 1 reproduced + calibrated the GBM
+**Status:** ✅ DONE 2026-06-20 — Tickets 1–3 all shipped (RUL Calibration screen live at `/lab/env/[envId]/telemetry/calibration`). No further build work; demo-prep only. Kept in `active/` for reference. Original status retained below.
+
+**Original status:** ACTIVE — **Tickets 1 & 2 DONE 2026-06-13.** Ticket 1 reproduced + calibrated the GBM
 baseline (gate PASS; `evidence/telemetry-calibration-baseline.md`, commit `92ac2865`). **Ticket 2: a
 CNN-LSTM challenger GRADUATED** as FD001 RUL champion — RMSE 17.33 (vs 20.32), PHM 742 (vs 1423),
 calibrated 80/90% coverage, tighter intervals (`evidence/telemetry-calibration-challenger.md`). Still

--- a/docs/plans/03-implementation-plans/active/telemetry-trust-gate0-ticket.md
+++ b/docs/plans/03-implementation-plans/active/telemetry-trust-gate0-ticket.md
@@ -1,7 +1,9 @@
 # Gate 0 Ticket — Telemetry Trust Layer Falsification
 
 **Created:** 2026-06-13
-**Status:** RECONCILED 2026-06-13 against the live Databricks workspace — ready to file via
+**Status:** ☠️ KILLED 2026-06-13 — Gate 0 falsification ran and returned a negative result: embedding distance anti-correlates with RUL error (within-band Spearman ρ ≈ −0.127). The Telemetry Trust Layer thesis is dead; do NOT proceed to SupCon training, Trust/Divergence schema, or UI. Canonical post-kill plan is `telemetry-calibration-layer.md`. Original status retained below.
+
+**Original status:** RECONCILED 2026-06-13 against the live Databricks workspace — ready to file via
 `azure-devops-intake` then run. See **Data Reconciliation** below: the original "reuse existing fused
 vector + existing RUL predictions" premise was corrected after inspecting `novendor_1.telemetry`.
 **Type:** Read-only / inference-only analysis spike (falsification gate).


### PR DESCRIPTION
Doc-only. Marks three `active/` implementation plans with their true current status so Monday's `docs/LATEST.md` reflects reality:

- **telemetry-trust-gate0-ticket** → ☠️ KILLED (Gate 0 falsification returned a negative result)
- **telemetry-calibration-layer** → ✅ DONE (Tickets 1–3 shipped; demo-prep only)
- **0006-ade-ops-orchestrator-skeleton** → PR 1–6 SHIPPED (6A #259, 6B #263 now on main)

`factory-pattern-intelligence` already carries a KILL banner — left as-is. Docs are left in place (not moved to an archive folder) to avoid breaking cross-references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)