### PR TITLE
fix(lab): load ADE + investigate pages on Next 14 (useParams)

### DIFF
--- a/repo-b/src/app/app/investigate/[sessionId]/page.tsx
+++ b/repo-b/src/app/app/investigate/[sessionId]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { use, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
+import { useParams } from "next/navigation";
 
 import { useEnv } from "@/components/EnvProvider";
 import {
@@ -19,8 +20,8 @@ const STATUS_TONE: Record<string, string> = {
   completed: "107,174,127", error: "212,122,114",
 };
 
-export default function InvestigatePage({ params }: { params: Promise<{ sessionId: string }> }) {
-  const { sessionId } = use(params);
+export default function InvestigatePage() {
+  const { sessionId } = useParams<{ sessionId: string }>();
   const { selectedEnv, environments, loading } = useEnv();
   const env = selectedEnv?.env_id ?? environments[0]?.env_id ?? null;
   const biz = selectedEnv?.business_id ?? environments[0]?.business_id ?? undefined;

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/audit/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/audit/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { use } from "react";
+import { useParams } from "next/navigation";
 import AuditDashboard from "@/components/automated-data-engineering/AuditDashboard";
 
-export default function AdeAuditPage({ params }: { params: Promise<{ envId: string }> }) {
-  const { envId } = use(params);
+export default function AdeAuditPage() {
+  const { envId } = useParams<{ envId: string }>();
   return <AuditDashboard envId={envId} />;
 }

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/layout.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/layout.tsx
@@ -3,13 +3,13 @@ import AdeShell from "@/components/automated-data-engineering/AdeShell";
 // Full-bleed control room. The lab shell yields full-bleed for
 // /automated-data-engineering (isDomainRoute), and AdeShell carries its dark
 // palette inline, so no theme pinning is needed here.
-export default async function AdeLayout({
+export default function AdeLayout({
   children,
   params,
 }: {
   children: React.ReactNode;
-  params: Promise<{ envId: string }>;
+  params: { envId: string };
 }) {
-  const { envId } = await params;
+  const { envId } = params;
   return <AdeShell envId={envId}>{children}</AdeShell>;
 }

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { use } from "react";
+import { useParams } from "next/navigation";
 import AdeOverview from "@/components/automated-data-engineering/AdeOverview";
 
-export default function AdeOverviewPage({ params }: { params: Promise<{ envId: string }> }) {
-  const { envId } = use(params);
+export default function AdeOverviewPage() {
+  const { envId } = useParams<{ envId: string }>();
   return <AdeOverview envId={envId} />;
 }

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/runs/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/runs/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { use } from "react";
+import { useParams } from "next/navigation";
 import ReceiptsFeed from "@/components/automated-data-engineering/ReceiptsFeed";
 
 // Route segment stays /runs; the user-facing label is "Execution Receipts".
-export default function AdeReceiptsPage({ params }: { params: Promise<{ envId: string }> }) {
-  const { envId } = use(params);
+export default function AdeReceiptsPage() {
+  const { envId } = useParams<{ envId: string }>();
   return <ReceiptsFeed envId={envId} />;
 }

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/workflows/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/workflows/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { use } from "react";
+import { useParams } from "next/navigation";
 import WorkflowCatalog from "@/components/automated-data-engineering/WorkflowCatalog";
 
-export default function AdeWorkflowsPage({ params }: { params: Promise<{ envId: string }> }) {
-  const { envId } = use(params);
+export default function AdeWorkflowsPage() {
+  const { envId } = useParams<{ envId: string }>();
   return <WorkflowCatalog envId={envId} />;
 }


### PR DESCRIPTION
## Problem
The Automated Data Engineering workspace (`/lab/env/<envId>/automated-data-engineering`) and the investigation workspace (`/app/investigate/<sessionId>`) crashed into the error boundary with minified **React error #438** — *"An unsupported type was passed to `use()`: [object Object]"*.

## Root cause
The app runs **Next.js 14.2.25** (React 18.3.1), where route `params` is a **plain synchronous object**, not a Promise. These pages were written against the **Next 15** `use(params)` pattern, so `use()` received a plain object and threw #438. The layout's `await params` survived (so the breadcrumb rendered) but the client page crashed.

## Fix
Switch the four ADE client pages and the investigate page to `useParams()` from `next/navigation` (the pattern every other working lab page already uses), and read `params` synchronously in the ADE layout.

- `automated-data-engineering/{page,runs,audit,workflows}/…tsx`
- `automated-data-engineering/layout.tsx`
- `app/investigate/[sessionId]/page.tsx`

## Verification
- `tsc --noEmit` clean for all touched files.
- APIs (`skill-registry`, `connectors`, `connector-lifecycle`, `runs`, `governance-stats`) confirmed healthy (200) — no backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)