### PR TITLE
style(telemetry): Overview heading — title case, mono, larger, purple Launch/Data

### DIFF
--- a/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
@@ -9,7 +9,7 @@ import TelemetryOverview from "./TelemetryOverview";
 describe("TelemetryOverview — charts-led Overview", () => {
   it("renders the dominant thesis header and the Bottleneck Map story module", () => {
     render(<TelemetryOverview />);
-    expect(screen.getByRole("heading", { name: "Why launch became a data problem" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Why Launch Became A Data Problem" })).toBeInTheDocument();
     expect(screen.getByText(/Spaceflight moves by breaking what holds it back/i)).toBeInTheDocument();
     expect(screen.getByTestId("bottleneck-map")).toBeInTheDocument();
   });

--- a/repo-b/src/components/telemetry/TelemetryOverview.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.tsx
@@ -8,6 +8,10 @@
 import { C, DisclosureFooter } from "./primitives";
 import BottleneckMap from "./context/BottleneckMap/BottleneckMap";
 
+// Brand fluorescent purple (--nv-purple-hot "wet reflect"); the marketing CSS var is
+// out of scope in the telemetry env, so the hex is inlined.
+const NV_PURPLE = "#B040FF";
+
 export default function TelemetryOverview() {
   return (
     <>
@@ -17,8 +21,9 @@ export default function TelemetryOverview() {
           <span aria-hidden style={{ width: 18, height: 2, borderRadius: 2, background: C.cyan, boxShadow: `0 0 8px ${C.cyan}aa` }} />
           <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.16em", color: C.cyan, textTransform: "uppercase" }}>Overview</span>
         </div>
-        <h1 style={{ fontFamily: C.sans, fontSize: 42, fontWeight: 800, letterSpacing: "-0.02em", lineHeight: 1.05, color: C.text, marginTop: 12 }}>
-          Why launch became a data problem
+        <h1 style={{ fontFamily: C.mono, fontSize: 48, fontWeight: 800, letterSpacing: "-0.01em", lineHeight: 1.08, color: C.text, marginTop: 12 }}>
+          Why <span style={{ color: NV_PURPLE, textShadow: `0 0 18px ${NV_PURPLE}99` }}>Launch</span> Became A{" "}
+          <span style={{ color: NV_PURPLE, textShadow: `0 0 18px ${NV_PURPLE}99` }}>Data</span> Problem
         </h1>
         <p style={{ fontFamily: C.sans, fontSize: 16, color: C.dim, lineHeight: 1.65, marginTop: 16 }}>
           Spaceflight moves by breaking what holds it back. First, reaching orbit. Then lowering the cost. Then


### PR DESCRIPTION
Per request: title-case the Overview thesis heading, change the font (mono display), make it a little bigger (42→48px), and color **Launch** and **Data** in the brand fluorescent purple (`#B040FF` / `--nv-purple-hot`) with a soft glow. Test name updated to match. Style-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)