### PR TITLE
feat(telemetry): conformal lower-bound RUL go/no-go (Phase 2, Story #716)

### DIFF
--- a/PLAN_DIVERGENCE_REVIEW.md
+++ b/PLAN_DIVERGENCE_REVIEW.md
@@ -270,3 +270,24 @@ evidence**. The Overview/Bottleneck Map gets attention; these pages defend the c
 - **Phases 2–6** (conformal lower-bound RUL, FD004 regime-conditioning, pre-test competence envelope,
   event-windowed analog retrieval, secondary findings) remain open; each is its own intake'd unit. Databricks
   access is available (`~/.databrickscfg`), so they are runnable with real data.
+
+---
+
+## Status — Phase 2 shipped (Spin 3, Story #716)
+
+Conformal lower-bound RUL go/no-go is built and **measured from real FD001 data** (split conformal,
+unit-grouped calibration):
+- measured **PICP 0.86** (two-sided) at a 0.90 target; lower-bound coverage 0.85; PINAW 0.448 (mean width 56
+  cycles); point RMSE 20.96.
+- operator gate on the calibrated **lower bound**: **15/100 units GO on the point estimate but flagged** by the
+  lower bound; **22 units disagree** between the two gates.
+- honest framing: PICP is slightly under nominal (n=30 calibration units; marginal intervals; FD001
+  single-condition). A first calibration on near-failure last cycles under-covered (PICP 0.44) — the measured
+  fix was to calibrate on operational-cycle rows matching the test-time RUL distribution. That break-then-fix is
+  itself the judgment artifact.
+- reproducible: `telemetry-platform/compute_rul_conformal.py` (real Databricks pull) → `rul_conformal_evidence.json`;
+  pure math in `conformal_core.py` with `test_conformal_core.py` (4 tests, numpy-only/CI-safe).
+- surface: `RulConformalCard` on `/telemetry/evidence` (computed artifact, not live serving).
+
+Phases 3–6 (FD004 regime-conditioning, pre-test competence envelope, event-windowed analog retrieval, secondary
+findings) remain open, each its own intake'd unit.

--- a/claim_coverage_matrix.md
+++ b/claim_coverage_matrix.md
@@ -42,3 +42,15 @@ surfacing) · **PARTIAL** · **LIABILITY** (collapses under scrutiny) · **WEAK*
 and prod-verified on novendor.ai (Story #707). The live-streaming row's follow-up is **done** — Stargate
 serves live capture replay and the Start control returns 200. Rows tied to Phases 2–6 (conformal RUL intervals,
 regime-conditioned anomaly, competence-envelope drift, telemetry analog retrieval) update as those findings land.
+
+---
+
+**Status (Phase 2 — conformal RUL, Story #716):** RUL is no longer point-prediction only. Split-conformal
+intervals are computed from real C-MAPSS FD001 data (unit-grouped calibration): **measured PICP 0.86**
+(two-sided) at a 0.90 target — near-nominal, slightly under — lower-bound coverage 0.85, mean width 56 cycles,
+point RMSE 20.96. The operator gate can clear on the calibrated **lower bound**: **15 of 100 units look GO on
+the point estimate but the conformal lower bound flags them** (REVIEW/NO-GO); 22 units disagree between the two
+gates. Surface: the RUL conformal card on `/telemetry/evidence` (computed evidence artifact, FD001, *not live
+serving*). **Must NOT overclaim:** PICP ~0.86 is slightly under the 0.90 target — present as *measured*, not
+guaranteed; intervals are marginal on FD001 single-condition data, not conditional or transferable to hot-fire
+regimes. **Brier** remains absent for telemetry (probabilistic-work talk-track only).

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4132,3 +4132,29 @@ Inventory of the real data behind the telemetry env (full per-surface contracts 
   renders "SIGN IN" (CSS uppercase); a `text=Sign in` click can miss — submit with
   `page.press("input[type=password]", "Enter")` instead. (3) The backend root `GET /version` is not under the
   `/api/telemetry` catch-all, so the frontend reads it through a dedicated `/api/version` proxy route handler.
+
+## Conformal lower-bound RUL (Phase 2, Story #716)
+
+- **Split conformal in ~30 lines, no heavy deps.** Pure numpy in `telemetry-platform/conformal_core.py`:
+  nonconformity quantile = `ceil((n+1)(1-alpha))/n` empirical quantile (finite-sample valid); two-sided
+  `[pred±qhat]`; one-sided lower = `pred - quantile(over-prediction residuals)`. Keep the math in a
+  Databricks-free module so the eval test runs without credentials.
+- **Calibration exchangeability is the whole game.** C-MAPSS test units truncate at a *varied* point in life, so
+  their last-cycle RUL spans a wide range. Calibrating on held-out TRAIN units' *last* cycles (all near-failure,
+  small RUL) breaks exchangeability and badly under-covers — **measured PICP 0.44 vs a 0.90 target**. Calibrate
+  on a random *operational* cycle per held-out unit (matching the score-at-an-arbitrary-point distribution) and
+  PICP recovers to **~0.86**. Report measured PICP honestly; near-nominal-but-under is a real result, not
+  something to hide.
+- **Lower-bound safety gating.** For a go/no-go, clear a unit on the calibrated **lower bound** of remaining
+  life, never the point estimate. The demo moment is the disagreement count: N units look GO on the point
+  estimate but the lower bound demands REVIEW/NO-GO.
+- **Databricks pull without a PAT.** `auth_gate.py` only checks `DATABRICKS_PAT`/`claude_token.txt`, but the CLI
+  and SDK authenticate via the OAuth profile in `~/.databrickscfg`. Use
+  `WorkspaceClient(profile='PaulMain').statement_execution.execute_statement(warehouse_id=…, disposition=INLINE,
+  format=JSON_ARRAY)`, page chunks via `get_statement_result_chunk_n`, start the serverless warehouse on demand.
+  Early-cycle rolling / rate-of-change gold features are NaN until their window fills — impute with train-median
+  (medians from fit rows only, no leakage).
+- **Evidence-artifact pattern for ML results.** Persist computed metrics as a committed JSON (in
+  `telemetry-platform/` plus a copy under `repo-b/src/lib/telemetry/`), import it into a card, and label it
+  "computed evidence artifact · not live serving" with `as_of` + the calibration-split description. Real numbers,
+  reproducible, never claimed as live.

--- a/repo-b/src/components/telemetry/EvidenceCards.tsx
+++ b/repo-b/src/components/telemetry/EvidenceCards.tsx
@@ -9,6 +9,7 @@
 
 import { C } from "./primitives";
 import ModelEvidenceCard from "./ModelEvidenceCard";
+import RulConformalCard from "./RulConformalCard";
 import PipelineEvidenceCard from "./PipelineEvidenceCard";
 import FeatureContractCard from "./FeatureContractCard";
 import KnownAnomalyCard from "./KnownAnomalyCard";
@@ -47,6 +48,8 @@ export default function EvidenceCards() {
     <div>
       <Lead />
       <ModelEvidenceCard />
+      <Divider />
+      <RulConformalCard />
       <Divider />
       <PipelineEvidenceCard />
       <Divider />

--- a/repo-b/src/components/telemetry/RulConformalCard.test.tsx
+++ b/repo-b/src/components/telemetry/RulConformalCard.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import RulConformalCard from "./RulConformalCard";
+import evidence from "@/lib/telemetry/rulConformalEvidence.json";
+
+// The card renders a committed, computed evidence artifact (real FD001 conformal run).
+// These assertions track the artifact's structure + headline, not hand-typed numbers.
+describe("RulConformalCard", () => {
+  it("renders the conformal metrics and the lower-bound clearance headline", () => {
+    render(<RulConformalCard />);
+    expect(screen.getAllByText(/lower bound/i).length).toBeGreaterThan(0);
+    // computed-artifact label (never claims live serving)
+    expect(screen.getByText(/not live serving/i)).toBeInTheDocument();
+    // measured PICP shown as a percentage
+    const picp = `${(evidence.metrics.picp_two_sided * 100).toFixed(1)}%`;
+    expect(screen.getAllByText(picp).length).toBeGreaterThan(0);
+    // the point-vs-lower-bound flagged headline
+    const flags = evidence.gate.point_go_but_lower_bound_flags;
+    expect(screen.getAllByText(new RegExp(`${flags} of ${evidence.n_test_units}`)).length).toBeGreaterThan(0);
+    // at least one example unit row (first example's unit id appears)
+    expect(screen.getByText(String(evidence.examples[0].unit))).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/RulConformalCard.tsx
+++ b/repo-b/src/components/telemetry/RulConformalCard.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+// RUL conformal lower-bound go/no-go. Renders a COMPUTED EVIDENCE ARTIFACT
+// (repo-b/src/lib/telemetry/rulConformalEvidence.json), produced by
+// telemetry-platform/compute_rul_conformal.py from real C-MAPSS FD001 data on
+// Databricks — split conformal with a unit-grouped calibration split. It is a
+// reproducible snapshot, explicitly labeled "not live serving". No value is
+// seeded: if the artifact is missing required fields the card fails closed.
+//
+// Before this card, RUL was point-prediction only (model card: "point predictions
+// only — no interval"). After it, RUL carries measured conformal interval evidence,
+// and the operator gate can clear on the calibrated LOWER BOUND, not just the point.
+
+import evidence from "@/lib/telemetry/rulConformalEvidence.json";
+import { C, EmptyState, MetricCard, PageHeading, Panel, ScrollTable, StatGrid, Tag, verdictColor } from "./primitives";
+
+type GateKey = "GO" | "REVIEW" | "NO_GO";
+interface Evidence {
+  as_of: string; dataset: string; model: string; method: string; calibration_split: string;
+  coverage_target: number; n_calibration_units: number; n_test_units: number;
+  metrics: {
+    picp_two_sided: number; lower_bound_coverage_one_sided: number; pinaw: number;
+    mean_interval_width_cycles: number; two_sided_half_width_qhat: number;
+    one_sided_lower_margin: number; point_rmse: number;
+  };
+  gate: {
+    thresholds_cycles: { NO_GO_at_or_below: number; REVIEW_at_or_below: number };
+    point_distribution: Record<GateKey, number>;
+    lower_bound_distribution: Record<GateKey, number>;
+    disagreement_units: number; point_go_but_lower_bound_flags: number;
+  };
+  examples: { unit: number; point: number; lower: number; upper: number; y_true: number;
+    point_gate: GateKey; lower_bound_gate: GateKey; covered: boolean }[];
+  limitations: string[];
+}
+
+const ev = evidence as Evidence;
+const pct = (x: number) => `${(x * 100).toFixed(1)}%`;
+
+function GateBar({ label, dist }: { label: string; dist: Record<GateKey, number> }) {
+  const total = dist.GO + dist.REVIEW + dist.NO_GO || 1;
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.dim, marginBottom: 4 }}>{label}</div>
+      <div style={{ display: "flex", height: 22, borderRadius: 5, overflow: "hidden", border: `1px solid ${C.border}` }}>
+        {(["GO", "REVIEW", "NO_GO"] as GateKey[]).map((k) =>
+          dist[k] > 0 ? (
+            <div key={k} title={`${k}: ${dist[k]}`} style={{
+              width: `${(dist[k] / total) * 100}%`, background: `${verdictColor(k)}33`,
+              borderRight: `1px solid ${C.bg}`, display: "flex", alignItems: "center",
+              justifyContent: "center", fontFamily: C.mono, fontSize: 10, color: verdictColor(k) }}>
+              {dist[k]}
+            </div>
+          ) : null,
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function RulConformalCard() {
+  const heading = (
+    <PageHeading eyebrow="RUL · conformal lower bound"
+      title="Clear on the worst case, not the point estimate"
+      blurb="Split-conformal intervals on the FD001 RUL model, computed from real Databricks data. In a go/no-go context you clear a unit on the calibrated lower bound of remaining life — never the point estimate." />
+  );
+  if (!ev?.metrics || !ev?.gate || !Array.isArray(ev.examples)) {
+    return <>{heading}<EmptyState label="Conformal RUL evidence unavailable"
+      hint="The computed evidence artifact is missing required fields." /></>;
+  }
+
+  const m = ev.metrics;
+  const flags = ev.gate.point_go_but_lower_bound_flags;
+  const picpUnder = m.picp_two_sided < ev.coverage_target;
+
+  return (
+    <>
+      {heading}
+      <div style={{ display: "flex", gap: 8, marginBottom: 14, flexWrap: "wrap" }}>
+        <Tag color={C.amber}>computed evidence artifact · not live serving</Tag>
+        <Tag color={C.dim}>{ev.dataset} · as of {ev.as_of}</Tag>
+      </div>
+
+      <StatGrid cols={5} style={{ marginBottom: 14 }}>
+        <MetricCard label="Coverage target" value={pct(ev.coverage_target)} sub="nominal" />
+        <MetricCard label="PICP (measured)" value={pct(m.picp_two_sided)}
+          accent={picpUnder ? C.amber : C.green}
+          sub={picpUnder ? "near-nominal, slightly under" : "at/above target"} />
+        <MetricCard label="Lower-bound coverage" value={pct(m.lower_bound_coverage_one_sided)} sub="one-sided" />
+        <MetricCard label="Mean width" value={`${m.mean_interval_width_cycles}`}
+          sub={`cycles · PINAW ${m.pinaw}`} />
+        <MetricCard label="Point RMSE" value={m.point_rmse} sub="cycles" />
+      </StatGrid>
+
+      <Panel title="Point estimate vs conformal lower bound — operator clearance"
+        right={<Tag color={C.red}>{flags} of {ev.n_test_units} flagged</Tag>}>
+        <p style={{ fontFamily: C.sans, fontSize: 13, color: C.dim, lineHeight: 1.6, margin: "0 0 14px" }}>
+          <strong style={{ color: C.text }}>{flags} of {ev.n_test_units}</strong> test units clear (GO) on the
+          point estimate but the conformal lower bound demands REVIEW or NO-GO. Deciding on the lower bound
+          changes the call on these units. Gate bands: NO-GO ≤ {ev.gate.thresholds_cycles.NO_GO_at_or_below},
+          REVIEW ≤ {ev.gate.thresholds_cycles.REVIEW_at_or_below} cycles of remaining life.
+        </p>
+        <GateBar label="Clearance on the POINT estimate" dist={ev.gate.point_distribution} />
+        <GateBar label="Clearance on the LOWER BOUND" dist={ev.gate.lower_bound_distribution} />
+        <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, marginTop: 4 }}>
+          {ev.gate.disagreement_units} units disagree between the two gates.
+        </div>
+      </Panel>
+
+      <Panel title="Units that look safe on the point estimate" pad={0} style={{ marginTop: 14 }}>
+        <ScrollTable minWidth={560}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontFamily: C.mono, fontSize: 11.5 }}>
+            <thead>
+              <tr style={{ color: C.faint, textAlign: "right" }}>
+                {["Unit", "Point", "Lower", "Upper", "True RUL", "Point gate", "Lower-bound gate", "Covered"].map((h, i) => (
+                  <th key={h} style={{ padding: "8px 12px", textAlign: i === 0 ? "left" : "right",
+                    borderBottom: `1px solid ${C.border}`, fontWeight: 500 }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {ev.examples.map((e) => (
+                <tr key={e.unit} style={{ color: C.dim }}>
+                  <td style={{ padding: "8px 12px", color: C.text }}>{e.unit}</td>
+                  <td style={{ padding: "8px 12px", textAlign: "right" }}>{e.point}</td>
+                  <td style={{ padding: "8px 12px", textAlign: "right", color: C.amber }}>{e.lower}</td>
+                  <td style={{ padding: "8px 12px", textAlign: "right" }}>{e.upper}</td>
+                  <td style={{ padding: "8px 12px", textAlign: "right", color: C.text }}>{e.y_true}</td>
+                  <td style={{ padding: "8px 12px", textAlign: "right", color: verdictColor(e.point_gate) }}>{e.point_gate}</td>
+                  <td style={{ padding: "8px 12px", textAlign: "right", color: verdictColor(e.lower_bound_gate) }}>{e.lower_bound_gate}</td>
+                  <td style={{ padding: "8px 12px", textAlign: "right", color: e.covered ? C.green : C.faint }}>{e.covered ? "yes" : "no"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </ScrollTable>
+      </Panel>
+
+      <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.7, marginTop: 14 }}>
+        <div><strong style={{ color: C.dim }}>Method:</strong> {ev.method}.</div>
+        <div><strong style={{ color: C.dim }}>Calibration:</strong> {ev.calibration_split}</div>
+        <div style={{ marginTop: 6 }}><strong style={{ color: C.dim }}>Limitations:</strong></div>
+        <ul style={{ margin: "2px 0 0", paddingLeft: 16 }}>
+          {ev.limitations.map((l, i) => <li key={i} style={{ marginBottom: 2 }}>{l}</li>)}
+        </ul>
+      </div>
+    </>
+  );
+}

--- a/repo-b/src/lib/telemetry/rulConformalEvidence.json
+++ b/repo-b/src/lib/telemetry/rulConformalEvidence.json
@@ -1,0 +1,105 @@
+{
+  "as_of": "2026-06-23",
+  "dataset": "C-MAPSS FD001",
+  "model": "GradientBoostingRegressor(n_estimators=300, max_depth=3, lr=0.05, subsample=0.8)",
+  "target": "RUL (cycles) at last observed cycle, capped at 125; truth = official RUL_FD001",
+  "method": "split conformal (absolute-residual two-sided + one-sided over-prediction lower bound)",
+  "calibration_split": "unit-grouped: 30 of 100 train units held out for calibration; scores on each calibration unit's last cycle (matches the last-cycle-per-unit test protocol). No unit in both fit and calibration.",
+  "coverage_target": 0.9,
+  "n_calibration_units": 30,
+  "n_test_units": 100,
+  "metrics": {
+    "picp_two_sided": 0.86,
+    "lower_bound_coverage_one_sided": 0.85,
+    "pinaw": 0.4477,
+    "mean_interval_width_cycles": 56.0,
+    "two_sided_half_width_qhat": 33.8,
+    "one_sided_lower_margin": 22.2,
+    "point_rmse": 20.96
+  },
+  "gate": {
+    "thresholds_cycles": {
+      "NO_GO_at_or_below": 30,
+      "REVIEW_at_or_below": 50
+    },
+    "point_distribution": {
+      "GO": 76,
+      "REVIEW": 7,
+      "NO_GO": 17
+    },
+    "lower_bound_distribution": {
+      "GO": 61,
+      "REVIEW": 14,
+      "NO_GO": 25
+    },
+    "disagreement_units": 22,
+    "point_go_but_lower_bound_flags": 15
+  },
+  "examples": [
+    {
+      "unit": 3,
+      "point": 55.4,
+      "lower": 33.2,
+      "upper": 89.2,
+      "y_true": 69,
+      "point_gate": "GO",
+      "lower_bound_gate": "REVIEW",
+      "covered": true
+    },
+    {
+      "unit": 11,
+      "point": 70.3,
+      "lower": 48.1,
+      "upper": 104.1,
+      "y_true": 97,
+      "point_gate": "GO",
+      "lower_bound_gate": "REVIEW",
+      "covered": true
+    },
+    {
+      "unit": 17,
+      "point": 67.2,
+      "lower": 44.9,
+      "upper": 101.0,
+      "y_true": 50,
+      "point_gate": "GO",
+      "lower_bound_gate": "REVIEW",
+      "covered": true
+    },
+    {
+      "unit": 18,
+      "point": 51.0,
+      "lower": 28.8,
+      "upper": 84.8,
+      "y_true": 28,
+      "point_gate": "GO",
+      "lower_bound_gate": "NO_GO",
+      "covered": true
+    },
+    {
+      "unit": 37,
+      "point": 68.6,
+      "lower": 46.4,
+      "upper": 102.4,
+      "y_true": 21,
+      "point_gate": "GO",
+      "lower_bound_gate": "REVIEW",
+      "covered": false
+    },
+    {
+      "unit": 41,
+      "point": 55.1,
+      "lower": 32.9,
+      "upper": 88.9,
+      "y_true": 18,
+      "point_gate": "GO",
+      "lower_bound_gate": "REVIEW",
+      "covered": false
+    }
+  ],
+  "limitations": [
+    "FD001 is single-operating-condition simulated turbofan data; coverage transfers as a pattern, not a guarantee, to multi-condition or hot-fire regimes.",
+    "Split conformal assumes exchangeability of calibration and test last-cycle rows; the unit-grouped split respects this but n_calibration_units is modest.",
+    "Intervals are marginal (one global width), not conditional on remaining-life regime."
+  ]
+}

--- a/telemetry-platform/compute_rul_conformal.py
+++ b/telemetry-platform/compute_rul_conformal.py
@@ -1,0 +1,232 @@
+"""Phase 2 — Conformal lower-bound RUL on C-MAPSS FD001 (REAL data, reproducible).
+
+Pulls the same Gold features + RUL truth the Databricks RUL notebook uses
+(novendor_1.telemetry.gold_cmapss_features / silver_cmapss_rul, FD001), trains the
+same GBM, then computes split-conformal prediction intervals with a unit-grouped
+calibration split (no unit appears in both fit and calibration — consistent with the
+grouped walk-forward finding). Reports measured PICP, one-sided lower-bound coverage,
+PINAW, and the point-estimate vs conformal-lower-bound go/no-go disagreement.
+
+Writes an evidence artifact (computed snapshot, not live) to:
+  - telemetry-platform/rul_conformal_evidence.json   (source of record)
+  - repo-b/src/lib/telemetry/rulConformalEvidence.json (frontend import)
+
+No fake calibration: every number here is computed from the pulled data. If coverage
+is weak it is reported as-is.
+
+Run: python telemetry-platform/compute_rul_conformal.py
+Auth: Databricks OAuth profile 'PaulMain' (~/.databrickscfg).
+"""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # for conformal_core when run from any cwd
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import GradientBoostingRegressor
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.sql import Disposition, Format, StatementState
+
+from conformal_core import conformal_quantile, gate as _gate
+
+TEL = "novendor_1.telemetry"
+WAREHOUSE_ID = "0e56420fb707d861"
+RUL_CAP = 125
+ALPHA = 0.10          # 90% coverage target
+CAL_UNITS = 30        # held-out calibration units (grouped split)
+SEED = 0
+T_NOGO = 30           # cycles: <= -> NO_GO (must service before next op)
+T_REVIEW = 50         # cycles: <= -> REVIEW
+
+ROOT = Path(__file__).resolve().parents[1]
+AS_OF = "2026-06-23"  # stamped (no Date.now in repo); update on recompute
+
+
+def query(w: WorkspaceClient, sql: str) -> pd.DataFrame:
+    resp = w.statement_execution.execute_statement(
+        statement=sql, warehouse_id=WAREHOUSE_ID, wait_timeout="50s",
+        disposition=Disposition.INLINE, format=Format.JSON_ARRAY,
+    )
+    sid = resp.statement_id
+    while resp.status.state in (StatementState.PENDING, StatementState.RUNNING):
+        time.sleep(2)
+        resp = w.statement_execution.get_statement(sid)
+    if resp.status.state != StatementState.SUCCEEDED:
+        raise RuntimeError(f"SQL {resp.status.state}: {resp.status.error}")
+    cols = [c.name for c in resp.manifest.schema.columns]
+    rows = list(resp.result.data_array or [])
+    total = resp.manifest.total_chunk_count or 1
+    for n in range(1, total):
+        ch = w.statement_execution.get_statement_result_chunk_n(sid, n)
+        rows.extend(ch.data_array or [])
+    return pd.DataFrame(rows, columns=cols)
+
+
+def gate(value: float) -> str:
+    return _gate(value, T_NOGO, T_REVIEW)
+
+
+def main() -> None:
+    w = WorkspaceClient(profile="PaulMain")
+    print("[conformal] starting warehouse if stopped...")
+    try:
+        w.warehouses.start(WAREHOUSE_ID).result(timeout=__import__("datetime").timedelta(minutes=5))
+    except Exception as exc:  # already running is fine
+        print(f"[conformal] warehouse start note: {str(exc)[:120]}")
+
+    print("[conformal] pulling FD001 gold features + RUL truth...")
+    feat = query(w, f"SELECT * FROM {TEL}.gold_cmapss_features WHERE subset = 'FD001'")
+    truth = query(w, f"SELECT unit, rul FROM {TEL}.silver_cmapss_rul WHERE subset = 'FD001'")
+
+    feat_cols = [c for c in feat.columns if c.startswith("sensor_")]
+    for c in feat_cols + ["unit", "cycle", "rul_target"]:
+        feat[c] = pd.to_numeric(feat[c], errors="coerce")
+    truth["unit"] = pd.to_numeric(truth["unit"], errors="coerce")
+    truth["rul"] = pd.to_numeric(truth["rul"], errors="coerce")
+    print(f"[conformal] feature rows={len(feat)} cols={len(feat_cols)} "
+          f"train_units={feat[feat.split=='train'].unit.nunique()} test_units={truth.unit.nunique()}")
+
+    train = feat[feat.split == "train"].copy()
+    test = feat[feat.split == "test"].copy()
+
+    # Unit-grouped calibration split (no unit in both fit and calibration).
+    rng = np.random.default_rng(SEED)
+    train_units = np.sort(train.unit.unique())
+    cal_units = set(rng.choice(train_units, size=CAL_UNITS, replace=False).tolist())
+    fit_mask = ~train.unit.isin(cal_units)
+
+    # Train-median imputation (the lakehouse convention): early-cycle rolling / rate-of-change
+    # features are NaN until their window fills. Medians are computed on the FIT rows only — no
+    # calibration/test leakage — and applied everywhere.
+    med = train.loc[fit_mask, feat_cols].median()
+    for df in (train, test):
+        df[feat_cols] = df[feat_cols].fillna(med)
+
+    Xfit = train.loc[fit_mask, feat_cols].to_numpy()
+    yfit = np.minimum(train.loc[fit_mask, "rul_target"].to_numpy(), RUL_CAP)
+    gbm = GradientBoostingRegressor(n_estimators=300, max_depth=3, learning_rate=0.05,
+                                    subsample=0.8, random_state=SEED)
+    gbm.fit(Xfit, yfit)
+
+    # Calibration scores: one row per calibration unit at a RANDOM operational cycle (not the last
+    # cycle). The official C-MAPSS test set truncates each unit at a varied point in its life, so its
+    # last-cycle RUL spans a wide range; calibrating only on near-failure last cycles breaks
+    # exchangeability and under-covers. A random cycle per unit matches the score-at-an-arbitrary-point
+    # distribution the test set actually has.
+    cal = (train[train.unit.isin(cal_units)]
+           .groupby("unit", group_keys=False)
+           .apply(lambda g: g.sample(1, random_state=SEED)).copy())
+    cal_pred = np.clip(gbm.predict(cal[feat_cols].to_numpy()), 0, RUL_CAP)
+    cal_y = np.minimum(cal["rul_target"].to_numpy(), RUL_CAP)
+    abs_res = np.abs(cal_y - cal_pred)
+    over_pred = cal_pred - cal_y          # positive => model over-predicted remaining life (unsafe)
+
+    qhat = conformal_quantile(abs_res, ALPHA)             # two-sided half-width
+    q_lower = conformal_quantile(np.clip(over_pred, 0, None), ALPHA)  # one-sided lower margin
+
+    # Test: one row per unit at last cycle, official truth.
+    test_last = test.sort_values(["unit", "cycle"]).groupby("unit").tail(1).copy()
+    test_last = test_last.merge(truth[["unit", "rul"]], on="unit", how="inner")
+    pred = np.clip(gbm.predict(test_last[feat_cols].to_numpy()), 0, RUL_CAP)
+    y_true = np.minimum(test_last["rul"].to_numpy(), RUL_CAP)
+
+    lower2 = np.clip(pred - qhat, 0, RUL_CAP)
+    upper2 = np.clip(pred + qhat, 0, RUL_CAP)
+    lower_os = np.clip(pred - q_lower, 0, RUL_CAP)
+
+    picp = float(np.mean((y_true >= lower2) & (y_true <= upper2)))
+    lb_cov = float(np.mean(y_true >= lower_os))
+    pinaw = float(np.mean(upper2 - lower2) / RUL_CAP)
+    rmse = float(np.sqrt(np.mean((pred - y_true) ** 2)))
+
+    point_gate = np.array([gate(v) for v in pred])
+    lb_gate = np.array([gate(v) for v in lower_os])
+    order = {"GO": 0, "REVIEW": 1, "NO_GO": 2}
+    flips = int(np.sum([order[lb_gate[i]] > order[point_gate[i]] for i in range(len(pred))]))
+    go_to_review_or_worse = int(np.sum([(point_gate[i] == "GO") and (lb_gate[i] != "GO")
+                                        for i in range(len(pred))]))
+
+    # Example: a unit that looks safe on the point estimate but the lower bound flags.
+    ex_idx = None
+    cand = [i for i in range(len(pred)) if point_gate[i] == "GO" and lb_gate[i] != "GO"]
+    if cand:
+        ex_idx = max(cand, key=lambda i: pred[i] - lower_os[i])
+    examples = []
+    sel = cand[:6] if cand else list(np.argsort(pred)[:6])
+    for i in sel:
+        examples.append({
+            "unit": int(test_last["unit"].to_numpy()[i]),
+            "point": round(float(pred[i]), 1),
+            "lower": round(float(lower_os[i]), 1),
+            "upper": round(float(upper2[i]), 1),
+            "y_true": int(y_true[i]),
+            "point_gate": point_gate[i],
+            "lower_bound_gate": lb_gate[i],
+            "covered": bool((y_true[i] >= lower2[i]) and (y_true[i] <= upper2[i])),
+        })
+
+    artifact = {
+        "as_of": AS_OF,
+        "dataset": "C-MAPSS FD001",
+        "model": "GradientBoostingRegressor(n_estimators=300, max_depth=3, lr=0.05, subsample=0.8)",
+        "target": f"RUL (cycles) at last observed cycle, capped at {RUL_CAP}; truth = official RUL_FD001",
+        "method": "split conformal (absolute-residual two-sided + one-sided over-prediction lower bound)",
+        "calibration_split": (f"unit-grouped: {CAL_UNITS} of {len(train_units)} train units held out for "
+                              f"calibration; scores on each calibration unit's last cycle (matches the "
+                              f"last-cycle-per-unit test protocol). No unit in both fit and calibration."),
+        "coverage_target": round(1 - ALPHA, 3),
+        "n_calibration_units": int(len(abs_res)),
+        "n_test_units": int(len(pred)),
+        "metrics": {
+            "picp_two_sided": round(picp, 4),
+            "lower_bound_coverage_one_sided": round(lb_cov, 4),
+            "pinaw": round(pinaw, 4),
+            "mean_interval_width_cycles": round(float(np.mean(upper2 - lower2)), 1),
+            "two_sided_half_width_qhat": round(qhat, 1),
+            "one_sided_lower_margin": round(q_lower, 1),
+            "point_rmse": round(rmse, 2),
+        },
+        "gate": {
+            "thresholds_cycles": {"NO_GO_at_or_below": T_NOGO, "REVIEW_at_or_below": T_REVIEW},
+            "point_distribution": {k: int(np.sum(point_gate == k)) for k in ("GO", "REVIEW", "NO_GO")},
+            "lower_bound_distribution": {k: int(np.sum(lb_gate == k)) for k in ("GO", "REVIEW", "NO_GO")},
+            "disagreement_units": flips,
+            "point_go_but_lower_bound_flags": go_to_review_or_worse,
+        },
+        "examples": examples,
+        "limitations": [
+            "FD001 is single-operating-condition simulated turbofan data; coverage transfers as a pattern, not a guarantee, to multi-condition or hot-fire regimes.",
+            "Split conformal assumes exchangeability of calibration and test last-cycle rows; the unit-grouped split respects this but n_calibration_units is modest.",
+            "Intervals are marginal (one global width), not conditional on remaining-life regime.",
+        ],
+    }
+
+    out_src = ROOT / "telemetry-platform" / "rul_conformal_evidence.json"
+    out_fe = ROOT / "repo-b" / "src" / "lib" / "telemetry" / "rulConformalEvidence.json"
+    out_src.write_text(json.dumps(artifact, indent=2), encoding="utf-8")
+    out_fe.write_text(json.dumps(artifact, indent=2), encoding="utf-8")
+
+    print("\n=== CONFORMAL RUL (FD001) — measured ===")
+    print(f"coverage target           : {1-ALPHA:.0%}")
+    print(f"PICP (two-sided)          : {picp:.3f}")
+    print(f"lower-bound coverage (1-s): {lb_cov:.3f}")
+    print(f"PINAW                     : {pinaw:.3f}  (mean width {np.mean(upper2-lower2):.1f} cycles)")
+    print(f"two-sided half-width qhat : {qhat:.1f} cycles")
+    print(f"one-sided lower margin    : {q_lower:.1f} cycles")
+    print(f"point RMSE                : {rmse:.2f}")
+    print(f"point gate dist           : {artifact['gate']['point_distribution']}")
+    print(f"lower-bound gate dist     : {artifact['gate']['lower_bound_distribution']}")
+    print(f"disagreement units        : {flips}  (point GO but lower-bound flags: {go_to_review_or_worse})")
+    if ex_idx is not None:
+        print(f"example flip unit         : {artifact['examples'][0]}")
+    print(f"\nwrote {out_src}")
+    print(f"wrote {out_fe}")
+
+
+if __name__ == "__main__":
+    main()

--- a/telemetry-platform/conformal_core.py
+++ b/telemetry-platform/conformal_core.py
@@ -1,0 +1,54 @@
+"""Pure split-conformal primitives (numpy only — no Databricks, CI-safe).
+
+Shared by compute_rul_conformal.py (which pulls real FD001 data) and the eval test
+test_conformal_core.py (which checks coverage on synthetic exchangeable data). Keeping
+the math here means the test runs without credentials or a warehouse.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def conformal_quantile(scores: np.ndarray, alpha: float) -> float:
+    """Finite-sample split-conformal quantile of nonconformity ``scores``.
+
+    Returns the ``ceil((n+1)(1-alpha))/n`` empirical quantile — the standard
+    finite-sample-valid threshold. With too few points the index is capped at n
+    (the bound degenerates to the max score rather than +inf).
+    """
+    scores = np.asarray(scores, dtype=float)
+    n = len(scores)
+    if n == 0:
+        raise ValueError("need >= 1 calibration score")
+    k = int(np.ceil((n + 1) * (1 - alpha)))
+    k = min(k, n)
+    return float(np.sort(scores)[k - 1])
+
+
+def two_sided_interval(pred: np.ndarray, qhat: float, lo: float, hi: float):
+    """Symmetric [pred-qhat, pred+qhat], clipped to [lo, hi]."""
+    pred = np.asarray(pred, dtype=float)
+    return np.clip(pred - qhat, lo, hi), np.clip(pred + qhat, lo, hi)
+
+
+def lower_bound(pred: np.ndarray, q_lower: float, lo: float, hi: float):
+    """One-sided lower bound pred - q_lower, clipped. For a RUL go/no-go this is the
+    worst-case remaining-life the calibration supports at the target confidence."""
+    pred = np.asarray(pred, dtype=float)
+    return np.clip(pred - q_lower, lo, hi)
+
+
+def gate(value: float, t_nogo: float, t_review: float) -> str:
+    """Three-tier clearance band on a remaining-life value (cycles)."""
+    if value <= t_nogo:
+        return "NO_GO"
+    if value <= t_review:
+        return "REVIEW"
+    return "GO"
+
+
+def picp(y_true: np.ndarray, lower: np.ndarray, upper: np.ndarray) -> float:
+    """Prediction Interval Coverage Probability."""
+    y_true = np.asarray(y_true, dtype=float)
+    return float(np.mean((y_true >= lower) & (y_true <= upper)))

--- a/telemetry-platform/rul_conformal_evidence.json
+++ b/telemetry-platform/rul_conformal_evidence.json
@@ -1,0 +1,105 @@
+{
+  "as_of": "2026-06-23",
+  "dataset": "C-MAPSS FD001",
+  "model": "GradientBoostingRegressor(n_estimators=300, max_depth=3, lr=0.05, subsample=0.8)",
+  "target": "RUL (cycles) at last observed cycle, capped at 125; truth = official RUL_FD001",
+  "method": "split conformal (absolute-residual two-sided + one-sided over-prediction lower bound)",
+  "calibration_split": "unit-grouped: 30 of 100 train units held out for calibration; scores on each calibration unit's last cycle (matches the last-cycle-per-unit test protocol). No unit in both fit and calibration.",
+  "coverage_target": 0.9,
+  "n_calibration_units": 30,
+  "n_test_units": 100,
+  "metrics": {
+    "picp_two_sided": 0.86,
+    "lower_bound_coverage_one_sided": 0.85,
+    "pinaw": 0.4477,
+    "mean_interval_width_cycles": 56.0,
+    "two_sided_half_width_qhat": 33.8,
+    "one_sided_lower_margin": 22.2,
+    "point_rmse": 20.96
+  },
+  "gate": {
+    "thresholds_cycles": {
+      "NO_GO_at_or_below": 30,
+      "REVIEW_at_or_below": 50
+    },
+    "point_distribution": {
+      "GO": 76,
+      "REVIEW": 7,
+      "NO_GO": 17
+    },
+    "lower_bound_distribution": {
+      "GO": 61,
+      "REVIEW": 14,
+      "NO_GO": 25
+    },
+    "disagreement_units": 22,
+    "point_go_but_lower_bound_flags": 15
+  },
+  "examples": [
+    {
+      "unit": 3,
+      "point": 55.4,
+      "lower": 33.2,
+      "upper": 89.2,
+      "y_true": 69,
+      "point_gate": "GO",
+      "lower_bound_gate": "REVIEW",
+      "covered": true
+    },
+    {
+      "unit": 11,
+      "point": 70.3,
+      "lower": 48.1,
+      "upper": 104.1,
+      "y_true": 97,
+      "point_gate": "GO",
+      "lower_bound_gate": "REVIEW",
+      "covered": true
+    },
+    {
+      "unit": 17,
+      "point": 67.2,
+      "lower": 44.9,
+      "upper": 101.0,
+      "y_true": 50,
+      "point_gate": "GO",
+      "lower_bound_gate": "REVIEW",
+      "covered": true
+    },
+    {
+      "unit": 18,
+      "point": 51.0,
+      "lower": 28.8,
+      "upper": 84.8,
+      "y_true": 28,
+      "point_gate": "GO",
+      "lower_bound_gate": "NO_GO",
+      "covered": true
+    },
+    {
+      "unit": 37,
+      "point": 68.6,
+      "lower": 46.4,
+      "upper": 102.4,
+      "y_true": 21,
+      "point_gate": "GO",
+      "lower_bound_gate": "REVIEW",
+      "covered": false
+    },
+    {
+      "unit": 41,
+      "point": 55.1,
+      "lower": 32.9,
+      "upper": 88.9,
+      "y_true": 18,
+      "point_gate": "GO",
+      "lower_bound_gate": "REVIEW",
+      "covered": false
+    }
+  ],
+  "limitations": [
+    "FD001 is single-operating-condition simulated turbofan data; coverage transfers as a pattern, not a guarantee, to multi-condition or hot-fire regimes.",
+    "Split conformal assumes exchangeability of calibration and test last-cycle rows; the unit-grouped split respects this but n_calibration_units is modest.",
+    "Intervals are marginal (one global width), not conditional on remaining-life regime."
+  ]
+}

--- a/telemetry-platform/test_conformal_core.py
+++ b/telemetry-platform/test_conformal_core.py
@@ -1,0 +1,47 @@
+"""Eval tests for the split-conformal primitives — numpy only, no Databricks.
+
+Run: python -m pytest telemetry-platform/test_conformal_core.py -q
+"""
+
+import numpy as np
+
+from conformal_core import conformal_quantile, gate, lower_bound, picp, two_sided_interval
+
+
+def test_conformal_quantile_known_values():
+    # 10 scores 1..10, alpha=0.1 -> k = ceil(11*0.9)=10 -> 10th sorted score = 10.
+    s = np.arange(1, 11, dtype=float)
+    assert conformal_quantile(s, 0.10) == 10.0
+    # alpha=0.5 -> k = ceil(11*0.5)=6 -> 6th = 6.
+    assert conformal_quantile(s, 0.50) == 6.0
+
+
+def test_split_conformal_achieves_target_coverage_on_exchangeable_data():
+    # Exchangeable Gaussian-noise regression: split conformal must cover ~ (1-alpha).
+    rng = np.random.default_rng(0)
+    n = 4000
+    pred = rng.uniform(0, 100, size=n)
+    noise = rng.normal(0, 8, size=n)
+    y = pred + noise
+    cal, test = slice(0, 2000), slice(2000, n)
+    qhat = conformal_quantile(np.abs(y[cal] - pred[cal]), 0.10)
+    lo, hi = two_sided_interval(pred[test], qhat, -1e9, 1e9)
+    cov = picp(y[test], lo, hi)
+    # finite-sample valid: coverage >= 0.90 - slack, and not absurdly over.
+    assert 0.88 <= cov <= 0.96, cov
+
+
+def test_lower_bound_is_below_point_and_monotone():
+    pred = np.array([60.0, 30.0, 10.0])
+    lb = lower_bound(pred, q_lower=15.0, lo=0, hi=125)
+    assert np.all(lb <= pred)
+    assert lb[2] == 0.0  # clipped at floor
+
+
+def test_gate_bands():
+    assert gate(20, 30, 50) == "NO_GO"
+    assert gate(40, 30, 50) == "REVIEW"
+    assert gate(80, 30, 50) == "GO"
+    # The safety point: a point estimate can clear (GO) while the lower bound flags.
+    assert gate(55, 30, 50) == "GO"
+    assert gate(33, 30, 50) == "REVIEW"


### PR DESCRIPTION
Adds real uncertainty-aware RUL evidence. Split-conformal intervals on C-MAPSS **FD001**, computed from real Databricks data with a unit-grouped calibration split.

## Measured (real, reproducible)
- **PICP 0.86** (two-sided) at a **0.90** target — near-nominal, slightly under (n=30 calibration units; marginal intervals).
- Lower-bound coverage 0.85 · mean width 56 cycles (PINAW 0.448) · point RMSE 20.96.
- **Lower-bound gate:** **15 of 100** units clear (GO) on the point estimate but the conformal **lower bound** flags them (REVIEW/NO-GO); **22 units disagree** between the two gates. Example: unit 3 — point 55.4 (GO), lower 33.2 (REVIEW), true 69.

## Honest finding (judgment artifact)
A first calibration on near-failure *last* cycles under-covered badly (**PICP 0.44**) because C-MAPSS test units truncate across a wide RUL range — not exchangeable. The measured fix: calibrate on a random *operational* cycle per held-out unit → PICP recovers to 0.86. Reported as measured, not a success claim.

## Files
- `telemetry-platform/conformal_core.py` (pure numpy, CI-safe) + `test_conformal_core.py` (4 tests, run locally green)
- `telemetry-platform/compute_rul_conformal.py` (reproducible Databricks pull) → `rul_conformal_evidence.json`
- `RulConformalCard` on `/telemetry/evidence` (computed artifact, **labeled not-live**) + test
- `claim_coverage_matrix.md`, `PLAN_DIVERGENCE_REVIEW.md`, `tips.md` updated

Frontend tests + typecheck green locally. Unbundled from FD004/envelope/analog/secondary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)