### PR TITLE
feat(telemetry): Overview as a tabbed Bottleneck Map story module (ADO #706)

### DIFF
--- a/repo-b/src/app/lab/env/[envId]/telemetry/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/telemetry/page.tsx
@@ -1,10 +1,5 @@
 import TelemetryOverview from "@/components/telemetry/TelemetryOverview";
 
-export default async function TelemetryHomePage({
-  params,
-}: {
-  params: Promise<{ envId: string }>;
-}) {
-  const { envId } = await params;
-  return <TelemetryOverview envId={envId} />;
+export default function TelemetryHomePage() {
+  return <TelemetryOverview />;
 }

--- a/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
@@ -7,17 +7,17 @@ vi.mock("./context/BottleneckMap/BottleneckMap", () => ({ default: () => <div da
 import TelemetryOverview from "./TelemetryOverview";
 
 describe("TelemetryOverview — charts-led Overview", () => {
-  it("renders the Overview heading and the launch-history Bottleneck Map charts", () => {
-    render(<TelemetryOverview envId="env-1" />);
-    expect(screen.getByText("Why launch became a data problem")).toBeInTheDocument();
+  it("renders the dominant thesis header and the Bottleneck Map story module", () => {
+    render(<TelemetryOverview />);
+    expect(screen.getByRole("heading", { name: "Why launch became a data problem" })).toBeInTheDocument();
+    expect(screen.getByText(/Spaceflight moves by breaking what holds it back/i)).toBeInTheDocument();
     expect(screen.getByTestId("bottleneck-map")).toBeInTheDocument();
-    expect(screen.getByText(/Context · why launch became a data problem/i)).toBeInTheDocument();
   });
 
-  it("does not render the KPI strip or the executive Mission Summary scaffolding", () => {
-    render(<TelemetryOverview envId="env-1" />);
+  it("does not render the serving KPI strip, the Trace-lineage CTA, or Mission Summary scaffolding", () => {
+    render(<TelemetryOverview />);
     expect(screen.queryByText("Promoted models")).not.toBeInTheDocument();
-    expect(screen.queryByText("Anomaly F1")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Trace lineage/i)).not.toBeInTheDocument();
     expect(screen.queryByText("Mission readiness")).not.toBeInTheDocument();
     expect(screen.queryByText("Continue the demo")).not.toBeInTheDocument();
   });

--- a/repo-b/src/components/telemetry/TelemetryOverview.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.tsx
@@ -1,37 +1,33 @@
 "use client";
 
-// Overview — the launch-history landing. Leads straight into the Spaceflight Bottleneck Map: the
-// launch-attempts timeline, who-flies commercial-vs-government, the cost-to-LEO curve, the pinned
-// event record, and presenter mode. The Bottleneck Map is a static public-data context module (no
-// API). No KPI strip and no executive "readiness"/"projection" scaffolding here — just the charts.
+// Overview — the opening-argument page. A dominant thesis header states the idea once, then the
+// Spaceflight Bottleneck Map carries it as one large tabbed story module (Bottleneck Map / Cost to
+// LEO / Who Flies), with an editorial "Big Numbers" band and the Terran 1 event record. Static
+// public-data context module — no serving API, no KPI dashboard strip, no lineage CTA here.
 
-import Link from "next/link";
-import { C, PageHeading, DisclosureFooter } from "./primitives";
+import { C, DisclosureFooter } from "./primitives";
 import BottleneckMap from "./context/BottleneckMap/BottleneckMap";
 
-export default function TelemetryOverview({ envId }: { envId: string }) {
+export default function TelemetryOverview() {
   return (
     <>
-      <PageHeading eyebrow="Overview"
-        title="Why launch became a data problem"
-        blurb="Every era of spaceflight solved the previous bottleneck and exposed a new one — today it is decision velocity. The live telemetry platform that addresses it is in the tabs at left; the launch-history charts below frame why it matters."
-        right={
-          <Link href={`/lab/env/${envId}/telemetry/metric-lineage`}
-            style={{ fontFamily: C.mono, fontSize: 13, fontWeight: 600, color: C.bg, background: C.cyan,
-              border: "none", borderRadius: 8, padding: "10px 18px", textDecoration: "none" }}>
-            Trace lineage →
-          </Link>
-        } />
-
-      {/* Spaceflight Bottleneck Map: launch timeline, commercial-vs-government, cost-to-LEO, event
-          record, and presenter mode. Static public-data context module. */}
-      <section aria-label="Spaceflight bottleneck — launch history">
-        <div style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.14em", color: C.dim,
-          textTransform: "uppercase", marginBottom: 12 }}>
-          Context · why launch became a data problem
+      {/* Thesis header — dominant; states the argument once. */}
+      <header style={{ marginBottom: 26, maxWidth: 880 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
+          <span aria-hidden style={{ width: 18, height: 2, borderRadius: 2, background: C.cyan, boxShadow: `0 0 8px ${C.cyan}aa` }} />
+          <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.16em", color: C.cyan, textTransform: "uppercase" }}>Overview</span>
         </div>
-        <BottleneckMap />
-      </section>
+        <h1 style={{ fontFamily: C.sans, fontSize: 42, fontWeight: 800, letterSpacing: "-0.02em", lineHeight: 1.05, color: C.text, marginTop: 12 }}>
+          Why launch became a data problem
+        </h1>
+        <p style={{ fontFamily: C.sans, fontSize: 16, color: C.dim, lineHeight: 1.65, marginTop: 16 }}>
+          Spaceflight moves by breaking what holds it back. First, reaching orbit. Then lowering the cost. Then
+          flying again. Then building at scale. Now the hard part is speed of judgment: reading the telemetry,
+          trusting the model, tracing the source, and acting before delay becomes risk.
+        </p>
+      </header>
+
+      <BottleneckMap />
 
       <DisclosureFooter />
     </>

--- a/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.tsx
@@ -19,8 +19,15 @@ import MapPanel from "./MapPanel";
 import MixPanel from "./MixPanel";
 import PresenterBanner from "./PresenterBanner";
 import type {
-  ColorByKey, DecoratedEvent, KpiSummary, LaunchEvent, SizeModeKey, TimeWindow,
+  ColorByKey, DecoratedEvent, FocusPanelKey, KpiSummary, LaunchEvent, SizeModeKey, TimeWindow,
 } from "./types";
+
+// The three story tabs. Keys reuse FocusPanelKey so presenter-mode dimming math stays trivial.
+const TABS: { key: FocusPanelKey; label: string; accent: string }[] = [
+  { key: "map", label: "Bottleneck Map", accent: RS.blue },
+  { key: "cost", label: "Cost to LEO", accent: RS.amber },
+  { key: "mix", label: "Who Flies: Commercial vs Government", accent: RS.green },
+];
 
 // TODO(P2 backlog): deep-link state (selected event and toggles) into the URL query string for
 // shareable demo states.
@@ -44,6 +51,7 @@ export default function BottleneckMap() {
   const [hoveredYear, setHoveredYear] = useState<number | null>(null);
   const [timeWindow, setTimeWindow] = useState<TimeWindow>(FULL_WINDOW);
   const [presenterIdx, setPresenterIdx] = useState<number | null>(null);
+  const [activeTab, setActiveTab] = useState<FocusPanelKey>("map");
 
   const presenting = presenterIdx !== null;
   const presenterEvent = presenterIdx !== null ? EVENTS_CHRONO[presenterIdx] : null;
@@ -57,6 +65,10 @@ export default function BottleneckMap() {
 
   const dimension = COLOR_DIMENSIONS[colorBy];
   const windowed = timeWindow[0] !== FULL_WINDOW[0] || timeWindow[1] !== FULL_WINDOW[1];
+
+  // While presenting, the visible tab follows the current step's focusPanel so each narration beat
+  // shows its own chart; otherwise it's the user's selected tab. The tab bar hides while presenting.
+  const effectiveTab: FocusPanelKey = presenting && focusPanel ? focusPanel : activeTab;
 
   // Bubbles: resolve color/label for the active dimension; chip filter applies outside presenter mode.
   const mapEvents = useMemo<DecoratedEvent[]>(() => {
@@ -135,13 +147,8 @@ export default function BottleneckMap() {
 
   return (
     <div style={{ fontFamily: RS_SANS, color: RS.text }}>
-      {/* thesis subtitle + presenter toggle */}
-      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
-        <p style={{ color: RS.dim, fontSize: 13, margin: 0, maxWidth: 680 }}>
-          Every leap solved the previous era&apos;s bottleneck and exposed a new one. The current
-          bottleneck is decision velocity. All four panels derive from one event model:
-          select, hover, or brush anywhere and the rest follows.
-        </p>
+      {/* presenter toggle — the thesis lives once in the page header above */}
+      <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 4 }}>
         <button type="button" className={styles.control}
           aria-label={presenting ? "Exit presenter mode" : "Enter presenter mode"}
           aria-pressed={presenting}
@@ -167,81 +174,113 @@ export default function BottleneckMap() {
 
       <KpiStrip kpi={kpi} presenting={presenting} windowed={windowed} inflationAdjusted={inflationAdjusted} />
 
-      {/* controls row */}
+      {/* tabbed story module: tab bar (hidden while presenting) + per-tab controls */}
       {!presenting && (
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 8, margin: "14px 0 4px", alignItems: "center" }}>
-          {Object.entries(dimension.lookup).map(([key, v]) => (
-            <button key={key} type="button" className={styles.control}
-              aria-pressed={chipFilter === key}
-              onClick={() => setChipFilter(chipFilter === key ? null : key)}
-              style={{
-                display: "flex", alignItems: "center", gap: 6,
-                background: chipFilter === key ? `${v.color}22` : "transparent",
-                border: `1px solid ${chipFilter === key ? v.color : RS.line}`,
-                borderRadius: 999, padding: "4px 10px", cursor: "pointer",
-                color: chipFilter === key ? v.color : RS.dim,
-                fontFamily: RS_MONO, fontSize: 10, letterSpacing: 0.5,
-                opacity: chipFilter && chipFilter !== key ? 0.45 : 1,
-              }}>
-              <span style={{ width: 8, height: 8, borderRadius: "50%", background: v.color }} />
-              {v.label}
-            </button>
-          ))}
+        <div style={{ marginTop: 16 }}>
+          <div role="tablist" aria-label="Launch-history charts"
+            style={{ display: "flex", gap: 0, borderBottom: `1px solid ${RS.line}`, flexWrap: "wrap" }}>
+            {TABS.map((t) => (
+              <button key={t.key} type="button" role="tab" className={styles.control}
+                aria-selected={effectiveTab === t.key}
+                onClick={() => setActiveTab(t.key)}
+                style={{
+                  background: "transparent", border: "none",
+                  borderBottom: `2px solid ${effectiveTab === t.key ? t.accent : "transparent"}`,
+                  color: effectiveTab === t.key ? RS.text : RS.faint,
+                  padding: "9px 16px", marginBottom: -1, cursor: "pointer", whiteSpace: "nowrap",
+                  fontFamily: RS_MONO, fontSize: 11.5, letterSpacing: 0.4,
+                }}>
+                {t.label}
+              </button>
+            ))}
+          </div>
 
-          <div style={{ marginLeft: "auto", display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
-            {/* color dimension */}
-            <div style={{ display: "flex", border: `1px solid ${RS.line}`, borderRadius: 6, overflow: "hidden" }}>
-              {(Object.keys(COLOR_DIMENSIONS) as ColorByKey[]).map((key) => (
-                <button key={key} type="button" className={styles.control}
-                  aria-pressed={colorBy === key}
-                  onClick={() => { setColorBy(key); setChipFilter(null); }}
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8, margin: "12px 0 4px", alignItems: "center", minHeight: 32 }}>
+            {effectiveTab === "map" && (
+              <>
+                {Object.entries(dimension.lookup).map(([key, v]) => (
+                  <button key={key} type="button" className={styles.control}
+                    aria-pressed={chipFilter === key}
+                    onClick={() => setChipFilter(chipFilter === key ? null : key)}
+                    style={{
+                      display: "flex", alignItems: "center", gap: 6,
+                      background: chipFilter === key ? `${v.color}22` : "transparent",
+                      border: `1px solid ${chipFilter === key ? v.color : RS.line}`,
+                      borderRadius: 999, padding: "4px 10px", cursor: "pointer",
+                      color: chipFilter === key ? v.color : RS.dim,
+                      fontFamily: RS_MONO, fontSize: 10, letterSpacing: 0.5,
+                      opacity: chipFilter && chipFilter !== key ? 0.45 : 1,
+                    }}>
+                    <span style={{ width: 8, height: 8, borderRadius: "50%", background: v.color }} />
+                    {v.label}
+                  </button>
+                ))}
+                <div style={{ marginLeft: "auto", display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+                  <div style={{ display: "flex", border: `1px solid ${RS.line}`, borderRadius: 6, overflow: "hidden" }}>
+                    {(Object.keys(COLOR_DIMENSIONS) as ColorByKey[]).map((key) => (
+                      <button key={key} type="button" className={styles.control}
+                        aria-pressed={colorBy === key}
+                        onClick={() => { setColorBy(key); setChipFilter(null); }}
+                        style={{
+                          background: colorBy === key ? RS.barFill : "transparent",
+                          color: colorBy === key ? RS.text : RS.faint,
+                          border: "none", padding: "5px 10px", cursor: "pointer",
+                          fontFamily: RS_MONO, fontSize: 9.5, letterSpacing: 0.3,
+                        }}>
+                        {COLOR_DIMENSIONS[key].label}
+                      </button>
+                    ))}
+                  </div>
+                  <div style={{ display: "flex", border: `1px solid ${RS.line}`, borderRadius: 6, overflow: "hidden" }}>
+                    {SIZE_MODES.map((m) => (
+                      <button key={m.key} type="button" className={styles.control} title={m.note}
+                        aria-pressed={sizeMode === m.key}
+                        onClick={() => setSizeMode(m.key)}
+                        style={{
+                          background: sizeMode === m.key ? RS.barFill : "transparent",
+                          color: sizeMode === m.key ? RS.text : RS.faint,
+                          border: "none", padding: "5px 10px", cursor: "pointer",
+                          fontFamily: RS_MONO, fontSize: 9.5, letterSpacing: 0.3,
+                        }}>
+                        {m.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </>
+            )}
+            {effectiveTab === "cost" && (
+              <>
+                <button type="button" className={styles.control}
+                  aria-label="Emphasize inflation-adjusted cost"
+                  aria-pressed={inflationAdjusted}
+                  onClick={() => setInflationAdjusted(!inflationAdjusted)}
                   style={{
-                    background: colorBy === key ? RS.barFill : "transparent",
-                    color: colorBy === key ? RS.text : RS.faint,
-                    border: "none", padding: "5px 10px", cursor: "pointer",
+                    display: "flex", alignItems: "center", gap: 7,
+                    background: inflationAdjusted ? `${RS.amber}18` : "transparent",
+                    border: `1px solid ${inflationAdjusted ? RS.amber : RS.line}`,
+                    borderRadius: 6, padding: "5px 10px", cursor: "pointer",
+                    color: inflationAdjusted ? RS.amber : RS.faint,
                     fontFamily: RS_MONO, fontSize: 9.5, letterSpacing: 0.3,
                   }}>
-                  {COLOR_DIMENSIONS[key].label}
+                  <span style={{ width: 22, height: 12, borderRadius: 999, position: "relative",
+                    background: inflationAdjusted ? RS.amber : RS.line, transition: "background 0.15s" }}>
+                    <span style={{ position: "absolute", top: 1.5, left: inflationAdjusted ? 11.5 : 1.5,
+                      width: 9, height: 9, borderRadius: "50%", background: RS.bg, transition: "left 0.15s" }} />
+                  </span>
+                  Inflation adjusted (2025 $)
                 </button>
-              ))}
-            </div>
-            {/* size mode */}
-            <div style={{ display: "flex", border: `1px solid ${RS.line}`, borderRadius: 6, overflow: "hidden" }}>
-              {SIZE_MODES.map((m) => (
-                <button key={m.key} type="button" className={styles.control} title={m.note}
-                  aria-pressed={sizeMode === m.key}
-                  onClick={() => setSizeMode(m.key)}
-                  style={{
-                    background: sizeMode === m.key ? RS.barFill : "transparent",
-                    color: sizeMode === m.key ? RS.text : RS.faint,
-                    border: "none", padding: "5px 10px", cursor: "pointer",
-                    fontFamily: RS_MONO, fontSize: 9.5, letterSpacing: 0.3,
-                  }}>
-                  {m.label}
-                </button>
-              ))}
-            </div>
-            {/* inflation emphasis */}
-            <button type="button" className={styles.control}
-              aria-label="Emphasize inflation-adjusted cost"
-              aria-pressed={inflationAdjusted}
-              onClick={() => setInflationAdjusted(!inflationAdjusted)}
-              style={{
-                display: "flex", alignItems: "center", gap: 7,
-                background: inflationAdjusted ? `${RS.amber}18` : "transparent",
-                border: `1px solid ${inflationAdjusted ? RS.amber : RS.line}`,
-                borderRadius: 6, padding: "5px 10px", cursor: "pointer",
-                color: inflationAdjusted ? RS.amber : RS.faint,
-                fontFamily: RS_MONO, fontSize: 9.5, letterSpacing: 0.3,
-              }}>
-              <span style={{ width: 22, height: 12, borderRadius: 999, position: "relative",
-                background: inflationAdjusted ? RS.amber : RS.line, transition: "background 0.15s" }}>
-                <span style={{ position: "absolute", top: 1.5, left: inflationAdjusted ? 11.5 : 1.5,
-                  width: 9, height: 9, borderRadius: "50%", background: RS.bg, transition: "left 0.15s" }} />
-              </span>
-              Inflation adjusted (2025 $)
-            </button>
-            {windowed && (
+                {windowed && (
+                  <button type="button" className={styles.control}
+                    onClick={() => setTimeWindow(FULL_WINDOW)}
+                    style={{ background: "transparent", border: `1px solid ${RS.line}`, color: RS.dim,
+                      borderRadius: 6, padding: "5px 10px", cursor: "pointer", fontFamily: RS_MONO, fontSize: 9.5 }}>
+                    Reset window
+                  </button>
+                )}
+              </>
+            )}
+            {effectiveTab === "mix" && windowed && (
               <button type="button" className={styles.control}
                 onClick={() => setTimeWindow(FULL_WINDOW)}
                 style={{ background: "transparent", border: `1px solid ${RS.line}`, color: RS.dim,
@@ -253,24 +292,26 @@ export default function BottleneckMap() {
         </div>
       )}
 
-      {/* panel 1: the bottleneck map */}
-      <div style={{ marginTop: 10 }}>
-        <MapPanel events={mapEvents} selectedId={selected?.id ?? null}
-          presenting={presenting} revealedIds={revealedIds} presenterYear={presenterYear}
-          timeWindow={windowed ? timeWindow : null} hoveredYear={hoveredYear}
-          sizeModeLabel={SIZE_MODES.find((m) => m.key === sizeMode)?.label ?? ""}
-          focused={focusPanel === "map"} dimmed={presenting && focusPanel !== "map"}
-          onHoverYear={onHoverYear} onSelect={onSelect} />
-      </div>
-
-      {/* panels 2 + 3: cost curve and funding mix */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-2.5" style={{ marginTop: 10 }}>
-        <CostPanel inflationAdjusted={inflationAdjusted} hoveredYear={hoveredYear}
-          focused={focusPanel === "cost"} dimmed={presenting && focusPanel !== "cost"}
-          onHoverYear={onHoverYear} />
-        <MixPanel hoveredYear={hoveredYear}
-          focused={focusPanel === "mix"} dimmed={presenting && focusPanel !== "mix"}
-          onHoverYear={onHoverYear} onBrush={onBrush} />
+      {/* one large tabbed panel — only the active tab renders, full width + tall */}
+      <div style={{ marginTop: 12 }}>
+        {effectiveTab === "map" && (
+          <MapPanel events={mapEvents} selectedId={selected?.id ?? null}
+            presenting={presenting} revealedIds={revealedIds} presenterYear={presenterYear}
+            timeWindow={windowed ? timeWindow : null} hoveredYear={hoveredYear}
+            sizeModeLabel={SIZE_MODES.find((m) => m.key === sizeMode)?.label ?? ""}
+            focused={focusPanel === "map"} dimmed={presenting && focusPanel !== "map"}
+            onHoverYear={onHoverYear} onSelect={onSelect} />
+        )}
+        {effectiveTab === "cost" && (
+          <CostPanel inflationAdjusted={inflationAdjusted} hoveredYear={hoveredYear}
+            focused={focusPanel === "cost"} dimmed={presenting && focusPanel !== "cost"}
+            onHoverYear={onHoverYear} />
+        )}
+        {effectiveTab === "mix" && (
+          <MixPanel hoveredYear={hoveredYear}
+            focused={focusPanel === "mix"} dimmed={presenting && focusPanel !== "mix"}
+            onHoverYear={onHoverYear} onBrush={onBrush} />
+        )}
       </div>
 
       {/* panel 4: pinned event record */}

--- a/repo-b/src/components/telemetry/context/BottleneckMap/CostPanel.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/CostPanel.tsx
@@ -62,9 +62,9 @@ export default function CostPanel({ inflationAdjusted, hoveredYear, focused, dim
 
   return (
     <PanelShell title="Cost to LEO" accent={RS.amber}
-      sub={`log scale · ${inflationAdjusted ? "2025 $ emphasized" : "nominal $ emphasized"}`}
+      sub={`Cost per kilogram to orbit fell ~94% since Apollo · log scale · ${inflationAdjusted ? "2025 $" : "nominal $"} emphasized`}
       focused={focused} dimmed={dimmed}>
-      <ResponsiveContainer width="100%" height={180}>
+      <ResponsiveContainer width="100%" height={460}>
         <ComposedChart data={YEAR_SERIES} margin={{ top: 16, right: 16, bottom: 4, left: 0 }}
           onMouseMove={(s) => onHoverYear(yearFromChartState(s))} onMouseLeave={() => onHoverYear(null)}>
           <CartesianGrid stroke={RS.line} strokeDasharray="2 6" vertical={false} />

--- a/repo-b/src/components/telemetry/context/BottleneckMap/KpiStrip.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/KpiStrip.tsx
@@ -28,14 +28,22 @@ export default function KpiStrip({ kpi, presenting, windowed, inflationAdjusted 
   inflationAdjusted: boolean;
 }) {
   return (
-    <div className="grid grid-cols-2 xl:grid-cols-4 gap-2.5" style={{ marginTop: 14 }}>
-      <KpiTile label="Active window" value={kpi.window} color={RS.text}
-        sub={presenting ? "presenter mode" : windowed ? "brushed" : "full range"} />
-      <KpiTile label="Orbital attempts" value={kpi.attempts} color={RS.blue} sub="in window" />
-      <KpiTile label="Commercial share" value={kpi.share} color={RS.green}
-        sub={kpi.shareYear != null ? `as of ${kpi.shareYear}` : ""} />
-      <KpiTile label="Cost to LEO" value={kpi.cost} color={RS.amber}
-        sub={`${kpi.costLabel}${inflationAdjusted ? ", 2025 $" : ", nominal"}`} />
+    <div style={{ marginTop: 16 }}>
+      {/* Editorial "Big Numbers" band — supports the argument; not a dashboard. The two numbers that
+          carry the story (commercial share rising, cost falling) keep a subtle accent; the framing
+          two are muted. */}
+      <div style={{ fontFamily: RS_MONO, fontSize: 10, letterSpacing: "0.18em", textTransform: "uppercase", color: RS.faint, marginBottom: 9 }}>
+        Big Numbers
+      </div>
+      <div className="grid grid-cols-2 xl:grid-cols-4 gap-2.5">
+        <KpiTile label="Timeline" value={kpi.window} color={RS.text}
+          sub={presenting ? "presenter mode" : windowed ? "brushed" : "full range"} />
+        <KpiTile label="Launch attempts" value={kpi.attempts} color={RS.text} sub="in window" />
+        <KpiTile label="Commercial share" value={kpi.share} color={RS.green}
+          sub={kpi.shareYear != null ? `as of ${kpi.shareYear}` : ""} />
+        <KpiTile label="Cost per kg to LEO" value={kpi.cost} color={RS.amber}
+          sub={`${kpi.costLabel}${inflationAdjusted ? ", 2025 $" : ", nominal"}`} />
+      </div>
     </div>
   );
 }

--- a/repo-b/src/components/telemetry/context/BottleneckMap/MapPanel.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/MapPanel.tsx
@@ -38,6 +38,7 @@ function MapTip({ active, payload }: TooltipProps<number, string>) {
       </div>
       <div style={{ color: RS.text, fontWeight: 600, fontSize: 13, marginTop: 4 }}>{d.name}</div>
       <div style={{ color: RS.dim, fontSize: 11, marginTop: 4 }}>Solved: {d.bottleneckSolved}</div>
+      <div style={{ color: RS.faint, fontSize: 10, marginTop: 4, fontFamily: RS_MONO, textTransform: "uppercase", letterSpacing: 0.5 }}>{d.outcome}</div>
       <div style={{ color: RS.faint, fontSize: 10, marginTop: 6, fontFamily: RS_MONO }}>Click to pin full record</div>
     </div>
   );
@@ -101,9 +102,9 @@ export default function MapPanel({
 
   return (
     <PanelShell title="Bottleneck Map" accent={RS.blue}
-      sub="bubbles: events · bars: world orbital attempts/yr"
+      sub="Each leap solved one bottleneck and exposed the next — now it is decision velocity · bubbles: events · bars: world orbital attempts/yr"
       focused={focused} dimmed={dimmed}>
-      <div className="h-[260px] lg:h-[350px]">
+      <div className="h-[460px] lg:h-[560px]">
         <ResponsiveContainer width="100%" height="100%">
           <ComposedChart data={YEAR_SERIES} margin={{ top: 12, right: 28, bottom: 4, left: 8 }}
             onMouseMove={(s) => onHoverYear(yearFromChartState(s))} onMouseLeave={() => onHoverYear(null)}>

--- a/repo-b/src/components/telemetry/context/BottleneckMap/MixPanel.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/MixPanel.tsx
@@ -37,9 +37,9 @@ export default function MixPanel({ hoveredYear, focused, dimmed, onHoverYear, on
 }) {
   return (
     <PanelShell title="Who flies: commercial vs government" accent={RS.green}
-      sub="share of orbital attempts · drag below to brush"
+      sub="Commercial share of orbital attempts climbed from ~0% to ~70% in 25 years · drag below to brush"
       focused={focused} dimmed={dimmed}>
-      <ResponsiveContainer width="100%" height={180}>
+      <ResponsiveContainer width="100%" height={460}>
         <ComposedChart data={YEAR_SERIES} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}
           onMouseMove={(s) => onHoverYear(yearFromChartState(s))} onMouseLeave={() => onHoverYear(null)}>
           <CartesianGrid stroke={RS.line} strokeDasharray="2 6" vertical={false} />


### PR DESCRIPTION
## What
Reframes the Overview into a polished, interactive opening argument.

- **Dominant thesis header** (42px) "Why launch became a data problem" + one tightened subheader. Removed the **duplicated** thesis line (it appeared in both the page blurb and inside the Bottleneck Map) and the **Trace-lineage CTA** (belongs on Mission Summary / Metric Lineage, not the history page).
- **Big Numbers** band — KpiStrip reframed editorially (same 4 real values, muted + relabeled: Timeline / Launch attempts / Commercial share / Cost per kg).
- **One large tabbed story module** replacing the 3 stacked charts: tabs **Bottleneck Map / Cost to LEO / Who Flies: Commercial vs Government**. Only the active tab renders, full-width + tall (~560px). Chart-specific controls moved under their tab (chips/colorBy/sizeMode → Map; inflation + reset → Cost; brush → Mix). Per-tab narrative takeaway in each panel subtitle; richer Map tooltip (outcome).
- **EventRecord (Terran 1)** stays at the bottom; methodology footer unchanged.
- **Presenter mode preserved** — while presenting, the visible tab follows each step's `focusPanel` so every beat shows its own chart; tab bar hides.

## Guardrails
Shared event model (select/hover/brush → EventRecord + KpiStrip) untouched. Static public-data context; no fake values.

## Tests
`vitest` BottleneckMap **8/8** (KpiStrip values, methodology footer, Terran 1, presenter aria-labels + 1/16→2/16, "Mission achievement" chip + "Funding model"→"Fixed-price commercial"), full telemetry **90/90**; `tsc` + `next lint` clean.

ADO #706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)