### PR TITLE
feat(telemetry): aggressive Mission Summary cut + Metric Lineage fail-close (ADO #702)

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4042,3 +4042,27 @@ Inventory of the real data behind the telemetry env (full per-surface contracts 
 - **Demo tenant is `env_id=telemetry-demo`, `business_id=7e1eb000-0000-4000-a000-000000000001`** (frontend constants `TELEMETRY_DEMO_ENV_ID` / `TELEMETRY_DEMO_BUSINESS_ID`). Data is keyed to this tenant regardless of the URL's `[envId]` — pages read the constants, not the route param, for the seeded backfill (46 runs / 2000+ predictions).
 - **No composite/derived telemetry metric exists yet** — no Mission Readiness score, no month-over-month delta (no snapshot store), no debt→launch causal edges. Any of these must be (a) defined with a ratified formula and (b) backed by a registry before it can render; otherwise fail closed. A "Program Control Tower" has **no backend at all** (would need a `tel_ct_program` table + endpoints).
 - **Backend telemetry map:** routes `backend/app/routes/telemetry.py|telemetry_copilot.py|telemetry_control_tower.py|telemetry_analyzer.py`; services `backend/app/services/telemetry_serving.py|telemetry_metadata.py|telemetry_registry.py|telemetry_factory.py|telemetry_stream_etl.py|control_tower/*`; schemas `backend/app/schemas/telemetry*.py|control_tower.py`; fixtures `backend/app/data/telemetry/{replay_fixture,metadata_catalog}.json`.
+
+### Executive landing composition + prod backend-stale gotcha (2026-06-22)
+
+- **An executive landing page links to detail pages; it does not re-host their tables.** The Mission Summary
+  redesign first stacked a new readiness panel on top of the *entire* old Overview (KPI strip + full model
+  registry + verdict panel + runs table + serving inventory + fused-vector + the full Bottleneck Map). Result:
+  ~7 panels, duplicate KPIs (the readiness component cards repeated the metric strip verbatim), and a wall of
+  five identical "Projection unavailable" cards. The fix was **subtraction**: one readiness block (the
+  component cards ARE the KPIs — no duplicate strip), a one-line scoring posture, a single compact
+  Operational-Leverage line, and **launchpad cards into `/registry`, `/runs`, `/system-health`,
+  `/metric-lineage`, `/copilot`** instead of inline tables. Rule: a landing should read in ~1–1.5 screens and
+  answer "how are we doing / what changed / where do I go", with detail one click away on its owning page.
+- **Fail closed with a dignified null state, never a raw error string.** A page whose data fetch can 404 must
+  render a labeled state ("Lineage index unavailable" + `null_reason: metadata_graph_unreachable` + a Retry),
+  not the generic `ErrorState` "Could not load: Error: Not Found". A primary CTA must never point at a page
+  that dumps a raw error.
+- **The prod Railway backend is NOT auto-deployed, so it lags the merged code.** `/api/telemetry/summary`
+  returns 200 in prod but `/api/telemetry/metadata/graph` returns **404** even though the route exists in
+  `backend/app/routes/telemetry.py` — it was added after the last `railway up`. Any new backend route reads as
+  "Not Found" in prod until the backend is shipped (`scripts/deploy_backend.sh` from `main`, then
+  `curl /version` to confirm the live SHA). When a frontend surface depends on a freshly-added endpoint,
+  assume the prod backend is stale and either ship it or fail the page closed. Quick prod check:
+  `curl -s -o /dev/null -w "%{http_code}" https://novendor.ai/api/telemetry/<path>` (200 vs 404 tells you
+  whether the route is deployed; 401 just means the unauth proxy gate, not a routing answer).

--- a/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
@@ -51,8 +51,21 @@ describe("TelemetryOverview — data-backed Mission Summary", () => {
     expect(screen.getByText(/Data as of/)).toBeInTheDocument();
   });
 
-  it("shows the Operational Leverage framework with projections failing closed", async () => {
+  it("collapses Operational Leverage to a single fail-closed projection (not a card wall)", async () => {
     render(<TelemetryOverview envId="env-1" />);
-    expect(await screen.findAllByText("Projection unavailable")).toHaveLength(5);
+    // Exactly one "Projection unavailable" now, not five large empty cards.
+    expect(await screen.findAllByText("Projection unavailable")).toHaveLength(1);
+  });
+
+  it("links to detail pages instead of re-hosting their tables (launchpads, no duplicate KPI strip)", async () => {
+    render(<TelemetryOverview envId="env-1" />);
+    expect(await screen.findByText("Continue the demo")).toBeInTheDocument();
+    // Launchpad cards link out; the Model Registry / Test Runs detail is NOT rendered inline.
+    expect(screen.getByText("Review model registry")).toBeInTheDocument();
+    expect(screen.getByText("Inspect test runs")).toBeInTheDocument();
+    expect(screen.getByText("Open metric lineage")).toBeInTheDocument();
+    // The old duplicate "Verdict distribution" panel is gone; scoring posture replaces it.
+    expect(screen.getByText("Current scoring posture")).toBeInTheDocument();
+    expect(screen.queryByText("Ingested test runs")).not.toBeInTheDocument();
   });
 });

--- a/repo-b/src/components/telemetry/TelemetryOverview.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.tsx
@@ -1,110 +1,90 @@
 "use client";
 
+// Mission Summary — the executive landing. Concise conclusions, not a telemetry exhibit:
+// readiness (fail-closed), a one-line scoring posture, a compact operational-leverage strip, and
+// launchpads INTO the detail pages (Model Registry, Test Runs, System Health, Metric Lineage,
+// Test Intelligence) rather than re-hosting their tables here. Reads only /api/telemetry/summary;
+// every value is real or fails closed. Detail lives on its owning page.
+
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import {
-  getModelPerformance, getSummary, getRuns, getFusedVectorInfo,
-  type ModelRun, type TelemetrySummary, type TestRun, type FusedVectorInfo,
+  getSummary, type TelemetrySummary,
   TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID,
 } from "@/lib/telemetry/api";
-import {
-  C, Tag, Panel, MetricCard, Loading, ErrorState, PageHeading, DisclosureFooter,
-  StatGrid, SplitGrid, ResponsiveSwap, RowCard,
-} from "./primitives";
-import BottleneckMap from "./context/BottleneckMap/BottleneckMap";
+import { C, Tag, Panel, Loading, ErrorState, PageHeading, DisclosureFooter } from "./primitives";
 
-function ModelCard({ m }: { m: ModelRun }) {
-  const champ = m.promotion_state === "promoted";
-  const accent = m.model_kind === "rul" ? C.green : C.cyan;
-  const metrics = m.metrics || {};
-  const primary = m.model_kind === "rul"
-    ? ["RMSE", metrics.rmse != null ? Number(metrics.rmse).toFixed(2) : "—"]
-    : ["F1", metrics.f1 != null ? Number(metrics.f1).toFixed(4) : "—"];
-  const secondary = m.model_kind === "rul"
-    ? `PHM ${metrics.phm != null ? Number(metrics.phm).toFixed(1) : "—"}`
-    : `recall ${metrics.recall != null ? Number(metrics.recall).toFixed(3) : "—"} · precision ${metrics.precision != null ? Number(metrics.precision).toFixed(3) : "—"}`;
-  const gate = (m.gate || {}) as Record<string, unknown>;
-  return (
-    <div style={{ background: champ ? C.panelHi : C.panel, border: `1px solid ${champ ? accent + "44" : C.border}`,
-      borderRadius: 9, padding: 16, opacity: champ ? 1 : 0.92 }}>
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-        <span style={{ fontFamily: C.mono, fontSize: 12.5, color: C.text }}>{m.model_name}</span>
-        <Tag color={C.cyan}>v{m.model_version}</Tag>
-      </div>
-      <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 8 }}>
-        {m.model_alias ? <Tag color={C.green}>{m.model_alias}</Tag> : <Tag color={C.faint}>challenger</Tag>}
-        <Tag color={C.dim}>{m.model_kind}</Tag>
-      </div>
-      <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", marginTop: 14 }}>
-        <div>
-          <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, letterSpacing: "0.1em" }}>{primary[0]}</div>
-          <div style={{ fontFamily: C.sans, fontSize: 28, fontWeight: 600, color: accent, lineHeight: 1, marginTop: 4 }}>{primary[1]}</div>
-        </div>
-        <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, textAlign: "right", maxWidth: 140 }}>{secondary}</div>
-      </div>
-      <div style={{ marginTop: 14, paddingTop: 12, borderTop: `1px solid ${C.border}` }}>
-        {champ ? (
-          <div style={{ display: "flex", alignItems: "flex-start", gap: 7 }}>
-            <span style={{ width: 6, height: 6, borderRadius: 999, background: C.green, boxShadow: `0 0 8px ${C.green}`, marginTop: 4, flexShrink: 0 }} />
-            <span style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, lineHeight: 1.4 }}>
-              Promoted · gate {String(gate.metric ?? "")} {String(gate.threshold ?? "")}
-              {gate.selected_over ? <><br />selected over {String(gate.selected_over)}</> : null}
-            </span>
-          </div>
-        ) : (
-          <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, lineHeight: 1.4 }}>
-            Evaluated · {String(gate.note ?? "challenger")}
-          </span>
-        )}
-      </div>
-    </div>
-  );
+function num(n: number | null | undefined): string {
+  return n == null ? "—" : Number(n).toLocaleString();
 }
-
-function num(n: number | null | undefined, digits = 0): string {
-  return n == null ? "—" : Number(n).toLocaleString(undefined, { maximumFractionDigits: digits });
-}
-
 function formatTs(value?: string | null): string {
   if (!value) return "as-of unknown";
   const parsed = new Date(value);
   return Number.isNaN(parsed.valueOf()) ? value : parsed.toLocaleString();
 }
 
-// One component-input card for the readiness panel. Shows a real headline value (or an explicit
-// "Not available here") and links to the surface that owns it. No composite score is computed.
+// A readiness component-input card: a real headline value (or explicit "Not available here") + a
+// link to the surface that owns it. No composite score is computed here.
 function ComponentCard({ name, value, href, hrefLabel }: {
   name: string; value: string; href: string; hrefLabel: string;
 }) {
   return (
     <div style={{ background: C.panel, border: `1px solid ${C.border}`, borderRadius: 9, padding: 14 }}>
       <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, letterSpacing: "0.1em", textTransform: "uppercase" }}>{name}</div>
-      <div style={{ fontFamily: C.mono, fontSize: 13, color: C.text, marginTop: 8, lineHeight: 1.4, minHeight: 34 }}>{value}</div>
+      <div style={{ fontFamily: C.mono, fontSize: 13, color: C.text, marginTop: 8, lineHeight: 1.4, minHeight: 18 }}>{value}</div>
       <Link href={href} style={{ fontFamily: C.mono, fontSize: 11, color: C.cyan, textDecoration: "none" }}>{hrefLabel} →</Link>
+    </div>
+  );
+}
+
+// A launchpad / "continue the demo" navigation card. Optional real sub-value; never a metric dump.
+function Launchpad({ title, sub, href }: { title: string; sub?: string; href: string }) {
+  return (
+    <Link href={href} style={{ textDecoration: "none", display: "block", background: C.panelHi,
+      border: `1px solid ${C.border}`, borderRadius: 9, padding: "12px 14px" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10 }}>
+        <span style={{ fontFamily: C.mono, fontSize: 12.5, color: C.text }}>{title}</span>
+        <span style={{ fontFamily: C.mono, fontSize: 13, color: C.cyan }}>→</span>
+      </div>
+      {sub && <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, marginTop: 5 }}>{sub}</div>}
+    </Link>
+  );
+}
+
+// Compact scoring posture — one slim GO / REVIEW / NO-GO bar from the live verdict distribution.
+function ScoringPosture({ verdicts }: { verdicts: Record<string, number> }) {
+  const order = [["GO", C.green], ["REVIEW", C.amber], ["NO_GO", C.red]] as const;
+  const total = Object.values(verdicts).reduce((a, b) => a + b, 0) || 1;
+  return (
+    <div>
+      <div style={{ display: "flex", height: 8, borderRadius: 5, overflow: "hidden", border: `1px solid ${C.border}` }}>
+        {order.map(([v, col]) => {
+          const n = verdicts[v] || 0;
+          return n ? <div key={v} title={`${v} ${n}`} style={{ width: `${(n / total) * 100}%`, background: col }} /> : null;
+        })}
+      </div>
+      <div style={{ display: "flex", gap: 16, marginTop: 9 }}>
+        {order.map(([v, col]) => (
+          <span key={v} style={{ display: "flex", alignItems: "center", gap: 6, fontFamily: C.mono, fontSize: 11, color: C.dim }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: col }} />
+            {v === "NO_GO" ? "NO-GO" : v} {num(verdicts[v] || 0)}
+          </span>
+        ))}
+      </div>
     </div>
   );
 }
 
 export default function TelemetryOverview({ envId }: { envId: string }) {
   const [summary, setSummary] = useState<TelemetrySummary | null>(null);
-  const [models, setModels] = useState<ModelRun[] | null>(null);
-  const [runs, setRuns] = useState<TestRun[] | null>(null);
-  const [fused, setFused] = useState<FusedVectorInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    Promise.all([
-      getSummary(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID),
-      getModelPerformance(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID),
-      getRuns(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID),
-      getFusedVectorInfo(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID).catch(() => null),
-    ])
-      .then(([s, mp, r, fv]) => { setSummary(s); setModels(mp.models); setRuns(r); setFused(fv); })
+    getSummary(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID)
+      .then(setSummary)
       .catch((e) => setError(String(e)));
   }, []);
 
-  // The page heading and the context module are static; only the operational sections below
-  // depend on the serving API, so the narrative on-ramp renders even while loading or erroring.
   const heading = (
     <PageHeading eyebrow="Mission Summary"
       title="Mission health, model posture, and operating readiness"
@@ -117,28 +97,12 @@ export default function TelemetryOverview({ envId }: { envId: string }) {
         </Link>
       } />
   );
-  const contextSection = (
-    <section aria-label="Context: why launch became a data problem" style={{ margin: "0 0 24px" }}>
-      <div style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.13em", color: C.faint,
-        textTransform: "uppercase", marginBottom: 12 }}>
-        Context: why launch became a data problem
-      </div>
-      <BottleneckMap />
-    </section>
-  );
-
-  if (error) return (
-    <>{heading}{contextSection}<ErrorState message={error} /></>
-  );
-  if (!summary || !models || !runs) return (
-    <>{heading}{contextSection}<Loading label="Loading console…" /></>
-  );
+  if (error) return <>{heading}<ErrorState message={error} /></>;
+  if (!summary) return <>{heading}<Loading label="Loading mission summary…" /></>;
 
   const k = summary.kpi;
-  const challengerF1 = models.find((m) => m.model_kind === "anomaly" && m.promotion_state !== "promoted")?.metrics?.f1;
-  const challengerRmse = models.find((m) => m.model_kind === "rul" && m.promotion_state !== "promoted")?.metrics?.rmse;
-  const noGoPct = summary.verdict_pct?.NO_GO != null ? Math.round(summary.verdict_pct.NO_GO * 100) : null;
   const inv = summary.inventory;
+  const base = `/lab/env/${envId}/telemetry`;
 
   return (
     <>
@@ -154,181 +118,67 @@ export default function TelemetryOverview({ envId }: { envId: string }) {
       {/* mission readiness — fail closed (no composite number until the formula is ratified) */}
       <Panel title="Mission readiness" right={<Tag color={C.amber}>not available</Tag>}>
         <div style={{ display: "flex", alignItems: "baseline", gap: 12, flexWrap: "wrap" }}>
-          <span style={{ fontFamily: C.sans, fontSize: 30, fontWeight: 700, color: C.amber, lineHeight: 1 }}>Not available</span>
-          <span style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, maxWidth: 580, lineHeight: 1.5 }}>
-            null_reason: composite_formula_not_ratified — Mission Readiness is a weighted composite; its formula,
-            weights, and one input (live stream) are not yet ratified or seeded. The real component inputs are below.
+          <span style={{ fontFamily: C.sans, fontSize: 28, fontWeight: 700, color: C.amber, lineHeight: 1 }}>Not available</span>
+          <span style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, maxWidth: 560, lineHeight: 1.5 }}>
+            null_reason: composite_formula_not_ratified — readiness is a weighted composite; its formula and
+            weights are not ratified yet. The real component inputs are below.
           </span>
         </div>
         <div className="grid grid-cols-2 gap-3 lg:grid-cols-4" style={{ marginTop: 14 }}>
-          <ComponentCard name="Operations" value={`${num(k.predictions)} predictions · ${k.test_runs} runs`}
-            href={`/lab/env/${envId}/telemetry/monitoring`} hrefLabel="Monitoring" />
+          <ComponentCard name="Operations" value={`${num(k.predictions)} predictions · ${k.test_runs} runs`} href={`${base}/system-health`} hrefLabel="System Health" />
           <ComponentCard name="Quality"
             value={`F1 ${k.anomaly_f1 != null ? Number(k.anomaly_f1).toFixed(4) : "—"} · RMSE ${k.rul_rmse != null ? Number(k.rul_rmse).toFixed(2) : "—"}`}
-            href={`/lab/env/${envId}/telemetry/model-performance`} hrefLabel="Model performance" />
-          <ComponentCard name="Models" value={`${k.promoted_models} promoted / ${inv.model_runs} evaluated`}
-            href={`/lab/env/${envId}/telemetry/registry`} hrefLabel="Model registry" />
-          <ComponentCard name="AI" value="Not available here"
-            href={`/lab/env/${envId}/telemetry/governance`} hrefLabel="Trust Center" />
+            href={`${base}/model-performance`} hrefLabel="Model performance" />
+          <ComponentCard name="Models" value={`${k.promoted_models} promoted / ${inv.model_runs} evaluated`} href={`${base}/registry`} hrefLabel="Model registry" />
+          <ComponentCard name="AI" value="Not available here" href={`${base}/governance`} hrefLabel="Trust Center" />
         </div>
       </Panel>
 
-      {/* metric strip */}
-      <StatGrid cols={4} style={{ marginTop: 16 }}>
-        <MetricCard label="Promoted models" value={String(k.promoted_models)} sub={`of ${inv.model_runs} evaluated`} />
-        <MetricCard label="Anomaly F1" value={k.anomaly_f1 != null ? Number(k.anomaly_f1).toFixed(4) : "—"}
-          sub={challengerF1 != null ? `champion vs ${Number(challengerF1).toFixed(4)} challenger` : undefined} accent={C.cyan} />
-        <MetricCard label="RUL RMSE" value={k.rul_rmse != null ? Number(k.rul_rmse).toFixed(2) : "—"}
-          sub={challengerRmse != null ? `champion vs ${Number(challengerRmse).toFixed(2)} challenger` : undefined} accent={C.green} />
-        <MetricCard label="Predictions" value={num(k.predictions)}
-          sub={noGoPct != null ? `${noGoPct}% no-go · ${k.test_runs} runs` : undefined} accent={C.amber} />
-      </StatGrid>
+      {/* compact scoring posture + operational leverage, side by side on desktop */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2" style={{ marginTop: 16 }}>
+        <Panel title="Current scoring posture" right={<Tag color={C.cyan}>{num(k.predictions)} scored</Tag>}>
+          <ScoringPosture verdicts={summary.verdicts} />
+          <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, marginTop: 10, lineHeight: 1.5 }}>
+            Live verdict distribution across scored events · governed prediction log.
+          </div>
+        </Panel>
+        <Panel title="Operational leverage — technical debt → launch impact" right={<Tag color={C.amber}>framework</Tag>}>
+          <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, lineHeight: 1.6 }}>
+            Tech debt → engineering throughput → test velocity → flight readiness → launch cadence.
+          </div>
+          <div style={{ fontFamily: C.mono, fontSize: 12, color: C.amber, marginTop: 10 }}>Projection unavailable</div>
+          <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 4, lineHeight: 1.5 }}>
+            requires a governed metric registry (modeled relationship + basis + confidence). No projection is invented.
+          </div>
+        </Panel>
+      </div>
 
-      {/* operational leverage — technical debt -> launch impact (framework only; figures fail closed) */}
-      <Panel title="Operational leverage — technical debt → launch impact" right={<Tag color={C.amber}>framework</Tag>} style={{ marginTop: 16 }}>
-        <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, lineHeight: 1.6 }}>
-          Causal chain: tech debt → engineering throughput → manufacturing &amp; test velocity → flight readiness → launch cadence.
-          The framework is shown; the figures stay fail-closed until a governed metric registry can supply each
-          modeled relationship with a basis + confidence. No projection is invented.
-        </div>
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3" style={{ marginTop: 12 }}>
-          {["Deployment failures", "Telemetry freshness", "Hot-fire analysis cycle", "Readiness-review duration", "Launch-cadence capacity"].map((label) => (
-            <div key={label} style={{ background: C.panel, border: `1px solid ${C.border}`, borderRadius: 8, padding: "10px 12px" }}>
-              <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase" }}>{label}</div>
-              <div style={{ fontFamily: C.mono, fontSize: 12, color: C.amber, marginTop: 6 }}>Projection unavailable</div>
-              <div style={{ fontFamily: C.mono, fontSize: 9, color: C.faint, marginTop: 4, lineHeight: 1.5 }}>requires metric registry (modeled relationship + basis + confidence)</div>
-            </div>
-          ))}
-        </div>
+      {/* continue the demo — launchpads into detail pages (not metric duplicates) */}
+      <div style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.13em", color: C.faint,
+        textTransform: "uppercase", margin: "26px 0 12px" }}>
+        Continue the demo
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <Launchpad title="Inspect live stream" href={`${base}/stream`} />
+        <Launchpad title="Open metric lineage" href={`${base}/metric-lineage`} />
+        <Launchpad title="Review model registry" sub={`${k.promoted_models} promoted / ${inv.model_runs} evaluated`} href={`${base}/registry`} />
+        <Launchpad title="Inspect test runs" sub={`${k.test_runs} runs · ${num(k.predictions)} prediction rows`} href={`${base}/runs`} />
+        <Launchpad title="System health" href={`${base}/system-health`} />
+        <Launchpad title="Ask grounded analyst" href={`${base}/copilot`} />
+      </div>
+
+      {/* historical context — subordinate takeaway only (full Bottleneck Map lives on its own surface) */}
+      <Panel title="Historical context" style={{ marginTop: 24 }} pad={16}>
+        <p style={{ fontFamily: C.mono, fontSize: 12, color: C.dim, lineHeight: 1.6, margin: 0 }}>
+          Current bottleneck: decision velocity. Launch cost fell; manufacturing complexity rose. The next gain
+          comes from faster, trusted telemetry-to-decision loops.
+        </p>
+        <Link href={`${base}/how-it-works`} style={{ fontFamily: C.mono, fontSize: 11, color: C.cyan, textDecoration: "none", display: "inline-block", marginTop: 10 }}>
+          How this works →
+        </Link>
       </Panel>
-
-      {/* model registry + (replay preview + drift) */}
-      <SplitGrid variant="main-side" style={{ marginTop: 16 }}>
-        <Panel title="Model registry" right={<Tag color={C.green}>{k.promoted_models} promoted · {models.length - k.promoted_models} challengers</Tag>}>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            {models.map((m) => <ModelCard key={`${m.model_name}-${m.model_version}`} m={m} />)}
-          </div>
-          <div style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, marginTop: 14 }}>
-            Aliases resolve from the MLflow registry. Only champions are exposed to /score.
-          </div>
-        </Panel>
-
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-          <Panel title="Verdict distribution" right={<Tag color={C.cyan}>{num(k.predictions)} scored</Tag>}>
-            <VerdictBar verdicts={summary.verdicts} />
-          </Panel>
-          <Panel title="Operated-history disclosure">
-            <p style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, lineHeight: 1.5 }}>{summary.note}</p>
-          </Panel>
-        </div>
-      </SplitGrid>
-
-      {/* Fused state vector (Phase 7A) — only when built + verified; shows the ACTUAL dim */}
-      {fused?.available && (
-        <Panel title="Fused state vector"
-          right={<Tag color={C.cyan}>{fused.vector_dim}-d</Tag>} style={{ marginTop: 16 }}>
-          <div style={{ display: "flex", alignItems: "baseline", gap: 10, flexWrap: "wrap" }}>
-            <span style={{ fontFamily: C.sans, fontSize: 18, fontWeight: 600, color: C.text }}>
-              {fused.vector_dim} features
-            </span>
-            <span style={{ fontFamily: C.mono, fontSize: 12, color: C.dim }}>
-              {fused.n_channels} NASA channels × {fused.features_per_channel} window features
-              {fused.d4_included ? " · incl. D-4" : ""}
-            </span>
-          </div>
-          <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, marginTop: 8 }}>
-            {fused.feature_names?.join(" · ")}
-          </div>
-          <div style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, marginTop: 10, lineHeight: 1.5 }}>
-            {fused.model}. {fused.fused_vectors} fused vectors ({fused.anomalous_test_vectors} labeled
-            anomalous in test). {fused.alignment}
-          </div>
-        </Panel>
-      )}
-
-      {/* test runs + serving inventory */}
-      <SplitGrid variant="main-side" style={{ marginTop: 16 }}>
-        <Panel title="Ingested test runs" right={<Tag color={C.cyan}>{inv.test_runs} runs</Tag>}>
-          <ResponsiveSwap
-            mobile={
-              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                {runs.slice(0, 8).map((r) => (
-                  <RowCard key={r.id} title={r.run_key} tags={<Tag color={C.dim}>{r.dataset}</Tag>}
-                    fields={[
-                      { label: "Unit / craft", value: `${r.unit_or_channel}${r.spacecraft ? ` · ${r.spacecraft}` : ""}` },
-                      { label: "Rows", value: r.row_count.toLocaleString() },
-                    ]} />
-                ))}
-              </div>
-            }
-            desktop={
-              <>
-                <div style={{ display: "grid", gridTemplateColumns: "1.6fr 1fr 1fr 0.7fr", gap: 8, fontFamily: C.mono,
-                  fontSize: 10, color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase", paddingBottom: 8 }}>
-                  <span>Run</span><span>Dataset</span><span>Unit / craft</span><span>Rows</span>
-                </div>
-                <div style={{ borderTop: `1px solid ${C.border}` }}>
-                  {runs.slice(0, 8).map((r) => (
-                    <div key={r.id} style={{ display: "grid", gridTemplateColumns: "1.6fr 1fr 1fr 0.7fr", gap: 8,
-                      fontFamily: C.mono, fontSize: 12, color: C.text, padding: "7px 0", borderBottom: `1px solid ${C.border}` }}>
-                      <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{r.run_key}</span>
-                      <span style={{ color: C.dim }}>{r.dataset}</span>
-                      <span style={{ color: C.dim }}>{r.unit_or_channel}{r.spacecraft ? ` · ${r.spacecraft}` : ""}</span>
-                      <span>{r.row_count.toLocaleString()}</span>
-                    </div>
-                  ))}
-                </div>
-              </>
-            } />
-          <div style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, marginTop: 12 }}>
-            SMAP/MSL anomaly channels (go/no-go) + C-MAPSS RUL units. {inv.test_runs} runs total.
-          </div>
-        </Panel>
-
-        <Panel title="Serving data inventory">
-          <div style={{ display: "flex", flexDirection: "column" }}>
-            {Object.entries(inv).map(([key, n]) => (
-              <div key={key} style={{ display: "flex", alignItems: "center", justifyContent: "space-between",
-                padding: "7px 0", borderBottom: `1px solid ${C.border}` }}>
-                <span style={{ fontFamily: C.mono, fontSize: 12, color: n > 0 ? C.text : C.faint }}>tel_{key}</span>
-                <Tag color={n > 0 ? C.green : C.amber}>{n} {n > 0 ? "rows" : "empty"}</Tag>
-              </div>
-            ))}
-          </div>
-          <div style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, marginTop: 12 }}>
-            Drift monitors: {k.drift_monitors} · last score {k.last_scored_at ? new Date(k.last_scored_at).toISOString().slice(0, 10) : "—"}
-          </div>
-        </Panel>
-      </SplitGrid>
-
-      {contextSection}
 
       <DisclosureFooter />
     </>
-  );
-}
-
-function VerdictBar({ verdicts }: { verdicts: Record<string, number> }) {
-  const order = [["GO", C.green], ["REVIEW", C.amber], ["NO_GO", C.red]] as const;
-  const total = Object.values(verdicts).reduce((a, b) => a + b, 0) || 1;
-  return (
-    <div>
-      <div style={{ display: "flex", height: 10, borderRadius: 6, overflow: "hidden", border: `1px solid ${C.border}` }}>
-        {order.map(([v, col]) => {
-          const n = verdicts[v] || 0;
-          return n ? <div key={v} title={`${v} ${n}`} style={{ width: `${(n / total) * 100}%`, background: col }} /> : null;
-        })}
-      </div>
-      <div style={{ display: "flex", gap: 14, marginTop: 10 }}>
-        {order.map(([v, col]) => (
-          <div key={v} style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <span style={{ width: 8, height: 8, borderRadius: 2, background: col }} />
-            <span style={{ fontFamily: C.mono, fontSize: 11, color: C.dim }}>
-              {v === "NO_GO" ? "NO-GO" : v} {verdicts[v] || 0}
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
   );
 }

--- a/repo-b/src/components/telemetry/metadata/MetricLineageExplorer.test.tsx
+++ b/repo-b/src/components/telemetry/metadata/MetricLineageExplorer.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+vi.mock("@/lib/telemetry/api", () => ({
+  TELEMETRY_DEMO_ENV_ID: "telemetry-demo",
+  TELEMETRY_DEMO_BUSINESS_ID: "biz-1",
+}));
+
+// Mock only getMetadataGraph; keep the real types/helpers (getUpstreamTrace etc.).
+const getMetadataGraph = vi.fn();
+vi.mock("@/lib/telemetry/metadata", async (orig) => ({
+  ...(await orig<typeof import("@/lib/telemetry/metadata")>()),
+  getMetadataGraph: (...args: unknown[]) => getMetadataGraph(...args),
+}));
+
+import MetricLineageExplorer from "./MetricLineageExplorer";
+
+const graphWithOneMetric = {
+  generated_at: "2026-06-22T00:00:00Z",
+  status: "ok",
+  warnings: [],
+  nodes: [
+    { id: "m1", label: "Flight Readiness", kind: "metric", layer: "metric", confidence: "explicit", status: "fresh",
+      metadata: { formula: "weighted sub-indices", owner: "Test Operations" } },
+  ],
+  edges: [],
+  stats: { source_count: 0, bronze_count: 0, silver_count: 0, gold_count: 1, metric_count: 1, model_count: 0, dashboard_count: 0, edge_count: 0, unavailable_count: 0 },
+};
+
+describe("MetricLineageExplorer", () => {
+  beforeEach(() => getMetadataGraph.mockReset());
+
+  it("fails closed gracefully when the metadata graph is unavailable (no catalog returned)", async () => {
+    // Same render branch as a 404 from the endpoint: no usable graph -> dignified null state, not a raw error.
+    getMetadataGraph.mockImplementation(() => Promise.resolve(null));
+    render(<MetricLineageExplorer envId="env-1" />);
+    expect(await screen.findByText("Lineage index unavailable")).toBeInTheDocument();
+    expect(screen.getByText(/metadata_graph_unreachable/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("lists governed metrics with a trace-source affordance when the catalog loads", async () => {
+    getMetadataGraph.mockImplementation(() => Promise.resolve(graphWithOneMetric));
+    render(<MetricLineageExplorer envId="env-1" />);
+    expect(await screen.findByText("Flight Readiness")).toBeInTheDocument();
+    expect(screen.getByText("Trace source →")).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/metadata/MetricLineageExplorer.tsx
+++ b/repo-b/src/components/telemetry/metadata/MetricLineageExplorer.tsx
@@ -20,7 +20,6 @@ import {
   C,
   DisclosureFooter,
   EmptyState,
-  ErrorState,
   Loading,
   MetricCard,
   PageHeading,
@@ -41,6 +40,7 @@ export default function MetricLineageExplorer({ envId }: { envId: string }) {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [selected, setSelected] = useState<TelemetryMetadataNode | null>(null);
+  const [reload, setReload] = useState(0);
 
   useEffect(() => {
     let active = true;
@@ -51,7 +51,7 @@ export default function MetricLineageExplorer({ envId }: { envId: string }) {
         if (active) setGraph(g);
       })
       .catch((reason) => {
-        if (active) setError(String(reason));
+        if (active) setError(reason instanceof Error ? reason.message : String(reason));
       })
       .finally(() => {
         if (active) setLoading(false);
@@ -59,7 +59,7 @@ export default function MetricLineageExplorer({ envId }: { envId: string }) {
     return () => {
       active = false;
     };
-  }, [envId]);
+  }, [envId, reload]);
 
   const heading = (
     <PageHeading
@@ -70,8 +70,34 @@ export default function MetricLineageExplorer({ envId }: { envId: string }) {
   );
 
   if (loading && !graph) return <>{heading}<Loading label="Loading metric catalog..." /></>;
-  if (error) return <>{heading}<ErrorState message={error} /></>;
-  if (!graph) return <>{heading}<ErrorState message="Metadata graph unavailable." /></>;
+  if (error || !graph) {
+    // Fail closed gracefully: the metadata-graph endpoint did not return a catalog (e.g. the route
+    // is not yet available on this deployment's backend). Show a dignified null state with a
+    // null_reason + retry — never a raw error, and never a fabricated chain.
+    return (
+      <>
+        {heading}
+        <Panel title="Lineage index unavailable" right={<Tag color={C.amber}>fail-closed</Tag>}>
+          <p style={{ fontFamily: C.mono, fontSize: 12, color: C.dim, lineHeight: 1.6, margin: 0 }}>
+            null_reason: metadata_graph_unreachable — the telemetry metadata-graph endpoint did not return a
+            catalog in this deployment, so no lineage can be shown. This fails closed rather than rendering a
+            fabricated chain.
+          </p>
+          {error && (
+            <p style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.5, marginTop: 8 }}>
+              Detail: {error}
+            </p>
+          )}
+          <button type="button" onClick={() => setReload((r) => r + 1)}
+            style={{ marginTop: 12, fontFamily: C.mono, fontSize: 12, color: C.cyan, background: "transparent",
+              border: `1px solid ${C.border}`, borderRadius: 8, padding: "8px 14px", cursor: "pointer" }}>
+            Retry
+          </button>
+        </Panel>
+        <DisclosureFooter />
+      </>
+    );
+  }
 
   const metrics = graph.nodes
     .filter((n) => n.kind === "metric")


### PR DESCRIPTION
## What
Reviewer flagged the Mission Summary as "still a bit busy" — it was honest but stacked the whole old Overview under the new executive page. Fixed by **subtraction**, frontend-only.

**Mission Summary cut:**
- Drop the **duplicate KPI strip** (the readiness component cards already carry F1 / RMSE / promoted / predictions).
- Collapse **Operational Leverage** from five "Projection unavailable" cards to **one compact fail-closed line**.
- Remove the full **Model Registry**, **Test Runs** table, **Serving inventory**, **Fused-vector**, and the full **Bottleneck Map** from the landing.
- Add **launchpad cards** into the detail pages (`/registry`, `/runs`, `/system-health`, `/metric-lineage`, `/copilot`) + a compact **Current scoring posture** + a subordinate **Historical context** takeaway.
- Reads only `/api/telemetry/summary`. Target ~1–1.5 screens.

**Prod bug fix (Metric Lineage 404):** `/metadata/graph` exists in code but the prod Railway backend is stale (not auto-deployed), so the page showed a raw `Could not load: Error: Not Found` and the "Trace lineage" CTA pointed at it. The page now **fails closed gracefully**: "Lineage index unavailable" + `null_reason: metadata_graph_unreachable` + Retry.

## Guardrails
No fake values; everything real or fail-closed; no silent fallback; CTA never lands on a raw error.

## Tests
`vitest` TelemetryOverview 5/5, MetricLineageExplorer 2/2, full telemetry suite **93/93**; `tsc` + `next lint` clean.

## Backend follow-up (NOT this ticket)
Redeploy the backend from `main` so `/metadata/graph` is live and Metric Lineage renders real lineage.

ADO #702.

🤖 Generated with [Claude Code](https://claude.com/claude-code)