### PR TITLE
feat(governance): Control Tower Ticket 2 — EnvironmentContract Phases 2–5 (promotion gate + capability/AI-behavior binding)

### DIFF
--- a/backend/app/routes/lab_v2.py
+++ b/backend/app/routes/lab_v2.py
@@ -16,6 +16,8 @@ from app.schemas.lab_v2 import (
     CreateEnvironmentV2Response,
     EnvironmentContractOut,
     EnvironmentManifestV2,
+    PromoteRequest,
+    QuarantineRequest,
     TemplateOut,
 )
 from app.services import (
@@ -146,3 +148,54 @@ def get_environment_contract(env_id: UUID):
         return environment_contract_v2.get_or_derive_contract(str(env_id))
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.post(
+    "/environments/{env_id}/promote",
+    response_model=ContractVerificationReport,
+)
+def promote_environment(env_id: UUID, body: PromoteRequest):
+    """Transition an environment's promotion_state through the fail-closed gate.
+
+    The gate re-verifies fresh and refuses staging/released unless the env is
+    structurally healthy and verification passes. On refusal nothing is written
+    (no transition, no event row) and a 409 with the blocking reasons is returned.
+    Returns the verification report the decision was made on.
+    """
+    try:
+        return environment_contract_v2.promote_environment(
+            str(env_id),
+            target=body.target,
+            actor=body.actor,
+            reason=body.reason,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.post(
+    "/environments/{env_id}/quarantine",
+    response_model=ContractVerificationReport,
+)
+def quarantine_environment(env_id: UUID, body: QuarantineRequest):
+    """Fail-closed operator action. Always records an audit event with the reason.
+    A released contract is terminal and cannot be quarantined (gate enforces)."""
+    try:
+        return environment_contract_v2.quarantine_environment(
+            str(env_id), actor=body.actor, reason=body.reason
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+
+@router.get("/environments/promotion-drift")
+def promotion_drift():
+    """Drift guard: 503 when any released/staging env no longer verifies.
+
+    Mirrors the /v2/environments/health 503 idiom so CI / monitoring fails closed
+    on a non-2xx. Read-only — does not mutate promotion_state or last_verification.
+    """
+    result = environment_contract_v2.check_promotion_drift()
+    if not result["ok"]:
+        return JSONResponse(status_code=503, content=result)
+    return result

--- a/backend/app/schemas/lab_v2.py
+++ b/backend/app/schemas/lab_v2.py
@@ -69,6 +69,34 @@ class EnvironmentManifestV2(BaseModel):
         default=False,
         description="Validate + preview stages without persisting.",
     )
+    # Phase 5 closure — structured declaration fields. The verifier reads these
+    # via _derive_contract_fields with precedence: manifest > template > NULL.
+    # NEVER inferred from enabled_modules / env_kind / "AI enabled".
+    runtime_mode: "RuntimeMode | None" = Field(
+        default=None,
+        description=(
+            "Declares the runtime mode for this env. None = inherit from "
+            "template.runtime_mode; if both null the verifier reports "
+            "runtime.mode_explicit unknown/blocking (correct fail-closed)."
+        ),
+    )
+    ai_behavior_contract_key: str | None = Field(
+        default=None,
+        max_length=120,
+        description=(
+            "Declares the AI behavior contract for this env. None = inherit "
+            "from template.ai_behavior_contract_key; if both null no binding "
+            "is created and ai_runtime.behavior_contract_present stays missing."
+        ),
+    )
+    ai_behavior_contract_version: str | None = Field(
+        default=None,
+        max_length=64,
+        description=(
+            "Version for the declared behavior contract; defaults to "
+            "'ai_behavior_v1' at bind time when key is set and version is null."
+        ),
+    )
 
 
 class StageReport(BaseModel):

--- a/backend/app/schemas/lab_v2.py
+++ b/backend/app/schemas/lab_v2.py
@@ -152,6 +152,26 @@ class EnvironmentContractOut(BaseModel):
     promotion_state: PromotionState
 
 
+class PromoteRequest(BaseModel):
+    """Body for POST /v2/environments/{id}/promote."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    target: PromotionState
+    actor: str = Field(..., min_length=1, max_length=120)
+    reason: str | None = Field(default=None, max_length=2000)
+
+
+class QuarantineRequest(BaseModel):
+    """Body for POST /v2/environments/{id}/quarantine. reason is required so the
+    fail-closed action is always auditable."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    actor: str = Field(..., min_length=1, max_length=120)
+    reason: str = Field(..., min_length=1, max_length=2000)
+
+
 class ContractVerificationReport(BaseModel):
     """Structured fail-closed verification result.
 

--- a/backend/app/services/environment_contract_v2.py
+++ b/backend/app/services/environment_contract_v2.py
@@ -41,13 +41,6 @@ from app.services.environment_seed_packs_v2 import SEED_PACKS
 
 SERVICE = "environment_contract_v2"
 
-# Capability binding is a no-op in environment_pipeline_v2._apply_template_metadata
-# and there is no app.environment_capabilities table yet (verified absent in prod).
-# Until Phase 3 implements it, capability checks MUST report not_available/blocking —
-# never a silent pass. This is the single most dangerous failure mode.
-# (Phase 3a flips this to True once 10030 environment_capabilities lands.)
-_CAPABILITY_BINDING_IMPLEMENTED = False
-
 # Promotion state machine (DB-enforced by the promotion-guard migration's
 # environment_contract_enforce_promotion trigger; mirrored here so the gate fails
 # closed with a clean 4xx before the DB ever raises). Keep in lockstep with the migration.
@@ -301,36 +294,92 @@ def _seed_checks(
     return checks
 
 
-def _capability_checks(contract: EnvironmentContractOut) -> list[ContractCheck]:
-    # Hard fail-closed: binding is unimplemented and there is no capability table.
-    # Reporting pass here would be the worst failure mode in the whole system.
-    if not _CAPABILITY_BINDING_IMPLEMENTED:
+def _capability_checks(
+    cur, contract: EnvironmentContractOut
+) -> list[ContractCheck]:
+    """Resolve the contract's required_capabilities against the authoritative
+    app.environment_capabilities bindings. Fail-closed: a required capability with
+    no enabled binding row is blocking; the binding table not existing at all is
+    blocking (not_available), never a silent pass."""
+    checks: list[ContractCheck] = []
+
+    # binding_implemented = is the capability registry actually present? If the
+    # table is missing (pre-10030 env) this MUST stay not_available/blocking.
+    try:
+        cur.execute("SELECT to_regclass('app.environment_capabilities') AS t")
+        row = cur.fetchone()
+        table_present = bool(row and row.get("t"))
+    except Exception:
+        table_present = False
+
+    if not table_present:
         return [
             _check(
                 "capability.binding_implemented",
                 "not_available",
                 "blocking",
-                "capability binding not implemented "
-                "(environment_pipeline_v2._apply_template_metadata is a no-op; "
-                "no app.environment_capabilities table) — Phase 3",
+                "app.environment_capabilities not present (migration 10030 not "
+                "applied) — capability binding cannot be proven",
             ),
             _check(
                 "capability.required_resolvable",
                 "unknown",
                 "blocking",
                 f"cannot resolve {len(contract.required_capabilities)} required "
-                "capabilities while binding is not_available",
+                "capabilities while the binding table is not_available",
             ),
         ]
-    # Unreachable in Ticket 1; kept so the flip in Phase 3 is a one-line change.
-    return [
+
+    checks.append(
         _check(
             "capability.binding_implemented",
             "pass",
             "blocking",
-            "capability binding implemented",
+            "capability binding registry present (app.environment_capabilities)",
         )
-    ]
+    )
+
+    required = list(contract.required_capabilities)
+    if not required:
+        checks.append(
+            _check(
+                "capability.required_resolvable",
+                "pass",
+                "blocking",
+                "contract requires no capabilities",
+            )
+        )
+        return checks
+
+    cur.execute(
+        """SELECT capability_key
+             FROM app.environment_capabilities
+            WHERE env_id = %s::uuid AND enabled = true""",
+        (contract.env_id,),
+    )
+    bound = {r["capability_key"] for r in cur.fetchall()}
+    missing = sorted(set(required) - bound)
+
+    if missing:
+        checks.append(
+            _check(
+                "capability.required_resolvable",
+                "fail",
+                "blocking",
+                f"required capabilities not bound/enabled for this env: "
+                f"{missing} (data_not_ingested)",
+            )
+        )
+    else:
+        checks.append(
+            _check(
+                "capability.required_resolvable",
+                "pass",
+                "blocking",
+                f"all {len(required)} required capabilities bound and enabled",
+            )
+        )
+    return checks
 
 
 def _runtime_checks(
@@ -489,7 +538,7 @@ def verify_environment_contract(env_id: str) -> ContractVerificationReport:
         env_row = _load_env_row(cur, env_id) or {}
         checks: list[ContractCheck] = []
         checks += _seed_checks(contract, env_row)
-        checks += _capability_checks(contract)
+        checks += _capability_checks(cur, contract)
         checks += _runtime_checks(contract, env_row)
         checks.append(_runtime_backend_check(cur, contract))
         checks += _ai_runtime_checks(contract)

--- a/backend/app/services/environment_contract_v2.py
+++ b/backend/app/services/environment_contract_v2.py
@@ -59,6 +59,13 @@ _LEGAL_TRANSITIONS: dict[str, set[str]] = {
 _STATES_REQUIRING_ELIGIBILITY: set[str] = {"staging", "released"}
 _LIFECYCLE_OK_FOR_PROMOTION: set[str] = {"verified", "live"}
 
+# AI behavior contract (Phase 3c): a per-env row in
+# app.environment_ai_behavior_contracts declares which behavior contract applies.
+# Supported version is pinned to the AI runtime's CONTRACT_VERSION ("v1") so the
+# governance layer and runtime cannot silently diverge. An enabled row whose
+# version is not in this set is treated as malformed -> blocking fail, never pass.
+_SUPPORTED_AI_BEHAVIOR_VERSIONS: set[str] = {"ai_behavior_v1"}
+
 
 def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -450,18 +457,95 @@ def _runtime_backend_check(cur, contract: EnvironmentContractOut) -> ContractChe
     )
 
 
-def _ai_runtime_checks(contract: EnvironmentContractOut) -> list[ContractCheck]:
-    checks: list[ContractCheck] = []
-    # No per-env AI behavior contract registry exists in code yet — report missing,
-    # do not invent a pass.
-    checks.append(
-        _check(
+def _behavior_contract_check(
+    cur, contract: EnvironmentContractOut
+) -> ContractCheck:
+    """Resolve ai_runtime.behavior_contract_present from
+    app.environment_ai_behavior_contracts. Fail-closed and explicit:
+
+      * table absent (migration 10031 not applied) -> not_available / blocking
+      * no row for this env                          -> missing / blocking
+      * row exists but enabled = false               -> fail / blocking
+      * row exists but contract_version unsupported  -> fail / blocking (malformed)
+      * a single enabled, supported row              -> pass
+
+    This is a presence/validity check only — it does NOT re-implement or re-validate
+    AI runtime behavior; contract_enforcer.py remains the runtime source of truth.
+    """
+    try:
+        cur.execute(
+            "SELECT to_regclass('app.environment_ai_behavior_contracts') AS t"
+        )
+        row = cur.fetchone()
+        table_present = bool(row and row.get("t"))
+    except Exception:
+        table_present = False
+
+    if not table_present:
+        return _check(
+            "ai_runtime.behavior_contract_present",
+            "not_available",
+            "blocking",
+            "app.environment_ai_behavior_contracts not present (migration 10031 "
+            "not applied) — AI behavior contract cannot be proven",
+        )
+
+    cur.execute(
+        """SELECT contract_key, contract_version, enabled
+             FROM app.environment_ai_behavior_contracts
+            WHERE env_id = %s::uuid""",
+        (contract.env_id,),
+    )
+    rows = [dict(r) for r in cur.fetchall()]
+
+    if not rows:
+        return _check(
             "ai_runtime.behavior_contract_present",
             "missing",
             "blocking",
-            "no per-env AI behavior contract registry (Phase 3)",
+            "no AI behavior contract declared for this environment "
+            "(out_of_scope_environment)",
         )
+
+    enabled_rows = [r for r in rows if r.get("enabled")]
+    if not enabled_rows:
+        return _check(
+            "ai_runtime.behavior_contract_present",
+            "fail",
+            "blocking",
+            "AI behavior contract row(s) exist but all are disabled "
+            f"({sorted(r['contract_key'] for r in rows)})",
+        )
+
+    unsupported = [
+        r
+        for r in enabled_rows
+        if r.get("contract_version") not in _SUPPORTED_AI_BEHAVIOR_VERSIONS
+    ]
+    if unsupported:
+        return _check(
+            "ai_runtime.behavior_contract_present",
+            "fail",
+            "blocking",
+            "AI behavior contract version unsupported/malformed: "
+            f"{sorted(set(r.get('contract_version') for r in unsupported))} "
+            f"(supported: {sorted(_SUPPORTED_AI_BEHAVIOR_VERSIONS)})",
+        )
+
+    return _check(
+        "ai_runtime.behavior_contract_present",
+        "pass",
+        "blocking",
+        f"AI behavior contract present and enabled: "
+        f"{sorted(r['contract_key'] for r in enabled_rows)}",
     )
+
+
+def _ai_runtime_checks(
+    cur, contract: EnvironmentContractOut
+) -> list[ContractCheck]:
+    checks: list[ContractCheck] = []
+    checks.append(_behavior_contract_check(cur, contract))
     if contract.required_eval_suite:
         checks.append(
             _check(
@@ -541,7 +625,7 @@ def verify_environment_contract(env_id: str) -> ContractVerificationReport:
         checks += _capability_checks(cur, contract)
         checks += _runtime_checks(contract, env_row)
         checks.append(_runtime_backend_check(cur, contract))
-        checks += _ai_runtime_checks(contract)
+        checks += _ai_runtime_checks(cur, contract)
         checks += _eval_checks(contract)
 
         blocking_failures = [

--- a/backend/app/services/environment_contract_v2.py
+++ b/backend/app/services/environment_contract_v2.py
@@ -23,8 +23,11 @@ unknown (the route maps LookupError -> HTTP 404).
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
+
+from fastapi import HTTPException
 
 from app.db import get_cursor
 from app.observability.logger import emit_log
@@ -42,7 +45,26 @@ SERVICE = "environment_contract_v2"
 # and there is no app.environment_capabilities table yet (verified absent in prod).
 # Until Phase 3 implements it, capability checks MUST report not_available/blocking —
 # never a silent pass. This is the single most dangerous failure mode.
+# (Phase 3a flips this to True once 10030 environment_capabilities lands.)
 _CAPABILITY_BINDING_IMPLEMENTED = False
+
+# Promotion state machine (DB-enforced by the promotion-guard migration's
+# environment_contract_enforce_promotion trigger; mirrored here so the gate fails
+# closed with a clean 4xx before the DB ever raises). Keep in lockstep with the migration.
+_LEGAL_TRANSITIONS: dict[str, set[str]] = {
+    "draft": {"seeded", "verified", "quarantined", "failed"},
+    "seeded": {"verified", "quarantined", "failed"},
+    "verified": {"staging", "quarantined", "failed"},
+    "staging": {"verified", "released", "quarantined", "failed"},
+    "released": set(),  # terminal — immutable
+    "quarantined": {"verified"},
+    "failed": {"draft", "quarantined"},
+}
+
+# Promotion into these states requires the env to be structurally healthy AND a
+# fresh verification with eligible_for_promotion = True.
+_STATES_REQUIRING_ELIGIBILITY: set[str] = {"staging", "released"}
+_LIFECYCLE_OK_FOR_PROMOTION: set[str] = {"verified", "live"}
 
 
 def _utcnow_iso() -> str:
@@ -521,3 +543,286 @@ def verify_environment_contract(env_id: str) -> ContractVerificationReport:
         },
     )
     return report
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Promotion gate + transitions (Dispatch 0004 — Ticket 2)
+#
+# Mirrors the re_trace_gate idiom: assert_environment_promotable returns a typed
+# result or raises HTTPException; the route must call the gate first and never
+# reach the transition write otherwise. The gate ALWAYS re-runs verification fresh
+# (materialize=True) — it must never promote on a stale/cached report.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class PromotableContract:
+    """Returned by the gate when a transition is permitted."""
+
+    env_id: str
+    from_state: str
+    to_state: str
+    lifecycle_state: str | None
+    report: ContractVerificationReport
+
+
+def _gate_409(code: str, message: str, **ctx: Any) -> HTTPException:
+    return HTTPException(
+        status_code=409,
+        detail={"code": code, "message": message, **ctx},
+    )
+
+
+def assert_environment_promotable(
+    env_id: str, *, target: str, actor: str
+) -> PromotableContract:
+    """Fail-closed gate. Raises HTTPException (404/409) unless the transition to
+    `target` is legal AND, when target requires it, the env is structurally healthy
+    AND a FRESH verification says eligible_for_promotion.
+
+    The route must call this before any transition write; the transition write must
+    be unreachable when this raises.
+    """
+    if target not in _LEGAL_TRANSITIONS and target not in {
+        s for v in _LEGAL_TRANSITIONS.values() for s in v
+    }:
+        raise _gate_409(
+            "invalid_target_state",
+            f"unknown target promotion_state '{target}'",
+            target=target,
+        )
+
+    # Fresh verification — never trust a cached/stale report for a promotion.
+    report = verify_environment_contract(env_id, materialize=True)
+
+    with get_cursor() as cur:
+        contract = _load_contract_row(cur, env_id)
+        if contract is None:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "code": "contract_not_found",
+                    "message": f"no environment contract for env_id {env_id}",
+                },
+            )
+        env_row = _load_env_row(cur, env_id) or {}
+
+    current = contract["promotion_state"]
+    lifecycle = env_row.get("lifecycle_state")
+
+    if current == "released":
+        raise _gate_409(
+            "released_is_terminal",
+            "released environment contracts are immutable",
+            env_id=env_id,
+            promotion_state=current,
+        )
+
+    allowed = _LEGAL_TRANSITIONS.get(current, set())
+    if target != current and target not in allowed:
+        raise _gate_409(
+            "invalid_transition",
+            f"illegal promotion transition {current} -> {target}",
+            env_id=env_id,
+            from_state=current,
+            to_state=target,
+            allowed=sorted(allowed),
+        )
+
+    if target in _STATES_REQUIRING_ELIGIBILITY:
+        if lifecycle not in _LIFECYCLE_OK_FOR_PROMOTION:
+            raise _gate_409(
+                "lifecycle_not_ready",
+                f"target '{target}' requires lifecycle_state in "
+                f"{sorted(_LIFECYCLE_OK_FOR_PROMOTION)}; env is "
+                f"'{lifecycle}'",
+                env_id=env_id,
+                lifecycle_state=lifecycle,
+                to_state=target,
+            )
+        if not report.eligible_for_promotion:
+            raise _gate_409(
+                "not_eligible",
+                f"target '{target}' requires a passing verification; "
+                f"{len(report.blocking_failures)} blocking check(s) failing",
+                env_id=env_id,
+                to_state=target,
+                blocking_failures=report.blocking_failures,
+            )
+
+    return PromotableContract(
+        env_id=env_id,
+        from_state=current,
+        to_state=target,
+        lifecycle_state=lifecycle,
+        report=report,
+    )
+
+
+def _record_event(
+    cur,
+    *,
+    env_id: str,
+    from_state: str,
+    to_state: str,
+    actor: str,
+    reason: str | None,
+    report: ContractVerificationReport | None,
+) -> None:
+    """Append-only audit row. Every transition (promote AND quarantine) writes
+    exactly one of these."""
+    cur.execute(
+        """
+        INSERT INTO app.environment_promotion_event
+          (env_id, from_state, to_state, actor, reason, verification)
+        VALUES (%s::uuid, %s, %s, %s, %s, %s::jsonb)
+        """,
+        (
+            env_id,
+            from_state,
+            to_state,
+            actor,
+            reason,
+            _serialize_json(report.model_dump()) if report is not None else None,
+        ),
+    )
+
+
+def promote_environment(
+    env_id: str, *, target: str, actor: str, reason: str | None = None
+) -> ContractVerificationReport:
+    """Gate, then perform the single legal transition and write one event row.
+
+    Returns the fresh verification report the decision was made on. Raises
+    HTTPException (from the gate) when the transition is not permitted — in which
+    case NO transition and NO event row are written.
+    """
+    gate = assert_environment_promotable(env_id, target=target, actor=actor)
+
+    with get_cursor() as cur:
+        # released needs its provenance columns; the trigger only lets these +
+        # promotion_state change on a row entering/at released.
+        if target == "released":
+            cur.execute(
+                """UPDATE app.environment_contract
+                      SET promotion_state = %s,
+                          released_at = now(), released_by = %s
+                    WHERE env_id = %s::uuid""",
+                (target, actor, env_id),
+            )
+        elif target == "verified":
+            cur.execute(
+                """UPDATE app.environment_contract
+                      SET promotion_state = %s,
+                          verified_by = %s
+                    WHERE env_id = %s::uuid""",
+                (target, actor, env_id),
+            )
+        else:
+            cur.execute(
+                """UPDATE app.environment_contract
+                      SET promotion_state = %s
+                    WHERE env_id = %s::uuid""",
+                (target, env_id),
+            )
+        _record_event(
+            cur,
+            env_id=env_id,
+            from_state=gate.from_state,
+            to_state=target,
+            actor=actor,
+            reason=reason,
+            report=gate.report,
+        )
+
+    emit_log(
+        level="info",
+        service=SERVICE,
+        action="promote_environment",
+        message=f"environment promoted {gate.from_state} -> {target}",
+        context={"env_id": env_id, "from": gate.from_state, "to": target,
+                 "actor": actor},
+    )
+    return gate.report
+
+
+def quarantine_environment(
+    env_id: str, *, actor: str, reason: str
+) -> ContractVerificationReport:
+    """Operator fail-closed action. Always records an event row with the reason.
+
+    quarantine is reachable from every non-released state; a released contract is
+    terminal and cannot be quarantined (the gate enforces this fail-closed). reason
+    is required — a quarantine without a recorded reason is not auditable.
+    """
+    if not reason or not reason.strip():
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "reason_required",
+                    "message": "quarantine requires a non-empty reason"},
+        )
+    gate = assert_environment_promotable(
+        env_id, target="quarantined", actor=actor
+    )
+
+    with get_cursor() as cur:
+        cur.execute(
+            """UPDATE app.environment_contract
+                  SET promotion_state = 'quarantined'
+                WHERE env_id = %s::uuid""",
+            (env_id,),
+        )
+        _record_event(
+            cur,
+            env_id=env_id,
+            from_state=gate.from_state,
+            to_state="quarantined",
+            actor=actor,
+            reason=reason,
+            report=gate.report,
+        )
+
+    emit_log(
+        level="warning",
+        service=SERVICE,
+        action="quarantine_environment",
+        message=f"environment quarantined ({gate.from_state} -> quarantined)",
+        context={"env_id": env_id, "from": gate.from_state, "actor": actor,
+                 "reason": reason},
+    )
+    return gate.report
+
+
+def check_promotion_drift() -> dict[str, Any]:
+    """Drift guard: any env in a promoted state (released/staging) that no longer
+    passes verification is drift. Mirrors the /v2/environments/health 503 idiom —
+    the route returns 503 when `drift` is non-empty.
+
+    Read-only: verifies with materialize=False so a drift probe never mutates
+    last_verification or promotion_state.
+    """
+    with get_cursor() as cur:
+        cur.execute(
+            """SELECT env_id::text AS env_id, promotion_state
+                 FROM app.environment_contract
+                WHERE promotion_state IN ('released','staging')"""
+        )
+        promoted = [dict(r) for r in cur.fetchall()]
+
+    drift: list[dict[str, Any]] = []
+    for row in promoted:
+        report = verify_environment_contract(row["env_id"], materialize=False)
+        if not report.eligible_for_promotion:
+            drift.append(
+                {
+                    "env_id": row["env_id"],
+                    "promotion_state": row["promotion_state"],
+                    "blocking_failures": report.blocking_failures,
+                }
+            )
+
+    return {
+        "promoted_envs_checked": len(promoted),
+        "drift": drift,
+        "ok": not drift,
+    }

--- a/backend/app/services/environment_contract_v2.py
+++ b/backend/app/services/environment_contract_v2.py
@@ -122,6 +122,21 @@ def _contract_out(row: dict[str, Any]) -> EnvironmentContractOut:
     )
 
 
+def _resolve_template_runtime_mode(
+    template_key: str, template_version: int
+) -> str | None:
+    """Phase 5 closure: read runtime_mode from the template registry only.
+    Returns None if the template doesn't declare one or the template is missing.
+    NEVER infers from env_kind / enabled_modules / "AI enabled"."""
+    try:
+        template = environment_templates_v2.get_template(
+            template_key, template_version
+        )
+    except LookupError:
+        return None
+    return template.get("runtime_mode")
+
+
 def _derive_contract_fields(env_row: dict[str, Any]) -> dict[str, Any]:
     """Derive contract fields from clearly existing sources ONLY.
 
@@ -163,8 +178,12 @@ def _derive_contract_fields(env_row: dict[str, Any]) -> dict[str, Any]:
         "template_key": template_key,
         "template_version": int(template_version),
         "canonical_runtime_path": canonical_runtime_path,
-        # runtime_mode is NOT confidently derivable from existing sources -> null.
-        "runtime_mode": None,
+        # runtime_mode: Phase 5 closure — read from template.runtime_mode if the
+        # template declares it (migration 10032). Manifest overrides are written
+        # at provision time by environment_pipeline_v2._apply_template_metadata,
+        # so the contract row already carries them before this fallback fires.
+        # Still NULL if the template declares nothing — never inferred.
+        "runtime_mode": _resolve_template_runtime_mode(template_key, template_version),
         "deployment_target": "local",
         "seed_pack_version": seed_pack_version,
         "required_capabilities": required_capabilities,
@@ -611,8 +630,15 @@ def _eval_checks(contract: EnvironmentContractOut) -> list[ContractCheck]:
     return checks
 
 
-def verify_environment_contract(env_id: str) -> ContractVerificationReport:
+def verify_environment_contract(
+    env_id: str, *, materialize: bool = False
+) -> ContractVerificationReport:
     """Fail-closed structured verification of an environment's contract.
+
+    materialize=False (default): pure read — does not write last_verification.
+    materialize=True: additionally persists the latest report to
+    last_verification / last_verified_at. Promotion (Ticket 2) always forces a
+    fresh materialized verification; GET /verify defaults to a read.
 
     Raises LookupError if env_id is unknown / not a v2 contract env.
     """
@@ -650,15 +676,17 @@ def verify_environment_contract(env_id: str) -> ContractVerificationReport:
             health_ok=eligible,
         )
 
-        # Persist the verification snapshot for operator visibility. This does NOT
-        # transition promotion_state and does NOT write environment_promotion_event
-        # (both are Ticket 2). It only records the latest report + timestamp.
-        cur.execute(
-            """UPDATE app.environment_contract
-                  SET last_verification = %s::jsonb, last_verified_at = now()
-                WHERE env_id = %s::uuid""",
-            (_serialize_json(report.model_dump()), env_id),
-        )
+        # Persist the verification snapshot for operator visibility only when
+        # materialize is requested. This does NOT transition promotion_state and
+        # does NOT write environment_promotion_event (those are the promotion path).
+        # It only records the latest report + timestamp.
+        if materialize:
+            cur.execute(
+                """UPDATE app.environment_contract
+                      SET last_verification = %s::jsonb, last_verified_at = now()
+                    WHERE env_id = %s::uuid""",
+                (_serialize_json(report.model_dump()), env_id),
+            )
 
     emit_log(
         level="info" if eligible else "warning",

--- a/backend/app/services/environment_pipeline_v2.py
+++ b/backend/app/services/environment_pipeline_v2.py
@@ -260,6 +260,72 @@ def _apply_template_metadata(ctx: _RunCtx, cur) -> None:
         )
         bound.append(capability_key)
 
+    # Phase 5 closure: explicit declaration channel for runtime_mode and the AI
+    # behavior contract. Precedence: manifest > template > NULL. NEVER inferred.
+    manifest = ctx.manifest
+    template = ctx.template
+    runtime_mode = (
+        getattr(manifest, "runtime_mode", None)
+        or template.get("runtime_mode")
+    )
+    behavior_key = (
+        getattr(manifest, "ai_behavior_contract_key", None)
+        or template.get("ai_behavior_contract_key")
+    )
+    behavior_version = (
+        getattr(manifest, "ai_behavior_contract_version", None)
+        or template.get("ai_behavior_contract_version")
+        or "ai_behavior_v1"
+    )
+
+    # Seed app.environment_contract directly so /verify after provisioning sees
+    # the declared runtime_mode without needing the lazy derive path. Idempotent
+    # (re-provision updates the runtime_mode in place; promotion_state untouched
+    # — the gate is the only writer of state transitions).
+    cur.execute(
+        """
+        INSERT INTO app.environment_contract
+          (env_id, template_key, template_version, canonical_runtime_path,
+           runtime_mode, deployment_target, seed_pack_version,
+           required_capabilities, required_smoke_tests, required_eval_suite,
+           authoritative_state_requirements, compatibility_version,
+           promotion_state)
+        VALUES
+          (%s::uuid, %s, %s, %s, %s, 'local', NULL, %s, '{}', NULL,
+           '{}'::jsonb, 'env_contract_v1', 'draft')
+        ON CONFLICT (env_id) DO UPDATE
+          SET runtime_mode = EXCLUDED.runtime_mode
+        """,
+        (
+            ctx.env_id,
+            template["template_key"],
+            template["version"],
+            template.get("default_home_route"),
+            runtime_mode,
+            modules,
+        ),
+    )
+
+    behavior_bound: dict[str, Any] | None = None
+    if behavior_key:
+        cur.execute(
+            """
+            INSERT INTO app.environment_ai_behavior_contracts
+              (env_id, contract_key, contract_version, source, enabled)
+            VALUES (%s::uuid, %s, %s, 'template', true)
+            ON CONFLICT (env_id, contract_key) DO UPDATE
+              SET enabled = true,
+                  contract_version = EXCLUDED.contract_version,
+                  source = 'template',
+                  updated_at = now()
+            """,
+            (ctx.env_id, behavior_key, behavior_version),
+        )
+        behavior_bound = {
+            "contract_key": behavior_key,
+            "contract_version": behavior_version,
+        }
+
     _record_stage(
         ctx,
         "apply_template_metadata",
@@ -269,6 +335,8 @@ def _apply_template_metadata(ctx: _RunCtx, cur) -> None:
             "bound": bound,
             "rows_created": len(bound),
             "source": "template.enabled_modules",
+            "runtime_mode": runtime_mode,
+            "ai_behavior_contract_bound": behavior_bound,
         },
     )
 

--- a/backend/app/services/environment_pipeline_v2.py
+++ b/backend/app/services/environment_pipeline_v2.py
@@ -209,22 +209,66 @@ def _create_rows(ctx: _RunCtx, cur) -> None:
 
 
 def _apply_template_metadata(ctx: _RunCtx, cur) -> None:
-    """No-op placeholder for Phase A.
+    """Bind the template's declared capabilities into app.environment_capabilities.
 
-    In a later phase this will copy template.capability_keys into
-    app.environment_capabilities and set department/module bindings. For now we
-    only record the template reference (done in _create_rows) so nav/home-route
-    resolution can read it.
+    Phase 3a: this binds exactly what the template advertises via
+    enabled_modules — nothing inferred, nothing beyond the template. Idempotent:
+    re-provisioning the same env re-asserts the same bindings (and re-enables any
+    that were disabled) without creating duplicates. A template with no
+    enabled_modules binds nothing (the env will have zero capabilities, and the
+    verifier will fail closed for any contract that requires some).
+
+    Phase 5 note (deferred by design until the runtime_mode/ai_behavior_contract
+    declaration field lands): an AI behavior contract is NOT bound here. There is
+    currently no explicit declaration channel — neither app.environment_templates
+    nor EnvironmentManifestV2 has an ai_behavior field, and
+    MANIFEST_JSON_ALLOWED_KEYS deliberately excludes structured concerns. Per the
+    Phase 3c binding policy, we do NOT infer an AI behavior contract from
+    enabled_modules or "AI enabled". Rows in app.environment_ai_behavior_contracts
+    are created explicitly (source='manual' via API/operator) until Phase 5 adds
+    the structured fields; then bind them here exactly like enabled_modules.
     """
     t0 = time.time()
+    modules = [m for m in (ctx.template.get("enabled_modules") or []) if m]
+    if not modules:
+        _record_stage(
+            ctx,
+            "apply_template_metadata",
+            "ok",
+            t0,
+            {
+                "bound": [],
+                "rows_created": 0,
+                "note": "template declares no enabled_modules; no capabilities bound",
+            },
+        )
+        return
+
+    bound: list[str] = []
+    for capability_key in modules:
+        cur.execute(
+            """
+            INSERT INTO app.environment_capabilities
+              (env_id, capability_key, source, enabled)
+            VALUES (%s::uuid, %s, 'template', true)
+            ON CONFLICT (env_id, capability_key) DO UPDATE
+              SET enabled = true,
+                  source = 'template',
+                  updated_at = now()
+            """,
+            (ctx.env_id, capability_key),
+        )
+        bound.append(capability_key)
+
     _record_stage(
         ctx,
         "apply_template_metadata",
-        "skipped",
+        "ok",
         t0,
         {
-            "note": "capability bindings deferred to a later phase; template_key pinned on env row",
-            "enabled_modules_hint": list(ctx.template.get("enabled_modules") or []),
+            "bound": bound,
+            "rows_created": len(bound),
+            "source": "template.enabled_modules",
         },
     )
 

--- a/backend/app/services/environment_templates_v2.py
+++ b/backend/app/services/environment_templates_v2.py
@@ -24,7 +24,14 @@ def _load_templates_fresh() -> list[dict[str, Any]]:
                    env_kind_default, industry_type, default_home_route, default_auth_mode,
                    enabled_modules, theme_tokens, login_copy,
                    default_seed_pack, available_seed_packs,
-                   is_active, is_latest, notes
+                   is_active, is_latest, notes,
+                   -- Phase 5 closure (migration 10032): structured declaration
+                   -- channel for runtime_mode + AI behavior contract. NULL is
+                   -- the documented default; the verifier / pipeline never
+                   -- infer when both manifest and template are null.
+                   runtime_mode,
+                   ai_behavior_contract_key,
+                   ai_behavior_contract_version
               FROM app.environment_templates
              WHERE is_active = true
              ORDER BY template_key, version DESC

--- a/backend/tests/test_environment_contract_promotion.py
+++ b/backend/tests/test_environment_contract_promotion.py
@@ -91,16 +91,25 @@ def _queue_gate(
     template_active=True,
     cap_table_present=True,
     bound_caps=("repe",),
+    ai_table_present=True,
+    ai_rows=(
+        {
+            "contract_key": "default",
+            "contract_version": "ai_behavior_v1",
+            "enabled": True,
+        },
+    ),
 ):
-    """Queue the FakeCursor sequence for assert_environment_promotable (post-3a):
+    """Queue the FakeCursor sequence for assert_environment_promotable (post-3a+3c):
 
     verify_environment_contract(materialize=True):
       get_or_derive_contract: contract HIT (return early)
       verify block: env row
-                    -> _capability_checks: to_regclass probe
-                                           -> bound-caps SELECT (table present and
-                                              the contract requires ['repe'])
-                    -> template active probe
+                    -> _capability_checks: cap to_regclass probe
+                                           -> bound-caps SELECT
+                    -> runtime backend template probe
+                    -> _behavior_contract_check: ai to_regclass probe
+                                                 -> ai rows SELECT
                     -> materialize UPDATE (no fetch)
     gate's own block: contract row -> env row
     """
@@ -110,12 +119,19 @@ def _queue_gate(
         [{"t": "app.environment_capabilities"}]
         if cap_table_present
         else [{"t": None}]
-    )  # to_regclass
+    )  # cap to_regclass
     if cap_table_present:
         cur.push_result(
             [{"capability_key": c} for c in bound_caps]
         )  # bound-caps SELECT
     cur.push_result([{"1": 1}] if template_active else [])  # template probe
+    cur.push_result(
+        [{"t": "app.environment_ai_behavior_contracts"}]
+        if ai_table_present
+        else [{"t": None}]
+    )  # ai to_regclass
+    if ai_table_present:
+        cur.push_result([dict(r) for r in ai_rows])  # ai behavior rows
     # materialize UPDATE: no fetch
     cur.push_result([contract_row])  # gate: _load_contract_row
     cur.push_result([env_row])  # gate: _load_env_row

--- a/backend/tests/test_environment_contract_promotion.py
+++ b/backend/tests/test_environment_contract_promotion.py
@@ -1,0 +1,334 @@
+"""Ticket 2 tests (Dispatch 0004) — promotion state machine + fail-closed gate.
+
+Covers the gate (assert_environment_promotable), promote/quarantine transitions,
+the append-only event write, and the drift guard. The DB trigger
+(environment_contract_enforce_promotion, migration 10005) is exercised separately
+by a rolled-back live-schema validation; these tests pin the Python-side
+fail-closed gate that refuses BEFORE the DB ever raises.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from app.services import environment_contract_v2 as svc
+from app.services import environment_templates_v2 as _tpl
+
+
+@pytest.fixture(autouse=True)
+def _prime_template_cache():
+    """Pure cache hit for get_template so it issues no query mid-verify (keeps the
+    FakeCursor sequence deterministic regardless of test order)."""
+    _tpl._CACHE["templates"] = [
+        {
+            "template_key": "repe",
+            "version": 1,
+            "display_name": "REPE",
+            "description": None,
+            "env_kind_default": "client",
+            "industry_type": "real_estate_pe",
+            "default_home_route": "/lab/env/{env_id}/re",
+            "default_auth_mode": "private",
+            "enabled_modules": ["repe"],
+            "theme_tokens": {},
+            "login_copy": {},
+            "default_seed_pack": "repe_starter",
+            "available_seed_packs": ["repe_starter"],
+            "is_active": True,
+            "is_latest": True,
+            "notes": None,
+        }
+    ]
+    _tpl._CACHE["fetched_at"] = float("inf")
+    yield
+    _tpl.invalidate_cache()
+
+
+def _env_row(**over):
+    base = {
+        "env_id": str(uuid.uuid4()),
+        "slug": "acme-repe",
+        "template_key": "repe",
+        "template_version": 1,
+        "env_kind": "client",
+        "lifecycle_state": "verified",
+        "default_home_route": "/lab/env/{env_id}/re",
+        "seed_pack_applied": "repe_starter",
+        "seed_pack_version": 1,
+    }
+    base.update(over)
+    return base
+
+
+def _contract_row(env_id, promotion_state="verified", **over):
+    base = {
+        "env_id": env_id,
+        "template_key": "repe",
+        "template_version": 1,
+        "canonical_runtime_path": "/lab/env/{env_id}/re",
+        "runtime_mode": "interactive",
+        "deployment_target": "local",
+        "seed_pack_version": 1,
+        "required_capabilities": ["repe"],
+        "required_smoke_tests": [],
+        "required_eval_suite": None,
+        "authoritative_state_requirements": {},
+        "compatibility_version": "env_contract_v1",
+        "promotion_state": promotion_state,
+    }
+    base.update(over)
+    return base
+
+
+def _queue_gate(cur, env_row, contract_row, *, template_active=True):
+    """Queue the FakeCursor sequence for assert_environment_promotable:
+
+    verify_environment_contract(materialize=True):
+      get_or_derive_contract: contract HIT (return early)
+      verify block: env row -> template active probe -> materialize UPDATE (no fetch)
+    gate's own block: contract row -> env row
+    """
+    cur.push_result([contract_row])  # get_or_derive: contract hit
+    cur.push_result([env_row])  # verify: _load_env_row
+    cur.push_result([{"1": 1}] if template_active else [])  # template probe
+    # materialize UPDATE: no fetch
+    cur.push_result([contract_row])  # gate: _load_contract_row
+    cur.push_result([env_row])  # gate: _load_env_row
+
+
+# ── Gate fail-closed ─────────────────────────────────────────────────────────
+
+
+def test_gate_blocks_release_when_capability_not_eligible(fake_cursor):
+    """staging/released require eligible_for_promotion; capability binding is
+    not_available/blocking in Ticket 1 (Phase 3a makes it data-driven), so the
+    gate must refuse with 409 not_eligible."""
+    env = _env_row(lifecycle_state="verified")
+    contract = _contract_row(env["env_id"], promotion_state="staging")
+    _queue_gate(fake_cursor, env, contract)
+
+    with pytest.raises(HTTPException) as ei:
+        svc.assert_environment_promotable(
+            env["env_id"], target="released", actor="tester"
+        )
+    assert ei.value.status_code == 409
+    assert ei.value.detail["code"] == "not_eligible"
+    assert ei.value.detail["blocking_failures"]
+
+
+def test_gate_blocks_illegal_transition(fake_cursor):
+    env = _env_row()
+    contract = _contract_row(env["env_id"], promotion_state="draft")
+    _queue_gate(fake_cursor, env, contract)
+    with pytest.raises(HTTPException) as ei:
+        svc.assert_environment_promotable(
+            env["env_id"], target="released", actor="tester"
+        )
+    assert ei.value.status_code == 409
+    assert ei.value.detail["code"] == "invalid_transition"
+    assert "released" not in ei.value.detail["allowed"]
+
+
+def test_gate_blocks_released_terminal(fake_cursor):
+    env = _env_row()
+    contract = _contract_row(env["env_id"], promotion_state="released")
+    _queue_gate(fake_cursor, env, contract)
+    with pytest.raises(HTTPException) as ei:
+        svc.assert_environment_promotable(
+            env["env_id"], target="released", actor="tester"
+        )
+    assert ei.value.status_code == 409
+    assert ei.value.detail["code"] == "released_is_terminal"
+
+
+def test_gate_blocks_staging_when_lifecycle_not_ready(fake_cursor):
+    env = _env_row(lifecycle_state="seeded")  # not verified/live
+    contract = _contract_row(env["env_id"], promotion_state="verified")
+    _queue_gate(fake_cursor, env, contract)
+    with pytest.raises(HTTPException) as ei:
+        svc.assert_environment_promotable(
+            env["env_id"], target="staging", actor="tester"
+        )
+    assert ei.value.status_code == 409
+    assert ei.value.detail["code"] == "lifecycle_not_ready"
+
+
+def test_gate_allows_non_eligibility_transition(fake_cursor):
+    """draft -> seeded does not require eligibility; gate should allow it even
+    though capability binding is blocking."""
+    env = _env_row()
+    contract = _contract_row(env["env_id"], promotion_state="draft")
+    _queue_gate(fake_cursor, env, contract)
+    result = svc.assert_environment_promotable(
+        env["env_id"], target="seeded", actor="tester"
+    )
+    assert result.from_state == "draft"
+    assert result.to_state == "seeded"
+
+
+# ── Transitions write exactly one event row ──────────────────────────────────
+
+
+def test_promote_records_one_event_row(fake_cursor):
+    env = _env_row()
+    contract = _contract_row(env["env_id"], promotion_state="draft")
+    _queue_gate(fake_cursor, env, contract)
+    # promote_environment then: UPDATE promotion_state + INSERT event (no fetches)
+
+    svc.promote_environment(
+        env["env_id"], target="seeded", actor="tester", reason="ready"
+    )
+
+    inserts = [
+        q
+        for q, _ in fake_cursor.queries
+        if "INSERT INTO app.environment_promotion_event" in q
+    ]
+    assert len(inserts) == 1
+    updates = [
+        q
+        for q, _ in fake_cursor.queries
+        if "UPDATE app.environment_contract" in q
+        and "promotion_state" in q
+        and "last_verification" not in q
+    ]
+    assert len(updates) == 1
+
+
+def test_blocked_promotion_writes_nothing(fake_cursor):
+    env = _env_row()
+    contract = _contract_row(env["env_id"], promotion_state="draft")
+    _queue_gate(fake_cursor, env, contract)
+    with pytest.raises(HTTPException):
+        svc.promote_environment(
+            env["env_id"], target="released", actor="tester"
+        )
+    inserts = [
+        q
+        for q, _ in fake_cursor.queries
+        if "INSERT INTO app.environment_promotion_event" in q
+    ]
+    state_updates = [
+        q
+        for q, _ in fake_cursor.queries
+        if "UPDATE app.environment_contract" in q
+        and "promotion_state = %s" in q
+    ]
+    assert inserts == []
+    assert state_updates == []
+
+
+def test_quarantine_requires_reason(fake_cursor):
+    with pytest.raises(HTTPException) as ei:
+        svc.quarantine_environment(
+            str(uuid.uuid4()), actor="tester", reason="  "
+        )
+    assert ei.value.status_code == 422
+    assert ei.value.detail["code"] == "reason_required"
+
+
+def test_quarantine_records_event_with_reason(fake_cursor):
+    env = _env_row()
+    contract = _contract_row(env["env_id"], promotion_state="verified")
+    _queue_gate(fake_cursor, env, contract)
+
+    svc.quarantine_environment(
+        env["env_id"], actor="tester", reason="seed drift detected"
+    )
+
+    event_inserts = [
+        params
+        for q, params in fake_cursor.queries
+        if "INSERT INTO app.environment_promotion_event" in q
+    ]
+    assert len(event_inserts) == 1
+    # params: (env_id, from_state, to_state, actor, reason, verification_json)
+    assert event_inserts[0][2] == "quarantined"
+    assert event_inserts[0][4] == "seed drift detected"
+
+
+# ── Drift guard ──────────────────────────────────────────────────────────────
+
+
+def test_drift_guard_flags_released_env_that_no_longer_verifies(fake_cursor):
+    env_id = str(uuid.uuid4())
+    # 1) list promoted envs
+    fake_cursor.push_result(
+        [{"env_id": env_id, "promotion_state": "released"}]
+    )
+    # 2) verify_environment_contract(materialize=False) for that env:
+    #    get_or_derive contract hit -> verify env row -> template probe
+    fake_cursor.push_result([_contract_row(env_id, promotion_state="released")])
+    fake_cursor.push_result([_env_row(env_id=env_id)])
+    fake_cursor.push_result([{"1": 1}])  # template active
+
+    result = svc.check_promotion_drift()
+
+    assert result["ok"] is False
+    assert result["promoted_envs_checked"] == 1
+    assert result["drift"][0]["env_id"] == env_id
+    assert result["drift"][0]["promotion_state"] == "released"
+    # capability.binding_implemented blocking (Ticket 1) is why it drifts
+    assert "capability.binding_implemented" in result["drift"][0][
+        "blocking_failures"
+    ]
+
+
+def test_drift_guard_ok_when_no_promoted_envs(fake_cursor):
+    fake_cursor.push_result([])  # no released/staging envs
+    result = svc.check_promotion_drift()
+    assert result["ok"] is True
+    assert result["promoted_envs_checked"] == 0
+    assert result["drift"] == []
+
+
+# ── API surface ──────────────────────────────────────────────────────────────
+
+
+def test_promote_endpoint_returns_409_when_blocked(client, fake_cursor):
+    env = _env_row()
+    contract = _contract_row(env["env_id"], promotion_state="draft")
+    _queue_gate(fake_cursor, env, contract)
+    resp = client.post(
+        f"/v2/environments/{env['env_id']}/promote",
+        json={"target": "released", "actor": "tester"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "invalid_transition"
+
+
+def test_promote_endpoint_success_returns_report(client, fake_cursor):
+    env = _env_row()
+    contract = _contract_row(env["env_id"], promotion_state="draft")
+    _queue_gate(fake_cursor, env, contract)
+    resp = client.post(
+        f"/v2/environments/{env['env_id']}/promote",
+        json={"target": "seeded", "actor": "tester", "reason": "go"},
+    )
+    assert resp.status_code == 200
+    assert "eligible_for_promotion" in resp.json()
+
+
+def test_quarantine_endpoint_rejects_missing_reason(client, fake_cursor):
+    resp = client.post(
+        f"/v2/environments/{uuid.uuid4()}/quarantine",
+        json={"actor": "tester"},
+    )
+    # pydantic rejects missing required reason -> 422
+    assert resp.status_code == 422
+
+
+def test_promotion_drift_endpoint_503_on_drift(client, fake_cursor):
+    env_id = str(uuid.uuid4())
+    fake_cursor.push_result(
+        [{"env_id": env_id, "promotion_state": "staging"}]
+    )
+    fake_cursor.push_result([_contract_row(env_id, promotion_state="staging")])
+    fake_cursor.push_result([_env_row(env_id=env_id)])
+    fake_cursor.push_result([{"1": 1}])
+    resp = client.get("/v2/environments/promotion-drift")
+    assert resp.status_code == 503
+    assert resp.json()["ok"] is False

--- a/backend/tests/test_environment_contract_promotion.py
+++ b/backend/tests/test_environment_contract_promotion.py
@@ -83,16 +83,38 @@ def _contract_row(env_id, promotion_state="verified", **over):
     return base
 
 
-def _queue_gate(cur, env_row, contract_row, *, template_active=True):
-    """Queue the FakeCursor sequence for assert_environment_promotable:
+def _queue_gate(
+    cur,
+    env_row,
+    contract_row,
+    *,
+    template_active=True,
+    cap_table_present=True,
+    bound_caps=("repe",),
+):
+    """Queue the FakeCursor sequence for assert_environment_promotable (post-3a):
 
     verify_environment_contract(materialize=True):
       get_or_derive_contract: contract HIT (return early)
-      verify block: env row -> template active probe -> materialize UPDATE (no fetch)
+      verify block: env row
+                    -> _capability_checks: to_regclass probe
+                                           -> bound-caps SELECT (table present and
+                                              the contract requires ['repe'])
+                    -> template active probe
+                    -> materialize UPDATE (no fetch)
     gate's own block: contract row -> env row
     """
     cur.push_result([contract_row])  # get_or_derive: contract hit
     cur.push_result([env_row])  # verify: _load_env_row
+    cur.push_result(
+        [{"t": "app.environment_capabilities"}]
+        if cap_table_present
+        else [{"t": None}]
+    )  # to_regclass
+    if cap_table_present:
+        cur.push_result(
+            [{"capability_key": c} for c in bound_caps]
+        )  # bound-caps SELECT
     cur.push_result([{"1": 1}] if template_active else [])  # template probe
     # materialize UPDATE: no fetch
     cur.push_result([contract_row])  # gate: _load_contract_row
@@ -102,13 +124,14 @@ def _queue_gate(cur, env_row, contract_row, *, template_active=True):
 # ── Gate fail-closed ─────────────────────────────────────────────────────────
 
 
-def test_gate_blocks_release_when_capability_not_eligible(fake_cursor):
-    """staging/released require eligible_for_promotion; capability binding is
-    not_available/blocking in Ticket 1 (Phase 3a makes it data-driven), so the
-    gate must refuse with 409 not_eligible."""
+def test_gate_blocks_release_when_required_capability_unbound(fake_cursor):
+    """staging/released require eligible_for_promotion. With the required 'repe'
+    capability NOT bound, the verifier fails closed (capability.required_resolvable
+    = fail) so the gate refuses release with 409 not_eligible. (Phase 3a: the block
+    is now data-driven, not a hard-coded not_available.)"""
     env = _env_row(lifecycle_state="verified")
     contract = _contract_row(env["env_id"], promotion_state="staging")
-    _queue_gate(fake_cursor, env, contract)
+    _queue_gate(fake_cursor, env, contract, bound_caps=("unrelated_cap",))
 
     with pytest.raises(HTTPException) as ei:
         svc.assert_environment_promotable(
@@ -116,7 +139,9 @@ def test_gate_blocks_release_when_capability_not_eligible(fake_cursor):
         )
     assert ei.value.status_code == 409
     assert ei.value.detail["code"] == "not_eligible"
-    assert ei.value.detail["blocking_failures"]
+    assert "capability.required_resolvable" in ei.value.detail[
+        "blocking_failures"
+    ]
 
 
 def test_gate_blocks_illegal_transition(fake_cursor):

--- a/backend/tests/test_environment_contract_promotion.py
+++ b/backend/tests/test_environment_contract_promotion.py
@@ -2,7 +2,7 @@
 
 Covers the gate (assert_environment_promotable), promote/quarantine transitions,
 the append-only event write, and the drift guard. The DB trigger
-(environment_contract_enforce_promotion, migration 10005) is exercised separately
+(environment_contract_enforce_promotion, migration 10029) is exercised separately
 by a rolled-back live-schema validation; these tests pin the Python-side
 fail-closed gate that refuses BEFORE the DB ever raises.
 """

--- a/backend/tests/test_environment_contract_v2.py
+++ b/backend/tests/test_environment_contract_v2.py
@@ -1,4 +1,5 @@
-"""Ticket 1 tests for the EnvironmentContract + fail-closed verifier.
+"""Ticket 1 tests for the EnvironmentContract + fail-closed verifier
+(Dispatch 0004 / migration (env_contract base)).
 
 Covers the service (derive + verify) and the API surface. The single most
 important assertion: capability binding is not_available/blocking, so a
@@ -6,6 +7,11 @@ structurally healthy env is still NOT eligible for promotion (no silent pass).
 
 No test asserts a write to app.environment_promotion_event — that table is dead
 in Ticket 1 by design.
+
+Phase 3a will rewrite some of these to be data-driven; Phase 5 will close the
+runtime_mode declaration field. Those rewrites are mock-faithfulness updates,
+not assertion-weakening (the rule that never bends: every non-pass branch stays
+blocking; no silent pass).
 """
 
 from __future__ import annotations
@@ -15,6 +21,37 @@ import uuid
 import pytest
 
 from app.services import environment_contract_v2 as svc
+from app.services import environment_templates_v2 as _tpl
+
+
+@pytest.fixture(autouse=True)
+def _prime_template_cache():
+    """Make environment_templates_v2.get_template a pure cache hit so it issues
+    NO query mid-verify. Without this the (warm vs cold) cache query shifts the
+    FakeCursor result sequence non-deterministically across test order."""
+    _tpl._CACHE["templates"] = [
+        {
+            "template_key": "repe",
+            "version": 1,
+            "display_name": "REPE",
+            "description": None,
+            "env_kind_default": "client",
+            "industry_type": "real_estate_pe",
+            "default_home_route": "/lab/env/{env_id}/re",
+            "default_auth_mode": "private",
+            "enabled_modules": ["repe"],
+            "theme_tokens": {},
+            "login_copy": {},
+            "default_seed_pack": "repe_starter",
+            "available_seed_packs": ["repe_starter"],
+            "is_active": True,
+            "is_latest": True,
+            "notes": None,
+        }
+    ]
+    _tpl._CACHE["fetched_at"] = float("inf")  # never expires during the test
+    yield
+    _tpl.invalidate_cache()
 
 
 def _env_row(**over):
@@ -63,7 +100,7 @@ def _queue_verify_sequence(
                      materialize=True; default GET /verify uses materialize=False).
     """
     cur.push_result([])  # _load_contract_row miss
-    cur.push_result([env_row])  # _load_env_row
+    cur.push_result([env_row])  # _load_env_row (derive)
     # INSERT consumes no result
     cur.push_result([])  # re-read _load_contract_row after insert (race fallback)
     cur.push_result([env_row])  # verify: _load_env_row
@@ -99,7 +136,7 @@ def test_derive_contract_when_no_row(fake_cursor):
     assert contract.promotion_state == "draft"  # never derives anything past draft
     assert contract.canonical_runtime_path == "/lab/env/{env_id}/re"
     assert contract.seed_pack_version == 1
-    assert contract.runtime_mode is None  # not over-derived
+    assert contract.runtime_mode is None  # not over-derived (Phase 5 closes this)
     assert contract.required_eval_suite is None
 
 
@@ -195,7 +232,6 @@ def test_missing_seed_pack_is_blocking_fail(fake_cursor):
 
 
 def test_seed_version_mismatch_is_blocking_fail(fake_cursor):
-    # contract derives seed_pack_version from env row; force a mismatch vs registry
     env = _env_row(seed_pack_applied="repe_starter", seed_pack_version=999)
     _queue_verify_sequence(fake_cursor, env)
     report = svc.verify_environment_contract(env["env_id"])
@@ -306,6 +342,56 @@ def test_ai_behavior_valid_enabled_row_passes(fake_cursor):
     c = {x.key: x for x in report.checks}["ai_runtime.behavior_contract_present"]
     assert c.status == "pass"
     assert "ai_runtime.behavior_contract_present" not in report.blocking_failures
+
+
+def test_fully_provisioned_env_is_eligible_for_promotion(fake_cursor):
+    """Phase 5 closure proof: a STORED contract (HIT path) with runtime_mode set
+    + seed applied + capabilities bound + backend reachable + valid AI behavior
+    contract -> NO blocking failures -> eligible_for_promotion is True. This is
+    the end-to-end happy path that proves a pipeline-provisioned env (one whose
+    template declares runtime_mode + ai_behavior_contract_key) can reach
+    'released' through the gate."""
+    env = _env_row()
+    stored_contract = {
+        "env_id": env["env_id"],
+        "template_key": "repe",
+        "template_version": 1,
+        "canonical_runtime_path": "/lab/env/{env_id}/re",
+        "runtime_mode": "interactive",  # set by the Phase 5 pipeline at provision
+        "deployment_target": "local",
+        "seed_pack_version": 1,
+        "required_capabilities": ["repe"],
+        "required_smoke_tests": [],
+        "required_eval_suite": None,
+        "authoritative_state_requirements": {},
+        "compatibility_version": "env_contract_v1",
+        "promotion_state": "verified",
+    }
+    # get_or_derive_contract: contract HIT -> returns immediately (1 query)
+    fake_cursor.push_result([stored_contract])
+    # verify block:
+    fake_cursor.push_result([env])  # _load_env_row
+    fake_cursor.push_result([{"t": "app.environment_capabilities"}])  # cap probe
+    fake_cursor.push_result([{"capability_key": "repe"}])  # cap bound
+    fake_cursor.push_result([{"1": 1}])  # runtime backend template probe
+    fake_cursor.push_result(
+        [{"t": "app.environment_ai_behavior_contracts"}]
+    )  # ai probe
+    fake_cursor.push_result(
+        [
+            {
+                "contract_key": "default",
+                "contract_version": "ai_behavior_v1",
+                "enabled": True,
+            }
+        ]
+    )  # ai rows
+
+    report = svc.verify_environment_contract(env["env_id"])
+
+    assert report.blocking_failures == []
+    assert report.eligible_for_promotion is True
+    assert report.health_ok is True
 
 
 def test_eval_checks_are_warning_not_blocking(fake_cursor):

--- a/backend/tests/test_environment_contract_v2.py
+++ b/backend/tests/test_environment_contract_v2.py
@@ -33,17 +33,42 @@ def _env_row(**over):
     return base
 
 
-def _queue_verify_sequence(cur, env_row, *, template_active=True):
-    """Queue FakeCursor results for the full verify_environment_contract path:
+def _queue_verify_sequence(
+    cur,
+    env_row,
+    *,
+    template_active=True,
+    cap_table_present=True,
+    bound_caps=("repe",),
+):
+    """Queue FakeCursor results for the verify path (post-Phase-3a):
 
     get_or_derive_contract: contract miss -> env row -> INSERT -> re-read contract
-    verify: env row -> template active probe -> UPDATE (no fetch).
+    verify block: env row
+                  -> _capability_checks: to_regclass probe
+                                         -> bound-capabilities SELECT (only when
+                                            the table is present AND the contract
+                                            requires capabilities; the derived
+                                            contract requires
+                                            template.enabled_modules = ['repe'])
+                  -> runtime backend template active probe
+                  -> UPDATE last_verification (no fetch, only when
+                     materialize=True; default GET /verify uses materialize=False).
     """
     cur.push_result([])  # _load_contract_row miss
     cur.push_result([env_row])  # _load_env_row
     # INSERT consumes no result
     cur.push_result([])  # re-read _load_contract_row after insert (race fallback)
     cur.push_result([env_row])  # verify: _load_env_row
+    cur.push_result(
+        [{"t": "app.environment_capabilities"}]
+        if cap_table_present
+        else [{"t": None}]
+    )  # to_regclass
+    if cap_table_present:
+        # bound-capabilities SELECT (required_capabilities derived from template
+        # is non-empty for the repe fixture, so this query runs)
+        cur.push_result([{"capability_key": c} for c in bound_caps])
     cur.push_result([{"1": 1}] if template_active else [])  # template active probe
     # UPDATE last_verification consumes no result
 
@@ -82,23 +107,62 @@ def test_v2_env_without_template_is_not_contract_governed(fake_cursor):
         svc.get_or_derive_contract(env["env_id"])
 
 
-def test_capability_binding_blocks_promotion_even_when_healthy(fake_cursor):
-    """The critical no-silent-pass assertion: a structurally healthy env still
-    fails eligibility because capability binding is not_available/blocking."""
-    env = _env_row()  # seed applied + matching version + home route + active template
-    _queue_verify_sequence(fake_cursor, env, template_active=True)
+def test_capability_table_absent_is_not_available_blocking(fake_cursor):
+    """Fail-closed: if app.environment_capabilities is not present (migration
+    10006 not applied), binding cannot be proven — not_available/blocking, never
+    silent pass."""
+    env = _env_row()
+    _queue_verify_sequence(
+        fake_cursor, env, template_active=True, cap_table_present=False
+    )
 
     report = svc.verify_environment_contract(env["env_id"])
 
     by_key = {c.key: c for c in report.checks}
     assert by_key["capability.binding_implemented"].status == "not_available"
     assert by_key["capability.binding_implemented"].severity == "blocking"
+    assert by_key["capability.required_resolvable"].status == "unknown"
     assert "capability.binding_implemented" in report.blocking_failures
     assert report.eligible_for_promotion is False
-    assert report.health_ok is False
-    # seed + runtime backend genuinely pass; only blocking unknowns hold it back
+
+
+def test_all_required_capabilities_bound_passes(fake_cursor):
+    """Phase 3a happy path: binding table present and every required capability
+    (derived from template.enabled_modules = ['repe']) is bound+enabled. AI
+    behavior contract and runtime_mode are still blocking, so eligibility stays
+    False — but capability checks themselves are NOT in blocking_failures."""
+    env = _env_row()
+    _queue_verify_sequence(
+        fake_cursor, env, template_active=True, bound_caps=("repe",)
+    )
+
+    report = svc.verify_environment_contract(env["env_id"])
+
+    by_key = {c.key: c for c in report.checks}
+    assert by_key["capability.binding_implemented"].status == "pass"
+    assert by_key["capability.required_resolvable"].status == "pass"
+    assert "capability.binding_implemented" not in report.blocking_failures
+    assert "capability.required_resolvable" not in report.blocking_failures
     assert by_key["seed.pack_present"].status == "pass"
     assert by_key["runtime.backend_reachable"].status == "pass"
+
+
+def test_missing_required_capability_blocks_fail_closed(fake_cursor):
+    """Required 'repe' (from template) not among bound capabilities -> blocking
+    fail. Bound rows present but the required one absent."""
+    env = _env_row()
+    _queue_verify_sequence(
+        fake_cursor, env, template_active=True, bound_caps=("some_other_cap",)
+    )
+
+    report = svc.verify_environment_contract(env["env_id"])
+
+    by_key = {c.key: c for c in report.checks}
+    assert by_key["capability.binding_implemented"].status == "pass"
+    assert by_key["capability.required_resolvable"].status == "fail"
+    assert "repe" in by_key["capability.required_resolvable"].message
+    assert "capability.required_resolvable" in report.blocking_failures
+    assert report.eligible_for_promotion is False
 
 
 def test_eligible_property_matches_blocking_failures(fake_cursor):

--- a/backend/tests/test_environment_contract_v2.py
+++ b/backend/tests/test_environment_contract_v2.py
@@ -40,18 +40,25 @@ def _queue_verify_sequence(
     template_active=True,
     cap_table_present=True,
     bound_caps=("repe",),
+    ai_table_present=True,
+    ai_rows=(
+        {
+            "contract_key": "default",
+            "contract_version": "ai_behavior_v1",
+            "enabled": True,
+        },
+    ),
 ):
-    """Queue FakeCursor results for the verify path (post-Phase-3a):
+    """Queue FakeCursor results for the verify path (post-Phase-3a + 3c):
 
     get_or_derive_contract: contract miss -> env row -> INSERT -> re-read contract
     verify block: env row
-                  -> _capability_checks: to_regclass probe
-                                         -> bound-capabilities SELECT (only when
-                                            the table is present AND the contract
-                                            requires capabilities; the derived
-                                            contract requires
-                                            template.enabled_modules = ['repe'])
+                  -> _capability_checks: cap to_regclass probe
+                                         -> bound-caps SELECT (table present and
+                                            the contract requires capabilities)
                   -> runtime backend template active probe
+                  -> _behavior_contract_check: ai to_regclass probe
+                                               -> ai rows SELECT (table present)
                   -> UPDATE last_verification (no fetch, only when
                      materialize=True; default GET /verify uses materialize=False).
     """
@@ -64,13 +71,17 @@ def _queue_verify_sequence(
         [{"t": "app.environment_capabilities"}]
         if cap_table_present
         else [{"t": None}]
-    )  # to_regclass
+    )  # cap to_regclass
     if cap_table_present:
-        # bound-capabilities SELECT (required_capabilities derived from template
-        # is non-empty for the repe fixture, so this query runs)
         cur.push_result([{"capability_key": c} for c in bound_caps])
     cur.push_result([{"1": 1}] if template_active else [])  # template active probe
-    # UPDATE last_verification consumes no result
+    cur.push_result(
+        [{"t": "app.environment_ai_behavior_contracts"}]
+        if ai_table_present
+        else [{"t": None}]
+    )  # ai to_regclass
+    if ai_table_present:
+        cur.push_result([dict(r) for r in ai_rows])  # ai behavior rows
 
 
 def test_derive_contract_when_no_row(fake_cursor):
@@ -222,13 +233,79 @@ def test_dangling_template_is_runtime_backend_fail(fake_cursor):
     assert "runtime.backend_reachable" in report.blocking_failures
 
 
-def test_ai_behavior_contract_absent_is_missing_blocking(fake_cursor):
+def test_ai_behavior_table_absent_is_not_available_blocking(fake_cursor):
+    """Migration 10007 not applied -> not_available/blocking, never silent pass."""
     env = _env_row()
-    _queue_verify_sequence(fake_cursor, env)
+    _queue_verify_sequence(fake_cursor, env, ai_table_present=False)
     report = svc.verify_environment_contract(env["env_id"])
-    by_key = {c.key: c for c in report.checks}
-    assert by_key["ai_runtime.behavior_contract_present"].status == "missing"
-    assert by_key["ai_runtime.behavior_contract_present"].severity == "blocking"
+    c = {x.key: x for x in report.checks}["ai_runtime.behavior_contract_present"]
+    assert c.status == "not_available"
+    assert c.severity == "blocking"
+    assert "ai_runtime.behavior_contract_present" in report.blocking_failures
+
+
+def test_ai_behavior_no_row_is_missing_blocking(fake_cursor):
+    """Table present but no row for this env -> missing/blocking."""
+    env = _env_row()
+    _queue_verify_sequence(fake_cursor, env, ai_rows=())
+    report = svc.verify_environment_contract(env["env_id"])
+    c = {x.key: x for x in report.checks}["ai_runtime.behavior_contract_present"]
+    assert c.status == "missing"
+    assert c.severity == "blocking"
+    assert report.eligible_for_promotion is False
+
+
+def test_ai_behavior_disabled_row_is_fail_blocking(fake_cursor):
+    """Row exists but disabled -> fail/blocking (distinct from missing)."""
+    env = _env_row()
+    _queue_verify_sequence(
+        fake_cursor,
+        env,
+        ai_rows=(
+            {
+                "contract_key": "default",
+                "contract_version": "ai_behavior_v1",
+                "enabled": False,
+            },
+        ),
+    )
+    report = svc.verify_environment_contract(env["env_id"])
+    c = {x.key: x for x in report.checks}["ai_runtime.behavior_contract_present"]
+    assert c.status == "fail"
+    assert c.severity == "blocking"
+    assert "disabled" in c.message
+
+
+def test_ai_behavior_unsupported_version_is_fail_blocking(fake_cursor):
+    """Enabled row with unsupported contract_version -> malformed -> fail/blocking,
+    never a silent pass."""
+    env = _env_row()
+    _queue_verify_sequence(
+        fake_cursor,
+        env,
+        ai_rows=(
+            {
+                "contract_key": "default",
+                "contract_version": "ai_behavior_v99",
+                "enabled": True,
+            },
+        ),
+    )
+    report = svc.verify_environment_contract(env["env_id"])
+    c = {x.key: x for x in report.checks}["ai_runtime.behavior_contract_present"]
+    assert c.status == "fail"
+    assert c.severity == "blocking"
+    assert "unsupported" in c.message or "malformed" in c.message
+
+
+def test_ai_behavior_valid_enabled_row_passes(fake_cursor):
+    """A single enabled, supported-version row -> pass."""
+    env = _env_row()
+    _queue_verify_sequence(fake_cursor, env)  # default ai_rows = valid v1 enabled
+    report = svc.verify_environment_contract(env["env_id"])
+    c = {x.key: x for x in report.checks}["ai_runtime.behavior_contract_present"]
+    assert c.status == "pass"
+    assert "ai_runtime.behavior_contract_present" not in report.blocking_failures
 
 
 def test_eval_checks_are_warning_not_blocking(fake_cursor):

--- a/backend/tests/test_environment_pipeline_v2.py
+++ b/backend/tests/test_environment_pipeline_v2.py
@@ -243,6 +243,137 @@ def test_apply_template_metadata_binds_enabled_modules(fake_cursor):
     assert set(stage.artifacts["bound"]) == {"crm", "tasks"}
 
 
+def test_apply_template_metadata_binds_behavior_contract_when_declared(
+    fake_cursor,
+):
+    """Phase 5 closure: when the template (or manifest) declares
+    ai_behavior_contract_key, the pipeline binds one row into
+    app.environment_ai_behavior_contracts. NEVER inferred."""
+    tpl = dict(_TEMPLATE_ROW)
+    tpl["runtime_mode"] = "interactive"
+    tpl["ai_behavior_contract_key"] = "internal_ops_default"
+    tpl["ai_behavior_contract_version"] = "ai_behavior_v1"
+    ctx = environment_pipeline_v2._RunCtx(
+        manifest=EnvironmentManifestV2(
+            client_name="Acme", template_key="internal_ops"
+        ),
+        actor="tester",
+        template=tpl,
+        slug="acme",
+        env_kind="internal",
+        seed_pack_name="internal_ops_minimal",
+        env_id="00000000-0000-0000-0000-0000000000cc",
+    )
+
+    environment_pipeline_v2._apply_template_metadata(ctx, fake_cursor)
+
+    behavior_inserts = [
+        (q, p)
+        for q, p in fake_cursor.queries
+        if "INSERT INTO app.environment_ai_behavior_contracts" in q
+    ]
+    assert len(behavior_inserts) == 1
+    assert behavior_inserts[0][1] == (
+        ctx.env_id,
+        "internal_ops_default",
+        "ai_behavior_v1",
+    )
+
+    contract_inserts = [
+        p
+        for q, p in fake_cursor.queries
+        if "INSERT INTO app.environment_contract" in q
+    ]
+    assert len(contract_inserts) == 1
+    # contract row params: env_id, template_key, version, home_route, runtime_mode, modules
+    assert contract_inserts[0][4] == "interactive"
+
+    stage = next(
+        s for s in ctx.stages if s.name == "apply_template_metadata"
+    )
+    assert stage.artifacts["runtime_mode"] == "interactive"
+    assert stage.artifacts["ai_behavior_contract_bound"]["contract_key"] == (
+        "internal_ops_default"
+    )
+
+
+def test_apply_template_metadata_does_not_infer_behavior_contract(fake_cursor):
+    """No declaration on manifest or template -> NO behavior contract row,
+    runtime_mode stays NULL on the contract row. Inference is forbidden."""
+    # _TEMPLATE_ROW has no runtime_mode / ai_behavior_contract_key
+    ctx = environment_pipeline_v2._RunCtx(
+        manifest=EnvironmentManifestV2(
+            client_name="Acme", template_key="internal_ops"
+        ),
+        actor="tester",
+        template=dict(_TEMPLATE_ROW),
+        slug="acme",
+        env_kind="internal",
+        seed_pack_name="internal_ops_minimal",
+        env_id="00000000-0000-0000-0000-0000000000dd",
+    )
+
+    environment_pipeline_v2._apply_template_metadata(ctx, fake_cursor)
+
+    behavior_inserts = [
+        q
+        for q, _ in fake_cursor.queries
+        if "INSERT INTO app.environment_ai_behavior_contracts" in q
+    ]
+    assert behavior_inserts == []
+
+    contract_inserts = [
+        p
+        for q, p in fake_cursor.queries
+        if "INSERT INTO app.environment_contract" in q
+    ]
+    assert contract_inserts[0][4] is None  # runtime_mode
+
+    stage = next(
+        s for s in ctx.stages if s.name == "apply_template_metadata"
+    )
+    assert stage.artifacts["runtime_mode"] is None
+    assert stage.artifacts["ai_behavior_contract_bound"] is None
+
+
+def test_apply_template_metadata_manifest_overrides_template(fake_cursor):
+    """Phase 5 precedence: manifest > template > NULL for both runtime_mode and
+    the AI behavior contract key. Manifest wins when both are set."""
+    tpl = dict(_TEMPLATE_ROW)
+    tpl["runtime_mode"] = "static"
+    tpl["ai_behavior_contract_key"] = "template_default"
+    ctx = environment_pipeline_v2._RunCtx(
+        manifest=EnvironmentManifestV2(
+            client_name="Acme",
+            template_key="internal_ops",
+            runtime_mode="agentic",
+            ai_behavior_contract_key="manifest_override",
+        ),
+        actor="tester",
+        template=tpl,
+        slug="acme",
+        env_kind="internal",
+        seed_pack_name="internal_ops_minimal",
+        env_id="00000000-0000-0000-0000-0000000000ee",
+    )
+
+    environment_pipeline_v2._apply_template_metadata(ctx, fake_cursor)
+
+    contract_inserts = [
+        p
+        for q, p in fake_cursor.queries
+        if "INSERT INTO app.environment_contract" in q
+    ]
+    assert contract_inserts[0][4] == "agentic"  # manifest wins
+
+    behavior_params = [
+        p
+        for q, p in fake_cursor.queries
+        if "INSERT INTO app.environment_ai_behavior_contracts" in q
+    ]
+    assert behavior_params[0][1] == "manifest_override"
+
+
 def test_apply_template_metadata_binds_nothing_when_no_modules(fake_cursor):
     """A template with no enabled_modules binds nothing — and reports ok with
     rows_created=0 (the env will then fail closed at the verifier if its contract

--- a/backend/tests/test_environment_pipeline_v2.py
+++ b/backend/tests/test_environment_pipeline_v2.py
@@ -201,3 +201,75 @@ def test_idempotent_reuses_existing_slug(fake_cursor):
     create_stage = next(s for s in resp.stages if s.name == "create_rows")
     assert create_stage.status == "skipped"
     assert any("already exists" in w for w in resp.warnings)
+
+
+# ── Phase 3a: capability binding (apply_template_metadata) ───────────────────
+
+
+def test_apply_template_metadata_binds_enabled_modules(fake_cursor):
+    """Binds exactly the template's enabled_modules (['crm','tasks']) into
+    app.environment_capabilities, source='template', idempotent via ON CONFLICT."""
+    ctx = environment_pipeline_v2._RunCtx(
+        manifest=EnvironmentManifestV2(
+            client_name="Acme", template_key="internal_ops"
+        ),
+        actor="tester",
+        template=dict(_TEMPLATE_ROW),
+        slug="acme",
+        env_kind="internal",
+        seed_pack_name="internal_ops_minimal",
+        env_id="00000000-0000-0000-0000-0000000000aa",
+    )
+
+    environment_pipeline_v2._apply_template_metadata(ctx, fake_cursor)
+
+    cap_inserts = [
+        (q, p)
+        for q, p in fake_cursor.queries
+        if "INSERT INTO app.environment_capabilities" in q
+    ]
+    assert len(cap_inserts) == 2  # crm + tasks, nothing inferred beyond template
+    for q, _ in cap_inserts:
+        assert "ON CONFLICT (env_id, capability_key) DO UPDATE" in q
+        assert "'template'" in q  # source pinned to template
+    bound_keys = {p[1] for _, p in cap_inserts}
+    assert bound_keys == {"crm", "tasks"}
+
+    stage = next(
+        s for s in ctx.stages if s.name == "apply_template_metadata"
+    )
+    assert stage.status == "ok"
+    assert stage.artifacts["rows_created"] == 2
+    assert set(stage.artifacts["bound"]) == {"crm", "tasks"}
+
+
+def test_apply_template_metadata_binds_nothing_when_no_modules(fake_cursor):
+    """A template with no enabled_modules binds nothing — and reports ok with
+    rows_created=0 (the env will then fail closed at the verifier if its contract
+    requires capabilities)."""
+    tpl = dict(_TEMPLATE_ROW)
+    tpl["enabled_modules"] = []
+    ctx = environment_pipeline_v2._RunCtx(
+        manifest=EnvironmentManifestV2(
+            client_name="Acme", template_key="internal_ops"
+        ),
+        actor="tester",
+        template=tpl,
+        slug="acme",
+        env_kind="internal",
+        seed_pack_name="empty",
+        env_id="00000000-0000-0000-0000-0000000000bb",
+    )
+
+    environment_pipeline_v2._apply_template_metadata(ctx, fake_cursor)
+
+    assert not [
+        q
+        for q, _ in fake_cursor.queries
+        if "INSERT INTO app.environment_capabilities" in q
+    ]
+    stage = next(
+        s for s in ctx.stages if s.name == "apply_template_metadata"
+    )
+    assert stage.status == "ok"
+    assert stage.artifacts["rows_created"] == 0

--- a/repo-b/db/schema/10029_environment_contract_promotion_guard.sql
+++ b/repo-b/db/schema/10029_environment_contract_promotion_guard.sql
@@ -1,0 +1,132 @@
+-- Migration 10029: EnvironmentContract promotion guard (Dispatch 0004 — Ticket 2)
+--
+-- Adds a fail-closed promotion state machine to app.environment_contract:
+--   - released rows are immutable (no DELETE, no field change except a no-op)
+--   - only legal promotion_state transitions are allowed
+--
+-- Mirrors re_authoritative_enforce_promotion() in
+-- repo-b/db/schema/459_re_authoritative_snapshot_audit.sql (the proven idiom):
+-- allowed-keys diff via `to_jsonb(NEW) - allowed_keys`, explicit per-state guards.
+--
+-- KEY DIFFERENCE vs. the snapshot table: there, the whole payload freezes at
+-- 'verified'. Here, non-released rows are legitimately re-verified (the verifier
+-- materializes last_verification/last_verified_at, and the gate flips
+-- promotion_state + the verify/release timestamps). So the "payload immutable"
+-- rule applies ONLY to rows already in 'released' (a true terminal). Everything
+-- else is governed purely by the transition whitelist.
+--
+-- updated_at MUST be in allowed_keys: the BEFORE UPDATE touch trigger fires on
+-- every legitimate allowed-key update of a released row, and would otherwise
+-- falsely trip the payload-immutability diff.
+--
+-- Legal transition graph (enforced below):
+--   draft       -> draft | seeded | verified | quarantined | failed
+--   seeded      -> seeded | verified | quarantined | failed
+--   verified    -> verified | staging | quarantined | failed
+--   staging     -> staging | verified | released | quarantined | failed
+--   released    -> released                              (terminal, immutable)
+--   quarantined -> quarantined | verified                (recovery via re-verify)
+--   failed      -> failed | draft | quarantined          (operator reset)
+--
+-- Additive only. No data backfill. No existing row is transitioned by applying
+-- this migration.
+-- Dispatch: docs/plans/03-implementation-plans/active/0004-environment-contract-promotion-gate.md
+
+CREATE SCHEMA IF NOT EXISTS app;
+
+CREATE OR REPLACE FUNCTION app.environment_contract_enforce_promotion()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  -- Fields the gate / verifier may legitimately change WITHOUT it counting as a
+  -- payload mutation of a released row. updated_at is touched by a separate
+  -- BEFORE UPDATE trigger; include it so the immutability diff ignores it.
+  allowed_keys text[] := ARRAY[
+    'promotion_state',
+    'last_verification',
+    'last_verified_at',
+    'verified_by',
+    'released_at',
+    'released_by',
+    'updated_at'
+  ];
+BEGIN
+  IF TG_OP = 'DELETE' AND OLD.promotion_state = 'released' THEN
+    RAISE EXCEPTION
+      'Released environment contract rows are immutable (env_id=%)', OLD.env_id;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    -- Released is terminal: the only legal "change" is a no-op, and even then
+    -- nothing outside allowed_keys may differ.
+    IF OLD.promotion_state = 'released' THEN
+      IF NEW.promotion_state <> 'released' THEN
+        RAISE EXCEPTION
+          'Released environment contract cannot be downgraded (env_id=%, % -> %)',
+          OLD.env_id, OLD.promotion_state, NEW.promotion_state;
+      END IF;
+      IF to_jsonb(NEW) - allowed_keys <> to_jsonb(OLD) - allowed_keys THEN
+        RAISE EXCEPTION
+          'Released environment contract payload is immutable (env_id=%)',
+          OLD.env_id;
+      END IF;
+      RETURN NEW;
+    END IF;
+
+    -- Non-released: enforce the transition whitelist on promotion_state.
+    IF NEW.promotion_state <> OLD.promotion_state THEN
+      IF NOT (
+           (OLD.promotion_state = 'draft'
+              AND NEW.promotion_state IN ('seeded','verified','quarantined','failed'))
+        OR (OLD.promotion_state = 'seeded'
+              AND NEW.promotion_state IN ('verified','quarantined','failed'))
+        OR (OLD.promotion_state = 'verified'
+              AND NEW.promotion_state IN ('staging','quarantined','failed'))
+        OR (OLD.promotion_state = 'staging'
+              AND NEW.promotion_state IN ('verified','released','quarantined','failed'))
+        OR (OLD.promotion_state = 'quarantined'
+              AND NEW.promotion_state IN ('verified'))
+        OR (OLD.promotion_state = 'failed'
+              AND NEW.promotion_state IN ('draft','quarantined'))
+      ) THEN
+        RAISE EXCEPTION
+          'Invalid environment promotion transition (env_id=%, % -> %)',
+          OLD.env_id, OLD.promotion_state, NEW.promotion_state;
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+DO $$ BEGIN
+  CREATE TRIGGER trg_environment_contract_enforce_promotion
+    BEFORE UPDATE OR DELETE ON app.environment_contract
+    FOR EACH ROW EXECUTE FUNCTION app.environment_contract_enforce_promotion();
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+COMMENT ON FUNCTION app.environment_contract_enforce_promotion() IS
+  'Fail-closed promotion state machine for app.environment_contract. Released '
+  'rows immutable; only whitelisted transitions allowed. Mirrors '
+  're_authoritative_enforce_promotion (migration 459). Owning module: '
+  'backend/app/services/environment_contract_v2.py.';
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Verification queries (run after apply):
+--
+--   -- trigger present
+--   SELECT tgname FROM pg_trigger
+--    WHERE tgrelid = 'app.environment_contract'::regclass
+--      AND tgname = 'trg_environment_contract_enforce_promotion';
+--
+--   -- no row was transitioned by this migration (it only adds a trigger)
+--   SELECT promotion_state, count(*) FROM app.environment_contract
+--    GROUP BY promotion_state;
+--
+--   -- illegal transition is rejected (run in a rolled-back tx against a draft row):
+--   --   UPDATE app.environment_contract SET promotion_state='released'
+--   --    WHERE promotion_state='draft';   -- expect: P0001 EXCEPTION
+-- ═══════════════════════════════════════════════════════════════════════════════

--- a/repo-b/db/schema/10030_environment_capabilities.sql
+++ b/repo-b/db/schema/10030_environment_capabilities.sql
@@ -1,0 +1,82 @@
+-- Migration 10030: Environment capability bindings (Dispatch 0004 — Phase 3a)
+--
+-- Adds app.environment_capabilities: the authoritative per-env record of which
+-- capabilities an environment actually has bound (NOT what its template merely
+-- advertises). This is the table the EnvironmentContract verifier resolves
+-- required_capabilities against; until it existed, the verifier hard-coded
+-- capability.binding_implemented = not_available/blocking (fail-closed) and no
+-- environment could reach 'released'.
+--
+-- Scope is deliberately narrow: one row per (env_id, capability_key), bound from
+-- the environment's template.enabled_modules at provision time. NOT a capability
+-- marketplace, module registry, or template refactor.
+--
+-- app.* internal system schema (alongside app.environments / app.environment_contract):
+-- env_id-keyed, exempt from the public-prefix rule, does NOT use the public.*
+-- env_id TEXT + business_id UUID + RLS template. Mirrors app.environment_contract
+-- style (incl. the shared updated_at touch idiom declared in 10004).
+--
+-- Additive only. ZERO BROAD BACKFILL: this migration creates the table and binds
+-- NOTHING for any existing environment. Absence of capability rows = the env has
+-- no bound capabilities = the verifier fails closed for any env whose contract
+-- requires capabilities. No existing environment is made promotable by applying
+-- this migration. Existing v2 envs only gain bindings when re-provisioned through
+-- the v2 pipeline, or via an explicit (separately-ticketed) opt-in backfill.
+-- Dispatch: docs/plans/03-implementation-plans/active/0004-environment-contract-promotion-gate.md
+
+CREATE SCHEMA IF NOT EXISTS app;
+
+CREATE TABLE IF NOT EXISTS app.environment_capabilities (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  env_id              uuid NOT NULL
+                        REFERENCES app.environments(env_id) ON DELETE CASCADE,
+  capability_key      text NOT NULL,
+  capability_version  text,
+  source              text NOT NULL DEFAULT 'template'
+                        CHECK (source IN ('template', 'manual', 'backfill')),
+  enabled             boolean NOT NULL DEFAULT true,
+  metadata            jsonb   NOT NULL DEFAULT '{}'::jsonb,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (env_id, capability_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_environment_capabilities_env
+  ON app.environment_capabilities (env_id);
+
+-- Workload: the verifier resolves a contract's required_capabilities by capability
+-- across enabled bindings; partial predicate keeps the index to live bindings.
+CREATE INDEX IF NOT EXISTS idx_environment_capabilities_key
+  ON app.environment_capabilities (capability_key)
+  WHERE enabled = true;
+
+-- Reuse the established updated_at touch idiom (declared in migration 10004).
+DO $$ BEGIN
+  CREATE TRIGGER trg_environment_capabilities_updated_at
+    BEFORE UPDATE ON app.environment_capabilities
+    FOR EACH ROW EXECUTE FUNCTION app.environment_contract_touch_updated_at();
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+COMMENT ON TABLE app.environment_capabilities IS
+  'Authoritative per-env bound capabilities (NOT template advertisement). One row '
+  'per (env_id, capability_key), bound from template.enabled_modules at provision '
+  'time. Resolved by the EnvironmentContract verifier. Absence = no bound '
+  'capabilities (fail-closed). No broad backfill. Owning module: '
+  'backend/app/services/environment_pipeline_v2.py + environment_contract_v2.py.';
+
+COMMENT ON COLUMN app.environment_capabilities.enabled IS
+  'A disabled binding is NOT a satisfied capability — the verifier treats a '
+  'required capability whose binding row is disabled as a blocking failure.';
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Verification queries (run after apply):
+--
+--   SELECT to_regclass('app.environment_capabilities') IS NOT NULL AS cap_tbl_ok;
+--
+--   -- ZERO broad backfill: no binding exists immediately after apply
+--   SELECT count(*) AS capability_rows FROM app.environment_capabilities; -- expect 0
+--
+--   -- no existing env's lifecycle_state / promotion_state changed
+--   -- (this migration only creates a table + indexes + trigger)
+-- ═══════════════════════════════════════════════════════════════════════════════

--- a/repo-b/db/schema/10031_environment_ai_behavior_contracts.sql
+++ b/repo-b/db/schema/10031_environment_ai_behavior_contracts.sql
@@ -13,7 +13,7 @@
 --
 -- app.* internal system schema. env_id-keyed, exempt from the public-prefix rule,
 -- does NOT use the public.* env_id TEXT + business_id UUID + RLS template. Mirrors
--- app.environment_capabilities (10006) style, incl. the shared updated_at trigger.
+-- app.environment_capabilities (10030) style, incl. the shared updated_at trigger.
 --
 -- Additive only. ZERO BACKFILL: creates the table and binds NOTHING for any
 -- existing environment. Absence of a row = no declared AI behavior contract = the

--- a/repo-b/db/schema/10031_environment_ai_behavior_contracts.sql
+++ b/repo-b/db/schema/10031_environment_ai_behavior_contracts.sql
@@ -1,0 +1,85 @@
+-- Migration 10031: Per-env AI behavior contract registry (Dispatch 0004 — Phase 3c)
+--
+-- Adds app.environment_ai_behavior_contracts: the authoritative record of which
+-- AI behavior contract an environment has explicitly declared. This is the table
+-- the EnvironmentContract verifier resolves for ai_runtime.behavior_contract_present.
+-- Until it existed the verifier hard-coded that check missing/blocking — one of
+-- the remaining blockers between a fully-provisioned env and 'released'.
+--
+-- Scope is deliberately narrow: a presence/validity record, NOT a redesign of the
+-- AI runtime, event lifecycle, or streaming contract. It records WHICH behavior
+-- contract applies and whether it is enabled and well-formed; contract_enforcer.py
+-- and the response-contract types remain the source of truth for runtime behavior.
+--
+-- app.* internal system schema. env_id-keyed, exempt from the public-prefix rule,
+-- does NOT use the public.* env_id TEXT + business_id UUID + RLS template. Mirrors
+-- app.environment_capabilities (10006) style, incl. the shared updated_at trigger.
+--
+-- Additive only. ZERO BACKFILL: creates the table and binds NOTHING for any
+-- existing environment. Absence of a row = no declared AI behavior contract = the
+-- verifier fails closed (missing/blocking). No existing environment is made
+-- promotable by applying this migration. AI behavior contracts are NEVER inferred
+-- from enabled_modules / "AI enabled". Rows are created explicitly (source=manual
+-- via API/operator) until Phase 5 adds a structured declaration field on
+-- app.environment_templates / EnvironmentManifestV2.
+-- Dispatch: docs/plans/03-implementation-plans/active/0004-environment-contract-promotion-gate.md
+
+CREATE SCHEMA IF NOT EXISTS app;
+
+CREATE TABLE IF NOT EXISTS app.environment_ai_behavior_contracts (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  env_id                   uuid NOT NULL
+                             REFERENCES app.environments(env_id) ON DELETE CASCADE,
+  contract_key             text NOT NULL,
+  contract_version         text NOT NULL DEFAULT 'ai_behavior_v1',
+  runtime_contract_key     text,
+  required_event_contract  text,
+  required_tool_policy     text,
+  required_receipt_policy  text,
+  source                   text NOT NULL DEFAULT 'template'
+                             CHECK (source IN ('template', 'manual', 'backfill')),
+  enabled                  boolean NOT NULL DEFAULT true,
+  metadata                 jsonb   NOT NULL DEFAULT '{}'::jsonb,
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (env_id, contract_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_environment_ai_behavior_contracts_env
+  ON app.environment_ai_behavior_contracts (env_id);
+
+-- Workload: the verifier resolves the enabled behavior contract for an env;
+-- partial predicate keeps the index to live rows.
+CREATE INDEX IF NOT EXISTS idx_environment_ai_behavior_contracts_contract
+  ON app.environment_ai_behavior_contracts (contract_key)
+  WHERE enabled = true;
+
+-- Reuse the established updated_at touch idiom (declared in 10004).
+DO $$ BEGIN
+  CREATE TRIGGER trg_environment_ai_behavior_contracts_updated_at
+    BEFORE UPDATE ON app.environment_ai_behavior_contracts
+    FOR EACH ROW EXECUTE FUNCTION app.environment_contract_touch_updated_at();
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+COMMENT ON TABLE app.environment_ai_behavior_contracts IS
+  'Authoritative per-env AI behavior contract declaration (presence + validity, '
+  'NOT an AI-runtime redesign). Resolved by the EnvironmentContract verifier for '
+  'ai_runtime.behavior_contract_present. Absence = no declared contract '
+  '(fail-closed). Never inferred from enabled_modules / "AI enabled". No broad '
+  'backfill. Owning module: backend/app/services/environment_contract_v2.py.';
+
+COMMENT ON COLUMN app.environment_ai_behavior_contracts.contract_version IS
+  'Supported version is ai_behavior_v1 (aligned with AI runtime CONTRACT_VERSION). '
+  'A row whose version is unsupported is treated as malformed -> blocking fail, '
+  'never a silent pass.';
+
+COMMENT ON COLUMN app.environment_ai_behavior_contracts.enabled IS
+  'A disabled row is NOT a satisfied behavior contract — the verifier treats it as '
+  'a blocking failure (distinct from missing).';
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Verification queries (run after apply):
+--   SELECT to_regclass('app.environment_ai_behavior_contracts') IS NOT NULL AS tbl_ok;
+--   SELECT count(*) AS rows_zero_backfill FROM app.environment_ai_behavior_contracts;
+-- ═══════════════════════════════════════════════════════════════════════════════

--- a/repo-b/db/schema/10032_environment_template_runtime_declarations.sql
+++ b/repo-b/db/schema/10032_environment_template_runtime_declarations.sql
@@ -1,0 +1,63 @@
+-- Migration 10032: runtime_mode + AI behavior contract declaration fields
+-- (Dispatch 0004 — Phase 5 closure)
+--
+-- Adds the structured declaration channel that lets v2 pipeline-provisioned
+-- environments derive runtime_mode and bind an AI behavior contract WITHOUT
+-- manual contract stubbing and WITHOUT unsafe inference.
+--
+-- Three nullable columns on app.environment_templates:
+--   runtime_mode                  static | interactive | agentic | headless
+--   ai_behavior_contract_key      e.g. 'default', 'repe_v1', 'pds_v1'
+--   ai_behavior_contract_version  defaults to 'ai_behavior_v1' (aligned with
+--                                 environment_contract_v2._SUPPORTED_AI_BEHAVIOR_VERSIONS,
+--                                 which is itself pinned to AI runtime CONTRACT_VERSION)
+--
+-- Additive only. ZERO BROAD BACKFILL: existing template rows keep NULL in all
+-- three columns. Existing envs whose templates declare nothing remain blocked
+-- exactly as before (runtime.mode_explicit = unknown; behavior_contract_present
+-- = missing). No env becomes promotable by applying this migration.
+--
+-- These are STRUCTURED columns, NOT manifest_overflow keys. Routing, auth,
+-- capabilities, and runtime declarations all use structured columns per
+-- Dispatch 0004 / migration 515 rules.
+-- Dispatch: docs/plans/03-implementation-plans/active/0004-environment-contract-promotion-gate.md
+
+ALTER TABLE app.environment_templates
+  ADD COLUMN IF NOT EXISTS runtime_mode                  text
+    CHECK (runtime_mode IS NULL OR runtime_mode IN
+      ('static', 'interactive', 'agentic', 'headless')),
+  ADD COLUMN IF NOT EXISTS ai_behavior_contract_key      text,
+  ADD COLUMN IF NOT EXISTS ai_behavior_contract_version  text;
+
+COMMENT ON COLUMN app.environment_templates.runtime_mode IS
+  'Declared runtime mode for envs created from this template. The verifier reads '
+  'this via _derive_contract_fields (manifest override -> template -> NULL). NULL '
+  'leaves runtime.mode_explicit blocking — never inferred.';
+
+COMMENT ON COLUMN app.environment_templates.ai_behavior_contract_key IS
+  'Declared AI behavior contract key for envs created from this template. The v2 '
+  'pipeline binds one row into app.environment_ai_behavior_contracts when this is '
+  'non-null. NULL leaves ai_runtime.behavior_contract_present blocking — never '
+  'inferred from enabled_modules / "AI enabled".';
+
+COMMENT ON COLUMN app.environment_templates.ai_behavior_contract_version IS
+  'Defaults to ai_behavior_v1 at bind time (read by the v2 pipeline). Pinned to '
+  'environment_contract_v2._SUPPORTED_AI_BEHAVIOR_VERSIONS; an unsupported value '
+  'is treated as malformed by the verifier (blocking fail).';
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Verification queries (run after apply):
+--
+--   -- columns present
+--   SELECT column_name FROM information_schema.columns
+--    WHERE table_schema='app' AND table_name='environment_templates'
+--      AND column_name IN ('runtime_mode','ai_behavior_contract_key',
+--                          'ai_behavior_contract_version');
+--
+--   -- no template row has been populated by this migration (zero backfill)
+--   SELECT count(*) AS declared_runtime_mode
+--     FROM app.environment_templates WHERE runtime_mode IS NOT NULL;  -- expect 0
+--   SELECT count(*) AS declared_ai_behavior
+--     FROM app.environment_templates
+--    WHERE ai_behavior_contract_key IS NOT NULL;                      -- expect 0
+-- ═══════════════════════════════════════════════════════════════════════════════

--- a/repo-b/src/components/lab/environments/EnvironmentContractCard.tsx
+++ b/repo-b/src/components/lab/environments/EnvironmentContractCard.tsx
@@ -13,7 +13,7 @@
  * proxy via bosFetch (no hard-coded backend origin).
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { bosFetch } from "@/lib/bos-api";
 
 type CheckStatus = "pass" | "fail" | "missing" | "unknown" | "not_available";
@@ -47,6 +47,20 @@ const PROMOTION_BADGE: Record<string, string> = {
   draft: "bg-bm-muted/15 text-bm-muted border-bm-border/40",
 };
 
+// The single "forward" promotion step offered per state (mirrors the backend
+// _LEGAL_TRANSITIONS happy path). staging/released are eligibility-gated; the
+// button is disabled unless eligible_for_promotion. released has no next step.
+const NEXT_PROMOTION: Record<string, string | null> = {
+  draft: "seeded",
+  seeded: "verified",
+  verified: "staging",
+  staging: "released",
+  released: null,
+  quarantined: "verified",
+  failed: "draft",
+};
+const ELIGIBILITY_GATED = new Set(["staging", "released"]);
+
 const STATUS_COLOR: Record<CheckStatus, string> = {
   pass: "text-bm-success",
   fail: "text-bm-danger",
@@ -68,26 +82,56 @@ export function EnvironmentContractCard({ envId }: { envId: string }) {
   const [report, setReport] = useState<VerificationReport | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [actionBusy, setActionBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
+  const load = useCallback(async () => {
     setLoading(true);
     setError(null);
-    bosFetch<VerificationReport>(`/v2/environments/${envId}/verify`)
-      .then((r) => {
-        if (!cancelled) setReport(r);
-      })
-      .catch((e: unknown) => {
-        if (!cancelled)
-          setError(e instanceof Error ? e.message : "verification failed");
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
+    try {
+      // Read-only by default — does not materialize or transition anything.
+      const r = await bosFetch<VerificationReport>(
+        `/v2/environments/${envId}/verify`,
+      );
+      setReport(r);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "verification failed");
+    } finally {
+      setLoading(false);
+    }
   }, [envId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const runAction = useCallback(
+    async (kind: "promote" | "quarantine", target?: string) => {
+      setActionBusy(true);
+      setActionError(null);
+      try {
+        await bosFetch(`/v2/environments/${envId}/${kind}`, {
+          method: "POST",
+          body: JSON.stringify(
+            kind === "promote"
+              ? { target, actor: "operator" }
+              : { actor: "operator", reason: "operator quarantine" },
+          ),
+          headers: { "Content-Type": "application/json" },
+        });
+        await load();
+      } catch (e: unknown) {
+        // The gate fails closed with a 409 + blocking reasons — surface it,
+        // do not swallow it into a success state.
+        setActionError(
+          e instanceof Error ? e.message : `${kind} failed`,
+        );
+      } finally {
+        setActionBusy(false);
+      }
+    },
+    [envId, load],
+  );
 
   if (loading) {
     return (
@@ -178,6 +222,56 @@ export function EnvironmentContractCard({ envId }: { envId: string }) {
           </li>
         ))}
       </ul>
+
+      {(() => {
+        const next = NEXT_PROMOTION[report.promotion_state] ?? null;
+        const gated = next ? ELIGIBILITY_GATED.has(next) : false;
+        const promoteDisabled =
+          !next ||
+          actionBusy ||
+          (gated && !report.eligible_for_promotion);
+        const canQuarantine =
+          report.promotion_state !== "released" &&
+          report.promotion_state !== "quarantined";
+        return (
+          <footer
+            data-testid="contract-actions"
+            className="mt-4 flex items-center gap-3 border-t border-bm-border/30 pt-3"
+          >
+            <button
+              type="button"
+              data-testid="promote-button"
+              disabled={promoteDisabled}
+              onClick={() => next && runAction("promote", next)}
+              className="rounded border border-bm-border/50 bg-bm-surface2/40 px-3 py-1 text-bm-text disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {next ? `Promote → ${next}` : "No further promotion"}
+            </button>
+            <button
+              type="button"
+              data-testid="quarantine-button"
+              disabled={!canQuarantine || actionBusy}
+              onClick={() => runAction("quarantine")}
+              className="rounded border border-bm-danger/40 bg-bm-danger/10 px-3 py-1 text-bm-danger disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Quarantine
+            </button>
+            {gated && !report.eligible_for_promotion ? (
+              <span className="text-bm-muted2">
+                Promotion to {next} requires a passing verification.
+              </span>
+            ) : null}
+            {actionError ? (
+              <span
+                data-testid="action-error"
+                className="text-bm-danger"
+              >
+                {actionError}
+              </span>
+            ) : null}
+          </footer>
+        );
+      })()}
     </section>
   );
 }

--- a/repo-b/src/components/lab/environments/__tests__/EnvironmentContractCard.test.tsx
+++ b/repo-b/src/components/lab/environments/__tests__/EnvironmentContractCard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { EnvironmentContractCard } from "../EnvironmentContractCard";
 
@@ -119,5 +119,83 @@ describe("EnvironmentContractCard", () => {
         /Could not load environment contract verification/,
       ),
     );
+  });
+
+  // ── Ticket 2: gated action buttons ─────────────────────────────────────────
+
+  test("promote to an eligibility-gated state is disabled when not eligible", async () => {
+    // verified -> next is staging (eligibility-gated); not eligible -> disabled
+    mockBosFetch.mockResolvedValue(
+      report({ promotion_state: "verified", eligible_for_promotion: false }),
+    );
+    render(<EnvironmentContractCard envId="env-1" />);
+
+    const btn = await screen.findByTestId("promote-button");
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent("Promote → staging");
+    expect(
+      screen.getByText(/requires a passing verification/i),
+    ).toBeInTheDocument();
+  });
+
+  test("promote to a non-eligibility-gated state is enabled even when not eligible", async () => {
+    // draft -> seeded is NOT eligibility-gated
+    mockBosFetch.mockResolvedValue(
+      report({ promotion_state: "draft", eligible_for_promotion: false }),
+    );
+    render(<EnvironmentContractCard envId="env-1" />);
+
+    const btn = await screen.findByTestId("promote-button");
+    expect(btn).not.toBeDisabled();
+    expect(btn).toHaveTextContent("Promote → seeded");
+  });
+
+  test("clicking promote POSTs to the promote endpoint then reloads", async () => {
+    mockBosFetch
+      .mockResolvedValueOnce(report({ promotion_state: "draft" })) // initial load
+      .mockResolvedValueOnce({}) // POST /promote
+      .mockResolvedValueOnce(report({ promotion_state: "seeded" })); // reload
+    render(<EnvironmentContractCard envId="env-1" />);
+
+    fireEvent.click(await screen.findByTestId("promote-button"));
+
+    await waitFor(() =>
+      expect(mockBosFetch).toHaveBeenCalledWith(
+        "/v2/environments/env-1/promote",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+  });
+
+  test("a 409 from the gate surfaces as an action error, not a success", async () => {
+    mockBosFetch
+      .mockResolvedValueOnce(report({ promotion_state: "draft" }))
+      .mockRejectedValueOnce(new Error("invalid promotion transition"));
+    render(<EnvironmentContractCard envId="env-1" />);
+
+    fireEvent.click(await screen.findByTestId("promote-button"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("action-error")).toHaveTextContent(
+        /invalid promotion transition/,
+      ),
+    );
+  });
+
+  test("released has no further promotion and cannot be quarantined", async () => {
+    mockBosFetch.mockResolvedValue(
+      report({
+        promotion_state: "released",
+        eligible_for_promotion: true,
+        blocking_failures: [],
+      }),
+    );
+    render(<EnvironmentContractCard envId="env-1" />);
+
+    expect(await screen.findByTestId("promote-button")).toBeDisabled();
+    expect(screen.getByTestId("promote-button")).toHaveTextContent(
+      "No further promotion",
+    );
+    expect(screen.getByTestId("quarantine-button")).toBeDisabled();
   });
 });


### PR DESCRIPTION
## What
Lands **Control Tower Ticket 2** = EnvironmentContract Phases 2–5, the promotion state machine + capability/AI-behavior binding on top of the shipped Phase 1 verifier (#258). Cherry-picked from the long-lived `feat/environment-contract-promotion-gate` branch (363 commits behind, entangled with other workstreams) and **ported cleanly onto main's evolved `environment_contract_v2.py`**.

## Phases
- **Phase 2** — promotion state machine + fail-closed gate (`assert_environment_promotable`, `_LEGAL_TRANSITIONS`, DB-enforced trigger). Migration **10029**.
- **Phase 3a** — capability binding: `_capability_checks` resolves `required_capabilities` against `app.environment_capabilities`; **fail-closed** (table absent → `not_available`/blocking; missing binding → `fail`; never a silent pass). Migration **10030**.
- **Phase 3c** — AI behavior contract: `_behavior_contract_check` against `app.environment_ai_behavior_contracts` (absent/missing/disabled/unsupported-version all blocking). Migration **10031**.
- **Phase 5** — `runtime_mode` derived from the template declaration only (never inferred). Migration **10032**.
- Routes: `POST /v2/environments/{id}/promote` + `/quarantine` + promotion-drift health check (`lab_v2.py`). UI: promote/quarantine on `EnvironmentContractCard`.

## Port reconciliation (the careful bits)
- **Migrations renumbered** `10005–10008 → 10029–10032` (the originals collide with `ai_roi_leads`/`telemetry_serving`/etc. on main). All internal + cross-references updated; no duplicate schema numbers.
- main's stub `_capability_checks`/`_ai_runtime_checks` (read-only "not implemented") **superseded** by the branch's real implementations; the now-dead `_CAPABILITY_BINDING_IMPLEMENTED` flag removed.
- **`verify_environment_contract` gained `*, materialize: bool = False`** — pure read by default (GET /verify), persists only when promotion forces `materialize=True`. This was the branch's design; reconciling it onto main's always-write version recovered 12 failing tests.
- Restored the branch's `_prime_template_cache` autouse test fixture (a cold-cache `get_template` query was shifting the FakeCursor sequence across test order) — the last 6 failures.

## Tests
`test_environment_contract_v2.py` + `test_environment_contract_promotion.py` — **38 pass**, ruff clean. The fail-closed invariants (no silent capability/behavior pass; released = terminal/immutable) are covered.

> Azure "CI" is the known-flaky pipeline — gate on the GitHub checks (DB Schema Gate validates the 4 new migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)