### PR TITLE
feat(telemetry): regroup nav into 6-section redesign narrative (ADO #692)

### DIFF
--- a/repo-b/src/components/telemetry/TelemetryBottomNav.tsx
+++ b/repo-b/src/components/telemetry/TelemetryBottomNav.tsx
@@ -32,7 +32,10 @@ export default function TelemetryBottomNav({ envId, onMore }: { envId: string; o
       style={{ background: C.rail, borderTop: `1px solid ${C.border}` }}>
       {tabs.map((t) => {
         const active = tabActive(t.slug);
-        const shortLabel = t.slug === "stream" ? "Stream" : t.slug === "copilot" ? "Copilot" : t.label;
+        const shortLabel =
+          t.slug === "" ? "Summary" :
+          t.slug === "stream" ? "Stream" :
+          t.slug === "copilot" ? "Copilot" : t.label;
         return (
           <Link key={t.slug || "overview"} href={telemetryHref(envId, t.slug)}
             aria-current={active ? "page" : undefined} style={itemStyle(active)}>

--- a/repo-b/src/components/telemetry/TelemetrySidebar.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetrySidebar.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import TelemetrySidebar from "./TelemetrySidebar";
+import { TELEMETRY_NAV, TELEMETRY_NAV_GROUPS, telemetryHref } from "./telemetryNav";
+
+// Render receipt for the 6-section restructure (ADO #692): the rail consumes the nav
+// list, so this proves all six section headers and every item link render without error.
+describe("TelemetrySidebar — 6-section rail", () => {
+  it("renders all six section headers", () => {
+    render(<TelemetrySidebar envId="env-1" />);
+    for (const group of TELEMETRY_NAV_GROUPS) {
+      // "Mission Summary" is both a section header and an item label, so allow >=1.
+      expect(screen.getAllByText(group).length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("renders a routable link for every nav item with the relabels applied", () => {
+    render(<TelemetrySidebar envId="env-1" />);
+    for (const item of TELEMETRY_NAV) {
+      const links = screen.getAllByRole("link", { name: new RegExp(`^${item.label}$`, "i") });
+      expect(links.some((l) => l.getAttribute("href") === telemetryHref("env-1", item.slug))).toBe(true);
+    }
+    // The four redesign relabels are present as links.
+    for (const label of ["Mission Summary", "Agent Control Tower", "Trust Center", "Flight Readiness"]) {
+      expect(screen.getAllByRole("link", { name: new RegExp(`^${label}$`, "i") }).length).toBeGreaterThanOrEqual(1);
+    }
+  });
+});

--- a/repo-b/src/components/telemetry/howItWorksData.ts
+++ b/repo-b/src/components/telemetry/howItWorksData.ts
@@ -171,7 +171,7 @@ export const CAPABILITIES: CapabilityItem[] = [
     capability: "Telemetry environment — 13-page dark full-bleed console",
     impl: "built", verify: "prod_verified",
     evidence: [{ label: "Overview", slug: "" }, { label: "Mission Control", slug: "stream" }],
-    note: "Operations, ML & Models, Factory, AI & Governance groups; this exhibit adds Evidence & Architecture.",
+    note: "Six sections: Mission Summary, Operations, Models & Intelligence, Factory & Quality, Evidence & Lineage, Agent Operations; this exhibit lives under Evidence & Lineage.",
   },
   {
     capability: "Live hot-fire / printer stream",

--- a/repo-b/src/components/telemetry/telemetryNav.test.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.test.ts
@@ -1,15 +1,66 @@
 import {
   TELEMETRY_NAV,
+  TELEMETRY_NAV_GROUPS,
   isTelemetryItemActive,
   telemetryHref,
 } from "./telemetryNav";
 
-describe("telemetry metadata navigation", () => {
-  it("registers Metadata Explorer in the grouped drawer without expanding mobile primary tabs", () => {
+describe("telemetry navigation structure (6-section redesign)", () => {
+  it("exposes exactly the six redesign sections in order", () => {
+    expect(TELEMETRY_NAV_GROUPS).toEqual([
+      "Mission Summary",
+      "Operations",
+      "Models & Intelligence",
+      "Factory & Quality",
+      "Evidence & Lineage",
+      "Agent Operations",
+    ]);
+  });
+
+  it("assigns every nav item to one of the six declared groups", () => {
+    for (const item of TELEMETRY_NAV) {
+      expect(TELEMETRY_NAV_GROUPS).toContain(item.group);
+    }
+  });
+
+  it("keeps every existing surface routable (regression guard — no slug dropped)", () => {
+    const slugs = TELEMETRY_NAV.map((n) => n.slug).sort();
+    expect(slugs).toEqual(
+      [
+        "",
+        "calibration",
+        "control-tower",
+        "copilot",
+        "factory",
+        "factory-ml",
+        "governance",
+        "how-it-works",
+        "metadata",
+        "model-performance",
+        "monitoring",
+        "registry",
+        "replay",
+        "runs",
+        "spike-inspector",
+        "stargate",
+        "stream",
+      ].sort(),
+    );
+  });
+
+  it("applies the four redesign relabels without changing slugs", () => {
+    const labelOf = (slug: string) => TELEMETRY_NAV.find((n) => n.slug === slug)?.label;
+    expect(labelOf("")).toBe("Mission Summary");
+    expect(labelOf("governance")).toBe("Trust Center");
+    expect(labelOf("control-tower")).toBe("Agent Control Tower");
+    expect(labelOf("factory-ml")).toBe("Flight Readiness");
+  });
+
+  it("groups Metadata Explorer under Evidence & Lineage without expanding mobile primary tabs", () => {
     const item = TELEMETRY_NAV.find((entry) => entry.slug === "metadata");
     expect(item).toMatchObject({
       label: "Metadata Explorer",
-      group: "AI & Governance",
+      group: "Evidence & Lineage",
     });
     expect(item?.mobilePrimary).not.toBe(true);
     expect(TELEMETRY_NAV.filter((entry) => entry.mobilePrimary)).toHaveLength(4);

--- a/repo-b/src/components/telemetry/telemetryNav.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.ts
@@ -2,8 +2,22 @@
 // the mobile drawer (same component), and the mobile bottom bar (TelemetryBottomNav) all
 // consume this list, so adding a section means adding one entry here.
 // Icon strings are 16x16 SVG path data, ported from the Option B reference.
+//
+// Sections follow the "Telemetry Experience Redesign" narrative order (ADO #692):
+// Mission Summary (conclusions) -> Operations (live/historical) -> Models & Intelligence
+// (how we know) -> Factory & Quality (what's broken) -> Evidence & Lineage (where it came
+// from) -> Agent Operations (execution). Six sections keeps primary nav within the shared
+// "<=7 primary items" rule. New pages (Program Control Tower, Metric Lineage Explorer,
+// Governed Metric Registry, System Health, Agent Control Tower mockup) are added in later
+// phases; this phase only regroups the existing surfaces and relabels four of them.
 
-export type TelemetryNavGroup = "Operations" | "ML & Models" | "Factory" | "AI & Governance" | "Evidence & Architecture";
+export type TelemetryNavGroup =
+  | "Mission Summary"
+  | "Operations"
+  | "Models & Intelligence"
+  | "Factory & Quality"
+  | "Evidence & Lineage"
+  | "Agent Operations";
 
 export type TelemetryNavItem = {
   slug: string;
@@ -15,26 +29,44 @@ export type TelemetryNavItem = {
 };
 
 export const TELEMETRY_NAV: TelemetryNavItem[] = [
-  { slug: "", label: "Overview", icon: "M2 9h3v5H2zM7 4h3v10H7zM12 7h3v7h-3z", group: "Operations", mobilePrimary: true },
+  // Section 1 — Mission Summary (executive conclusions)
+  { slug: "", label: "Mission Summary", icon: "M2 9h3v5H2zM7 4h3v10H7zM12 7h3v7h-3z", group: "Mission Summary", mobilePrimary: true },
+
+  // Section 2 — Operations (live + historical telemetry)
   { slug: "stream", label: "Mission Control", icon: "M2 12c2-6 10-6 12 0M8 3v3M8 8l3 3", group: "Operations", mobilePrimary: true },
   { slug: "replay", label: "Replay", icon: "M4 3l9 6-9 6z", group: "Operations" },
   { slug: "stargate", label: "Stargate Live", icon: "M8 1l6 3.5v7L8 15l-6-3.5v-7zM8 8l6-3.5M8 8L2 4.5M8 8v7", group: "Operations" },
+  { slug: "runs", label: "Test Runs", icon: "M2 4h13v2H2zM2 8h13v2H2zM2 12h9v2H2z", group: "Operations", mobilePrimary: true },
   { slug: "monitoring", label: "Monitoring", icon: "M2 9h3l2-5 3 10 2-5h3", group: "Operations" },
-  { slug: "runs", label: "Test Runs", icon: "M2 4h13v2H2zM2 8h13v2H2zM2 12h9v2H2z", group: "ML & Models", mobilePrimary: true },
-  { slug: "model-performance", label: "Model Performance", icon: "M2 13l4-5 3 2 5-7", group: "ML & Models" },
-  { slug: "calibration", label: "RUL Calibration", icon: "M2 13h12M4 13V7m4 6V4m4 9V9", group: "ML & Models" },
-  { slug: "registry", label: "Model Registry", icon: "M3 2h10v3H3zM3 7h10v3H3zM3 12h6v2H3z", group: "ML & Models" },
-  { slug: "factory", label: "Factory · NCR", icon: "M2 13V7l4 3V7l4 3V4h4v9z", group: "Factory" },
-  { slug: "factory-ml", label: "Factory ML", icon: "M2 14V7l3-2 3 2 3-5 3 2v10zM5 14v-4M8 14V8M11 14V6", group: "Factory" },
-  { slug: "copilot", label: "Test Intelligence", icon: "M8 1l2 4 4 1-3 3 1 4-4-2-4 2 1-4-3-3 4-1z", group: "AI & Governance", mobilePrimary: true },
-  { slug: "metadata", label: "Metadata Explorer", icon: "M2 3h5v4H2zM9 3h5v4H9zM5 9h6v4H5zM4.5 7v2M11.5 7v2M7 11H5M11 11h-1", group: "AI & Governance" },
-  { slug: "control-tower", label: "Control Tower", icon: "M8 1l6 3v4c0 3-2.5 5.5-6 7-3.5-1.5-6-4-6-7V4zM8 5v6M5 8h6", group: "AI & Governance" },
-  { slug: "spike-inspector", label: "Spike Inspector", icon: "M1 11h3l2-7 3 11 2-6 1 2h3", group: "AI & Governance" },
-  { slug: "governance", label: "AI Governance", icon: "M8 1l6 2v4c0 3.5-2.5 6-6 7-3.5-1-6-3.5-6-7V3z", group: "AI & Governance" },
-  { slug: "how-it-works", label: "How This Works", icon: "M2 4l4-2 4 2 4-2v10l-4 2-4-2-4 2zM6 2v10M10 4v10", group: "Evidence & Architecture" },
+  { slug: "spike-inspector", label: "Spike Inspector", icon: "M1 11h3l2-7 3 11 2-6 1 2h3", group: "Operations" },
+
+  // Section 3 — Models & Intelligence (how we know / can we trust it)
+  { slug: "model-performance", label: "Model Performance", icon: "M2 13l4-5 3 2 5-7", group: "Models & Intelligence" },
+  { slug: "calibration", label: "RUL Calibration", icon: "M2 13h12M4 13V7m4 6V4m4 9V9", group: "Models & Intelligence" },
+  { slug: "registry", label: "Model Registry", icon: "M3 2h10v3H3zM3 7h10v3H3zM3 12h6v2H3z", group: "Models & Intelligence" },
+  { slug: "copilot", label: "Test Intelligence", icon: "M8 1l2 4 4 1-3 3 1 4-4-2-4 2 1-4-3-3 4-1z", group: "Models & Intelligence", mobilePrimary: true },
+
+  // Section 4 — Factory & Quality (what's broken / needs intervention)
+  { slug: "factory", label: "Factory · NCR", icon: "M2 13V7l4 3V7l4 3V4h4v9z", group: "Factory & Quality" },
+  { slug: "factory-ml", label: "Flight Readiness", icon: "M2 14V7l3-2 3 2 3-5 3 2v10zM5 14v-4M8 14V8M11 14V6", group: "Factory & Quality" },
+
+  // Section 5 — Evidence & Lineage (where did this number come from / why trust it)
+  { slug: "metadata", label: "Metadata Explorer", icon: "M2 3h5v4H2zM9 3h5v4H9zM5 9h6v4H5zM4.5 7v2M11.5 7v2M7 11H5M11 11h-1", group: "Evidence & Lineage" },
+  { slug: "governance", label: "Trust Center", icon: "M8 1l6 2v4c0 3.5-2.5 6-6 7-3.5-1-6-3.5-6-7V3z", group: "Evidence & Lineage" },
+  { slug: "how-it-works", label: "How This Works", icon: "M2 4l4-2 4 2 4-2v10l-4 2-4-2-4 2zM6 2v10M10 4v10", group: "Evidence & Lineage" },
+
+  // Section 6 — Agent Operations (approved execution)
+  { slug: "control-tower", label: "Agent Control Tower", icon: "M8 1l6 3v4c0 3-2.5 5.5-6 7-3.5-1.5-6-4-6-7V4zM8 5v6M5 8h6", group: "Agent Operations" },
 ];
 
-export const TELEMETRY_NAV_GROUPS: TelemetryNavGroup[] = ["Operations", "ML & Models", "Factory", "AI & Governance", "Evidence & Architecture"];
+export const TELEMETRY_NAV_GROUPS: TelemetryNavGroup[] = [
+  "Mission Summary",
+  "Operations",
+  "Models & Intelligence",
+  "Factory & Quality",
+  "Evidence & Lineage",
+  "Agent Operations",
+];
 
 export function telemetryHref(envId: string, slug: string): string {
   const base = `/lab/env/${envId}/telemetry`;
@@ -51,5 +83,5 @@ export function isTelemetryItemActive(pathname: string, envId: string, slug: str
 /** Label of the section owning the current pathname (for the mobile header). */
 export function telemetrySectionLabel(pathname: string, envId: string): string {
   const match = TELEMETRY_NAV.find((n) => n.slug && isTelemetryItemActive(pathname, envId, n.slug));
-  return match?.label ?? "Overview";
+  return match?.label ?? "Mission Summary";
 }


### PR DESCRIPTION
## What
Phase 1.1 of the Telemetry Experience Redesign — restructures the telemetry env navigation from **17 flat items in 5 groups** into the **6 redesign sections**:
Mission Summary / Operations / Models & Intelligence / Factory & Quality / Evidence & Lineage / Agent Operations.

This brings the env back within the shared *"≤7 primary nav items"* rule (`docs/plans/01-shared-standards/design-system/shell-navigation-rules.md`).

## Changes
- `telemetryNav.ts` — 6-section `TelemetryNavGroup` union + `TELEMETRY_NAV_GROUPS`; all 17 slugs preserved; relabels Overview→Mission Summary, governance→Trust Center, control-tower→Agent Control Tower, factory-ml→Flight Readiness.
- `TelemetryBottomNav.tsx` — short "Summary" tab label; still 4 primary + More.
- `telemetryNav.test.ts` — strengthened (6 groups, full slug set regression guard, relabels).
- `TelemetrySidebar.test.tsx` — **new** render receipt (all 6 headers + every link).
- `howItWorksData.ts` — fixed stale nav-group description.

## Deferred (honest)
`system-health` slug + Monitoring/Spike Inspector merge → Phase 4.1 (adding a dangling slug now would 404). Both pages remain reachable under Operations.

## Tests
`vitest` telemetryNav 6/6 + TelemetrySidebar 2/2 green; full telemetry suite green; `tsc --noEmit` exit 0. No page deleted; every slug still routes.

ADO #692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)