### PR TITLE
fix(telemetry): start live stream worker + Mission Control Start button

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 from app.config import (
     ALLOWED_ORIGINS,
     STARGATE_BRIDGE_ENABLED,
+    TELEMETRY_STREAM_ENABLED,
 )
 from app.auth.middleware import AuthMiddleware
 from app.middleware import RequestLoggingMiddleware
@@ -310,6 +311,50 @@ async def lifespan(app: FastAPI):
             emit_log(
                 level="warn", service="backend", action="startup.stargate_bridge_failed",
                 message="Stargate bridge init failed (non-fatal)", context={}, error=exc,
+            )
+
+    # RS Demo live telemetry stream: start the ingest worker + ETL loop when
+    # enabled. Without this the StreamWorker is never created, no fresh bronze
+    # frames land, and Mission Control renders a frozen silver tail (the demo
+    # "stream isn't moving" symptom). Gated on TELEMETRY_STREAM_ENABLED; default
+    # off keeps the shared backend inert. The shutdown loop below cancels both
+    # tasks. Non-fatal: a failed start logs and leaves the DB-tail fallback.
+    if db_connected and TELEMETRY_STREAM_ENABLED:
+        try:
+            import asyncio as _tel_asyncio
+            from uuid import UUID as _UUID
+
+            from app.config import (
+                TELEMETRY_ETL_INTERVAL_SECONDS,
+                TELEMETRY_STREAM_BUSINESS_ID,
+                TELEMETRY_STREAM_ENV_ID,
+                TELEMETRY_STREAM_SOURCE,
+            )
+            from app.services.telemetry_stream_etl import run_etl_loop
+            from app.services.telemetry_stream_ingest import StreamWorker, set_stream_worker
+
+            _tel_business_id = _UUID(TELEMETRY_STREAM_BUSINESS_ID)
+            _tel_worker = StreamWorker(
+                env_id=TELEMETRY_STREAM_ENV_ID,
+                business_id=TELEMETRY_STREAM_BUSINESS_ID,
+                source=TELEMETRY_STREAM_SOURCE,
+            )
+            set_stream_worker(_tel_worker)
+            stream_task = _tel_asyncio.create_task(_tel_worker.run())
+            stream_etl_task = _tel_asyncio.create_task(run_etl_loop(
+                env_id=TELEMETRY_STREAM_ENV_ID,
+                business_id=_tel_business_id,
+                interval_seconds=TELEMETRY_ETL_INTERVAL_SECONDS,
+            ))
+            emit_log(
+                level="info", service="backend", action="startup.telemetry_stream",
+                message=f"Telemetry stream worker started (source={TELEMETRY_STREAM_SOURCE})",
+                context={"env_id": TELEMETRY_STREAM_ENV_ID},
+            )
+        except Exception as exc:
+            emit_log(
+                level="warn", service="backend", action="startup.telemetry_stream_failed",
+                message="Telemetry stream worker failed to start (non-fatal)", context={}, error=exc,
             )
 
     yield

--- a/backend/app/routes/telemetry.py
+++ b/backend/app/routes/telemetry.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 import psycopg
-from fastapi import APIRouter, Header, HTTPException, Query
+from fastapi import APIRouter, Header, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from app.mcp.auth import McpContext
@@ -261,6 +261,72 @@ def stream_health(env_id: str = Query(...), business_id: UUID = Query(...)):
         return stream_svc.stream_health(env_id=env_id, business_id=business_id)
     except Exception as exc:  # noqa: BLE001
         raise _to_http(exc)
+
+
+@router.post("/stream/control")
+async def stream_control(request: Request):
+    """Start (or restart) the live telemetry ingest worker + ETL loop in this
+    process. Backs the Mission Control "Start stream" button: if the worker was
+    never started (flag off at boot) or died, this brings it online on demand so
+    fresh frames flow again — no redeploy needed. Idempotent: an already-running
+    healthy worker is left in place and reported. Capture mode is the safe default
+    (deterministic, no network), matching the demo proof path."""
+    import asyncio
+
+    from app.config import (
+        TELEMETRY_ETL_INTERVAL_SECONDS,
+        TELEMETRY_STREAM_BUSINESS_ID,
+        TELEMETRY_STREAM_ENV_ID,
+        TELEMETRY_STREAM_SOURCE,
+    )
+    from app.services.telemetry_stream_etl import run_etl_loop
+    from app.services.telemetry_stream_ingest import (
+        StreamWorker, get_stream_worker, set_stream_worker,
+    )
+
+    worker = get_stream_worker()
+    app_state = request.app.state
+    restarted = False
+
+    # Tear down a stale/stopping worker and its tasks before re-creating.
+    existing_task = getattr(app_state, "telemetry_stream_task", None)
+    if worker is not None and (worker._stopping or (existing_task is not None and existing_task.done())):
+        try:
+            await worker.stop()
+        except Exception:  # noqa: BLE001
+            pass
+        for attr in ("telemetry_stream_task", "telemetry_stream_etl_task"):
+            t = getattr(app_state, attr, None)
+            if t is not None and not t.done():
+                t.cancel()
+                try:
+                    await t
+                except BaseException:  # noqa: BLE001
+                    pass
+        worker = None
+        restarted = True
+
+    if worker is None:
+        worker = StreamWorker(
+            env_id=TELEMETRY_STREAM_ENV_ID,
+            business_id=TELEMETRY_STREAM_BUSINESS_ID,
+            source=TELEMETRY_STREAM_SOURCE,
+        )
+        set_stream_worker(worker)
+        app_state.telemetry_stream_task = asyncio.create_task(worker.run())
+        app_state.telemetry_stream_etl_task = asyncio.create_task(run_etl_loop(
+            env_id=TELEMETRY_STREAM_ENV_ID,
+            business_id=UUID(TELEMETRY_STREAM_BUSINESS_ID),
+            interval_seconds=TELEMETRY_ETL_INTERVAL_SECONDS,
+        ))
+        emit_log(level="info", service="telemetry", action="stream_control_started",
+                 message=f"stream worker started via control (source={worker.source})")
+        return {"status": "restarted" if restarted else "started", "source": worker.source,
+                "env_id": TELEMETRY_STREAM_ENV_ID}
+
+    return {"status": "already_running", "source": worker.source,
+            "env_id": TELEMETRY_STREAM_ENV_ID,
+            "last_frame_at": worker.last_frame_at.isoformat() if worker.last_frame_at else None}
 
 
 @router.post("/stream/source")

--- a/repo-b/src/components/telemetry/MissionControlStream.tsx
+++ b/repo-b/src/components/telemetry/MissionControlStream.tsx
@@ -11,7 +11,7 @@ import {
 
 import { getModelPerformance, TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID } from "@/lib/telemetry/api";
 import {
-  deriveLag, STREAM_REASON_HINT, useStreamPoll,
+  deriveLag, startStream, STREAM_REASON_HINT, useStreamPoll,
   type StreamChannel, type StreamEvent, type StreamLive,
 } from "@/lib/telemetry/stream";
 import { SplitGrid } from "./primitives";
@@ -88,7 +88,24 @@ export default function MissionControlStream() {
   const { live, error, clientNowMs } = useStreamPoll(1000, hold);
   const [selected, setSelected] = useState<string[]>([]);
   const [champion, setChampion] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
+  const [startMsg, setStartMsg] = useState<string | null>(null);
   const lagHistory = useRef<number[]>([]);
+
+  const handleStart = async () => {
+    setStarting(true);
+    setStartMsg(null);
+    try {
+      const r = await startStream();
+      setStartMsg(r.status === "already_running"
+        ? `already running (${r.source})`
+        : `${r.status} (${r.source}) — frames flowing shortly`);
+    } catch (e) {
+      setStartMsg(`start failed: ${String(e)}`);
+    } finally {
+      setStarting(false);
+    }
+  };
 
   useEffect(() => {
     getModelPerformance(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID)
@@ -152,6 +169,15 @@ export default function MissionControlStream() {
             padding: "4px 12px", borderRadius: 4, fontSize: 13 }}>
             {verdict.text}
           </span>
+          <button type="button" onClick={handleStart} disabled={starting}
+            title="Start (or restart) the live ingest worker on the backend"
+            style={{ fontFamily: RS_MONO, fontSize: 11, fontWeight: 700, padding: "4px 12px",
+              borderRadius: 4, cursor: starting ? "default" : "pointer",
+              color: starting ? RS.faint : RS.bg,
+              background: starting ? "transparent" : RS.green,
+              border: `1px solid ${starting ? RS.line : RS.green}` }}>
+            {starting ? "Starting…" : "Start stream"}
+          </button>
           <button type="button" onClick={() => setHold((h) => !h)}
             style={{ fontFamily: RS_MONO, fontSize: 11, padding: "4px 10px", borderRadius: 4,
               cursor: "pointer", color: hold ? RS.bg : RS.dim,
@@ -160,6 +186,13 @@ export default function MissionControlStream() {
           </button>
         </div>
       </div>
+
+      {startMsg && (
+        <div style={{ padding: "0 4px 8px", fontFamily: RS_MONO, fontSize: 11,
+          color: startMsg.startsWith("start failed") ? RS.red : RS.green }}>
+          stream control: {startMsg}
+        </div>
+      )}
 
       {error && !live && (
         <RsPanel><div style={{ padding: 16, fontFamily: RS_MONO, fontSize: 12, color: RS.red }}>

--- a/repo-b/src/lib/telemetry/stream.ts
+++ b/repo-b/src/lib/telemetry/stream.ts
@@ -87,6 +87,17 @@ export const getStreamHealth = () =>
     params: { env_id: TELEMETRY_DEMO_ENV_ID, business_id: TELEMETRY_DEMO_BUSINESS_ID },
   });
 
+export interface StreamControlResult {
+  status: "started" | "restarted" | "already_running";
+  source: string;
+  env_id: string;
+  last_frame_at?: string | null;
+}
+
+/** Start (or restart) the live ingest worker on the backend so frames flow again. */
+export const startStream = () =>
+  apiFetch<StreamControlResult>("/api/telemetry/stream/control", { method: "POST" });
+
 /** Pure derivation for the latency overlay (unit-testable). */
 export function deriveLag(live: StreamLive, clientNowMs: number): {
   ingestLagS: number | null; clientLagS: number | null;


### PR DESCRIPTION
## Problem
Mission Control's live stream wasn't advancing — ingest lag ~7 days, charts frozen.

**Root cause:** the `StreamWorker` that produces live telemetry frames was never wired into the backend lifespan. `main.py` left `stream_task`/`stream_etl_task` as `None` with a "future phase wires their creation" TODO. `TELEMETRY_STREAM_ENABLED=1` was already set in prod but dead — no worker meant no fresh bronze rows, so `/stream/live` rendered a frozen silver tail.

## Fix
- **`main.py`**: start `StreamWorker` + `run_etl_loop` in the lifespan when `TELEMETRY_STREAM_ENABLED` and the DB is connected (capture source by default — deterministic, no network). The existing shutdown loop already cancels both tasks.
- **`POST /api/telemetry/stream/control`**: start/restart the worker on demand so the feed can be kicked from the UI without a redeploy (idempotent).
- **MissionControlStream**: "Start stream" button wired to the control endpoint, with status feedback.

## Verification
- `test_telemetry_stream_etl.py`: 20 passed
- Backend imports clean; new route registered (`/api/telemetry/stream/control`)
- Frontend tsc: no errors in changed files
- Capture fixture present: 177 frames / 12 channels (matches the channels shown in Mission Control)

🤖 Generated with [Claude Code](https://claude.com/claude-code)