### PR TITLE
feat(telemetry): 'why launch became a data problem' narrative alignment (Story #717)

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4158,3 +4158,20 @@ Inventory of the real data behind the telemetry env (full per-surface contracts 
   `telemetry-platform/` plus a copy under `repo-b/src/lib/telemetry/`), import it into a card, and label it
   "computed evidence artifact · not live serving" with `as_of` + the calibration-split description. Real numbers,
   reproducible, never claimed as live.
+
+## Relativity / aerospace telemetry surfaces — the three-question rule (Story #717)
+
+When building any Relativity / aerospace telemetry feature, every technical surface should answer three
+questions, or it reads as an isolated demo rather than part of one argument:
+
+1. **How is the data collected?** (the stream / sensor / test-stand / record source, and its provenance)
+2. **How is trust established?** (lineage to source, calibration / coverage, governed metrics, fail-closed nulls)
+3. **How does the result change a test/build/launch action?** (the operator decision it informs — abort/review,
+   go/no-go, manufacturing feedback, readiness margin).
+
+The thesis the demo must consistently support: modern launch operations are increasingly constrained not by
+hardware or cost alone but by the ability to collect, process, trust, and act on telemetry/model/lineage/operational
+data fast enough to improve test, build, and launch outcomes. Frame the Kafka/streaming surface as the live proof
+of that thesis (recorded capture replayed through real streaming infra + anomaly routing + provenance + a
+human-facing review state), never as an isolated technical demo. Do not present specific historical launch-program
+claims as fact unless sourced; keep era framing general (access → cost → reuse → manufacturing scale → data velocity).

--- a/repo-b/src/components/telemetry/DataCollectionCard.test.tsx
+++ b/repo-b/src/components/telemetry/DataCollectionCard.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import DataCollectionCard from "./DataCollectionCard";
+
+describe("DataCollectionCard", () => {
+  it("renders the data-type -> action methodology and labels itself a framework, not live metrics", () => {
+    render(<DataCollectionCard />);
+    expect(screen.getByText(/What modern launch operations actually run on/i)).toBeInTheDocument();
+    // explicitly framed as methodology, not live values (no overclaim)
+    expect(screen.getByText(/Framework, not live metrics/i)).toBeInTheDocument();
+    // a representative data type and the action it changes
+    expect(screen.getByText(/Telemetry streams/i)).toBeInTheDocument();
+    expect(screen.getByText(/Model predictions/i)).toBeInTheDocument();
+    expect(screen.getByText(/launch-readiness margin/i)).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/DataCollectionCard.tsx
+++ b/repo-b/src/components/telemetry/DataCollectionCard.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+// Data Collection / Methodology layer — the bridge between the "why launch became a
+// data problem" thesis and the proof cards below it. This is a METHODOLOGY explainer:
+// it names the data types a modern launch/test program depends on and ties each to the
+// operational decision it changes. It claims no metrics and presents no live values —
+// it is the framework, labeled as such, that the rest of the evidence page proves out.
+
+import { C, PageHeading, Panel, ScrollTable } from "./primitives";
+
+type Row = { type: string; collected: string; affects: string };
+
+const DATA_TYPES: Row[] = [
+  { type: "Telemetry streams", collected: "protobuf-over-Kafka, windowed in flight, ring-buffered",
+    affects: "real-time test abort / review calls" },
+  { type: "Sensor channels", collected: "per-channel residuals + rolling features (no look-ahead)",
+    affects: "anomaly detection & per-channel attribution" },
+  { type: "Test-stand data", collected: "recorded capture replayed through the live bridge",
+    affects: "hot-fire go/no-go and post-test review" },
+  { type: "Manufacturing / quality records", collected: "NCR corpus + clustering + backlog forecast",
+    affects: "manufacturing feedback loops & build quality" },
+  { type: "Model predictions", collected: "anomaly score + RUL with conformal intervals",
+    affects: "model confidence & launch-readiness margin" },
+  { type: "Anomaly events", collected: "threshold-routed to their own topic + labeled events",
+    affects: "anomaly investigation & root-cause" },
+  { type: "Lineage / source records", collected: "governed metric catalog + provenance per number",
+    affects: "whether a number is trusted enough to act on" },
+  { type: "Operator decisions & receipts", collected: "GO/REVIEW/NO-GO verdicts + Ed25519 signed receipts",
+    affects: "auditable reliability improvement over time" },
+];
+
+export default function DataCollectionCard() {
+  return (
+    <>
+      <PageHeading eyebrow="Data collection · methodology"
+        title="What modern launch operations actually run on"
+        blurb="Increasing vehicle complexity, reuse, rapid iteration, and higher cadence make telemetry and operational data central to launch reliability — not a side effect of it. This is the data a modern test/build/launch program depends on, and the decision each type changes. (Framework, not live metrics — the cards below prove each one out.)" />
+      <Panel title="Data type → what it changes" pad={0}>
+        <ScrollTable minWidth={640}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontFamily: C.sans, fontSize: 12.5 }}>
+            <thead>
+              <tr style={{ color: C.faint, textAlign: "left" }}>
+                {["Data type", "How it is collected", "What it changes"].map((h) => (
+                  <th key={h} style={{ padding: "10px 14px", borderBottom: `1px solid ${C.border}`,
+                    fontFamily: C.mono, fontSize: 10.5, fontWeight: 500, textTransform: "uppercase",
+                    letterSpacing: "0.05em" }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {DATA_TYPES.map((r) => (
+                <tr key={r.type} style={{ borderBottom: `1px solid ${C.border}` }}>
+                  <td style={{ padding: "10px 14px", color: C.text, fontWeight: 600 }}>{r.type}</td>
+                  <td style={{ padding: "10px 14px", color: C.dim }}>{r.collected}</td>
+                  <td style={{ padding: "10px 14px", color: C.cyan }}>{r.affects}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </ScrollTable>
+      </Panel>
+    </>
+  );
+}

--- a/repo-b/src/components/telemetry/EvidenceCards.tsx
+++ b/repo-b/src/components/telemetry/EvidenceCards.tsx
@@ -8,6 +8,7 @@
 // explicit unavailable state; the Stargate capture is labeled recorded.
 
 import { C } from "./primitives";
+import DataCollectionCard from "./DataCollectionCard";
 import ModelEvidenceCard from "./ModelEvidenceCard";
 import RulConformalCard from "./RulConformalCard";
 import PipelineEvidenceCard from "./PipelineEvidenceCard";
@@ -47,6 +48,8 @@ export default function EvidenceCards() {
   return (
     <div>
       <Lead />
+      <DataCollectionCard />
+      <Divider />
       <ModelEvidenceCard />
       <Divider />
       <RulConformalCard />

--- a/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
+++ b/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
@@ -115,7 +115,7 @@ export default function StargateConsole() {
       <PageHeading
         eyebrow="Stargate Live"
         title="Printer telemetry stream"
-        blurb="Protobuf telemetry over Kafka, windowed in flight, anomalies routed to their own topic. Live state is ring-buffered in the bridge — no database in the hot path."
+        blurb="The live proof of the thesis: historical launch progress created more data than judgment could keep up with. The modern answer is governed streaming + model evidence + lineage + operator-facing actions. This is recorded test-stand capture replayed through real streaming infrastructure — protobuf over Kafka, windowed in flight, anomalies routed to their own topic, ring-buffered in the bridge with no database in the hot path. Recorded capture, not a live printer."
         right={
           <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", justifyContent: "flex-end" }}>
             {startMsg && <span style={{ fontFamily: C.mono, fontSize: 10, color: C.red }}>{startMsg}</span>}


### PR DESCRIPTION
Narrative-alignment pass so the technical surfaces read as one coherent argument. No fake or unsourced launch facts; era framing kept general.

- **Data Collection / Methodology card** on `/telemetry/evidence`: the data types a modern test/build/launch program depends on (telemetry, sensor channels, test-stand, manufacturing/quality, model predictions, anomaly events, lineage, operator decisions/receipts), each tied to the decision it changes. Explicitly labeled *framework, not live metrics*.
- **Stargate** reframed as the **live proof** of the thesis (governed streaming + model evidence + lineage + operator actions; recorded capture replayed through real infra — not a live printer).
- **Overview** thesis 'Why launch became a data problem' already in place from the redesign.
- **tips.md**: the three-question rule (how collected / how trust is established / how it changes a test/build/launch action) + the thesis + keep historical-program claims general or sourced.

Tests + typecheck green locally (DataCollectionCard + Stargate console).

🤖 Generated with [Claude Code](https://claude.com/claude-code)