### PR TITLE
refactor(telemetry): thesis-first evidence/overview pages + card dedup (PR B)

### DIFF
--- a/repo-b/src/components/telemetry/EvidenceCards.tsx
+++ b/repo-b/src/components/telemetry/EvidenceCards.tsx
@@ -7,7 +7,7 @@
 // PLAN_DIVERGENCE_REVIEW.md. Nothing here is seeded: every value is fetched or an
 // explicit unavailable state; the Stargate capture is labeled recorded.
 
-import { C } from "./primitives";
+import { C, TelemetryThesisHeading } from "./primitives";
 import DataCollectionCard from "./DataCollectionCard";
 import ModelEvidenceCard from "./ModelEvidenceCard";
 import RulConformalCard from "./RulConformalCard";
@@ -21,24 +21,11 @@ import DeploymentReceiptCard from "./DeploymentReceiptCard";
 
 function Lead() {
   return (
-    <header style={{ marginBottom: 26, maxWidth: 880 }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
-        <span aria-hidden style={{ width: 18, height: 2, borderRadius: 2, background: C.cyan,
-          boxShadow: `0 0 8px ${C.cyan}aa` }} />
-        <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.16em", color: C.cyan,
-          textTransform: "uppercase" }}>Resume-Claim Evidence</span>
-      </div>
-      <h1 style={{ fontFamily: C.sans, fontSize: 34, fontWeight: 800, letterSpacing: "-0.02em",
-        lineHeight: 1.08, color: C.text, marginTop: 12 }}>
-        Every claim, mapped to a live proof
-      </h1>
-      <p style={{ fontFamily: C.sans, fontSize: 15, color: C.dim, lineHeight: 1.65, marginTop: 14 }}>
-        Each card binds to a real endpoint and fails closed when a source is missing — no seeded
-        numbers. Honest by construction: the autoencoder is shown as the judgment artifact it is (the
-        rolling-MAD detector is the champion), RUL is point-prediction until conformal intervals land,
-        and the live stream is labeled recorded capture, not a live printer.
-      </p>
-    </header>
+    <TelemetryThesisHeading
+      eyebrow="Resume-Claim Evidence"
+      title="Every claim, mapped to a live proof"
+      blurb="Each card binds to a real endpoint and fails closed when a source is missing — no seeded numbers. Honest by construction: the autoencoder is shown as the judgment artifact it is (the rolling-MAD detector is the champion), RUL is point-prediction until conformal intervals land, and the live stream is labeled recorded capture, not a live printer."
+    />
   );
 }
 

--- a/repo-b/src/components/telemetry/ModelEvidenceCard.tsx
+++ b/repo-b/src/components/telemetry/ModelEvidenceCard.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/telemetry/api";
 import {
   C, Tag, Panel, Loading, ErrorState, EmptyState, PageHeading, DisclosureFooter,
+  MetricRow, Stat,
 } from "./primitives";
 
 // Format a registry metric, only ever from a present numeric value. Absent → "—" (never a fake 0).
@@ -26,25 +27,6 @@ function psiBand(psi: number | null): { label: string; color: string } {
   if (psi < 0.1) return { label: "stable", color: C.green };
   if (psi <= 0.25) return { label: "watch", color: C.amber };
   return { label: "drift", color: C.red };
-}
-
-function Row({ label, value, tone }: { label: string; value: string; tone?: string }) {
-  return (
-    <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12,
-      padding: "7px 0", borderBottom: `1px solid ${C.border}` }}>
-      <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint }}>{label}</span>
-      <span style={{ fontFamily: C.mono, fontSize: 12, color: tone || C.text, textAlign: "right" }}>{value}</span>
-    </div>
-  );
-}
-
-function Stat({ label, value, tone }: { label: string; value: string; tone?: string }) {
-  return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      <span style={{ fontFamily: C.mono, fontSize: 9, color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase" }}>{label}</span>
-      <span style={{ fontFamily: C.mono, fontSize: 16, fontWeight: 600, color: tone || C.text }}>{value}</span>
-    </div>
-  );
 }
 
 // Metrics block for one model, branching on kind. Anomaly shows the honest point-wise F1 AND, when
@@ -80,8 +62,8 @@ function ModelCard({ m, psi }: { m: ModelRun; psi: number | null }) {
       title={`${m.model_kind === "rul" ? "Remaining useful life" : "Anomaly detection"} — ${m.model_name}`}
       right={<Tag color={m.promotion_state === "promoted" || m.model_alias === "champion" ? C.green : C.faint}>{m.promotion_state}</Tag>}
     >
-      <Row label="Model version" value={`v${m.model_version}${m.model_alias ? ` (${m.model_alias})` : ""}`} />
-      <Row label="MLflow run" value={m.mlflow_run_id || "—"} />
+      <MetricRow label="Model version" value={`v${m.model_version}${m.model_alias ? ` (${m.model_alias})` : ""}`} />
+      <MetricRow label="MLflow run" value={m.mlflow_run_id || "—"} />
 
       <div style={{ marginTop: 16, marginBottom: 4 }}>
         <span style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, letterSpacing: "0.1em", textTransform: "uppercase" }}>Metrics</span>
@@ -95,13 +77,13 @@ function ModelCard({ m, psi }: { m: ModelRun; psi: number | null }) {
       </div>
       {gateEntries.length > 0 ? (
         gateEntries.map(([k, v]) => (
-          <Row key={k} label={k} value={typeof v === "object" ? JSON.stringify(v) : String(v)} />
+          <MetricRow key={k} label={k} value={typeof v === "object" ? JSON.stringify(v) : String(v)} />
         ))
       ) : (
-        <Row label="gate" value="—" />
+        <MetricRow label="gate" value="—" />
       )}
 
-      <Row label="Drift status (PSI)" value={psi != null ? `${psi.toFixed(2)} · ${band.label}` : band.label} tone={band.color} />
+      <MetricRow label="Drift status (PSI)" value={psi != null ? `${psi.toFixed(2)} · ${band.label}` : band.label} tone={band.color} />
 
       <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.6, display: "block",
         borderTop: `1px solid ${C.border}`, paddingTop: 10, marginTop: 12 }}>

--- a/repo-b/src/components/telemetry/TelemetryOverview.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.tsx
@@ -5,7 +5,7 @@
 // LEO / Who Flies), with an editorial "Big Numbers" band and the Terran 1 event record. Static
 // public-data context module — no serving API, no KPI dashboard strip, no lineage CTA here.
 
-import { C, DisclosureFooter } from "./primitives";
+import { C, TelemetryPageShell, TelemetryThesisHeading } from "./primitives";
 import BottleneckMap from "./context/BottleneckMap/BottleneckMap";
 import { computeBigNumbers } from "./context/BottleneckMap/data";
 
@@ -13,45 +13,48 @@ import { computeBigNumbers } from "./context/BottleneckMap/data";
 // out of scope in the telemetry env, so the hex is inlined.
 const NV_PURPLE = "#B040FF";
 
-export default function TelemetryOverview() {
+// Editorial "Big Numbers" band — inline stats under the thesis, not a card dashboard.
+function BigNumbers() {
   return (
-    <>
-      {/* Thesis header — dominant; states the argument once. */}
-      <header style={{ marginBottom: 26, maxWidth: 880 }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
-          <span aria-hidden style={{ width: 18, height: 2, borderRadius: 2, background: C.cyan, boxShadow: `0 0 8px ${C.cyan}aa` }} />
-          <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.16em", color: C.cyan, textTransform: "uppercase" }}>Overview</span>
+    <div style={{ display: "flex", flexWrap: "wrap", gap: "26px 48px", marginTop: 24 }}>
+      {computeBigNumbers().map((b) => (
+        <div key={b.label}>
+          <div style={{ fontFamily: C.mono, fontSize: 10.5, letterSpacing: "0.12em", textTransform: "uppercase", color: C.faint, marginBottom: 5 }}>
+            {b.label}
+          </div>
+          <div style={{ fontFamily: C.mono, fontSize: 25, fontWeight: 700, letterSpacing: "-0.01em",
+            color: b.accent === "share" ? C.green : b.accent === "cost" ? C.amber : C.text }}>
+            {b.value}
+          </div>
+          <div style={{ fontFamily: C.sans, fontSize: 11.5, color: C.dim, marginTop: 3 }}>{b.sub}</div>
         </div>
-        <h1 style={{ fontFamily: C.mono, fontSize: 48, fontWeight: 800, letterSpacing: "-0.01em", lineHeight: 1.08, color: C.text, marginTop: 12 }}>
+      ))}
+    </div>
+  );
+}
+
+export default function TelemetryOverview() {
+  // Thesis-first: the dominant header states the argument once, Big Numbers sit under it, then the
+  // Spaceflight Bottleneck Map carries the story. Same copy and editorial layout as before.
+  const heading = (
+    <TelemetryThesisHeading
+      eyebrow="Overview"
+      size={48}
+      title={
+        <>
           Why <span style={{ color: NV_PURPLE, textShadow: `0 0 18px ${NV_PURPLE}99` }}>Launch</span> Became A{" "}
           <span style={{ color: NV_PURPLE, textShadow: `0 0 18px ${NV_PURPLE}99` }}>Data</span> Problem
-        </h1>
-        <p style={{ fontFamily: C.sans, fontSize: 16, color: C.dim, lineHeight: 1.65, marginTop: 16 }}>
-          Spaceflight moves by breaking what holds it back. First, reaching orbit. Then lowering the cost. Then
-          flying again. Then building at scale. Now the hard part is speed of judgment: reading the telemetry,
-          trusting the model, tracing the source, and acting before delay becomes risk.
-        </p>
+        </>
+      }
+      blurb="Spaceflight moves by breaking what holds it back. First, reaching orbit. Then lowering the cost. Then flying again. Then building at scale. Now the hard part is speed of judgment: reading the telemetry, trusting the model, tracing the source, and acting before delay becomes risk."
+    >
+      <BigNumbers />
+    </TelemetryThesisHeading>
+  );
 
-        {/* Big Numbers — inline editorial stats under the thesis, not a card dashboard. */}
-        <div style={{ display: "flex", flexWrap: "wrap", gap: "26px 48px", marginTop: 24 }}>
-          {computeBigNumbers().map((b) => (
-            <div key={b.label}>
-              <div style={{ fontFamily: C.mono, fontSize: 10.5, letterSpacing: "0.12em", textTransform: "uppercase", color: C.faint, marginBottom: 5 }}>
-                {b.label}
-              </div>
-              <div style={{ fontFamily: C.mono, fontSize: 25, fontWeight: 700, letterSpacing: "-0.01em",
-                color: b.accent === "share" ? C.green : b.accent === "cost" ? C.amber : C.text }}>
-                {b.value}
-              </div>
-              <div style={{ fontFamily: C.sans, fontSize: 11.5, color: C.dim, marginTop: 3 }}>{b.sub}</div>
-            </div>
-          ))}
-        </div>
-      </header>
-
+  return (
+    <TelemetryPageShell heading={heading}>
       <BottleneckMap />
-
-      <DisclosureFooter />
-    </>
+    </TelemetryPageShell>
   );
 }


### PR DESCRIPTION
## PR B of the telemetry frontend production-readiness refactor

Behavior-preserving. **No metric/claim/copy/fetch changes** — all strings byte-identical (the existing card tests assert the exact metric + null_reason text and still pass).

### Changes
- **TelemetryOverview** — hand-rolled hero → `TelemetryThesisHeading` inside `TelemetryPageShell` (thesis-first; purple Launch/Data spans, Big Numbers band, and all copy unchanged).
- **EvidenceCards** — local `Lead` header → `TelemetryThesisHeading` (eyebrow/title/blurb verbatim).
- **ModelEvidenceCard** — removed local `Row`/`Stat` helpers, now uses the shared `MetricRow`/`Stat` primitives (byte-identical styling) — pure dedup, zero visual change.

### Scope note
This intentionally **preserves the Evidence page's per-claim section layout** (each claim as its own headed section) rather than collapsing every card into the compact `TelemetryEvidenceCard` wrapper — that would restructure the story, which is out of scope without sign-off. The lighter per-card dedups (verdict/source chips → `Tag`/`VerdictChip`, provenance → `TelemetryProvenancePanel`) ride in the PR D consistency sweep. `TelemetryEvidenceCard` remains available for new cards.

### Verification
- `tsc --noEmit` clean · `next lint` clean · `vitest run src/components/telemetry` — 30 files / 115 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)