### PR TITLE
chore(security): redact plaintext admin password from ai-testing handoff docs

### DIFF
--- a/docs/ai-testing/2026-04-11-chatgpt-agent-mode-handoff.md
+++ b/docs/ai-testing/2026-04-11-chatgpt-agent-mode-handoff.md
@@ -10,7 +10,7 @@ You are testing Winston as a real user on the live site and must return a concis
 - Site: `https://paulmalmquist.com`
 - Primary login URL: `https://paulmalmquist.com/login`
 - Email: `info@novendor.ai`
-- Password: `winston2026!`
+- Password: see `docs/reference/ENV_KEYS.md` (`NOVENDOR_ADMIN_PASSWORD`) — not stored in plaintext here
 
 ### Goal
 Test Winston's front-end agent mode based on the most recent development work and conversation history themes from today. Focus on real user behavior, not implementation details.

--- a/docs/ai-testing/2026-04-18-chatgpt-agent-mode-handoff.md
+++ b/docs/ai-testing/2026-04-18-chatgpt-agent-mode-handoff.md
@@ -10,7 +10,7 @@ You are testing Winston on the live site as a real end user after deployment. Yo
 - Site: `https://paulmalmquist.com`
 - Primary login URL: `https://paulmalmquist.com/login`
 - Email: `info@novendor.ai`
-- Password: `winston2026!`
+- Password: see `docs/reference/ENV_KEYS.md` (`NOVENDOR_ADMIN_PASSWORD`) — not stored in plaintext here
 
 ### Goal
 Verify four things:
@@ -30,7 +30,7 @@ Verify four things:
 
 ### Login and environment access instructions
 1. Open `https://paulmalmquist.com/login`.
-2. Sign in with `info@novendor.ai` and `winston2026!`.
+2. Sign in with `info@novendor.ai` (password in `docs/reference/ENV_KEYS.md`).
 3. Note where login lands you: `/app`, an environment home, or an environment selector.
 4. Confirm whether this account can access these branded entries:
    - `https://paulmalmquist.com/novendor/login`


### PR DESCRIPTION
Two April handoff docs committed the admin password in plaintext. Redacted to a pointer to `docs/reference/ENV_KEYS.md` (`NOVENDOR_ADMIN_PASSWORD`). **The value remains in git history — recommend rotating the credential.** Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)