### PR TITLE
feat(telemetry): pre-test competence-envelope gate (Phase 4 / Spin 5, Story #719)

### DIFF
--- a/PLAN_DIVERGENCE_REVIEW.md
+++ b/PLAN_DIVERGENCE_REVIEW.md
@@ -314,3 +314,26 @@ Regime-conditioned anomaly detection on C-MAPSS **FD004**, measured from real Da
 Remaining spins: **5** (pre-test competence envelope — FD001→FD004 shift, the natural next), **6** (event-windowed
 telemetry analog retrieval), **2** (subsystem + lead-lag attribution), **4** (feature-completeness gate),
 **7** (anomaly grouped-by-channel split). Each its own intake'd unit.
+
+---
+
+## Status — Phase 4 / Spin 5 shipped (pre-test competence envelope, Story #719)
+
+Drift, flipped from a post-deployment afterthought into an upstream gate, measured on real C-MAPSS data
+(`silver_cmapss`, reusing the Phase 3 FD001→FD004 framing):
+- Competence envelope = Mahalanobis distance to the FD001 training distribution; in-envelope = d² ≤ τ
+  (τ = FD001 99th-pctl), near-boundary = τ..3τ (review), out = >3τ (abstain).
+- **FD001 held-out: 98.9% in-envelope** (the envelope holds for the trained operating condition).
+- **FD004 stress test: 90.5% out-of-envelope** (+1.5% near) — the FD001-trained model is outside its
+  competence for most of FD004's six conditions; the gate **abstains** instead of scoring confidently.
+- Examples: FD001 unit (settings ~[0,0,100], d²=18 < τ=62 → SCORE) vs FD004 unit (settings [25,0.6,60], d² far
+  beyond τ → ABSTAIN).
+- reproducible: `compute_competence_envelope.py` → `competence_envelope_evidence.json`; pure math in
+  `envelope_core.py` with `test_envelope_core.py` (3 tests, numpy-only/CI-safe).
+- surface: `CompetenceEnvelopeCard` on `/telemetry/evidence`.
+- honest framing: FD004 is a regime-shift stress test (not hot-fire); the envelope gates input distribution,
+  not correctness; "abstain/review/within trained scope" wording, never "safe/certified".
+
+Remaining spins: **6** (event-windowed telemetry analog retrieval), **2** (subsystem + lead-lag attribution),
+**4** (feature-completeness gate), **7** (anomaly grouped-by-channel split). Each its own intake'd unit. The
+regime/distribution trio (1, 3, 5) is now complete.

--- a/claim_coverage_matrix.md
+++ b/claim_coverage_matrix.md
@@ -69,3 +69,14 @@ tracks regime → shipped regime-conditioned normalization.* **Must NOT overclai
 (metric is false-positives on healthy rows, not detection recall); the global baseline is the single-mode
 assumption (a real naive baseline, not a strawman — a model that explicitly accounts for all six conditions
 also works; the point is operating-condition awareness is required).
+
+---
+
+**Status (Phase 4 / Spin 5 — pre-test competence envelope, Story #719):** The **Drift monitoring** row gains an
+upstream gate. A competence envelope fit on FD001 (single operating condition) via Mahalanobis distance holds
+for its own held-out units (**98.9% in-envelope**) but flags **90.5% of FD004** (regime-shift stress test) as
+**out-of-envelope** (+1.5% near-boundary). The gate **abstains/reviews** on out-of-envelope inputs instead of a
+confident score. Surface: the Competence Envelope card on `/telemetry/evidence` (computed artifact, *not live
+serving*) with in/out examples and the score/review/abstain action. **Must NOT overclaim:** FD004 is a
+regime-shift stress test, **not rocket hot-fire**; the envelope gates the INPUT distribution (operating regime),
+not label correctness — in-envelope means "within trained scope," never "safe" or "certified."

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4198,3 +4198,22 @@ claims as fact unless sourced; keep era framing general (access → cost → reu
   also works — the point is that operating-condition awareness is required, and per-regime normalization is the
   scalable way to get it. Keep the testable math (regime z-score, per-regime FP, η²) in a numpy-only core
   module so the eval test runs in CI without Databricks.
+
+## Pre-test competence-envelope gate (Phase 4 / Spin 5, Story #719)
+
+- **Flip drift upstream.** Instead of "today vs training" calendar drift, ask BEFORE scoring: is this input
+  inside the model's trained operating envelope? Fit a transparent envelope (Mahalanobis distance to the FD001
+  training distribution over standardized sensors); band by in-envelope (≤ τ, τ = FD001 99th pctl → score),
+  near-boundary (τ..3τ → review), out-of-envelope (>3τ → abstain). Measured: FD001 held-out 98.9% in-envelope;
+  FD004 (six conditions) 90.5% out-of-envelope. The gate abstains on the shift instead of issuing a confident
+  score — caught before scoring, not after deployment.
+- **Mahalanobis on a single-condition training set explodes on shifted regimes.** FD001's covariance is tiny in
+  near-constant sensor directions, so FD004's different-condition values produce astronomically large d² (e.g.
+  1e8 vs τ=62). That's real and is exactly the "way outside the envelope" signal — display it (scientific
+  notation) rather than clipping. Ridge-regularize the covariance inverse (`cov + 1e-3·I`, pinv) for stability.
+- **Wording discipline.** Use "abstain", "review", "outside trained envelope", "within trained scope" — never
+  "safe" or "certified". The envelope gates INPUT distribution (operating regime), not label correctness:
+  in-envelope ≠ correct prediction. FD004 is a regime-shift STRESS TEST, not rocket hot-fire data.
+- **Reuse FD001→FD004 across spins.** The same split powers Spin 3 (regime-conditioned anomaly) and Spin 5
+  (competence envelope) — one stress test, two findings. Keep the testable math (mahalanobis, band, band_rates)
+  in a numpy-only core so the eval test runs in CI without Databricks.

--- a/repo-b/src/components/telemetry/CompetenceEnvelopeCard.test.tsx
+++ b/repo-b/src/components/telemetry/CompetenceEnvelopeCard.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import CompetenceEnvelopeCard from "./CompetenceEnvelopeCard";
+import evidence from "@/lib/telemetry/competenceEnvelopeEvidence.json";
+
+// Renders a committed, computed evidence artifact (real FD001->FD004 envelope run).
+describe("CompetenceEnvelopeCard", () => {
+  it("renders the in/out envelope rates, the gate, and both examples", () => {
+    render(<CompetenceEnvelopeCard />);
+    expect(screen.getByText(/inside the model's trained envelope/i)).toBeInTheDocument();
+    expect(screen.getByText(/not live serving/i)).toBeInTheDocument();
+    // FD004 out-of-envelope rate is shown as a percentage
+    expect(
+      screen.getAllByText(`${(evidence.metrics.fd004_out_of_envelope_rate * 100).toFixed(1)}%`).length,
+    ).toBeGreaterThan(0);
+    // both operational actions appear: a SCORE (in-envelope) and an ABSTAIN (out-of-envelope)
+    expect(screen.getAllByText("SCORE").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("ABSTAIN").length).toBeGreaterThan(0);
+    // honest framing: regime-shift stress test, not rocket hot-fire
+    expect(screen.getAllByText(/regime shift/i).length).toBeGreaterThan(0);
+  });
+});

--- a/repo-b/src/components/telemetry/CompetenceEnvelopeCard.tsx
+++ b/repo-b/src/components/telemetry/CompetenceEnvelopeCard.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+// Pre-test competence-envelope gate (Spin 5). Renders a COMPUTED EVIDENCE ARTIFACT
+// (repo-b/src/lib/telemetry/competenceEnvelopeEvidence.json) from compute_competence_envelope.py,
+// run on real C-MAPSS FD001 (training) vs FD004 (regime-shift stress test). Flips drift into an
+// upstream check: before scoring, ask whether the input is inside the model's trained operating
+// envelope; if not, ABSTAIN/REVIEW rather than issue a confident score. Labeled not-live; FD004 is
+// a regime-shift stress test, not rocket hot-fire data. No "safe"/"certified" language.
+
+import evidence from "@/lib/telemetry/competenceEnvelopeEvidence.json";
+import { C, EmptyState, MetricCard, PageHeading, Panel, StatGrid, Tag } from "./primitives";
+
+interface Example {
+  subset: string; unit: number; cycle: number; op_settings: number[];
+  mahalanobis_sq: number; tau: number; band: string; action: string;
+}
+interface Evidence {
+  as_of: string; training_reference: string; challenge_set: string; method: string; gate: string;
+  n_fd001_fit: number; n_fd001_eval: number; n_fd004: number;
+  metrics: {
+    tau_mahalanobis_sq: number; k_out: number;
+    fd001_in_envelope_rate: number; fd001_near_boundary_rate: number; fd001_out_of_envelope_rate: number;
+    fd004_in_envelope_rate: number; fd004_near_boundary_rate: number; fd004_out_of_envelope_rate: number;
+  };
+  examples: Example[]; finding: string; limitations: string[];
+}
+
+const ev = evidence as Evidence;
+const pct = (x: number) => `${(x * 100).toFixed(1)}%`;
+const fmtD = (x: number) => (x >= 1e4 ? x.toExponential(1) : x.toFixed(1));
+const actionColor = (a: string) => (a === "SCORE" ? C.green : a === "REVIEW" ? C.amber : C.red);
+
+function BandBar({ label, inR, nearR, outR }: { label: string; inR: number; nearR: number; outR: number }) {
+  const seg = (w: number, color: string, t: string) =>
+    w > 0.001 ? <div title={`${t}: ${pct(w)}`} style={{ width: `${w * 100}%`, background: `${color}aa`,
+      display: "flex", alignItems: "center", justifyContent: "center", fontFamily: C.mono, fontSize: 9.5,
+      color: C.bg, fontWeight: 700 }}>{w > 0.08 ? pct(w) : ""}</div> : null;
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.dim, marginBottom: 4 }}>{label}</div>
+      <div style={{ display: "flex", height: 24, borderRadius: 5, overflow: "hidden", border: `1px solid ${C.border}` }}>
+        {seg(inR, C.green, "in-envelope")}
+        {seg(nearR, C.amber, "near-boundary")}
+        {seg(outR, C.red, "out-of-envelope")}
+      </div>
+    </div>
+  );
+}
+
+function ExampleCard({ e }: { e: Example }) {
+  return (
+    <div style={{ flex: 1, minWidth: 240, padding: "12px 14px", background: C.panel,
+      border: `1px solid ${actionColor(e.action)}55`, borderRadius: 8 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+        <span style={{ fontFamily: C.mono, fontSize: 11, color: C.dim }}>{e.subset} · unit {e.unit} · cyc {e.cycle}</span>
+        <Tag color={actionColor(e.action)}>{e.action}</Tag>
+      </div>
+      <div style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, lineHeight: 1.8 }}>
+        <div>op settings: [{e.op_settings.join(", ")}]</div>
+        <div>distance² to FD001: <span style={{ color: C.text }}>{fmtD(e.mahalanobis_sq)}</span> &nbsp;(τ = {fmtD(e.tau)})</div>
+        <div>band: <span style={{ color: actionColor(e.action) }}>{e.band.replace(/_/g, " ")}</span></div>
+      </div>
+    </div>
+  );
+}
+
+export default function CompetenceEnvelopeCard() {
+  const heading = (
+    <PageHeading eyebrow="Pre-test · competence envelope"
+      title="Is this input inside the model's trained envelope?"
+      blurb="Drift, flipped upstream: before scoring a unit, check whether its inputs are inside the operating envelope the model was trained on. Fit on FD001 (one operating condition), stress-tested on FD004 (six conditions). Out-of-envelope inputs abstain or go to review — never a confident score." />
+  );
+  if (!ev?.metrics || !Array.isArray(ev.examples) || ev.examples.length < 2) {
+    return <>{heading}<EmptyState label="Competence-envelope evidence unavailable" hint="Computed artifact missing required fields." /></>;
+  }
+  const m = ev.metrics;
+
+  return (
+    <>
+      {heading}
+      <div style={{ display: "flex", gap: 8, marginBottom: 14, flexWrap: "wrap" }}>
+        <Tag color={C.amber}>computed evidence artifact · not live serving</Tag>
+        <Tag color={C.dim}>train: {ev.training_reference}</Tag>
+        <Tag color={C.dim}>stress: FD004 regime shift</Tag>
+      </div>
+
+      <StatGrid cols={4} style={{ marginBottom: 14 }}>
+        <MetricCard label="FD001 in-envelope (held-out)" value={pct(m.fd001_in_envelope_rate)}
+          accent={C.green} sub="envelope holds for trained scope" />
+        <MetricCard label="FD004 out-of-envelope" value={pct(m.fd004_out_of_envelope_rate)}
+          accent={C.red} sub="→ abstain, not a confident score" />
+        <MetricCard label="FD004 near-boundary" value={pct(m.fd004_near_boundary_rate)}
+          accent={C.amber} sub="→ review" />
+        <MetricCard label="Gate" value="abstain / review / score"
+          sub={`Mahalanobis · τ = ${fmtD(m.tau_mahalanobis_sq)} (FD001 99th pctl)`} />
+      </StatGrid>
+
+      <Panel title="Where each set lands in the FD001-trained envelope">
+        <BandBar label="FD001 held-out (the trained operating condition)"
+          inR={m.fd001_in_envelope_rate} nearR={m.fd001_near_boundary_rate} outR={m.fd001_out_of_envelope_rate} />
+        <BandBar label="FD004 (six operating conditions — regime-shift stress test)"
+          inR={m.fd004_in_envelope_rate} nearR={m.fd004_near_boundary_rate} outR={m.fd004_out_of_envelope_rate} />
+        <div style={{ display: "flex", gap: 12, marginTop: 6, fontFamily: C.mono, fontSize: 9.5, color: C.faint }}>
+          <span style={{ color: C.green }}>■ in-envelope → score</span>
+          <span style={{ color: C.amber }}>■ near-boundary → review</span>
+          <span style={{ color: C.red }}>■ out-of-envelope → abstain</span>
+        </div>
+      </Panel>
+
+      <Panel title="Two candidate inputs, two operational actions" style={{ marginTop: 14 }}>
+        <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+          {ev.examples.map((e, i) => <ExampleCard key={i} e={e} />)}
+        </div>
+      </Panel>
+
+      <div style={{ fontFamily: C.sans, fontSize: 13, color: C.text, lineHeight: 1.6, margin: "14px 0",
+        padding: "12px 14px", background: C.panel, border: `1px solid ${C.border}`, borderRadius: 8 }}>
+        {ev.finding}
+      </div>
+
+      <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.7 }}>
+        <div><strong style={{ color: C.dim }}>Gate:</strong> {ev.gate}</div>
+        <div><strong style={{ color: C.dim }}>Method:</strong> {ev.method}</div>
+        <div style={{ marginTop: 6 }}><strong style={{ color: C.dim }}>Limitations:</strong></div>
+        <ul style={{ margin: "2px 0 0", paddingLeft: 16 }}>
+          {ev.limitations.map((l, i) => <li key={i} style={{ marginBottom: 2 }}>{l}</li>)}
+        </ul>
+      </div>
+    </>
+  );
+}

--- a/repo-b/src/components/telemetry/EvidenceCards.tsx
+++ b/repo-b/src/components/telemetry/EvidenceCards.tsx
@@ -12,6 +12,7 @@ import DataCollectionCard from "./DataCollectionCard";
 import ModelEvidenceCard from "./ModelEvidenceCard";
 import RulConformalCard from "./RulConformalCard";
 import RegimeAnomalyCard from "./RegimeAnomalyCard";
+import CompetenceEnvelopeCard from "./CompetenceEnvelopeCard";
 import PipelineEvidenceCard from "./PipelineEvidenceCard";
 import FeatureContractCard from "./FeatureContractCard";
 import KnownAnomalyCard from "./KnownAnomalyCard";
@@ -56,6 +57,8 @@ export default function EvidenceCards() {
       <RulConformalCard />
       <Divider />
       <RegimeAnomalyCard />
+      <Divider />
+      <CompetenceEnvelopeCard />
       <Divider />
       <PipelineEvidenceCard />
       <Divider />

--- a/repo-b/src/lib/telemetry/competenceEnvelopeEvidence.json
+++ b/repo-b/src/lib/telemetry/competenceEnvelopeEvidence.json
@@ -1,0 +1,58 @@
+{
+  "as_of": "2026-06-24",
+  "training_reference": "C-MAPSS FD001 (single operating condition)",
+  "challenge_set": "C-MAPSS FD004 (six operating conditions) \u2014 a regime-shift stress test, NOT rocket hot-fire data",
+  "source_table": "novendor_1.telemetry.silver_cmapss (split=train)",
+  "method": "Mahalanobis distance to the FD001 training distribution over standardized sensors. in-envelope = d^2 <= tau (tau = 99th pctl of FD001 training distances); near-boundary = tau..3x tau (review); out-of-envelope = > 3x tau (abstain). Held-out FD001 units validate the in-envelope rate.",
+  "gate": "out-of-envelope -> ABSTAIN; near-boundary -> REVIEW; in-envelope -> SCORE. Never a confident GO outside the trained envelope.",
+  "n_fd001_fit": 14191,
+  "n_fd001_eval": 6440,
+  "n_fd004": 61249,
+  "n_active_sensors": 15,
+  "metrics": {
+    "tau_mahalanobis_sq": 61.6,
+    "k_out": 3.0,
+    "fd001_in_envelope_rate": 0.9891,
+    "fd001_near_boundary_rate": 0.0104,
+    "fd001_out_of_envelope_rate": 0.0005,
+    "fd004_in_envelope_rate": 0.0799,
+    "fd004_near_boundary_rate": 0.0147,
+    "fd004_out_of_envelope_rate": 0.9054
+  },
+  "examples": [
+    {
+      "subset": "FD001",
+      "unit": 85,
+      "cycle": 188,
+      "op_settings": [
+        -0.001,
+        0.0,
+        100.0
+      ],
+      "mahalanobis_sq": 18.2,
+      "tau": 61.6,
+      "band": "in_envelope",
+      "action": "SCORE"
+    },
+    {
+      "subset": "FD004",
+      "unit": 83,
+      "cycle": 184,
+      "op_settings": [
+        25.005,
+        0.62,
+        60.0
+      ],
+      "mahalanobis_sq": 362539616.9,
+      "tau": 61.6,
+      "band": "out_of_envelope",
+      "action": "ABSTAIN"
+    }
+  ],
+  "finding": "An FD001-trained model's competence envelope holds for its own held-out units (98.9% in-envelope), but 90.5% of FD004 falls OUT of that envelope (a further 1.5% near the boundary). The pre-test gate abstains/reviews on those shifted inputs instead of issuing a confident score \u2014 catching the regime shift before scoring, not after deployment.",
+  "limitations": [
+    "FD004 is a regime-shift STRESS TEST (different operating conditions), not rocket hot-fire data; it stands in for 'an input outside the model's trained operating envelope'.",
+    "Mahalanobis distance assumes an roughly elliptical training distribution; it is a transparent first-line envelope, not a calibrated probability of competence.",
+    "The envelope gates on INPUT distribution (operating regime), not on label correctness; in-envelope does not mean the prediction is right, only that it is within trained scope."
+  ]
+}

--- a/telemetry-platform/competence_envelope_evidence.json
+++ b/telemetry-platform/competence_envelope_evidence.json
@@ -1,0 +1,58 @@
+{
+  "as_of": "2026-06-24",
+  "training_reference": "C-MAPSS FD001 (single operating condition)",
+  "challenge_set": "C-MAPSS FD004 (six operating conditions) \u2014 a regime-shift stress test, NOT rocket hot-fire data",
+  "source_table": "novendor_1.telemetry.silver_cmapss (split=train)",
+  "method": "Mahalanobis distance to the FD001 training distribution over standardized sensors. in-envelope = d^2 <= tau (tau = 99th pctl of FD001 training distances); near-boundary = tau..3x tau (review); out-of-envelope = > 3x tau (abstain). Held-out FD001 units validate the in-envelope rate.",
+  "gate": "out-of-envelope -> ABSTAIN; near-boundary -> REVIEW; in-envelope -> SCORE. Never a confident GO outside the trained envelope.",
+  "n_fd001_fit": 14191,
+  "n_fd001_eval": 6440,
+  "n_fd004": 61249,
+  "n_active_sensors": 15,
+  "metrics": {
+    "tau_mahalanobis_sq": 61.6,
+    "k_out": 3.0,
+    "fd001_in_envelope_rate": 0.9891,
+    "fd001_near_boundary_rate": 0.0104,
+    "fd001_out_of_envelope_rate": 0.0005,
+    "fd004_in_envelope_rate": 0.0799,
+    "fd004_near_boundary_rate": 0.0147,
+    "fd004_out_of_envelope_rate": 0.9054
+  },
+  "examples": [
+    {
+      "subset": "FD001",
+      "unit": 85,
+      "cycle": 188,
+      "op_settings": [
+        -0.001,
+        0.0,
+        100.0
+      ],
+      "mahalanobis_sq": 18.2,
+      "tau": 61.6,
+      "band": "in_envelope",
+      "action": "SCORE"
+    },
+    {
+      "subset": "FD004",
+      "unit": 83,
+      "cycle": 184,
+      "op_settings": [
+        25.005,
+        0.62,
+        60.0
+      ],
+      "mahalanobis_sq": 362539616.9,
+      "tau": 61.6,
+      "band": "out_of_envelope",
+      "action": "ABSTAIN"
+    }
+  ],
+  "finding": "An FD001-trained model's competence envelope holds for its own held-out units (98.9% in-envelope), but 90.5% of FD004 falls OUT of that envelope (a further 1.5% near the boundary). The pre-test gate abstains/reviews on those shifted inputs instead of issuing a confident score \u2014 catching the regime shift before scoring, not after deployment.",
+  "limitations": [
+    "FD004 is a regime-shift STRESS TEST (different operating conditions), not rocket hot-fire data; it stands in for 'an input outside the model's trained operating envelope'.",
+    "Mahalanobis distance assumes an roughly elliptical training distribution; it is a transparent first-line envelope, not a calibrated probability of competence.",
+    "The envelope gates on INPUT distribution (operating regime), not on label correctness; in-envelope does not mean the prediction is right, only that it is within trained scope."
+  ]
+}

--- a/telemetry-platform/compute_competence_envelope.py
+++ b/telemetry-platform/compute_competence_envelope.py
@@ -1,0 +1,178 @@
+"""Phase 4 / Spin 5 — Pre-test competence-envelope gate (REAL data, reproducible).
+
+Flips drift from a post-deployment monitoring idea into an UPSTREAM safety check: before
+scoring a unit, ask whether its inputs are inside the operating envelope the model was trained
+on. If not, abstain/REVIEW instead of issuing a confident score.
+
+Setup (reuses the Phase 3 FD001->FD004 framing): fit the envelope on C-MAPSS FD001 (a single
+operating condition) via Mahalanobis distance to the training distribution, then stress-test on
+FD004 (six operating conditions) — a regime-shift the FD001-trained model never saw. Most of
+FD004 should land OUT of the FD001 envelope.
+
+Bands: in-envelope (d^2 <= tau) -> score; near-boundary (tau..k_out*tau) -> review;
+out-of-envelope (> k_out*tau) -> abstain. tau = 99th percentile of FD001's own training
+distances (so FD001 holdout stays ~in-envelope by construction).
+
+Data: silver_cmapss (preserves op-settings + 21 sensors). FD004 is a REGIME-SHIFT STRESS TEST,
+not rocket hot-fire data. No fake scores; no "safe"/"certified" language.
+
+Run: python telemetry-platform/compute_competence_envelope.py   (Databricks OAuth profile 'PaulMain')
+"""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.sql import Disposition, Format, StatementState
+
+from envelope_core import ACTION, IN, NEAR, OUT, band, band_rates, fit_envelope, mahalanobis_sq
+
+TEL = "novendor_1.telemetry"
+WAREHOUSE_ID = "0e56420fb707d861"
+TAU_PCTL = 0.99      # FD001 training percentile that defines the in-envelope boundary
+K_OUT = 3.0          # beyond k_out * tau => out-of-envelope (abstain)
+SEED = 0
+SETTINGS = ["op_setting_1", "op_setting_2", "op_setting_3"]
+SENSORS = [f"sensor_{i}" for i in range(1, 22)]
+ROOT = Path(__file__).resolve().parents[1]
+AS_OF = "2026-06-24"
+
+
+def query(w: WorkspaceClient, sql: str) -> pd.DataFrame:
+    resp = w.statement_execution.execute_statement(
+        statement=sql, warehouse_id=WAREHOUSE_ID, wait_timeout="50s",
+        disposition=Disposition.INLINE, format=Format.JSON_ARRAY,
+    )
+    sid = resp.statement_id
+    while resp.status.state in (StatementState.PENDING, StatementState.RUNNING):
+        time.sleep(2)
+        resp = w.statement_execution.get_statement(sid)
+    if resp.status.state != StatementState.SUCCEEDED:
+        raise RuntimeError(f"SQL {resp.status.state}: {resp.status.error}")
+    cols = [c.name for c in resp.manifest.schema.columns]
+    rows = list(resp.result.data_array or [])
+    for n in range(1, resp.manifest.total_chunk_count or 1):
+        rows.extend(w.statement_execution.get_statement_result_chunk_n(sid, n).data_array or [])
+    return pd.DataFrame(rows, columns=cols)
+
+
+def main() -> None:
+    w = WorkspaceClient(profile="PaulMain")
+    print("[envelope] starting warehouse if stopped...")
+    try:
+        import datetime
+        w.warehouses.start(WAREHOUSE_ID).result(timeout=datetime.timedelta(minutes=5))
+    except Exception as exc:
+        print(f"[envelope] warehouse note: {str(exc)[:120]}")
+
+    print("[envelope] pulling FD001 + FD004 train rows from silver_cmapss...")
+    cols = ", ".join(["subset", "unit", "cycle", "rul_target"] + SETTINGS + SENSORS)
+    df = query(w, f"SELECT {cols} FROM {TEL}.silver_cmapss "
+                  f"WHERE subset IN ('FD001','FD004') AND split = 'train'")
+    for c in ["unit", "cycle", "rul_target"] + SETTINGS + SENSORS:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+    df = df.dropna(subset=SENSORS)
+    fd001 = df[df.subset == "FD001"].copy()
+    fd004 = df[df.subset == "FD004"].copy()
+    print(f"[envelope] FD001 rows={len(fd001)} units={fd001.unit.nunique()} | "
+          f"FD004 rows={len(fd004)} units={fd004.unit.nunique()}")
+
+    active = [s for s in SENSORS if fd001[s].std() > 1e-6]
+
+    # FD001 fit/eval split by unit (held-out in-envelope validation).
+    rng = np.random.default_rng(SEED)
+    units = np.sort(fd001.unit.unique())
+    eval_units = set(rng.choice(units, size=max(1, len(units) * 3 // 10), replace=False).tolist())
+    fit = fd001[~fd001.unit.isin(eval_units)]
+    ev1 = fd001[fd001.unit.isin(eval_units)]
+
+    scaler = StandardScaler().fit(fit[active].to_numpy())
+    mean, cov_inv = fit_envelope(scaler.transform(fit[active].to_numpy()))
+    d2_fit = mahalanobis_sq(scaler.transform(fit[active].to_numpy()), mean, cov_inv)
+    tau = float(np.quantile(d2_fit, TAU_PCTL))
+
+    d2_ev1 = mahalanobis_sq(scaler.transform(ev1[active].to_numpy()), mean, cov_inv)
+    d2_fd4 = mahalanobis_sq(scaler.transform(fd004[active].to_numpy()), mean, cov_inv)
+    rates_fd001 = band_rates(d2_ev1, tau, K_OUT)
+    rates_fd004 = band_rates(d2_fd4, tau, K_OUT)
+
+    def example(frame: pd.DataFrame, d2: np.ndarray, pick: str) -> dict:
+        # last cycle of a representative unit; pick = 'in' (FD001, low d2) or 'out' (FD004, high d2)
+        last = frame.sort_values(["unit", "cycle"]).groupby("unit").tail(1)
+        idx_last = last.index.to_numpy()
+        d2_last = d2[[list(frame.index).index(i) for i in idx_last]]
+        order = np.argsort(d2_last)
+        chosen = idx_last[order[len(order) // 4]] if pick == "in" else idx_last[order[-1]]
+        row = frame.loc[chosen]
+        dist = float(d2[list(frame.index).index(chosen)])
+        b = band(dist, tau, K_OUT)
+        return {
+            "subset": row.subset, "unit": int(row.unit), "cycle": int(row.cycle),
+            "op_settings": [round(float(row[s]), 3) for s in SETTINGS],
+            "mahalanobis_sq": round(dist, 1), "tau": round(tau, 1),
+            "band": b, "action": ACTION[b].upper(),
+        }
+
+    ex_in = example(ev1, d2_ev1, "in")
+    ex_out = example(fd004, d2_fd4, "out")
+
+    artifact = {
+        "as_of": AS_OF,
+        "training_reference": "C-MAPSS FD001 (single operating condition)",
+        "challenge_set": "C-MAPSS FD004 (six operating conditions) — a regime-shift stress test, NOT rocket hot-fire data",
+        "source_table": f"{TEL}.silver_cmapss (split=train)",
+        "method": ("Mahalanobis distance to the FD001 training distribution over standardized sensors. "
+                   f"in-envelope = d^2 <= tau (tau = {int(TAU_PCTL*100)}th pctl of FD001 training distances); "
+                   f"near-boundary = tau..{K_OUT:g}x tau (review); out-of-envelope = > {K_OUT:g}x tau (abstain). "
+                   "Held-out FD001 units validate the in-envelope rate."),
+        "gate": "out-of-envelope -> ABSTAIN; near-boundary -> REVIEW; in-envelope -> SCORE. Never a confident GO outside the trained envelope.",
+        "n_fd001_fit": int(len(fit)), "n_fd001_eval": int(len(ev1)), "n_fd004": int(len(fd004)),
+        "n_active_sensors": int(len(active)),
+        "metrics": {
+            "tau_mahalanobis_sq": round(tau, 1), "k_out": K_OUT,
+            "fd001_in_envelope_rate": round(rates_fd001[IN], 4),
+            "fd001_near_boundary_rate": round(rates_fd001[NEAR], 4),
+            "fd001_out_of_envelope_rate": round(rates_fd001[OUT], 4),
+            "fd004_in_envelope_rate": round(rates_fd004[IN], 4),
+            "fd004_near_boundary_rate": round(rates_fd004[NEAR], 4),
+            "fd004_out_of_envelope_rate": round(rates_fd004[OUT], 4),
+        },
+        "examples": [ex_in, ex_out],
+        "finding": (
+            f"An FD001-trained model's competence envelope holds for its own held-out units "
+            f"({round(rates_fd001[IN]*100,1)}% in-envelope), but {round(rates_fd004[OUT]*100,1)}% of FD004 "
+            f"falls OUT of that envelope (a further {round(rates_fd004[NEAR]*100,1)}% near the boundary). "
+            f"The pre-test gate abstains/reviews on those shifted inputs instead of issuing a confident score "
+            f"— catching the regime shift before scoring, not after deployment."
+        ),
+        "limitations": [
+            "FD004 is a regime-shift STRESS TEST (different operating conditions), not rocket hot-fire data; it stands in for 'an input outside the model's trained operating envelope'.",
+            "Mahalanobis distance assumes an roughly elliptical training distribution; it is a transparent first-line envelope, not a calibrated probability of competence.",
+            "The envelope gates on INPUT distribution (operating regime), not on label correctness; in-envelope does not mean the prediction is right, only that it is within trained scope.",
+        ],
+    }
+
+    out_src = ROOT / "telemetry-platform" / "competence_envelope_evidence.json"
+    out_fe = ROOT / "repo-b" / "src" / "lib" / "telemetry" / "competenceEnvelopeEvidence.json"
+    out_src.write_text(json.dumps(artifact, indent=2), encoding="utf-8")
+    out_fe.write_text(json.dumps(artifact, indent=2), encoding="utf-8")
+
+    print("\n=== COMPETENCE ENVELOPE (FD001 trained -> FD004 stress) — measured ===")
+    print(f"tau (FD001 {int(TAU_PCTL*100)}th pctl d^2) = {tau:.1f} | k_out = {K_OUT}")
+    print(f"FD001 held-out: in {rates_fd001[IN]:.3f} near {rates_fd001[NEAR]:.3f} out {rates_fd001[OUT]:.3f}")
+    print(f"FD004 stress  : in {rates_fd004[IN]:.3f} near {rates_fd004[NEAR]:.3f} out {rates_fd004[OUT]:.3f}")
+    print(f"example in : {ex_in}")
+    print(f"example out: {ex_out}")
+    print(f"\nwrote {out_src}\nwrote {out_fe}")
+
+
+if __name__ == "__main__":
+    main()

--- a/telemetry-platform/envelope_core.py
+++ b/telemetry-platform/envelope_core.py
@@ -1,0 +1,51 @@
+"""Pure competence-envelope primitives (numpy only — no Databricks/sklearn, CI-safe).
+
+Shared by compute_competence_envelope.py (which pulls real FD001/FD004 data) and the eval
+test test_envelope_core.py. The envelope is a transparent Mahalanobis distance to the
+training distribution: in-envelope = close to what the model was trained on; out-of-envelope
+= a regime the model has not seen, where it should abstain rather than score confidently.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Band labels + the operational action each implies.
+IN, NEAR, OUT = "in_envelope", "near_boundary", "out_of_envelope"
+ACTION = {IN: "score", NEAR: "review", OUT: "abstain"}
+
+
+def fit_envelope(X: np.ndarray, ridge: float = 1e-3) -> tuple[np.ndarray, np.ndarray]:
+    """Mean + (ridge-regularized) inverse covariance from the training rows only.
+    Ridge keeps the inverse stable when sensors are collinear."""
+    X = np.asarray(X, dtype=float)
+    mean = X.mean(axis=0)
+    cov = np.cov(X, rowvar=False)
+    cov = cov + ridge * np.eye(cov.shape[0])
+    return mean, np.linalg.pinv(cov)
+
+
+def mahalanobis_sq(X: np.ndarray, mean: np.ndarray, cov_inv: np.ndarray) -> np.ndarray:
+    """Squared Mahalanobis distance of each row to the training distribution."""
+    d = np.asarray(X, dtype=float) - mean
+    return np.einsum("ij,jk,ik->i", d, cov_inv, d)
+
+
+def band(d2: float, tau: float, k_out: float) -> str:
+    """in-envelope (<= tau) -> score; near-boundary (tau..k_out*tau) -> review; out -> abstain."""
+    if d2 <= tau:
+        return IN
+    if d2 <= k_out * tau:
+        return NEAR
+    return OUT
+
+
+def band_rates(d2: np.ndarray, tau: float, k_out: float) -> dict:
+    """Fraction of rows in each band."""
+    d2 = np.asarray(d2, dtype=float)
+    n = len(d2) or 1
+    return {
+        IN: float(np.mean(d2 <= tau)),
+        NEAR: float(np.mean((d2 > tau) & (d2 <= k_out * tau))),
+        OUT: float(np.mean(d2 > k_out * tau)),
+    }

--- a/telemetry-platform/test_envelope_core.py
+++ b/telemetry-platform/test_envelope_core.py
@@ -1,0 +1,42 @@
+"""Eval tests for the competence-envelope primitives — numpy only, no Databricks.
+
+Run: python -m pytest telemetry-platform/test_envelope_core.py -q
+"""
+
+import numpy as np
+
+from envelope_core import ACTION, IN, NEAR, OUT, band, band_rates, fit_envelope, mahalanobis_sq
+
+
+def test_mahalanobis_reduces_to_squared_euclidean_under_identity():
+    X = np.array([[0.0, 0.0], [3.0, 4.0]])
+    d2 = mahalanobis_sq(X, np.zeros(2), np.eye(2))
+    assert np.isclose(d2[0], 0.0)
+    assert np.isclose(d2[1], 25.0)  # 3^2 + 4^2
+
+
+def test_band_thresholds_and_actions():
+    assert band(0.5, tau=1.0, k_out=3.0) == IN
+    assert band(2.0, tau=1.0, k_out=3.0) == NEAR
+    assert band(5.0, tau=1.0, k_out=3.0) == OUT
+    assert ACTION[IN] == "score" and ACTION[NEAR] == "review" and ACTION[OUT] == "abstain"
+
+
+def test_training_distribution_is_mostly_in_envelope_shift_is_out():
+    # Fit the envelope on a training cluster; a far-shifted cluster (a regime the model never
+    # saw) must land out-of-envelope, while held-out training-like points stay in-envelope.
+    rng = np.random.default_rng(0)
+    train = rng.normal(size=(2000, 5))
+    mean, cov_inv = fit_envelope(train)
+    d2_train = mahalanobis_sq(train, mean, cov_inv)
+    tau = float(np.quantile(d2_train, 0.99))
+
+    in_like = rng.normal(size=(1000, 5))            # same distribution
+    shifted = rng.normal(size=(1000, 5)) + 8.0       # a far operating regime
+
+    rates_in = band_rates(mahalanobis_sq(in_like, mean, cov_inv), tau, k_out=3.0)
+    rates_shift = band_rates(mahalanobis_sq(shifted, mean, cov_inv), tau, k_out=3.0)
+
+    assert rates_in[IN] > 0.9          # training-like stays in-envelope
+    assert rates_shift[OUT] > 0.9      # the shifted regime is flagged out-of-envelope
+    assert rates_shift[IN] < 0.05      # ...and almost none of it looks in-envelope


### PR DESCRIPTION
Flips drift into an upstream safety check: before scoring a unit, is its input inside the model's trained operating envelope? If not, abstain/review — never a confident score.

Measured (real C-MAPSS via silver_cmapss): competence envelope = Mahalanobis distance to the FD001 training distribution; bands in (score) / near (review) / out (abstain), tau = FD001 99th pctl. FD001 held-out 98.9% in-envelope; FD004 (six conditions, regime-shift stress test) 90.5% out-of-envelope. Examples: FD001 unit settings ~[0,0,100] d2=18 SCORE vs FD004 unit settings [25,0.6,60] d2 far beyond tau ABSTAIN.

Honest: FD004 is a regime-shift stress test, not rocket hot-fire; envelope gates input distribution not label correctness; abstain/review wording, no safe/certified. Completes the regime/distribution trio (Spins 1,3,5).

envelope_core.py (pure numpy) + test_envelope_core.py (3 tests); compute_competence_envelope.py -> competence_envelope_evidence.json; CompetenceEnvelopeCard + test; matrix/plan/tips updated.

Generated with Claude Code