### PR TITLE
refactor(telemetry): shared UI primitives + evidence-card contract (PR A)

### DIFF
--- a/repo-b/src/components/telemetry/TELEMETRY_FRONTEND_REFACTOR_INVENTORY.md
+++ b/repo-b/src/components/telemetry/TELEMETRY_FRONTEND_REFACTOR_INVENTORY.md
@@ -1,0 +1,134 @@
+# Telemetry Frontend Refactor — Inventory
+
+Verified inventory of `repo-b/src/components/telemetry/**` for the production-readiness refactor.
+Behavior-preserving: no metric/claim/backend changes; the dark `C` palette stays (it is the env theme
+adapter, not drift). Source: read-only multi-agent sweep + direct reads, June 2026.
+
+## Scale
+
+- ~46 component `.tsx` files (excl. `.test.tsx`), ~10,200 LOC, + 21 thin page routes (~5 LOC each).
+- ~1,180+ inline `style={{…}}` sites, almost all re-declaring `C`-token typography/spacing/borders that a
+  primitive could own.
+- ~40 of 46 files use `C` directly. The exceptions use `RS` (`rsTokens.tsx`) — a second design language on
+  RegistryConsole / FactoryNcrIntelligence / MissionControlStream / context/BottleneckMap/*. **Decision:
+  RS is being unified into `C`** (approved visual change; data/metrics/claim copy unchanged). The only
+  intentionally non-`C` inline values that stay are runtime-derived (`MetadataGraphNode.LAYER_COLORS`).
+
+### Top files by inline-style density
+
+| Count | File |
+|---|---|
+| 77 | `GovernanceDashboard.tsx` |
+| 71 | `Copilot.tsx` |
+| 58 | `SpikeInspector.tsx` |
+| 57 | `RegistryConsole.tsx` |
+| 53 | `TelemetryArchitectureMap.tsx` |
+| 50 | `metadata/TelemetryMetadataExplorer.tsx` |
+| 47 | `FactoryNcrIntelligence.tsx` |
+| 44 | `MissionControlStream.tsx` |
+| 40 | `RulCalibration.tsx` |
+| 38 | `ControlTower.tsx` |
+| 28 | `AiEvidenceCard.tsx`, `RulConformalCard.tsx` |
+| 26 | `metadata/MetadataDetailDrawer.tsx` |
+| 25 | `CompetenceEnvelopeCard.tsx`, `metadata/LineageDrawer.tsx` |
+
+## Primitive gap map
+
+Rule: reuse before rename before create — never a second implementation of an existing primitive.
+Status as of PR A (`primitives.tsx` + `chartPrimitives.tsx` + `evidenceCard.tsx` + `drawerPrimitives.tsx`).
+
+| Desired | Action | Status |
+|---|---|---|
+| `TelemetryPageHeading` | alias `PageHeading` | done (PR A) |
+| `TelemetryPanel` | alias `Panel` | done (PR A) |
+| `TelemetryNullState` | alias `EmptyState` | done (PR A) |
+| verdict chip | `VerdictChip` over `Tag` + `verdictColor()` | done (PR A) |
+| `StatusDot` | create | done (PR A) |
+| `MetricRow` / `Stat` | create | done (PR A) |
+| `TelemetryActionButton` / `SelectField` | create | done (PR A) |
+| `InlineCode` (`TelemetryInlineCode`) | create | done (PR A) |
+| `TelemetrySection` | create | done (PR A) |
+| `TelemetryStatusBanner` | create (aria-live) | done (PR A) |
+| `TelemetryProvenancePanel` | create | done (PR A) |
+| `SectionTabButton` | create | done (PR A) |
+| `TelemetryThesisHeading` / `TelemetryPageShell` | create | done (PR A) |
+| `TelemetryChartFrame` / `TelemetryLegend` | create (`chartPrimitives.tsx`) | done (PR A) |
+| `TelemetryEvidenceCard` + `EvidenceContract` | create (`evidenceCard.tsx`) | done (PR A) |
+| `DrawerWrapper` / `DrawerHeader` / `FieldRow` | create (`drawerPrimitives.tsx`) | done (PR A) |
+
+## Evidence-card contract gap (PR B)
+
+Contract: title · thesisRole · sourceStatus · asOf · coreMetrics · method · claimBoundary · null_reason ·
+detail · provenance. `RulConformalCard` and `RegimeAnomalyCard` already carry all fields (reference shape).
+
+| Card | Missing fields to fill |
+|---|---|
+| `DataCollectionCard` | sourceStatus, asOf, method, claimBoundary (mark as static framework note, not evidence-tier) |
+| `FeatureContractCard` | asOf, method, claimBoundary |
+| `PipelineEvidenceCard` | asOf, method, claimBoundary |
+| `ModelEvidenceCard` | asOf, claimBoundary |
+| `AiEvidenceCard` | asOf, method, claimBoundary |
+| `DeploymentReceiptCard` | claimBoundary (live `/version` vs build-time) |
+| `KnownAnomalyCard` | null_reason wiring |
+| `CompetenceEnvelopeCard` | asOf, claimBoundary |
+
+Keep every metric and claim string byte-identical when adopting the frame.
+
+## God-component split plan (PR C)
+
+Container (fetch/state) + presentational subcomponents + chart + status + provenance:
+
+- **ReplayConsole** → container + `ReplayControls` + `ReplayStageUnavailableBanner` (→ `TelemetryStatusBanner`)
+  + `TelemetryTraceChart` (geometry inline, frame via `TelemetryChartFrame`) + `ReplayVerdictCard`
+  (aria-live) + `SensorAttributionCard` + provenance (→ `TelemetryProvenancePanel`).
+- **GovernanceDashboard** → fetch hook + `PosturePanel`/`EvalSuitePanel`/`McpToolsPanel`/`UsefulnessPanel`/
+  `RecentInteractionsTable`/`RefusalExamplesPanel` (dots → `StatusDot`, metrics → `MetricRow`/`Stat`).
+- **Copilot** → message hook + `CopilotMessageThread`/`CapabilityListPanel`/`LimitationListPanel`/`TabButton`.
+- **ControlTower** → run/decision hook + `RunControls`/`RoutingPanel`/`GemmaPanel`/`ApprovalGate`/`ReceiptPanel`
+  (Ed25519 → `TelemetryProvenancePanel`; `btn`/`inputStyle` → `TelemetryActionButton`/`SelectField`).
+- **TelemetryMetadataExplorer** → ~200-LOC controller + `MetadataExplorerHeader` + `MetadataStatsGrid`
+  (`StatGrid`) + `MetadataGraphVisualization` (ReactFlow, pure).
+- **MetadataDetailDrawer / LineageDrawer** → shared `DrawerWrapper`/`DrawerHeader`/`FieldRow`.
+- **SpikeInspector / RulCalibration / TelemetryArchitectureMap / MissionControlStream / ModelPerformance /
+  Monitoring / RunsExplorer / SystemHealth** → same shape; charts → `TelemetryChartFrame`/`TelemetryLegend`.
+- **RS→C**: RegistryConsole, FactoryNcrIntelligence, MissionControlStream, context/BottleneckMap/* migrate
+  `RS*` → `C`/primitives. Re-skin only; screenshot-gate each (top visual-regression risk).
+
+Sub-split PR C if review-heavy: C1 consoles · C2 metadata · C3 RS→C.
+
+## Duplication hotlist
+
+1. label/value mono row (15+) → `MetricRow`.
+2. glowing status dot (20+) → `StatusDot`.
+3. panel-title styling (8+) → `Panel` title slot.
+4. verdict/status chip re-inlined → `Tag`/`VerdictChip`.
+5. recharts boilerplate (margins, `isAnimationActive=false`) (4 files) → `TelemetryChartFrame`.
+6. bar-chart flex (`GateBar`/`FpBar`/`BandBar`) (3 cards) → shared viz utility.
+7. button/input (`btn`/`inputStyle`/`FilterSelect`) → `TelemetryActionButton`/`SelectField`.
+8. Radix drawer Portal/Overlay/Content + header (~80 lines ×2) → `DrawerWrapper`/`DrawerHeader`.
+9. field 2-col grid → `FieldRow`.
+10. section tabs → `SectionTabButton`.
+11. RS token refs scattered vs `rsTokens` helpers → fold into `C` (PR C).
+
+## Behavior-preservation risks (must hold)
+
+- **Fail-closed/null copy (verbatim):** `metadata_graph_unreachable`, `no_upstream_edges_in_catalog`,
+  `out_of_scope_requires_waterfall`, governance N=0 reason, "Unavailable reason", `model_not_promoted`.
+- **Claim copy (never strengthen):** "recorded capture replayed" / "CAPTURE (recorded live session)" /
+  "not live serving" / "computed artifact" / "committed JSON, not a live Databricks query"; honest-F1 dual
+  labeling; gate thresholds (F1≥0.30, RMSE≤25, GO<1.0 / REVIEW 1.0–2.0 / NO-GO>2.0); Ed25519
+  tamper-evident; "promotion = alias update, fail-closed"; "no seeded numbers".
+- **Geometry stays inline:** `MetadataGraphNode.LAYER_COLORS`, `TelemetryArchitectureMap` NodeShapeEl/route,
+  `RulCalibration` TrajectoryChart SVG, `ReplayConsole.pathFor`, xyflow/d3 positioning. Frame the chrome,
+  not the math. Keep recharts `isAnimationActive=false` through `TelemetryChartFrame`.
+- **Drawer Radix contract:** preserve `Dialog.Root/Portal/Overlay/Content`, responsive `lg:right-0`,
+  close-on-Escape, focus trap.
+- **Tests:** assert on text/role/null_reason; RS→C surfaces are the top visual-regression risk → screenshots.
+
+## Consolidation recommendations (LATER pass — not executed)
+
+- Model Performance + Registry + RUL Calibration → "Model Lifecycle".
+- Metric Lineage + Trust Center + Metadata Explorer → "Trust & Lineage".
+- Replay + Known Anomaly + Test Runs → "Run Replay / Go-No-Go".
+- Evidence + How This Works → "Evidence".
+- Collapse the two metadata drawers into one parameterized drawer once `DrawerWrapper` is adopted.

--- a/repo-b/src/components/telemetry/chartPrimitives.tsx
+++ b/repo-b/src/components/telemetry/chartPrimitives.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import type { CSSProperties, ReactNode } from "react";
+import { C, Panel, EmptyState } from "./primitives";
+
+// ===========================================================================
+// Chart chrome primitives. These own the *frame* around a chart — title, legend,
+// caption, accessible label, and the empty state — so the chart body (recharts
+// container or raw SVG) only carries geometry. Geometry/coordinates stay inline
+// in the chart body; the chrome stops being copy-pasted.
+// ---------------------------------------------------------------------------
+
+export type LegendItem = { label: string; color: string; dashed?: boolean };
+
+// Swatch + label legend. A dashed item renders a line instead of a filled chip.
+export function TelemetryLegend({ items, style }: { items: LegendItem[]; style?: CSSProperties }) {
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: "6px 16px", ...style }}>
+      {items.map((it) => (
+        <span key={it.label} style={{ display: "inline-flex", alignItems: "center", gap: 7 }}>
+          {it.dashed ? (
+            <span aria-hidden style={{ width: 16, height: 0, borderTop: `2px dashed ${it.color}` }} />
+          ) : (
+            <span aria-hidden style={{ width: 11, height: 11, borderRadius: 3, background: it.color }} />
+          )}
+          <span style={{ fontFamily: C.mono, fontSize: 11, color: C.dim }}>{it.label}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// Framed chart. Pass recharts ResponsiveContainer or an <svg> as children.
+// When `empty` is true, renders the designed fail-closed EmptyState instead of a
+// broken/blank chart (per the Charts component contract).
+export function TelemetryChartFrame({
+  title, right, legend, caption, ariaLabel, empty, emptyLabel = "No data to plot",
+  emptyHint = "evidence unavailable", pad = 12, children,
+}: {
+  title?: string;
+  right?: ReactNode;
+  legend?: LegendItem[];
+  caption?: ReactNode;
+  ariaLabel?: string;
+  empty?: boolean;
+  emptyLabel?: string;
+  emptyHint?: string;
+  pad?: number;
+  children: ReactNode;
+}) {
+  return (
+    <Panel title={title} right={right} pad={pad}>
+      {legend && legend.length > 0 && (
+        <div style={{ marginBottom: 10 }}>
+          <TelemetryLegend items={legend} />
+        </div>
+      )}
+      {empty ? (
+        <EmptyState label={emptyLabel} hint={emptyHint} />
+      ) : (
+        <figure style={{ margin: 0 }} role="group" aria-label={ariaLabel}>
+          {children}
+          {caption && (
+            <figcaption style={{ textAlign: "center", fontFamily: C.mono, fontSize: 11, color: C.faint, marginTop: 6 }}>
+              {caption}
+            </figcaption>
+          )}
+        </figure>
+      )}
+    </Panel>
+  );
+}

--- a/repo-b/src/components/telemetry/drawerPrimitives.tsx
+++ b/repo-b/src/components/telemetry/drawerPrimitives.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import type { ReactNode } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { C } from "./primitives";
+
+// ===========================================================================
+// Shared right/bottom drawer primitives (Radix Dialog). Both metadata drawers
+// duplicated this Portal/Overlay/Content + header + field-row boilerplate. The
+// contract is preserved exactly: right-open on lg / bottom sheet on mobile,
+// close-on-Escape + overlay click via Dialog.Root, focus trap via Radix, and an
+// explicit close control. Geometry/responsive layout stays in literal classes.
+// ---------------------------------------------------------------------------
+
+function isPresent(value: unknown) {
+  return value !== undefined && value !== null && value !== "";
+}
+
+// Fail-closed 2-column field row: a missing value renders "Not available", never blank.
+export function FieldRow({ label, value }: { label: string; value: unknown }) {
+  const present = isPresent(value);
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "minmax(96px,0.8fr) minmax(0,1.5fr)", gap: 12,
+      padding: "8px 0", borderBottom: `1px solid ${C.border}` }}>
+      <div style={{ color: C.faint, fontFamily: C.mono, fontSize: 9, letterSpacing: "0.09em", textTransform: "uppercase" }}>{label}</div>
+      <div style={{ color: present ? C.dim : C.faint, fontFamily: C.mono, fontSize: 11, lineHeight: 1.5, overflowWrap: "anywhere" }}>
+        {present ? String(value) : "Not available"}
+      </div>
+    </div>
+  );
+}
+
+// Drawer title + description + close control (Radix Title/Description/Close).
+export function DrawerHeader({ title, description, closeLabel = "Close" }: {
+  title: ReactNode; description?: ReactNode; closeLabel?: string;
+}) {
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", gap: 16 }}>
+      <div style={{ minWidth: 0 }}>
+        <Dialog.Title style={{ fontFamily: C.sans, fontSize: 19, fontWeight: 700, overflowWrap: "anywhere" }}>
+          {title}
+        </Dialog.Title>
+        {description != null && (
+          <Dialog.Description style={{ color: C.dim, fontFamily: C.mono, fontSize: 10, lineHeight: 1.5, marginTop: 6 }}>
+            {description}
+          </Dialog.Description>
+        )}
+      </div>
+      <Dialog.Close asChild>
+        <button type="button" aria-label={closeLabel}
+          style={{ width: 36, height: 36, borderRadius: 7, border: `1px solid ${C.borderHi}`,
+            background: C.panel, color: C.dim, cursor: "pointer", flexShrink: 0 }}>
+          ×
+        </button>
+      </Dialog.Close>
+    </div>
+  );
+}
+
+// Right/bottom drawer shell. `open` + `onClose` drive Radix; children render the
+// drawer body (typically a DrawerHeader followed by sections). When closed,
+// nothing renders (Radix unmounts via Portal). Matches the existing metadata
+// drawer geometry exactly (460px right panel on lg, bottom sheet on mobile).
+export function DrawerWrapper({ open, onClose, children }: {
+  open: boolean; onClose: () => void; children: ReactNode;
+}) {
+  return (
+    <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.52)", zIndex: 70 }} />
+        <Dialog.Content
+          className="fixed bottom-0 left-0 right-0 z-[80] max-h-[86vh] rounded-t-xl lg:bottom-auto lg:left-auto lg:right-0 lg:top-0 lg:h-screen lg:max-h-none lg:w-[460px] lg:rounded-none lg:rounded-l-xl"
+          style={{ background: C.rail, border: `1px solid ${C.borderHi}`, color: C.text, overflowY: "auto",
+            padding: 20, boxShadow: "-18px 0 50px rgba(0,0,0,0.38)" }}
+        >
+          {children}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/repo-b/src/components/telemetry/evidenceCard.test.tsx
+++ b/repo-b/src/components/telemetry/evidenceCard.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TelemetryEvidenceCard, type EvidenceContract } from "./evidenceCard";
+import { TelemetryChartFrame } from "./chartPrimitives";
+
+const base: EvidenceContract = {
+  title: "Can you trust this model?",
+  thesisRole: "One card per promoted champion.",
+};
+
+describe("TelemetryEvidenceCard fail-closed precedence", () => {
+  it("shows the error state and not the body when error is set", () => {
+    render(<TelemetryEvidenceCard contract={base} error="boom"><span>BODY</span></TelemetryEvidenceCard>);
+    expect(screen.getByText(/Could not load/i)).toBeInTheDocument();
+    expect(screen.queryByText("BODY")).not.toBeInTheDocument();
+  });
+
+  it("shows loading and not the body when loading", () => {
+    render(<TelemetryEvidenceCard contract={base} loading><span>BODY</span></TelemetryEvidenceCard>);
+    expect(screen.getByText(/Loading evidence/i)).toBeInTheDocument();
+    expect(screen.queryByText("BODY")).not.toBeInTheDocument();
+  });
+
+  it("renders the null_reason verbatim and not the body", () => {
+    render(
+      <TelemetryEvidenceCard contract={base} nullReason="model_not_promoted">
+        <span>BODY</span>
+      </TelemetryEvidenceCard>
+    );
+    expect(screen.getByText(/model_not_promoted/)).toBeInTheDocument();
+    expect(screen.queryByText("BODY")).not.toBeInTheDocument();
+  });
+
+  it("renders the body, method, claim boundary, source chip and provenance when healthy", () => {
+    render(
+      <TelemetryEvidenceCard
+        contract={{
+          ...base,
+          sourceStatus: { label: "recorded capture", tone: "recorded" },
+          method: "grouped-by-unit walk-forward",
+          claimBoundary: "not live serving",
+          provenance: "tel_model_runs",
+        }}
+      >
+        <span>BODY</span>
+      </TelemetryEvidenceCard>
+    );
+    expect(screen.getByText("BODY")).toBeInTheDocument();
+    expect(screen.getByText("recorded capture")).toBeInTheDocument();
+    expect(screen.getByText(/grouped-by-unit walk-forward/)).toBeInTheDocument();
+    expect(screen.getByText(/not live serving/)).toBeInTheDocument();
+    expect(screen.getByText(/tel_model_runs/)).toBeInTheDocument();
+  });
+});
+
+describe("TelemetryChartFrame", () => {
+  it("renders the empty fail-closed state instead of the chart when empty", () => {
+    render(
+      <TelemetryChartFrame title="Trace" empty emptyHint="evidence unavailable">
+        <svg data-testid="chart" />
+      </TelemetryChartFrame>
+    );
+    expect(screen.getByText(/evidence unavailable/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("chart")).not.toBeInTheDocument();
+  });
+
+  it("renders the chart body and caption when not empty", () => {
+    render(
+      <TelemetryChartFrame title="Trace" caption="D-4 telemetry">
+        <svg data-testid="chart" />
+      </TelemetryChartFrame>
+    );
+    expect(screen.getByTestId("chart")).toBeInTheDocument();
+    expect(screen.getByText("D-4 telemetry")).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/evidenceCard.tsx
+++ b/repo-b/src/components/telemetry/evidenceCard.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+import {
+  C, Panel, Tag, Loading, ErrorState, EmptyState, PageHeading, InlineCode,
+} from "./primitives";
+
+// ===========================================================================
+// Evidence-card contract. Every resume-claim evidence surface answers the same
+// questions in the same order so the page scans as one system:
+//   title · thesis role (operational question) · source status · as-of ·
+//   core metrics (children) · method · claim boundary · null_reason ·
+//   detail link · provenance.
+//
+// This is a presentational FRAME. Cards still own their own fetch; they pass the
+// resolved state in. Fail-closed is built in: a nullReason renders the designed
+// EmptyState, an error renders ErrorState, loading renders Loading — the card
+// body never shows partial/seeded data.
+// ---------------------------------------------------------------------------
+
+export type EvidenceSourceTone = "live" | "computed" | "recorded" | "static" | "unavailable";
+
+const SOURCE_TONE_COLOR: Record<EvidenceSourceTone, string> = {
+  live: C.green,
+  computed: C.cyan,
+  recorded: C.amber,
+  static: C.dim,
+  unavailable: C.faint,
+};
+
+export interface EvidenceContract {
+  /** Card title (the claim, plainly). */
+  title: string;
+  /** Operational question / why this matters — the thesis role. */
+  thesisRole: string;
+  /** Source status chip, e.g. {label: "recorded capture", tone: "recorded"}. */
+  sourceStatus?: { label: string; tone?: EvidenceSourceTone };
+  /** As-of / last-updated marker (already formatted). */
+  asOf?: string;
+  /** How the number was produced (method line). */
+  method?: ReactNode;
+  /** What must NOT be over-read (claim boundary). */
+  claimBoundary?: ReactNode;
+  /** Provenance / artifact reference (table, run id, source). */
+  provenance?: ReactNode;
+  /** Link to a detail page or source. */
+  detail?: { href: string; label: string };
+}
+
+function SourceChip({ status }: { status: NonNullable<EvidenceContract["sourceStatus"]> }) {
+  return <Tag color={SOURCE_TONE_COLOR[status.tone ?? "static"]}>{status.label}</Tag>;
+}
+
+// The standardized evidence-card frame. `children` is the core-metrics body.
+export function TelemetryEvidenceCard({
+  contract, loading, error, nullReason, children,
+}: {
+  contract: EvidenceContract;
+  loading?: boolean;
+  error?: string | null;
+  /** When set, the card fails closed with this exact reason (kept verbatim). */
+  nullReason?: string | null;
+  children?: ReactNode;
+}) {
+  const header = (
+    <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+      <div>
+        <div style={{ fontFamily: C.sans, fontSize: 16, fontWeight: 600, color: C.text }}>{contract.title}</div>
+        <div style={{ fontFamily: C.mono, fontSize: 11.5, color: C.dim, marginTop: 5, lineHeight: 1.5, maxWidth: 640 }}>
+          {contract.thesisRole}
+        </div>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
+        {contract.sourceStatus && <SourceChip status={contract.sourceStatus} />}
+        {contract.asOf && <InlineCode color={C.faint}>{contract.asOf}</InlineCode>}
+      </div>
+    </div>
+  );
+
+  let body: ReactNode;
+  if (error) {
+    body = <ErrorState message={error} />;
+  } else if (loading) {
+    body = <Loading label="Loading evidence…" />;
+  } else if (nullReason) {
+    body = <EmptyState label="Evidence unavailable" hint={nullReason} />;
+  } else {
+    body = (
+      <>
+        {children}
+        {(contract.method || contract.claimBoundary) && (
+          <div style={{ borderTop: `1px solid ${C.border}`, marginTop: 14, paddingTop: 12,
+            display: "flex", flexDirection: "column", gap: 8 }}>
+            {contract.method && (
+              <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.6 }}>
+                <span style={{ color: C.dim }}>Method. </span>{contract.method}
+              </div>
+            )}
+            {contract.claimBoundary && (
+              <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.6 }}>
+                <span style={{ color: C.dim }}>Claim boundary. </span>{contract.claimBoundary}
+              </div>
+            )}
+          </div>
+        )}
+        {(contract.provenance || contract.detail) && (
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12,
+            flexWrap: "wrap", marginTop: 12 }}>
+            <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.6 }}>
+              {contract.provenance && <><span style={{ color: C.dim }}>Provenance. </span>{contract.provenance}</>}
+            </span>
+            {contract.detail && (
+              <Link href={contract.detail.href}
+                style={{ fontFamily: C.mono, fontSize: 11, color: C.cyan, textDecoration: "none", flexShrink: 0 }}>
+                {contract.detail.label} →
+              </Link>
+            )}
+          </div>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <Panel>
+      {header}
+      <div style={{ marginTop: 14 }}>{body}</div>
+    </Panel>
+  );
+}
+
+// Editorial section heading for an evidence page (delegates to PageHeading so
+// there is one heading implementation).
+export function EvidencePageHeading(props: Parameters<typeof PageHeading>[0]) {
+  return <PageHeading {...props} />;
+}

--- a/repo-b/src/components/telemetry/primitives.test.tsx
+++ b/repo-b/src/components/telemetry/primitives.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  VerdictChip, TelemetryActionButton, TelemetryStatusBanner, MetricRow, InlineCode,
+  TelemetrySection, SectionTabButton,
+} from "./primitives";
+
+describe("VerdictChip", () => {
+  it("renders NO_GO as NO-GO", () => {
+    render(<VerdictChip verdict="NO_GO" />);
+    expect(screen.getByText("NO-GO")).toBeInTheDocument();
+  });
+  it("renders GO verbatim and a dash for missing verdicts", () => {
+    const { rerender } = render(<VerdictChip verdict="GO" />);
+    expect(screen.getByText("GO")).toBeInTheDocument();
+    rerender(<VerdictChip verdict={null} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});
+
+describe("TelemetryActionButton", () => {
+  it("is a real button that fires onClick and respects disabled", () => {
+    const onClick = vi.fn();
+    const { rerender } = render(<TelemetryActionButton onClick={onClick}>Replay</TelemetryActionButton>);
+    const btn = screen.getByRole("button", { name: "Replay" });
+    btn.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+    rerender(<TelemetryActionButton onClick={onClick} disabled>Replay</TelemetryActionButton>);
+    screen.getByRole("button", { name: "Replay" }).click();
+    expect(onClick).toHaveBeenCalledTimes(1); // disabled → no further calls
+  });
+});
+
+describe("TelemetryStatusBanner", () => {
+  it("uses role=alert for the error tone and role=status otherwise", () => {
+    const { rerender } = render(<TelemetryStatusBanner tone="error">down</TelemetryStatusBanner>);
+    expect(screen.getByRole("alert")).toHaveTextContent("down");
+    rerender(<TelemetryStatusBanner tone="warn">heads up</TelemetryStatusBanner>);
+    expect(screen.getByRole("status")).toHaveTextContent("heads up");
+  });
+});
+
+describe("MetricRow / InlineCode / sections", () => {
+  it("renders label and value", () => {
+    render(<MetricRow label="MLflow run" value="abc123" />);
+    expect(screen.getByText("MLflow run")).toBeInTheDocument();
+    expect(screen.getByText("abc123")).toBeInTheDocument();
+  });
+  it("InlineCode renders its children", () => {
+    render(<InlineCode>no_upstream_edges_in_catalog</InlineCode>);
+    expect(screen.getByText("no_upstream_edges_in_catalog")).toBeInTheDocument();
+  });
+  it("TelemetrySection renders its label and children", () => {
+    render(<TelemetrySection label="Posture"><span>body</span></TelemetrySection>);
+    expect(screen.getByText("Posture")).toBeInTheDocument();
+    expect(screen.getByText("body")).toBeInTheDocument();
+  });
+  it("SectionTabButton reflects active via aria-pressed", () => {
+    render(<SectionTabButton active onClick={() => {}}>Map</SectionTabButton>);
+    expect(screen.getByRole("button", { name: "Map" })).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/repo-b/src/components/telemetry/primitives.tsx
+++ b/repo-b/src/components/telemetry/primitives.tsx
@@ -231,3 +231,204 @@ export function DisclosureFooter() {
     </p>
   );
 }
+
+// ===========================================================================
+// Shared telemetry UI atoms (production-readiness refactor). These fold the
+// repeated inline-C-token patterns that were copy-pasted across consoles and
+// evidence cards. The dark look stays on the C palette (intentional env theme
+// adapter); inline style is reserved for runtime/chart geometry only. Existing
+// exports above are unchanged — these are purely additive.
+//
+// Aliases: prefer the Telemetry*-prefixed name at call sites where it reads as
+// part of one system; never introduce a second IMPLEMENTATION of an existing
+// primitive — alias it.
+// ---------------------------------------------------------------------------
+
+export const TelemetryPanel = Panel;
+export const TelemetryPageHeading = PageHeading;
+export const TelemetryNullState = EmptyState;
+
+// The glowing status dot reused by every console/sidebar/empty/error state.
+export function StatusDot({ color, size = 8, glow = true }: { color: string; size?: number; glow?: boolean }) {
+  return (
+    <span aria-hidden style={{ width: size, height: size, borderRadius: 999, background: color,
+      boxShadow: glow ? `0 0 8px ${color}99` : undefined, flexShrink: 0, display: "inline-block" }} />
+  );
+}
+
+// Mono label/value row (the most-duplicated card/console line). border-bottom
+// optional so it composes into lists.
+export function MetricRow({ label, value, tone, divider = true }: {
+  label: ReactNode; value: ReactNode; tone?: string; divider?: boolean;
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12,
+      padding: "7px 0", borderBottom: divider ? `1px solid ${C.border}` : undefined }}>
+      <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint }}>{label}</span>
+      <span style={{ fontFamily: C.mono, fontSize: 12, color: tone || C.text, textAlign: "right" }}>{value}</span>
+    </div>
+  );
+}
+
+// Stacked label-over-value stat (used in metric blocks / strips).
+export function Stat({ label, value, tone }: { label: ReactNode; value: ReactNode; tone?: string }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <span style={{ fontFamily: C.mono, fontSize: 9, color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase" }}>{label}</span>
+      <span style={{ fontFamily: C.mono, fontSize: 16, fontWeight: 600, color: tone || C.text }}>{value}</span>
+    </div>
+  );
+}
+
+// Mono inline code for ids / null_reason / formulas / version strings.
+export function InlineCode({ children, color = C.dim }: { children: ReactNode; color?: string }) {
+  return <span style={{ fontFamily: C.mono, fontSize: 11, color }}>{children}</span>;
+}
+export const TelemetryInlineCode = InlineCode;
+
+type ButtonVariant = "primary" | "secondary" | "ghost";
+const BTN_BASE: CSSProperties = { fontFamily: C.mono, fontSize: 13, borderRadius: 8, padding: "10px 16px", cursor: "pointer" };
+function btnStyle(variant: ButtonVariant, disabled?: boolean): CSSProperties {
+  const base: CSSProperties = { ...BTN_BASE, opacity: disabled ? 0.6 : 1, cursor: disabled ? "default" : "pointer" };
+  if (variant === "primary") return { ...base, fontWeight: 600, color: C.bg, background: C.cyan, border: "none" };
+  if (variant === "secondary") return { ...base, color: C.dim, background: "transparent", border: `1px solid ${C.border}` };
+  return { ...base, color: C.dim, background: "transparent", border: "none" };
+}
+
+// Semantic action button with three console variants. Wraps a real <button>.
+export function TelemetryActionButton({
+  variant = "primary", disabled, onClick, children, type = "button", fullWidth, style, ...rest
+}: {
+  variant?: ButtonVariant; disabled?: boolean; onClick?: () => void; children: ReactNode;
+  type?: "button" | "submit"; fullWidth?: boolean; style?: CSSProperties;
+  "aria-label"?: string; "aria-pressed"?: boolean;
+}) {
+  return (
+    <button type={type} onClick={onClick} disabled={disabled}
+      style={{ ...btnStyle(variant, disabled), width: fullWidth ? "100%" : undefined, ...style }} {...rest}>
+      {children}
+    </button>
+  );
+}
+
+// Styled <select> matching the console panel chrome.
+export function SelectField({ value, onChange, children, ariaLabel, style }: {
+  value: string; onChange: (v: string) => void; children: ReactNode; ariaLabel?: string; style?: CSSProperties;
+}) {
+  return (
+    <select value={value} aria-label={ariaLabel} onChange={(e) => onChange(e.target.value)}
+      style={{ fontFamily: C.mono, fontSize: 12, color: C.text, background: C.panelHi,
+        border: `1px solid ${C.borderHi}`, borderRadius: 7, padding: "8px 10px", minHeight: 38, ...style }}>
+      {children}
+    </select>
+  );
+}
+
+// Section divider: accent dot + uppercase label + optional right slot.
+export function TelemetrySection({ label, right, children, accent = C.cyan }: {
+  label?: string; right?: ReactNode; children: ReactNode; accent?: string;
+}) {
+  return (
+    <section style={{ marginTop: 8 }}>
+      {label && (
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, marginBottom: 12 }}>
+          <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <StatusDot color={accent} size={6} />
+            <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.14em", color: C.dim, textTransform: "uppercase" }}>{label}</span>
+          </span>
+          {right}
+        </div>
+      )}
+      {children}
+    </section>
+  );
+}
+
+type BannerTone = "info" | "warn" | "error";
+const BANNER_COLOR: Record<BannerTone, string> = { info: C.cyan, warn: C.amber, error: C.red };
+
+// Inline status/info banner (source/freshness/"stage unavailable"). Carries an
+// aria-live region so changing status is announced.
+export function TelemetryStatusBanner({ tone = "info", children, live }: {
+  tone?: BannerTone; children: ReactNode; live?: boolean;
+}) {
+  const color = BANNER_COLOR[tone];
+  return (
+    <div role={tone === "error" ? "alert" : "status"} aria-live={live ? "polite" : undefined}
+      style={{ border: `1px solid ${color}33`, background: `${color}0d`, borderRadius: 8,
+        padding: "9px 12px", display: "flex", alignItems: "center", gap: 9,
+        fontFamily: C.mono, fontSize: 11, color: C.dim, lineHeight: 1.5 }}>
+      <StatusDot color={color} size={7} />
+      <span>{children}</span>
+    </div>
+  );
+}
+
+// Provenance footer panel — the recurring "Provenance. …" disclosure.
+export function TelemetryProvenancePanel({ label = "Provenance", children, style }: {
+  label?: string; children: ReactNode; style?: CSSProperties;
+}) {
+  return (
+    <Panel pad={14} style={style}>
+      <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, lineHeight: 1.6 }}>
+        <span style={{ color: C.dim, fontWeight: 600 }}>{label}. </span>
+        {children}
+      </span>
+    </Panel>
+  );
+}
+
+// Verdict chip — GO/REVIEW/NO_GO via the shared verdictColor(); NO_GO renders as
+// "NO-GO" to match existing copy. Thin wrapper over Tag (no new color logic).
+export function VerdictChip({ verdict }: { verdict?: string | null }) {
+  const display = verdict === "NO_GO" || verdict === "NO-GO" ? "NO-GO" : (verdict ?? "—");
+  return <Tag color={verdictColor(verdict)}>{display}</Tag>;
+}
+
+// Tab button with active fill — the section-tab pattern across map/factory/bottleneck.
+export function SectionTabButton({ active, onClick, children }: {
+  active: boolean; onClick: () => void; children: ReactNode;
+}) {
+  return (
+    <button type="button" onClick={onClick} aria-pressed={active}
+      style={{ fontFamily: C.mono, fontSize: 12, letterSpacing: "0.04em", cursor: "pointer",
+        color: active ? C.text : C.dim, background: active ? C.panelHi : "transparent",
+        border: `1px solid ${active ? C.borderHi : C.border}`, borderRadius: 7, padding: "7px 13px" }}>
+      {children}
+    </button>
+  );
+}
+
+// Editorial thesis hero (the larger Overview/Evidence header). Distinct from
+// PageHeading (the standard console heading) by scale; title accepts a node so
+// brand-accented spans survive. Big Numbers / supporting content go in children.
+export function TelemetryThesisHeading({ eyebrow, title, blurb, size = 34, children }: {
+  eyebrow: string; title: ReactNode; blurb?: ReactNode; size?: number; children?: ReactNode;
+}) {
+  return (
+    <header style={{ marginBottom: 26, maxWidth: 880 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
+        <span aria-hidden style={{ width: 18, height: 2, borderRadius: 2, background: C.cyan, boxShadow: `0 0 8px ${C.cyan}aa` }} />
+        <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.16em", color: C.cyan, textTransform: "uppercase" }}>{eyebrow}</span>
+      </div>
+      <h1 style={{ fontFamily: size >= 44 ? C.mono : C.sans, fontSize: size, fontWeight: 800,
+        letterSpacing: "-0.015em", lineHeight: 1.08, color: C.text, marginTop: 12 }}>{title}</h1>
+      {blurb && <p style={{ fontFamily: C.sans, fontSize: 15, color: C.dim, lineHeight: 1.65, marginTop: 14 }}>{blurb}</p>}
+      {children}
+    </header>
+  );
+}
+
+// Thesis-first page wrapper: heading first, content, then the public-data
+// disclosure footer (the consistent page rhythm).
+export function TelemetryPageShell({ heading, children, disclosure = true }: {
+  heading: ReactNode; children: ReactNode; disclosure?: boolean;
+}) {
+  return (
+    <>
+      {heading}
+      {children}
+      {disclosure && <DisclosureFooter />}
+    </>
+  );
+}


### PR DESCRIPTION
## PR A of the telemetry frontend production-readiness refactor

Additive foundation only — **no consumers changed, no behavior change, no metric/claim/backend changes.** The dark `C` palette stays (it is the env theme adapter, not drift).

### What's here
- **`primitives.tsx`** (additive): `StatusDot`, `MetricRow`, `Stat`, `InlineCode`, `TelemetryActionButton`, `SelectField`, `TelemetrySection`, `TelemetryStatusBanner` (aria-live), `TelemetryProvenancePanel`, `VerdictChip`, `SectionTabButton`, `TelemetryThesisHeading`, `TelemetryPageShell`; aliases `TelemetryPanel`/`TelemetryPageHeading`/`TelemetryNullState`. Existing exports untouched.
- **`chartPrimitives.tsx`**: `TelemetryChartFrame` + `TelemetryLegend` — frame the chart chrome (title/legend/caption/empty), geometry stays inline. Fail-closed empty state.
- **`evidenceCard.tsx`**: `EvidenceContract` + `TelemetryEvidenceCard` — fail-closed precedence error > loading > null_reason > body.
- **`drawerPrimitives.tsx`**: `DrawerWrapper`/`DrawerHeader`/`FieldRow` — Radix Dialog contract preserved (right/bottom, close-on-Escape, focus trap).
- **14 unit tests** for the new primitives (verdict mapping, fail-closed precedence, aria roles, empty chart state).
- **`TELEMETRY_FRONTEND_REFACTOR_INVENTORY.md`** — verified inventory + PR A–D plan.

Reuse-before-create: existing `Panel`/`PageHeading`/`Tag`/`EmptyState`/`verdictColor` reused or aliased, never reimplemented.

### Verification
- `tsc --noEmit -p tsconfig.typecheck.json` clean
- `next lint` clean (no new warnings)
- `vitest run` — 14/14 new tests pass

Follow-ups: PR B (evidence cards onto the contract + thesis-first pages), PR C (god-component splits + RS→C + chart framing), PR D (final consistency + docs + screenshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)