### PR TITLE
feat(telemetry): Metric Lineage Explorer + reusable LineageDrawer (data-backed) (ADO #697)

### DIFF
--- a/repo-b/src/app/lab/env/[envId]/telemetry/metric-lineage/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/telemetry/metric-lineage/page.tsx
@@ -1,0 +1,10 @@
+import MetricLineageExplorer from "@/components/telemetry/metadata/MetricLineageExplorer";
+
+export default async function TelemetryMetricLineagePage({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  return <MetricLineageExplorer envId={envId} />;
+}

--- a/repo-b/src/components/telemetry/metadata/LineageDrawer.test.tsx
+++ b/repo-b/src/components/telemetry/metadata/LineageDrawer.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import LineageDrawer from "./LineageDrawer";
+import type {
+  TelemetryMetadataEdge,
+  TelemetryMetadataNode,
+} from "@/lib/telemetry/metadata";
+
+// A metric with a real upstream chain: source -> bronze -> silver -> gold -> metric.
+const chainNodes: TelemetryMetadataNode[] = [
+  { id: "src", label: "GCP Pub/Sub", kind: "source", layer: "source", confidence: "explicit", status: "fresh" },
+  { id: "bronze", label: "bronze_raw", kind: "table", layer: "bronze", confidence: "explicit", status: "fresh" },
+  { id: "silver", label: "silver_clean", kind: "table", layer: "silver", confidence: "explicit", status: "fresh" },
+  { id: "gold", label: "gold_daily", kind: "table", layer: "gold", confidence: "explicit", status: "fresh" },
+  {
+    id: "m1",
+    label: "Flight Readiness",
+    kind: "metric",
+    layer: "metric",
+    confidence: "explicit",
+    status: "fresh",
+    metadata: { formula: "weighted sub-indices", owner: "Test Operations", freshness_as_of: "2026-06-22T00:00:00Z" },
+  },
+];
+const chainEdges: TelemetryMetadataEdge[] = [
+  { id: "e1", source: "src", target: "bronze", relationship: "ingests_to", confidence: "explicit" },
+  { id: "e2", source: "bronze", target: "silver", relationship: "cleans_to", confidence: "explicit" },
+  { id: "e3", source: "silver", target: "gold", relationship: "aggregates_to", confidence: "explicit" },
+  { id: "e4", source: "gold", target: "m1", relationship: "defines_metric", confidence: "explicit" },
+];
+
+// A metric with NO upstream edge — must fail closed.
+const orphanNode: TelemetryMetadataNode = {
+  id: "m2",
+  label: "Orphan Metric",
+  kind: "metric",
+  layer: "metric",
+  confidence: "inferred",
+  status: "unknown",
+};
+
+describe("LineageDrawer — reusable lineage chain", () => {
+  it("renders the full upstream chain grouped by layer for a metric with lineage", () => {
+    render(
+      <LineageDrawer
+        node={chainNodes[4]}
+        nodes={chainNodes}
+        edges={chainEdges}
+        generatedAt="2026-06-22T00:00:00Z"
+        onClose={() => {}}
+      />,
+    );
+    // Lane headers for each upstream layer present in the trace.
+    expect(screen.getByText("Source")).toBeInTheDocument();
+    expect(screen.getByText("Bronze")).toBeInTheDocument();
+    expect(screen.getByText("Silver")).toBeInTheDocument();
+    expect(screen.getByText("Gold")).toBeInTheDocument();
+    // Upstream node labels render.
+    expect(screen.getByText("GCP Pub/Sub")).toBeInTheDocument();
+    expect(screen.getByText("gold_daily")).toBeInTheDocument();
+    // Focus-node detail fields render real metadata (not "Not available").
+    expect(screen.getByText("weighted sub-indices")).toBeInTheDocument();
+    expect(screen.getByText("Test Operations")).toBeInTheDocument();
+    // Does NOT show the no-lineage fail-closed state.
+    expect(screen.queryByText("No lineage yet")).not.toBeInTheDocument();
+  });
+
+  it("fails closed with 'No lineage yet' for a metric with no upstream edge", () => {
+    render(
+      <LineageDrawer node={orphanNode} nodes={[orphanNode]} edges={[]} onClose={() => {}} />,
+    );
+    expect(screen.getByText("No lineage yet")).toBeInTheDocument();
+    expect(screen.getByText(/no_upstream_edges_in_catalog/)).toBeInTheDocument();
+  });
+
+  it("renders nothing when no node is focused", () => {
+    const { container } = render(
+      <LineageDrawer node={null} nodes={chainNodes} edges={chainEdges} onClose={() => {}} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/repo-b/src/components/telemetry/metadata/LineageDrawer.tsx
+++ b/repo-b/src/components/telemetry/metadata/LineageDrawer.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+// Reusable, data-backed lineage drawer — the shared "where did this number come from?" standard.
+// Given any catalog node + the full metadata graph, it renders the COMPLETE upstream chain
+// (source -> bronze -> silver -> gold -> metric -> consumer/model) computed from getUpstreamTrace,
+// plus the node's own definition/owner/freshness fields. Fail-closed: if a node has no cataloged
+// upstream edge it renders "No lineage yet" with a null_reason rather than implying provenance.
+//
+// This is intentionally simple visually (RS polish is a later phase). It is built to be invoked
+// from any surface (a Mission Summary KPI, a chart) — keep the props minimal and presentational.
+
+import * as Dialog from "@radix-ui/react-dialog";
+
+import { C, Tag } from "../primitives";
+import {
+  METADATA_LANES,
+  getUpstreamTrace,
+  metadataVisualLane,
+  type MetadataVisualLane,
+  type TelemetryMetadataEdge,
+  type TelemetryMetadataNode,
+} from "@/lib/telemetry/metadata";
+
+const LANE_LABEL: Record<MetadataVisualLane, string> = {
+  source: "Source",
+  bronze: "Bronze",
+  silver: "Silver",
+  gold: "Gold",
+  metric: "Metric",
+  consumer: "Consumer",
+  model: "Model",
+  runtime: "Runtime / AI",
+};
+
+function humanize(value: string) {
+  return value.replace(/_/g, " ");
+}
+
+function isPresent(value: unknown) {
+  return value !== undefined && value !== null && value !== "";
+}
+
+/** A field row that fails closed: missing values render "Not available", never blank. */
+function Field({ label, value }: { label: string; value: unknown }) {
+  const present = isPresent(value);
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "minmax(96px,0.8fr) minmax(0,1.5fr)", gap: 12, padding: "8px 0", borderBottom: `1px solid ${C.border}` }}>
+      <div style={{ color: C.faint, fontFamily: C.mono, fontSize: 9, letterSpacing: "0.09em", textTransform: "uppercase" }}>{label}</div>
+      <div style={{ color: present ? C.dim : C.faint, fontFamily: C.mono, fontSize: 11, lineHeight: 1.5, overflowWrap: "anywhere" }}>
+        {present ? String(value) : "Not available"}
+      </div>
+    </div>
+  );
+}
+
+/** Detail fields shown for the focused node; metric-aware, all fail-closed. */
+function focusFields(node: TelemetryMetadataNode): { label: string; value: unknown }[] {
+  const m = node.metadata ?? {};
+  if (node.kind === "metric") {
+    return [
+      { label: "Definition", value: m.definition ?? node.description },
+      { label: "Formula", value: m.formula },
+      { label: "Owner", value: m.owner },
+      { label: "Grain", value: m.grain },
+      { label: "Direct source", value: m.source_model ?? m.source_table },
+      { label: "Lineage query", value: m.lineage_sql_reference ?? m.query_reference },
+      { label: "Freshness as of", value: m.freshness_as_of ?? m.last_updated_at ?? m.last_refreshed },
+      { label: "Unavailable reason", value: m.unavailable_reason ?? m.null_reason },
+    ];
+  }
+  return [
+    { label: "Object", value: node.object_name ?? node.label },
+    { label: "Schema", value: node.schema },
+    { label: "Owner", value: m.owner },
+    { label: "Freshness as of", value: m.freshness_as_of ?? m.last_updated_at ?? m.last_refreshed },
+    { label: "Unavailable reason", value: m.unavailable_reason ?? m.null_reason },
+  ];
+}
+
+export default function LineageDrawer({
+  node,
+  nodes,
+  edges,
+  generatedAt,
+  onClose,
+}: {
+  node: TelemetryMetadataNode | null;
+  nodes: TelemetryMetadataNode[];
+  edges: TelemetryMetadataEdge[];
+  /** graph.generated_at — shown as the lineage freshness/provenance stamp. */
+  generatedAt?: string;
+  onClose: () => void;
+}) {
+  // Compute the full upstream trace for the focused node.
+  const trace = node ? getUpstreamTrace(node.id, edges) : { nodeIds: new Set<string>(), edgeIds: new Set<string>() };
+  const hasLineage = node ? trace.edgeIds.size > 0 : false;
+  const nodeMap = new Map(nodes.map((n) => [n.id, n]));
+
+  // Group the traced nodes (excluding the focus node itself) by lane, ordered source -> consumer.
+  const laneGroups: { lane: MetadataVisualLane; nodes: TelemetryMetadataNode[] }[] = [];
+  if (node) {
+    for (const lane of METADATA_LANES) {
+      const laneNodes = [...trace.nodeIds]
+        .filter((id) => id !== node.id)
+        .map((id) => nodeMap.get(id))
+        .filter((n): n is TelemetryMetadataNode => Boolean(n) && metadataVisualLane(n as TelemetryMetadataNode) === lane)
+        .sort((a, b) => a.label.localeCompare(b.label));
+      if (laneNodes.length) laneGroups.push({ lane, nodes: laneNodes });
+    }
+  }
+
+  const tracedEdges = node ? edges.filter((e) => trace.edgeIds.has(e.id)) : [];
+
+  return (
+    <Dialog.Root open={Boolean(node)} onOpenChange={(open) => !open && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.52)", zIndex: 70 }} />
+        <Dialog.Content
+          className="fixed bottom-0 left-0 right-0 z-[80] max-h-[86vh] rounded-t-xl lg:bottom-auto lg:left-auto lg:right-0 lg:top-0 lg:h-screen lg:max-h-none lg:w-[460px] lg:rounded-none lg:rounded-l-xl"
+          style={{ background: C.rail, border: `1px solid ${C.borderHi}`, color: C.text, overflowY: "auto", padding: 20, boxShadow: "-18px 0 50px rgba(0,0,0,0.38)" }}
+        >
+          {node && (
+            <>
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 16 }}>
+                <div style={{ minWidth: 0 }}>
+                  <Dialog.Title style={{ fontFamily: C.sans, fontSize: 19, fontWeight: 700, overflowWrap: "anywhere" }}>
+                    {node.label}
+                  </Dialog.Title>
+                  <Dialog.Description style={{ color: C.dim, fontFamily: C.mono, fontSize: 10, lineHeight: 1.5, marginTop: 6 }}>
+                    Lineage — where this value comes from.
+                  </Dialog.Description>
+                </div>
+                <Dialog.Close asChild>
+                  <button type="button" aria-label="Close lineage" style={{ width: 36, height: 36, borderRadius: 7, border: `1px solid ${C.borderHi}`, background: C.panel, color: C.dim, cursor: "pointer", flexShrink: 0 }}>
+                    x
+                  </button>
+                </Dialog.Close>
+              </div>
+
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 7, marginTop: 14 }}>
+                <Tag color={C.cyan}>{node.kind}</Tag>
+                <Tag color={C.amber}>{node.layer ?? "runtime"}</Tag>
+                <Tag color={node.status === "fresh" ? C.green : node.status === "missing" ? C.red : C.amber}>{node.status ?? "unknown"}</Tag>
+                <Tag color={node.confidence === "inferred" ? C.amber : C.cyan}>{node.confidence}</Tag>
+              </div>
+
+              {/* Upstream lineage chain */}
+              <section style={{ marginTop: 18 }} aria-label="Upstream lineage chain">
+                <div style={{ fontFamily: C.mono, color: C.faint, fontSize: 9, letterSpacing: "0.12em", textTransform: "uppercase", marginBottom: 8 }}>
+                  Upstream lineage
+                </div>
+                {!hasLineage ? (
+                  <div style={{ border: `1px solid ${C.border}`, borderRadius: 7, background: C.panelHi, padding: "10px 12px", color: C.amber, fontFamily: C.mono, fontSize: 11, lineHeight: 1.5 }}>
+                    No lineage yet
+                    <div style={{ color: C.faint, fontSize: 10, marginTop: 4 }}>
+                      null_reason: no_upstream_edges_in_catalog — this node has no cataloged source.
+                    </div>
+                  </div>
+                ) : (
+                  <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                    {laneGroups.map(({ lane, nodes: laneNodes }) => (
+                      <div key={lane} style={{ border: `1px solid ${C.border}`, borderRadius: 7, background: C.panelHi, padding: "9px 10px" }}>
+                        <div style={{ color: C.faint, fontFamily: C.mono, fontSize: 9, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: 6 }}>
+                          {LANE_LABEL[lane]}
+                        </div>
+                        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                          {laneNodes.map((n) => (
+                            <span key={n.id} title={n.object_name ?? n.label}
+                              style={{ display: "inline-flex", alignItems: "center", gap: 6, border: `1px solid ${C.border}`, borderRadius: 6, background: C.panel, padding: "3px 8px", color: C.text, fontFamily: C.mono, fontSize: 10 }}>
+                              <span style={{ width: 6, height: 6, borderRadius: 999, background: n.status === "fresh" ? C.green : n.status === "missing" ? C.red : C.amber }} />
+                              {n.label}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                    <div style={{ color: C.faint, fontFamily: C.mono, fontSize: 9, marginTop: 2 }}>
+                      {trace.nodeIds.size - 1} upstream node(s) · {tracedEdges.length} relationship(s) ·
+                      relationships: {[...new Set(tracedEdges.map((e) => humanize(e.relationship)))].join(", ")}
+                    </div>
+                  </div>
+                )}
+              </section>
+
+              {/* Focus node detail (fail-closed fields) */}
+              <section style={{ marginTop: 18 }} aria-label="Node detail">
+                <div style={{ fontFamily: C.mono, color: C.faint, fontSize: 9, letterSpacing: "0.12em", textTransform: "uppercase", marginBottom: 4 }}>
+                  Definition
+                </div>
+                {focusFields(node).map((f) => (
+                  <Field key={f.label} label={f.label} value={f.value} />
+                ))}
+              </section>
+
+              {/* Provenance stamp */}
+              <div style={{ marginTop: 16, color: C.faint, fontFamily: C.mono, fontSize: 9, lineHeight: 1.6 }}>
+                Source: telemetry metadata catalog + enrichment (/api/telemetry/metadata/graph).
+                {generatedAt ? ` Generated ${generatedAt}.` : " Generated-at unavailable."}
+              </div>
+            </>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/repo-b/src/components/telemetry/metadata/MetricLineageExplorer.tsx
+++ b/repo-b/src/components/telemetry/metadata/MetricLineageExplorer.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+// Metric Lineage Explorer — the first data-backed redesign surface. Lists the governed metrics
+// from the live telemetry metadata catalog (/api/telemetry/metadata/graph) and opens the reusable
+// LineageDrawer to trace each one to its source. Data-backed and fail-closed: real catalog values
+// where present, explicit null states where not. Visual polish (RS language) is a later phase.
+
+import { useEffect, useState } from "react";
+
+import {
+  TELEMETRY_DEMO_BUSINESS_ID,
+  TELEMETRY_DEMO_ENV_ID,
+} from "@/lib/telemetry/api";
+import {
+  getMetadataGraph,
+  type TelemetryMetadataGraph,
+  type TelemetryMetadataNode,
+} from "@/lib/telemetry/metadata";
+import {
+  C,
+  DisclosureFooter,
+  EmptyState,
+  ErrorState,
+  Loading,
+  MetricCard,
+  PageHeading,
+  Panel,
+  StatGrid,
+  Tag,
+} from "../primitives";
+import LineageDrawer from "./LineageDrawer";
+
+function formatTs(value?: string | null) {
+  if (!value) return "as-of unknown";
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.valueOf()) ? value : parsed.toLocaleString();
+}
+
+export default function MetricLineageExplorer({ envId }: { envId: string }) {
+  const [graph, setGraph] = useState<TelemetryMetadataGraph | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<TelemetryMetadataNode | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    getMetadataGraph(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID, envId)
+      .then((g) => {
+        if (active) setGraph(g);
+      })
+      .catch((reason) => {
+        if (active) setError(String(reason));
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [envId]);
+
+  const heading = (
+    <PageHeading
+      eyebrow="Evidence & Lineage"
+      title="Metric Lineage Explorer"
+      blurb="Every governed metric, traced to its source. Click a metric to see its full upstream chain (gold to silver to bronze to source) with freshness and owner. Lineage is read live from the telemetry metadata catalog; a metric with no cataloged source shows 'No lineage yet' rather than implying provenance."
+    />
+  );
+
+  if (loading && !graph) return <>{heading}<Loading label="Loading metric catalog..." /></>;
+  if (error) return <>{heading}<ErrorState message={error} /></>;
+  if (!graph) return <>{heading}<ErrorState message="Metadata graph unavailable." /></>;
+
+  const metrics = graph.nodes
+    .filter((n) => n.kind === "metric")
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+  return (
+    <>
+      {heading}
+
+      {graph.status !== "ok" && (
+        <div
+          role="status"
+          style={{
+            border: `1px solid ${C.amber}`,
+            background: "rgba(243,177,74,0.10)",
+            borderRadius: 8,
+            padding: "10px 14px",
+            margin: "0 0 16px",
+            color: C.amber,
+            fontFamily: C.mono,
+            fontSize: 11,
+            lineHeight: 1.5,
+          }}
+        >
+          Catalog status: {graph.status} — some enrichments are unavailable; affected nodes fail closed.
+          {graph.warnings?.length ? ` (${graph.warnings.map((w) => w.message).join("; ")})` : ""}
+        </div>
+      )}
+
+      <StatGrid cols={4}>
+        <MetricCard label="Governed metrics" value={String(graph.stats.metric_count)} accent={C.cyan} />
+        <MetricCard label="Gold tables" value={String(graph.stats.gold_count)} />
+        <MetricCard label="Lineage edges" value={String(graph.stats.edge_count)} />
+        <MetricCard
+          label="Unavailable nodes"
+          value={String(graph.stats.unavailable_count)}
+          accent={graph.stats.unavailable_count > 0 ? C.amber : undefined}
+        />
+      </StatGrid>
+
+      <Panel
+        title="Governed metrics"
+        right={<Tag color={C.cyan}>{metrics.length} metrics · {formatTs(graph.generated_at)}</Tag>}
+        style={{ marginTop: 16 }}
+      >
+        {metrics.length === 0 ? (
+          <EmptyState
+            label="No governed metrics in the catalog yet"
+            hint="Metric lineage appears once metric nodes are cataloged in metadata_catalog.json."
+          />
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {metrics.map((m) => (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => setSelected(m)}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 12,
+                  textAlign: "left",
+                  width: "100%",
+                  border: `1px solid ${C.border}`,
+                  borderRadius: 8,
+                  background: C.panelHi,
+                  padding: "11px 13px",
+                  cursor: "pointer",
+                  color: C.text,
+                }}
+              >
+                <span style={{ minWidth: 0 }}>
+                  <span style={{ fontFamily: C.mono, fontSize: 12.5, color: C.text }}>{m.label}</span>
+                  {m.description && (
+                    <span
+                      style={{
+                        display: "block",
+                        fontFamily: C.mono,
+                        fontSize: 10,
+                        color: C.faint,
+                        marginTop: 3,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        maxWidth: 460,
+                      }}
+                    >
+                      {m.description}
+                    </span>
+                  )}
+                </span>
+                <span style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
+                  <Tag color={m.status === "fresh" ? C.green : m.status === "missing" ? C.red : C.amber}>
+                    {m.status ?? "unknown"}
+                  </Tag>
+                  <span style={{ fontFamily: C.mono, fontSize: 11, color: C.cyan }}>Trace source →</span>
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+        <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 12, lineHeight: 1.5 }}>
+          Source: telemetry metadata catalog + enrichment SQL over tel_* tables. Lineage is live; no values are
+          seeded. A metric with no upstream edge renders "No lineage yet".
+        </div>
+      </Panel>
+
+      <LineageDrawer
+        node={selected}
+        nodes={graph.nodes}
+        edges={graph.edges}
+        generatedAt={graph.generated_at}
+        onClose={() => setSelected(null)}
+      />
+
+      <DisclosureFooter />
+    </>
+  );
+}

--- a/repo-b/src/components/telemetry/metadata/MetricLineageExplorer.tsx
+++ b/repo-b/src/components/telemetry/metadata/MetricLineageExplorer.tsx
@@ -176,7 +176,7 @@ export default function MetricLineageExplorer({ envId }: { envId: string }) {
         )}
         <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 12, lineHeight: 1.5 }}>
           Source: telemetry metadata catalog + enrichment SQL over tel_* tables. Lineage is live; no values are
-          seeded. A metric with no upstream edge renders "No lineage yet".
+          seeded. A metric with no upstream edge renders the no-lineage-yet state instead of implying provenance.
         </div>
       </Panel>
 

--- a/repo-b/src/components/telemetry/telemetryNav.test.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.test.ts
@@ -36,6 +36,7 @@ describe("telemetry navigation structure (6-section redesign)", () => {
         "governance",
         "how-it-works",
         "metadata",
+        "metric-lineage",
         "model-performance",
         "monitoring",
         "registry",

--- a/repo-b/src/components/telemetry/telemetryNav.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.ts
@@ -51,6 +51,7 @@ export const TELEMETRY_NAV: TelemetryNavItem[] = [
   { slug: "factory-ml", label: "Flight Readiness", icon: "M2 14V7l3-2 3 2 3-5 3 2v10zM5 14v-4M8 14V8M11 14V6", group: "Factory & Quality" },
 
   // Section 5 — Evidence & Lineage (where did this number come from / why trust it)
+  { slug: "metric-lineage", label: "Metric Lineage", icon: "M4 2v12M4 6h6M4 11h5M10 4v4M9 9v3", group: "Evidence & Lineage" },
   { slug: "metadata", label: "Metadata Explorer", icon: "M2 3h5v4H2zM9 3h5v4H9zM5 9h6v4H5zM4.5 7v2M11.5 7v2M7 11H5M11 11h-1", group: "Evidence & Lineage" },
   { slug: "governance", label: "Trust Center", icon: "M8 1l6 2v4c0 3.5-2.5 6-6 7-3.5-1-6-3.5-6-7V3z", group: "Evidence & Lineage" },
   { slug: "how-it-works", label: "How This Works", icon: "M2 4l4-2 4 2 4-2v10l-4 2-4-2-4 2zM6 2v10M10 4v10", group: "Evidence & Lineage" },


### PR DESCRIPTION
## What
First **data-backed** surface of the redesign (data-first pivot). A new **Metric Lineage** page (Evidence & Lineage) lists governed metrics from the **live** telemetry metadata catalog (`/api/telemetry/metadata/graph`) and opens a new **reusable `LineageDrawer`** that traces any node's full upstream chain (source → bronze → silver → gold → metric) via `getUpstreamTrace`, grouped by layer, with the node's definition / owner / freshness.

This is the trust spine — `LineageDrawer` is built to be invoked from any surface (the shared lineage-first standard), so Mission Summary KPIs can open it next.

## Fail-closed (no seeded values)
- "No lineage yet" (`null_reason: no_upstream_edges_in_catalog`) for a metric with no cataloged source.
- "Not available" for any missing field.
- Amber banner when catalog `status` is partial (lists warnings).
- `EmptyState` when no metric nodes exist.
- All values read live; nothing seeded.

## Files
- `metadata/LineageDrawer.tsx` (new, reusable) + test
- `metadata/MetricLineageExplorer.tsx` (new page component)
- `telemetry/metric-lineage/page.tsx` (new route)
- `telemetryNav.ts` (+ test) — new "Metric Lineage" entry under Evidence & Lineage

## Tests
`vitest` LineageDrawer 3/3 (full chain · no-lineage fail-closed · closed state), telemetryNav slug-set updated, TelemetrySidebar render covers the new entry; `tsc --noEmit` exit 0.

ADO #697.

🤖 Generated with [Claude Code](https://claude.com/claude-code)