### PR TITLE
feat(telemetry): RS design pass — presentation polish on real-data surfaces (ADO #703)

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4066,3 +4066,36 @@ Inventory of the real data behind the telemetry env (full per-surface contracts 
   assume the prod backend is stale and either ship it or fail the page closed. Quick prod check:
   `curl -s -o /dev/null -w "%{http_code}" https://novendor.ai/api/telemetry/<path>` (200 vs 404 tells you
   whether the route is deployed; 401 just means the unauth proxy gate, not a routing answer).
+
+### Telemetry presentation polish (RS visual language) — durable lessons (2026-06-22)
+
+- **Polish the shared design system, not each page.** Every telemetry surface consumes
+  `repo-b/src/components/telemetry/primitives.tsx` (the `C` palette + `PageHeading`/`Panel`/`MetricCard`/
+  `Tag`/`EmptyState`/`ErrorState`). Brightening the `C` tokens and enlarging those shared components lifts
+  all ~18 pages at once, consistently, with one low-risk edit — far better than per-page restyling. Keep the
+  **token names stable** (only move the values) so nothing breaks. `C` is telemetry-scoped (nothing outside
+  `components/telemetry/` imports it — `historyrhymes/cockpit/primitives.tsx` only *references* it in a
+  comment), so the blast radius is just telemetry.
+- **Contrast: the killer is dim/faint used for *important facts*.** The old `faint #56616f` at 9–11px on
+  panel titles and key labels read as unreadable gray. Fixes that landed: panel titles use `dim` (not
+  `faint`); `dim`→`#9fb0c4`, `faint`→`#6f7e90` (raised luminance); accents moved to the RS set
+  (cyan `#67e8f9`, green `#6ee7a0`, amber `#f5b452`, red `#f4715f`); `PageHeading` title 26→30 with an accent
+  eyebrow bar; `MetricCard` value 26→30. Reserve true faint only for genuinely tertiary footnotes.
+- **Fail-closed states must look *designed*, not broken.** Replace dashed "sad box" empties and raw
+  "Could not load: …" dumps with a composed card: a status dot (amber for unavailable, red for error,
+  cyan for loading) + a clear label + a `null_reason`/hint line. An honest "Lineage index unavailable" or
+  "Projection unavailable" should read as a deliberate posture a reviewer trusts, not a crash.
+- **Lineage-card layout (the trust spine):** list each governed metric as a row with name + one-line
+  definition on the left, and on the right a status tag **plus a bordered "Trace source →" pill** (border +
+  tinted bg, not bare text) so the affordance is unmistakable. The drawer renders the upstream chain grouped
+  by medallion lane (source→bronze→silver→gold→metric). Verified live: 8 governed metrics / 22 gold tables /
+  133 lineage edges from `/api/telemetry/metadata/graph`.
+- **Mobile/contrast gotchas:** layout stays in literal Tailwind classes (the content scanner only sees
+  literal strings — never compose class names from props); color/typography stay on the inline `C` palette.
+  Telemetry grids already reflow at `sm`/`lg` via `StatGrid`/`SplitGrid`. When polishing, change inline
+  *style* (color/size/spacing) but never the Tailwind class strings, and keep panel titles ≤ one line on a
+  375px viewport. Verify both widths with a Playwright screenshot at 1600px and 390px.
+- **Verification without leaking secrets:** drive prod with a throwaway Playwright `.cjs` (deleted after run,
+  never committed); have it read the admin login from the memory index (`MEMORY.md` records it in backticks)
+  and print only the password *length*, never the value. Login form on `/login` uses
+  `input[autocomplete=username]` (type=text, not `type=email`) + `input[type=password]` + a "Sign in" submit.

--- a/repo-b/src/components/telemetry/SystemHealth.tsx
+++ b/repo-b/src/components/telemetry/SystemHealth.tsx
@@ -11,18 +11,12 @@ import SpikeInspector from "./SpikeInspector";
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 10,
-        margin: "22px 0 12px",
-      }}
-    >
-      <span style={{ fontFamily: C.mono, fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: C.faint, whiteSpace: "nowrap" }}>
+    <div style={{ display: "flex", alignItems: "center", gap: 11, margin: "28px 0 14px" }}>
+      <span aria-hidden style={{ width: 8, height: 8, borderRadius: 999, background: C.cyan, boxShadow: `0 0 8px ${C.cyan}aa`, flexShrink: 0 }} />
+      <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.14em", textTransform: "uppercase", color: C.dim, whiteSpace: "nowrap" }}>
         {children}
       </span>
-      <span style={{ flex: 1, height: 1, background: C.border }} />
+      <span style={{ flex: 1, height: 1, background: `linear-gradient(90deg, ${C.borderHi}, transparent)` }} />
     </div>
   );
 }

--- a/repo-b/src/components/telemetry/metadata/MetricLineageExplorer.tsx
+++ b/repo-b/src/components/telemetry/metadata/MetricLineageExplorer.tsx
@@ -190,11 +190,14 @@ export default function MetricLineageExplorer({ envId }: { envId: string }) {
                     </span>
                   )}
                 </span>
-                <span style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
+                <span style={{ display: "flex", alignItems: "center", gap: 10, flexShrink: 0 }}>
                   <Tag color={m.status === "fresh" ? C.green : m.status === "missing" ? C.red : C.amber}>
                     {m.status ?? "unknown"}
                   </Tag>
-                  <span style={{ fontFamily: C.mono, fontSize: 11, color: C.cyan }}>Trace source →</span>
+                  <span style={{ fontFamily: C.mono, fontSize: 11, color: C.cyan, letterSpacing: "0.03em",
+                    border: `1px solid ${C.cyan}55`, background: `${C.cyan}14`, borderRadius: 6, padding: "5px 11px", whiteSpace: "nowrap" }}>
+                    Trace source →
+                  </span>
                 </span>
               </button>
             ))}

--- a/repo-b/src/components/telemetry/primitives.tsx
+++ b/repo-b/src/components/telemetry/primitives.tsx
@@ -2,13 +2,17 @@
 
 import type { CSSProperties, ReactNode } from "react";
 
-// Option B "Lab Workbench" palette — ported verbatim from OptionB_DataBound_Overview.jsx.
-// Self-contained inline-style tokens so the telemetry console is dark regardless of the global theme.
+// Telemetry workbench palette, aligned to the Mission Control / RS visual language (brighter text,
+// brighter accents, deeper blue-black panels) for a polished aerospace operating feel. Self-contained
+// inline-style tokens so the console is dark regardless of the global theme. Token NAMES are stable —
+// every telemetry surface consumes these, so only the values move (toward RS) here.
 export const C = {
-  bg: "#06090d", rail: "#0a0e14", panel: "#0e141d", panelHi: "#121a25",
-  border: "rgba(110,150,190,0.12)", borderHi: "rgba(110,150,190,0.24)",
-  text: "#e6edf4", dim: "#8a98aa", faint: "#56616f",
-  cyan: "#3fb1e8", green: "#3ddc97", amber: "#f3b14a", red: "#ef7066",
+  bg: "#070b11", rail: "#0a0f16", panel: "#0f1622", panelHi: "#14202f",
+  border: "rgba(120,162,205,0.16)", borderHi: "rgba(120,162,205,0.30)",
+  // text brighter; "dim" (secondary) and "faint" (labels) raised so important facts read clearly.
+  text: "#e9eff6", dim: "#9fb0c4", faint: "#6f7e90",
+  // RS signal accents (match Mission Control): high-contrast cyan/green/amber/red.
+  cyan: "#67e8f9", green: "#6ee7a0", amber: "#f5b452", red: "#f4715f",
   mono: "'JetBrains Mono', 'SF Mono', ui-monospace, Menlo, monospace",
   sans: "'Söhne', 'Inter', -apple-system, system-ui, sans-serif",
 };
@@ -36,9 +40,10 @@ export function Panel({ title, right, children, pad = 18, style }: {
   return (
     <div style={{ background: C.panel, border: `1px solid ${C.border}`, borderRadius: 10, ...style }}>
       {title && (
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between",
-          padding: "12px 16px", borderBottom: `1px solid ${C.border}` }}>
-          <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.13em", color: C.faint, textTransform: "uppercase" }}>{title}</span>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10,
+          padding: "11px 16px", borderBottom: `1px solid ${C.border}`, background: "rgba(255,255,255,0.018)" }}>
+          {/* Panel titles read as labels but stay legible — brighter than the old faint gray. */}
+          <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.14em", color: C.dim, textTransform: "uppercase" }}>{title}</span>
           {right}
         </div>
       )}
@@ -51,49 +56,69 @@ export function MetricCard({ label, value, sub, accent }: {
   label: string; value: ReactNode; sub?: ReactNode; accent?: string;
 }) {
   return (
-    <div style={{ background: C.panel, border: `1px solid ${C.border}`, borderRadius: 9, padding: 14 }}>
-      <div style={{ fontFamily: C.mono, fontSize: 10, letterSpacing: "0.1em", color: C.faint, textTransform: "uppercase" }}>{label}</div>
-      <div style={{ fontFamily: C.sans, fontSize: 26, fontWeight: 600, color: accent || C.text, marginTop: 6, lineHeight: 1 }}>{value}</div>
-      {sub != null && <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, marginTop: 6 }}>{sub}</div>}
+    <div style={{ background: C.panel, border: `1px solid ${C.border}`, borderRadius: 9, padding: 15 }}>
+      <div style={{ fontFamily: C.mono, fontSize: 10, letterSpacing: "0.11em", color: C.dim, textTransform: "uppercase" }}>{label}</div>
+      <div style={{ fontFamily: C.sans, fontSize: 30, fontWeight: 600, color: accent || C.text, marginTop: 8, lineHeight: 1 }}>{value}</div>
+      {sub != null && <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, marginTop: 7 }}>{sub}</div>}
     </div>
   );
 }
 
+// Intentional "fail-closed / nothing here yet" state — a designed card with an amber status dot,
+// NOT a broken-looking dashed box. Used wherever a real value is honestly unavailable.
 export function EmptyState({ label, hint }: { label: string; hint: string }) {
   return (
-    <div style={{ border: `1px dashed ${C.borderHi}`, borderRadius: 8, padding: "18px 16px", textAlign: "center" }}>
-      <div style={{ fontFamily: C.mono, fontSize: 12, color: C.amber }}>{label}</div>
-      <div style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, marginTop: 6, lineHeight: 1.5 }}>{hint}</div>
+    <div style={{ border: `1px solid ${C.amber}33`, background: `${C.amber}0d`, borderRadius: 9, padding: "16px 18px" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
+        <span style={{ width: 8, height: 8, borderRadius: 999, background: C.amber, boxShadow: `0 0 8px ${C.amber}99`, flexShrink: 0 }} />
+        <span style={{ fontFamily: C.mono, fontSize: 13, color: C.amber, letterSpacing: "0.02em" }}>{label}</span>
+      </div>
+      <div style={{ fontFamily: C.mono, fontSize: 11.5, color: C.dim, marginTop: 8, lineHeight: 1.55, paddingLeft: 17 }}>{hint}</div>
     </div>
   );
 }
 
 export function Loading({ label = "Loading…" }: { label?: string }) {
-  return <Panel><span style={{ fontFamily: C.mono, fontSize: 12, color: C.dim }}>{label}</span></Panel>;
-}
-
-export function ErrorState({ message }: { message: string }) {
   return (
-    <Panel style={{ borderColor: C.red + "55" }}>
-      <span style={{ fontFamily: C.mono, fontSize: 12, color: C.red }}>Could not load: {message}</span>
+    <Panel>
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 9, fontFamily: C.mono, fontSize: 12.5, color: C.dim }}>
+        <span style={{ width: 8, height: 8, borderRadius: 999, background: C.cyan, boxShadow: `0 0 8px ${C.cyan}99` }} />
+        {label}
+      </span>
     </Panel>
   );
 }
 
-// Page heading (eyebrow + title + optional blurb), Option B style.
+// Intentional unavailable/error state — composed card with a red status dot, reads as a deliberate
+// fail-closed posture rather than a crash.
+export function ErrorState({ message }: { message: string }) {
+  return (
+    <Panel style={{ borderColor: C.red + "55" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
+        <span style={{ width: 8, height: 8, borderRadius: 999, background: C.red, boxShadow: `0 0 8px ${C.red}99`, flexShrink: 0 }} />
+        <span style={{ fontFamily: C.mono, fontSize: 12.5, color: C.red }}>Could not load: {message}</span>
+      </div>
+    </Panel>
+  );
+}
+
+// Page heading (accent eyebrow bar + large title + brighter blurb), Mission Control style.
 export function PageHeading({ eyebrow, title, blurb, right }: {
   eyebrow: string; title: string; blurb?: string; right?: ReactNode;
 }) {
   return (
-    <div style={{ marginBottom: 22 }}>
+    <div style={{ marginBottom: 24 }}>
       <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", flexWrap: "wrap", gap: 12 }}>
         <div>
-          <div style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.14em", color: C.cyan, textTransform: "uppercase" }}>{eyebrow}</div>
-          <h1 style={{ fontFamily: C.sans, fontSize: 26, fontWeight: 700, letterSpacing: "-0.01em", marginTop: 6, color: C.text }}>{title}</h1>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <span aria-hidden style={{ width: 16, height: 2, borderRadius: 2, background: C.cyan, boxShadow: `0 0 8px ${C.cyan}aa` }} />
+            <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.16em", color: C.cyan, textTransform: "uppercase" }}>{eyebrow}</span>
+          </div>
+          <h1 style={{ fontFamily: C.sans, fontSize: 30, fontWeight: 700, letterSpacing: "-0.012em", marginTop: 9, color: C.text }}>{title}</h1>
         </div>
         {right}
       </div>
-      {blurb && <p style={{ fontFamily: C.sans, fontSize: 14, color: C.dim, lineHeight: 1.55, marginTop: 12, maxWidth: 760 }}>{blurb}</p>}
+      {blurb && <p style={{ fontFamily: C.sans, fontSize: 14.5, color: C.dim, lineHeight: 1.6, marginTop: 13, maxWidth: 780 }}>{blurb}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## What
Phase 4 — presentation polish toward the Mission Control / RS visual language on the verified real-data surfaces. **Presentation only**: no data semantics, no invented metrics, no backend, no migrations.

The leverage move: evolve the **shared** telemetry design system (`primitives.tsx`) so every surface brightens consistently with one low-risk edit.

- `C` palette → RS accents (cyan `#67e8f9`, green `#6ee7a0`, amber `#f5b452`, red `#f4715f`), brighter `dim`/`faint`, deeper blue-black panels. **Token names unchanged** → every telemetry page inherits it.
- **Readability:** panel titles use `dim` (not the murky old `faint`); `PageHeading` 30px + accent eyebrow bar; `MetricCard` value 30px + brighter label. Fixes "tiny gray text for important facts."
- **Fail-closed states look intentional:** `EmptyState`/`ErrorState`/`Loading` are composed cards with status dots (amber / red / cyan), not dashed sad-boxes or raw error dumps.
- Per-page: **Metric Lineage** gets a bordered "Trace source →" pill; **System Health** gets accented section dividers so it reads as one operational page.

Mission Summary stays slim; Trust Center / Replay inherit the brightening.

## Guardrails honored
No data semantics changed · no fake values · all real values + `null_reason` behavior preserved (no text/structure changes) · Mission Summary still ~1–1.5 screens · Metric Lineage still 8 metrics + drawer · credential-safety scan passed (no secret in source/tips/plan/temp).

## Tests
`vitest` full telemetry suite **93/93** green; `tsc --noEmit` exit 0; `next lint` clean.

## Verification
Prod screenshots (desktop + mobile) of all five routes to follow after deploy.

ADO #703.

🤖 Generated with [Claude Code](https://claude.com/claude-code)