### PR TITLE
feat(telemetry): color-coded nav rail — section accents + glowing active pill

### DIFF
--- a/repo-b/src/components/telemetry/TelemetryShell.tsx
+++ b/repo-b/src/components/telemetry/TelemetryShell.tsx
@@ -27,9 +27,11 @@ export default function TelemetryShell({ envId, children }: { envId: string; chi
 
   const Brand = (
     <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-      <div style={{ width: 24, height: 24, borderRadius: 6, border: `1px solid ${C.cyan}55`,
-        background: "rgba(63,177,232,0.1)", display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
-        <svg width="13" height="13" viewBox="0 0 14 14">
+      <div style={{ width: 28, height: 28, borderRadius: 7, border: "1px solid #B040FF66",
+        background: "linear-gradient(135deg, rgba(176,64,255,0.22), rgba(63,177,232,0.20))",
+        boxShadow: "0 0 14px rgba(176,64,255,0.25)",
+        display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+        <svg width="15" height="15" viewBox="0 0 14 14">
           <path d="M1 10l3-4 2.5 2L9 4l4 6" stroke={C.cyan} strokeWidth="1.4" fill="none" strokeLinejoin="round" />
         </svg>
       </div>

--- a/repo-b/src/components/telemetry/TelemetrySidebar.tsx
+++ b/repo-b/src/components/telemetry/TelemetrySidebar.tsx
@@ -3,7 +3,25 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { C } from "./primitives";
-import { TELEMETRY_NAV, TELEMETRY_NAV_GROUPS, isTelemetryItemActive, telemetryHref } from "./telemetryNav";
+import {
+  TELEMETRY_NAV, TELEMETRY_NAV_GROUPS, isTelemetryItemActive, telemetryHref,
+  type TelemetryNavGroup,
+} from "./telemetryNav";
+
+// Brand fluorescent purple (shared with the Overview thesis); the active-item glow blends
+// the section accent into this purple.
+const NV_PURPLE = "#B040FF";
+
+// Per-section accent — section labels and item icons take their group's color so the rail
+// reads as a color-coded map. Purple/pink are from the cyberpunk accent token range.
+const GROUP_ACCENT: Record<TelemetryNavGroup, string> = {
+  Overview: C.cyan,
+  Operations: C.cyan,
+  "Models & Intelligence": "#a855f7",
+  "Factory & Quality": C.amber,
+  "Evidence & Lineage": C.green,
+  "Agent Operations": "#f472b6",
+};
 
 // Grouped navigation rail. Rendered in the desktop rail and inside the mobile
 // drawer (TelemetryShell), so item height stays >=40px for touch.
@@ -11,9 +29,11 @@ export default function TelemetrySidebar({ envId, onNavigate }: { envId: string;
   const pathname = usePathname() || "";
   return (
     <nav style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      {TELEMETRY_NAV_GROUPS.map((group, gi) => (
+      {TELEMETRY_NAV_GROUPS.map((group, gi) => {
+        const accent = GROUP_ACCENT[group];
+        return (
         <div key={group} style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-          <div style={{ fontFamily: C.mono, fontSize: 9, letterSpacing: "0.16em", color: C.faint,
+          <div style={{ fontFamily: C.mono, fontSize: 9, letterSpacing: "0.16em", color: accent,
             textTransform: "uppercase", padding: gi === 0 ? "2px 10px 4px" : "14px 10px 4px" }}>
             {group}
           </div>
@@ -23,19 +43,26 @@ export default function TelemetrySidebar({ envId, onNavigate }: { envId: string;
               <Link key={n.slug || "overview"} href={telemetryHref(envId, n.slug)} onClick={onNavigate}
                 aria-current={active ? "page" : undefined}
                 style={{ display: "flex", alignItems: "center", gap: 10, textDecoration: "none",
-                  minHeight: 40, padding: "9px 10px", borderRadius: 7,
+                  minHeight: 40, padding: "9px 10px", borderRadius: 8,
                   color: active ? C.text : C.dim,
-                  background: active ? "rgba(63,177,232,0.10)" : "transparent",
-                  boxShadow: active ? `inset 2px 0 0 ${C.cyan}` : "none" }}>
+                  // Active item: a glowing pill that blends the section accent into brand purple,
+                  // with a soft outer glow. Inactive items stay flat.
+                  background: active ? `linear-gradient(90deg, ${accent}26, ${NV_PURPLE}1f)` : "transparent",
+                  border: `1px solid ${active ? `${accent}66` : "transparent"}`,
+                  boxShadow: active ? `0 0 16px ${accent}33` : "none" }}>
                 <svg width="15" height="15" viewBox="0 0 16 16" style={{ flexShrink: 0 }}>
-                  <path d={n.icon} stroke={active ? C.cyan : C.faint} strokeWidth="1.3" fill="none" strokeLinejoin="round" />
+                  <path d={n.icon} stroke={active ? accent : `${accent}b3`} strokeWidth="1.3" fill="none" strokeLinejoin="round" />
                 </svg>
                 <span style={{ fontFamily: C.mono, fontSize: 12 }}>{n.label}</span>
+                {active && (
+                  <span aria-hidden style={{ marginLeft: "auto", color: accent, fontSize: 13, lineHeight: 1 }}>›</span>
+                )}
               </Link>
             );
           })}
         </div>
-      ))}
+        );
+      })}
       {/* Cross-surface link: the ADE control room is its own portable package mounted in this env. */}
       <div style={{ fontFamily: C.mono, fontSize: 9, letterSpacing: "0.16em", color: C.faint,
         textTransform: "uppercase", padding: "14px 10px 4px" }}>


### PR DESCRIPTION
Sidebar visual upgrade requested by Paul (match the color-coded rail mockup). **Behavior unchanged** — same nav data, links, active detection, labels, and Platform/ADE link; `TelemetrySidebar.test.tsx` still passes.

### Changes
- Per-section **accent color** on group labels + item icons (Overview/Operations cyan · Models & Intelligence purple · Factory & Quality amber · Evidence & Lineage green · Agent Operations pink) — the rail reads as a color-coded map.
- **Active item** is a glowing pill blending the section accent into brand purple, with a chevron, replacing the flat inset bar.
- Brand mark gets the **purple→cyan gradient** logo box.

### Honest-by-construction
Deliberately omits the mockup's hover **flyout panel**, the **"12" alerts badge**, and **Theme/Settings** controls — those would fabricate sub-navigation and an alert count this surface does not actually have (this console's whole pitch is "no seeded numbers"). The real serving/auth status footer is kept.

### Verification
`tsc --noEmit` clean · `next lint` clean · sidebar + nav tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)