### PR TITLE
feat(telemetry): Overview brings back launch-history charts; drop Mission Summary scaffolding (ADO #704)

### DIFF
--- a/repo-b/src/components/telemetry/TelemetryBottomNav.tsx
+++ b/repo-b/src/components/telemetry/TelemetryBottomNav.tsx
@@ -33,7 +33,7 @@ export default function TelemetryBottomNav({ envId, onMore }: { envId: string; o
       {tabs.map((t) => {
         const active = tabActive(t.slug);
         const shortLabel =
-          t.slug === "" ? "Summary" :
+          t.slug === "" ? "Overview" :
           t.slug === "stream" ? "Stream" :
           t.slug === "copilot" ? "Copilot" : t.label;
         return (

--- a/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
@@ -1,71 +1,44 @@
 import { render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 
-// Mock the telemetry serving client with a real-shaped, minimal payload.
 vi.mock("@/lib/telemetry/api", () => ({
   TELEMETRY_DEMO_ENV_ID: "telemetry-demo",
   TELEMETRY_DEMO_BUSINESS_ID: "biz-1",
   getSummary: vi.fn().mockResolvedValue({
-    kpi: {
-      promoted_models: 2,
-      anomaly_f1: 0.41,
-      rul_rmse: 18.2,
-      predictions: 2000,
-      test_runs: 46,
-      last_scored_at: "2026-06-22T00:00:00Z",
-      drift_monitors: 4,
-    },
-    inventory: { model_runs: 4, test_runs: 46, predictions: 2000 },
-    verdicts: { GO: 10, REVIEW: 2, NO_GO: 1 },
-    verdict_pct: { NO_GO: 0.08 },
+    kpi: { promoted_models: 4, anomaly_f1: 0.6387, rul_rmse: 20.32, predictions: 59898, test_runs: 43, last_scored_at: "2026-06-16T00:00:00Z", drift_monitors: 4 },
+    inventory: { model_runs: 6 },
+    verdicts: { GO: 59793, REVIEW: 31, NO_GO: 74 },
+    verdict_pct: { NO_GO: 0.001 },
     note: "operated history",
   }),
-  getModelPerformance: vi.fn().mockResolvedValue({ models: [] }),
-  getRuns: vi.fn().mockResolvedValue([]),
-  getFusedVectorInfo: vi.fn().mockResolvedValue(null),
 }));
 
-// The Bottleneck Map is a heavy recharts context module — stub it for this unit test.
-vi.mock("./context/BottleneckMap/BottleneckMap", () => ({ default: () => null }));
+// Stub the heavy Bottleneck Map (recharts) — its own tests cover its behavior.
+vi.mock("./context/BottleneckMap/BottleneckMap", () => ({ default: () => <div data-testid="bottleneck-map">charts</div> }));
 
 import TelemetryOverview from "./TelemetryOverview";
 
-describe("TelemetryOverview — data-backed Mission Summary", () => {
-  it("renders the executive page contract heading", async () => {
+describe("TelemetryOverview — charts-led Overview", () => {
+  it("renders the Overview heading and the launch-history Bottleneck Map charts", async () => {
     render(<TelemetryOverview envId="env-1" />);
-    expect(
-      await screen.findByText("Mission health, model posture, and operating readiness"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Why launch became a data problem")).toBeInTheDocument();
+    expect(screen.getByTestId("bottleneck-map")).toBeInTheDocument();
+    expect(screen.getByText(/Context · why launch became a data problem/i)).toBeInTheDocument();
   });
 
-  it("fails closed on Mission Readiness (no invented composite) and shows the null_reason", async () => {
+  it("shows the real telemetry KPI strip (genuine serving metrics)", async () => {
     render(<TelemetryOverview envId="env-1" />);
-    expect(await screen.findByText("Not available")).toBeInTheDocument();
-    expect(screen.getByText(/composite_formula_not_ratified/)).toBeInTheDocument();
+    expect(await screen.findByText("Promoted models")).toBeInTheDocument();
+    expect(screen.getByText("0.6387")).toBeInTheDocument(); // anomaly F1
+    expect(screen.getByText("59,898")).toBeInTheDocument(); // predictions
   });
 
-  it("shows real component inputs and a real as-of timestamp", async () => {
+  it("no longer renders the executive Mission Summary scaffolding", async () => {
     render(<TelemetryOverview envId="env-1" />);
-    // Operations component card built from real summary fields.
-    expect(await screen.findByText(/2,000 predictions · 46 runs/)).toBeInTheDocument();
-    expect(screen.getByText(/Data as of/)).toBeInTheDocument();
-  });
-
-  it("collapses Operational Leverage to a single fail-closed projection (not a card wall)", async () => {
-    render(<TelemetryOverview envId="env-1" />);
-    // Exactly one "Projection unavailable" now, not five large empty cards.
-    expect(await screen.findAllByText("Projection unavailable")).toHaveLength(1);
-  });
-
-  it("links to detail pages instead of re-hosting their tables (launchpads, no duplicate KPI strip)", async () => {
-    render(<TelemetryOverview envId="env-1" />);
-    expect(await screen.findByText("Continue the demo")).toBeInTheDocument();
-    // Launchpad cards link out; the Model Registry / Test Runs detail is NOT rendered inline.
-    expect(screen.getByText("Review model registry")).toBeInTheDocument();
-    expect(screen.getByText("Inspect test runs")).toBeInTheDocument();
-    expect(screen.getByText("Open metric lineage")).toBeInTheDocument();
-    // The old duplicate "Verdict distribution" panel is gone; scoring posture replaces it.
-    expect(screen.getByText("Current scoring posture")).toBeInTheDocument();
-    expect(screen.queryByText("Ingested test runs")).not.toBeInTheDocument();
+    await screen.findByTestId("bottleneck-map");
+    expect(screen.queryByText("Mission readiness")).not.toBeInTheDocument();
+    expect(screen.queryByText(/composite_formula_not_ratified/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Projection unavailable")).not.toBeInTheDocument();
+    expect(screen.queryByText("Continue the demo")).not.toBeInTheDocument();
   });
 });

--- a/repo-b/src/components/telemetry/TelemetryOverview.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-// Mission Summary — the executive landing. Concise conclusions, not a telemetry exhibit:
-// readiness (fail-closed), a one-line scoring posture, a compact operational-leverage strip, and
-// launchpads INTO the detail pages (Model Registry, Test Runs, System Health, Metric Lineage,
-// Test Intelligence) rather than re-hosting their tables here. Reads only /api/telemetry/summary;
-// every value is real or fails closed. Detail lives on its owning page.
+// Overview — the charts-led landing. Leads with a compact real-telemetry KPI strip (genuine product
+// metrics from the serving API), then the Spaceflight Bottleneck Map: the launch-attempts timeline,
+// who-flies commercial-vs-government, the cost-to-LEO curve, the pinned event record, and presenter
+// mode. The Bottleneck Map is a static public-data context module (no API) so it always renders; the
+// KPI strip is the only API-dependent part and fails closed. No executive "readiness"/"projection"
+// scaffolding here — real metrics + the launch-history charts.
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -12,67 +13,11 @@ import {
   getSummary, type TelemetrySummary,
   TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID,
 } from "@/lib/telemetry/api";
-import { C, Tag, Panel, Loading, ErrorState, PageHeading, DisclosureFooter } from "./primitives";
+import { C, StatGrid, MetricCard, PageHeading, DisclosureFooter } from "./primitives";
+import BottleneckMap from "./context/BottleneckMap/BottleneckMap";
 
 function num(n: number | null | undefined): string {
   return n == null ? "—" : Number(n).toLocaleString();
-}
-function formatTs(value?: string | null): string {
-  if (!value) return "as-of unknown";
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.valueOf()) ? value : parsed.toLocaleString();
-}
-
-// A readiness component-input card: a real headline value (or explicit "Not available here") + a
-// link to the surface that owns it. No composite score is computed here.
-function ComponentCard({ name, value, href, hrefLabel }: {
-  name: string; value: string; href: string; hrefLabel: string;
-}) {
-  return (
-    <div style={{ background: C.panel, border: `1px solid ${C.border}`, borderRadius: 9, padding: 14 }}>
-      <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, letterSpacing: "0.1em", textTransform: "uppercase" }}>{name}</div>
-      <div style={{ fontFamily: C.mono, fontSize: 13, color: C.text, marginTop: 8, lineHeight: 1.4, minHeight: 18 }}>{value}</div>
-      <Link href={href} style={{ fontFamily: C.mono, fontSize: 11, color: C.cyan, textDecoration: "none" }}>{hrefLabel} →</Link>
-    </div>
-  );
-}
-
-// A launchpad / "continue the demo" navigation card. Optional real sub-value; never a metric dump.
-function Launchpad({ title, sub, href }: { title: string; sub?: string; href: string }) {
-  return (
-    <Link href={href} style={{ textDecoration: "none", display: "block", background: C.panelHi,
-      border: `1px solid ${C.border}`, borderRadius: 9, padding: "12px 14px" }}>
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10 }}>
-        <span style={{ fontFamily: C.mono, fontSize: 12.5, color: C.text }}>{title}</span>
-        <span style={{ fontFamily: C.mono, fontSize: 13, color: C.cyan }}>→</span>
-      </div>
-      {sub && <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, marginTop: 5 }}>{sub}</div>}
-    </Link>
-  );
-}
-
-// Compact scoring posture — one slim GO / REVIEW / NO-GO bar from the live verdict distribution.
-function ScoringPosture({ verdicts }: { verdicts: Record<string, number> }) {
-  const order = [["GO", C.green], ["REVIEW", C.amber], ["NO_GO", C.red]] as const;
-  const total = Object.values(verdicts).reduce((a, b) => a + b, 0) || 1;
-  return (
-    <div>
-      <div style={{ display: "flex", height: 8, borderRadius: 5, overflow: "hidden", border: `1px solid ${C.border}` }}>
-        {order.map(([v, col]) => {
-          const n = verdicts[v] || 0;
-          return n ? <div key={v} title={`${v} ${n}`} style={{ width: `${(n / total) * 100}%`, background: col }} /> : null;
-        })}
-      </div>
-      <div style={{ display: "flex", gap: 16, marginTop: 9 }}>
-        {order.map(([v, col]) => (
-          <span key={v} style={{ display: "flex", alignItems: "center", gap: 6, fontFamily: C.mono, fontSize: 11, color: C.dim }}>
-            <span style={{ width: 8, height: 8, borderRadius: 2, background: col }} />
-            {v === "NO_GO" ? "NO-GO" : v} {num(verdicts[v] || 0)}
-          </span>
-        ))}
-      </div>
-    </div>
-  );
 }
 
 export default function TelemetryOverview({ envId }: { envId: string }) {
@@ -86,9 +31,9 @@ export default function TelemetryOverview({ envId }: { envId: string }) {
   }, []);
 
   const heading = (
-    <PageHeading eyebrow="Mission Summary"
-      title="Mission health, model posture, and operating readiness"
-      blurb="Executive summary read live from the telemetry serving API. Every value below is real or fails closed — nothing is seeded. Trace any governed number to its source on the Metric Lineage page."
+    <PageHeading eyebrow="Overview"
+      title="Why launch became a data problem"
+      blurb="Every era of spaceflight solved the previous bottleneck and exposed a new one — today it is decision velocity. The live telemetry platform that addresses it is in the tabs at left; the launch-history charts below frame why it matters. The KPI strip is read from the serving API; the history is public-data context."
       right={
         <Link href={`/lab/env/${envId}/telemetry/metric-lineage`}
           style={{ fontFamily: C.mono, fontSize: 13, fontWeight: 600, color: C.bg, background: C.cyan,
@@ -97,86 +42,45 @@ export default function TelemetryOverview({ envId }: { envId: string }) {
         </Link>
       } />
   );
-  if (error) return <>{heading}<ErrorState message={error} /></>;
-  if (!summary) return <>{heading}<Loading label="Loading mission summary…" /></>;
 
-  const k = summary.kpi;
-  const inv = summary.inventory;
-  const base = `/lab/env/${envId}/telemetry`;
+  const k = summary?.kpi;
+  const inv = summary?.inventory;
+  const noGoPct = summary?.verdict_pct?.NO_GO != null ? Math.round(summary.verdict_pct.NO_GO * 100) : null;
+
+  // Real telemetry KPI strip — genuine product metrics, fail-closed.
+  const kpiStrip = error ? (
+    <div style={{ border: `1px solid ${C.amber}33`, background: `${C.amber}0d`, borderRadius: 9, padding: "12px 14px",
+      fontFamily: C.mono, fontSize: 11.5, color: C.amber, lineHeight: 1.5 }}>
+      Live KPIs unavailable — serving API did not respond. null_reason: serving_unreachable. The launch-history
+      context below is static public data and still renders.
+    </div>
+  ) : !summary || !k || !inv ? (
+    <div style={{ fontFamily: C.mono, fontSize: 12.5, color: C.dim }}>Loading serving KPIs…</div>
+  ) : (
+    <StatGrid cols={4}>
+      <MetricCard label="Promoted models" value={String(k.promoted_models)} sub={`of ${inv.model_runs} evaluated`} />
+      <MetricCard label="Anomaly F1" value={k.anomaly_f1 != null ? Number(k.anomaly_f1).toFixed(4) : "—"} accent={C.cyan} />
+      <MetricCard label="RUL RMSE" value={k.rul_rmse != null ? Number(k.rul_rmse).toFixed(2) : "—"} accent={C.green} />
+      <MetricCard label="Predictions" value={num(k.predictions)}
+        sub={noGoPct != null ? `${noGoPct}% no-go · ${k.test_runs} runs` : undefined} accent={C.amber} />
+    </StatGrid>
+  );
 
   return (
     <>
       {heading}
 
-      {/* freshness / as-of — first-class, fail-closed */}
-      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", margin: "0 0 16px",
-        fontFamily: C.mono, fontSize: 11, color: C.dim }}>
-        <span style={{ width: 7, height: 7, borderRadius: 999, background: k.last_scored_at ? C.green : C.amber }} />
-        Data as of {formatTs(k.last_scored_at)} · live serving API · values real or fail closed
-      </div>
+      {kpiStrip}
 
-      {/* mission readiness — fail closed (no composite number until the formula is ratified) */}
-      <Panel title="Mission readiness" right={<Tag color={C.amber}>not available</Tag>}>
-        <div style={{ display: "flex", alignItems: "baseline", gap: 12, flexWrap: "wrap" }}>
-          <span style={{ fontFamily: C.sans, fontSize: 28, fontWeight: 700, color: C.amber, lineHeight: 1 }}>Not available</span>
-          <span style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, maxWidth: 560, lineHeight: 1.5 }}>
-            null_reason: composite_formula_not_ratified — readiness is a weighted composite; its formula and
-            weights are not ratified yet. The real component inputs are below.
-          </span>
+      {/* Spaceflight Bottleneck Map: launch timeline, commercial-vs-government, cost-to-LEO, event
+          record, and presenter mode. Static public-data context module. */}
+      <section aria-label="Spaceflight bottleneck — launch history" style={{ marginTop: 22 }}>
+        <div style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.14em", color: C.dim,
+          textTransform: "uppercase", marginBottom: 12 }}>
+          Context · why launch became a data problem
         </div>
-        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4" style={{ marginTop: 14 }}>
-          <ComponentCard name="Operations" value={`${num(k.predictions)} predictions · ${k.test_runs} runs`} href={`${base}/system-health`} hrefLabel="System Health" />
-          <ComponentCard name="Quality"
-            value={`F1 ${k.anomaly_f1 != null ? Number(k.anomaly_f1).toFixed(4) : "—"} · RMSE ${k.rul_rmse != null ? Number(k.rul_rmse).toFixed(2) : "—"}`}
-            href={`${base}/model-performance`} hrefLabel="Model performance" />
-          <ComponentCard name="Models" value={`${k.promoted_models} promoted / ${inv.model_runs} evaluated`} href={`${base}/registry`} hrefLabel="Model registry" />
-          <ComponentCard name="AI" value="Not available here" href={`${base}/governance`} hrefLabel="Trust Center" />
-        </div>
-      </Panel>
-
-      {/* compact scoring posture + operational leverage, side by side on desktop */}
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2" style={{ marginTop: 16 }}>
-        <Panel title="Current scoring posture" right={<Tag color={C.cyan}>{num(k.predictions)} scored</Tag>}>
-          <ScoringPosture verdicts={summary.verdicts} />
-          <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, marginTop: 10, lineHeight: 1.5 }}>
-            Live verdict distribution across scored events · governed prediction log.
-          </div>
-        </Panel>
-        <Panel title="Operational leverage — technical debt → launch impact" right={<Tag color={C.amber}>framework</Tag>}>
-          <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, lineHeight: 1.6 }}>
-            Tech debt → engineering throughput → test velocity → flight readiness → launch cadence.
-          </div>
-          <div style={{ fontFamily: C.mono, fontSize: 12, color: C.amber, marginTop: 10 }}>Projection unavailable</div>
-          <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 4, lineHeight: 1.5 }}>
-            requires a governed metric registry (modeled relationship + basis + confidence). No projection is invented.
-          </div>
-        </Panel>
-      </div>
-
-      {/* continue the demo — launchpads into detail pages (not metric duplicates) */}
-      <div style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.13em", color: C.faint,
-        textTransform: "uppercase", margin: "26px 0 12px" }}>
-        Continue the demo
-      </div>
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        <Launchpad title="Inspect live stream" href={`${base}/stream`} />
-        <Launchpad title="Open metric lineage" href={`${base}/metric-lineage`} />
-        <Launchpad title="Review model registry" sub={`${k.promoted_models} promoted / ${inv.model_runs} evaluated`} href={`${base}/registry`} />
-        <Launchpad title="Inspect test runs" sub={`${k.test_runs} runs · ${num(k.predictions)} prediction rows`} href={`${base}/runs`} />
-        <Launchpad title="System health" href={`${base}/system-health`} />
-        <Launchpad title="Ask grounded analyst" href={`${base}/copilot`} />
-      </div>
-
-      {/* historical context — subordinate takeaway only (full Bottleneck Map lives on its own surface) */}
-      <Panel title="Historical context" style={{ marginTop: 24 }} pad={16}>
-        <p style={{ fontFamily: C.mono, fontSize: 12, color: C.dim, lineHeight: 1.6, margin: 0 }}>
-          Current bottleneck: decision velocity. Launch cost fell; manufacturing complexity rose. The next gain
-          comes from faster, trusted telemetry-to-decision loops.
-        </p>
-        <Link href={`${base}/how-it-works`} style={{ fontFamily: C.mono, fontSize: 11, color: C.cyan, textDecoration: "none", display: "inline-block", marginTop: 10 }}>
-          How this works →
-        </Link>
-      </Panel>
+        <BottleneckMap />
+      </section>
 
       <DisclosureFooter />
     </>

--- a/repo-b/src/components/telemetry/TelemetrySidebar.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetrySidebar.test.tsx
@@ -20,7 +20,7 @@ describe("TelemetrySidebar — 6-section rail", () => {
       expect(links.some((l) => l.getAttribute("href") === telemetryHref("env-1", item.slug))).toBe(true);
     }
     // The four redesign relabels are present as links.
-    for (const label of ["Mission Summary", "Agent Control Tower", "Trust Center", "Flight Readiness"]) {
+    for (const label of ["Overview", "Agent Control Tower", "Trust Center", "Flight Readiness"]) {
       expect(screen.getAllByRole("link", { name: new RegExp(`^${label}$`, "i") }).length).toBeGreaterThanOrEqual(1);
     }
   });

--- a/repo-b/src/components/telemetry/telemetryNav.test.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.test.ts
@@ -8,7 +8,7 @@ import {
 describe("telemetry navigation structure (6-section redesign)", () => {
   it("exposes exactly the six redesign sections in order", () => {
     expect(TELEMETRY_NAV_GROUPS).toEqual([
-      "Mission Summary",
+      "Overview",
       "Operations",
       "Models & Intelligence",
       "Factory & Quality",
@@ -48,9 +48,9 @@ describe("telemetry navigation structure (6-section redesign)", () => {
     );
   });
 
-  it("applies the four redesign relabels without changing slugs", () => {
+  it("applies the redesign relabels without changing slugs", () => {
     const labelOf = (slug: string) => TELEMETRY_NAV.find((n) => n.slug === slug)?.label;
-    expect(labelOf("")).toBe("Mission Summary");
+    expect(labelOf("")).toBe("Overview");
     expect(labelOf("governance")).toBe("Trust Center");
     expect(labelOf("control-tower")).toBe("Agent Control Tower");
     expect(labelOf("factory-ml")).toBe("Flight Readiness");

--- a/repo-b/src/components/telemetry/telemetryNav.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.ts
@@ -4,7 +4,7 @@
 // Icon strings are 16x16 SVG path data, ported from the Option B reference.
 //
 // Sections follow the "Telemetry Experience Redesign" narrative order (ADO #692):
-// Mission Summary (conclusions) -> Operations (live/historical) -> Models & Intelligence
+// Overview (launch-history context + live KPIs) -> Operations (live/historical) -> Models & Intelligence
 // (how we know) -> Factory & Quality (what's broken) -> Evidence & Lineage (where it came
 // from) -> Agent Operations (execution). Six sections keeps primary nav within the shared
 // "<=7 primary items" rule. New pages (Program Control Tower, Metric Lineage Explorer,
@@ -12,7 +12,7 @@
 // phases; this phase only regroups the existing surfaces and relabels four of them.
 
 export type TelemetryNavGroup =
-  | "Mission Summary"
+  | "Overview"
   | "Operations"
   | "Models & Intelligence"
   | "Factory & Quality"
@@ -29,8 +29,8 @@ export type TelemetryNavItem = {
 };
 
 export const TELEMETRY_NAV: TelemetryNavItem[] = [
-  // Section 1 — Mission Summary (executive conclusions)
-  { slug: "", label: "Mission Summary", icon: "M2 9h3v5H2zM7 4h3v10H7zM12 7h3v7h-3z", group: "Mission Summary", mobilePrimary: true },
+  // Section 1 — Overview (launch-history context charts + live serving KPIs)
+  { slug: "", label: "Overview", icon: "M2 9h3v5H2zM7 4h3v10H7zM12 7h3v7h-3z", group: "Overview", mobilePrimary: true },
 
   // Section 2 — Operations (live + historical telemetry)
   { slug: "stream", label: "Mission Control", icon: "M2 12c2-6 10-6 12 0M8 3v3M8 8l3 3", group: "Operations", mobilePrimary: true },
@@ -62,7 +62,7 @@ export const TELEMETRY_NAV: TelemetryNavItem[] = [
 ];
 
 export const TELEMETRY_NAV_GROUPS: TelemetryNavGroup[] = [
-  "Mission Summary",
+  "Overview",
   "Operations",
   "Models & Intelligence",
   "Factory & Quality",
@@ -85,5 +85,5 @@ export function isTelemetryItemActive(pathname: string, envId: string, slug: str
 /** Label of the section owning the current pathname (for the mobile header). */
 export function telemetrySectionLabel(pathname: string, envId: string): string {
   const match = TELEMETRY_NAV.find((n) => n.slug && isTelemetryItemActive(pathname, envId, n.slug));
-  return match?.label ?? "Mission Summary";
+  return match?.label ?? "Overview";
 }


### PR DESCRIPTION
## What
Course-correction: the aggressive Mission Summary cut kept the executive scaffolding and dropped the launch-history charts — the reviewer wanted the opposite.

**Landing is now charts-led:**
- Compact **real-telemetry KPI strip** (promoted models, anomaly F1, RUL RMSE, predictions / no-go) — genuine serving metrics, fail-closed.
- The full **Spaceflight Bottleneck Map**: launch-attempts timeline, **who-flies commercial vs government**, **cost-to-LEO** curve, pinned event record, and **presenter mode**. (Component was never deleted — it had been demoted to a one-liner in #297; now re-rendered.)

**Removed** the executive scaffolding: Mission Readiness "Not available" composite, Operational Leverage "Projection unavailable", scoring-posture panel, launchpad grid, historical-context stub.

**Nav:** "Mission Summary" tab/section → **"Overview"** (slug unchanged); bottom-bar short label → "Overview".

## Guardrails
No fake values; KPI strip fails closed (static charts still render); RS palette retained.

## Tests
`vitest` full telemetry suite **91/91**; `tsc` + `next lint` clean.

ADO #704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)