### PR TITLE
refactor(telemetry): unify RS palette into the C token system (PR C3)

### DIFF
--- a/repo-b/src/components/telemetry/rsTokens.tsx
+++ b/repo-b/src/components/telemetry/rsTokens.tsx
@@ -1,20 +1,28 @@
 "use client";
 
 // RS Demo design language — shared tokens + primitives for the three RS surfaces
-// (Mission Control stream, Model Registry console, Factory/NCR Intelligence), ported from the
-// rs_jsx/ design templates. Existing telemetry pages keep primitives.tsx untouched.
+// (Mission Control stream, Model Registry console, Factory/NCR Intelligence) + the Bottleneck Map.
+//
+// Palette unification (telemetry refactor): the base/accent tokens now source from the canonical
+// telemetry `C` palette so RS surfaces share ONE token system. The RS accent hexes were already
+// byte-identical to C (cyan/amber/red/green); base tones snap to C with no layout change. Only the
+// RS-specific chart-scale colors (teal/violet/blue + bottleneck bar/crosshair fills), which have no
+// `C` equivalent, keep their literal hexes. Component shapes (RsPanel/RsChip/RsKpi) are unchanged —
+// this is a recolor, not a restructure. Folding RsPanel/RsChip/RsKpi into the C primitives is a later
+// screenshot-gated pass.
 import React from "react";
+import { C } from "./primitives";
 
 export const RS = {
-  bg: "#0A0F16", panel: "#0F1622", panelAlt: "#121B2A", line: "#1D2A3B",
-  text: "#D7E2EC", dim: "#7E93A8", faint: "#54677A",
-  teal: "#4FD1C5", cyan: "#67E8F9", amber: "#F5B452", red: "#F4715F",
-  green: "#6EE7A0", violet: "#A78BFA", blue: "#6CA8F0", gray: "#3D4D60",
-  // Chart-scale tokens used by the Bottleneck Map context module.
+  bg: C.bg, panel: C.panel, panelAlt: C.panelHi, line: C.border,
+  text: C.text, dim: C.dim, faint: C.faint,
+  teal: "#4FD1C5", cyan: C.cyan, amber: C.amber, red: C.red,
+  green: C.green, violet: "#A78BFA", blue: "#6CA8F0", gray: "#3D4D60",
+  // RS-specific chart-scale tokens (no C equivalent) used by the Bottleneck Map context module.
   crosshair: "#3D567A", barFill: "#22324A", barFillHot: "#2E4A6E",
 };
-export const RS_MONO = "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
-export const RS_SANS = "Inter, 'Helvetica Neue', Arial, sans-serif";
+export const RS_MONO = C.mono;
+export const RS_SANS = C.sans;
 
 export function RsPanel({ title, right, children, style }: {
   title?: string; right?: React.ReactNode; children: React.ReactNode; style?: React.CSSProperties;


### PR DESCRIPTION
First step of the approved RS→C unification. `rsTokens` now sources its base/accent tokens from the canonical telemetry `C` palette, so the RS surfaces (Mission Control stream, Model Registry, Factory/NCR, Bottleneck Map) share **one** token system.

- The RS accent hexes were already byte-identical to `C` (cyan/amber/red/green); base tones snap to `C`.
- Only RS-specific chart-scale colors (teal/violet/blue + bottleneck bar/crosshair fills, no `C` equivalent) keep their literal hexes.
- Component shapes (`RsPanel`/`RsChip`/`RsKpi`) unchanged — a **recolor, not a restructure**, in a single file. Zero layout change.

No data/metric/claim/copy changes.

### Verification
`tsc` clean · `next lint` clean · full telemetry `vitest` (30 files / 115 tests) pass.

**Follow-up:** a screenshot verify of the RS surfaces is recommended (minor base-tone shift); folding `RsPanel`/`RsChip`/`RsKpi` fully into the `C` primitives is a later gated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)