### PR TITLE
feat(telemetry): Trust Center identity + Replay fail-closed launch stages (ADO #691)

### DIFF
--- a/repo-b/src/components/telemetry/GovernanceDashboard.tsx
+++ b/repo-b/src/components/telemetry/GovernanceDashboard.tsx
@@ -51,9 +51,9 @@ export default function GovernanceDashboard() {
   }, []);
 
   const head = (
-    <PageHeading eyebrow="AI Governance"
-      title="Can we trust the AI layer — and how do we know?"
-      blurb="Every number on this page is aggregated from real logged copilot interactions and a real eval run. Nothing is hardcoded. Where a metric isn't available, it says so." />
+    <PageHeading eyebrow="Evidence &amp; Lineage · Trust Center"
+      title="Trust Center — why you can trust the AI layer"
+      blurb="AI governance, security posture, model governance, and audit receipts in one place. Every number is aggregated from real logged copilot interactions and a real eval run — nothing is hardcoded. Where a metric is not available, it says so." />
   );
   if (err) return <>{head}<ErrorState message={err} /></>;
   if (!g) return <>{head}<Loading label="Loading governance metrics…" /></>;

--- a/repo-b/src/components/telemetry/ReplayConsole.tsx
+++ b/repo-b/src/components/telemetry/ReplayConsole.tsx
@@ -61,6 +61,13 @@ export default function ReplayConsole() {
   return (
     <>
       {heading}
+      {/* Launch-stage timeline: fail-closed. The replay feed has no stage boundaries yet. */}
+      <div style={{ border: `1px solid ${C.border}`, background: C.panel, borderRadius: 8, padding: "9px 12px",
+        marginBottom: 16, fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.5 }}>
+        Launch stages (T-60 · T-30 · Ignition · Max-Q · Stage Sep · Orbit):{" "}
+        <span style={{ color: C.amber }}>not available</span> — the replay feed carries no stage boundaries yet
+        (requires a backend stage field). Showing the raw tick timeline below.
+      </div>
       <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap", marginBottom: 16 }}>
         <button onClick={() => { setCursor(0); setPlaying(true); }} disabled={playing}
           style={{ fontFamily: C.mono, fontSize: 13, fontWeight: 600, color: C.bg, background: C.cyan,


### PR DESCRIPTION
## What
Two small data-backed / fail-closed touches.

- **Trust Center** (Governance): align the page identity with the nav rename — eyebrow "Evidence & Lineage · Trust Center", title "Trust Center", blurb naming the four trust dimensions (AI governance / security / model governance / audit receipts). Same real_backend data; no behavior change.
- **Replay**: add a fail-closed launch-stage strip (T-60 · T-30 · Ignition · Max-Q · Stage Sep · Orbit → "not available") because the replay feed carries no stage boundaries yet (requires a backend stage field). No invented stages; the raw tick timeline is shown below as before.

## Tests
`tsc` + `next lint` clean (copy/static changes over existing real_backend surfaces).

ADO #691.

🤖 Generated with [Claude Code](https://claude.com/claude-code)