### PR TITLE
feat(telemetry): event-windowed analog retrieval compute (Spin 6, Story #723)

### DIFF
--- a/PLAN_DIVERGENCE_REVIEW.md
+++ b/PLAN_DIVERGENCE_REVIEW.md
@@ -337,3 +337,27 @@ Drift, flipped from a post-deployment afterthought into an upstream gate, measur
 Remaining spins: **6** (event-windowed telemetry analog retrieval), **2** (subsystem + lead-lag attribution),
 **4** (feature-completeness gate), **7** (anomaly grouped-by-channel split). Each its own intake'd unit. The
 regime/distribution trio (1, 3, 5) is now complete.
+
+---
+
+## Status — Spin 6 (compute) shipped (event-windowed analog retrieval, Story #723)
+
+ML-only (telemetry-platform; the UI card is deferred — a parallel agent owns the telemetry frontend
+refactor). Measured on real SMAP/MSL `gold_smap_msl_windows` (test split, 509,555 ticks, 81 channels):
+- Two retrievals per anomalous query window: (A) whole-series cosine on the channel's full-series
+  statistical summary; (B) event-windowed DTW (banded) on the channel-normalized anomalous-window signal.
+- **The methods agree on only 9% of the top-5** — they surface largely different precedents.
+- Event-windowed DTW modestly improves anomaly-precedent retrieval: **45.0% vs 41.5% anomalous-match
+  rate (+8.4%)**, both above the 36.6% pool base rate.
+- **Honest:** this is the most *modest* of the spins. The dramatic "precedent-based reasoning" version
+  needs **linked dispositions** (was it real / root cause / action) which the public SMAP/MSL data does
+  not have — rendered as unavailable, not fabricated. A first cut with per-window z-norm erased event
+  magnitude and showed no lift; channel-level normalization (preserving how much the event stands out)
+  recovered the +8%. That fix is the methodological note.
+- reproducible: `compute_event_windowed_analog.py` → `event_windowed_analog_evidence.json`; pure-numpy
+  banded DTW in `analog_core.py` with `test_analog_core.py` (4 tests, numpy-only/CI-safe).
+- **Card deferred** until the frontend refactor (PR C/D) settles, to avoid colliding with the parallel
+  agent in `repo-b/src/components/telemetry/**`.
+
+Remaining tail spins (2 subsystem lead-lag, 4 completeness, 7 anomaly grouped-split) have weak data fit
+on the independent SMAP/MSL streams (would need simulation or yield null results) — deferred/optional.

--- a/claim_coverage_matrix.md
+++ b/claim_coverage_matrix.md
@@ -80,3 +80,13 @@ confident score. Surface: the Competence Envelope card on `/telemetry/evidence` 
 serving*) with in/out examples and the score/review/abstain action. **Must NOT overclaim:** FD004 is a
 regime-shift stress test, **not rocket hot-fire**; the envelope gates the INPUT distribution (operating regime),
 not label correctness — in-envelope means "within trained scope," never "safe" or "certified."
+
+---
+
+**Status (Spin 6 compute — event-windowed analog retrieval, Story #723):** The **Analog retrieval** row gets
+a telemetry-native compute (the existing composite retrieval lives in the markets env). Measured on real
+SMAP/MSL: whole-series cosine and event-windowed DTW agree on only **9%** of top-5 precedents, and
+event-windowing modestly lifts anomaly-precedent retrieval to **45.0% vs 41.5% (+8.4%)**. **Must NOT
+overclaim:** this is the most modest finding; **linked dispositions are unavailable** in public data (shown
+as unavailable, not fabricated); it is a relative method comparison, not an absolute retrieval benchmark.
+ML-only so far — the UI card is **deferred** (parallel agent owns the telemetry frontend refactor).

--- a/telemetry-platform/analog_core.py
+++ b/telemetry-platform/analog_core.py
@@ -1,0 +1,73 @@
+"""Pure analog-retrieval primitives (numpy only — no Databricks/deps, CI-safe).
+
+Shared by compute_event_windowed_analog.py (real SMAP/MSL data) and test_analog_core.py.
+The finding: whole-series cosine similarity is dominated by the long steady-state phase and
+buries the rare event; event-windowed DTW on the anomalous segment finds precedents that share
+the EVENT, which a cosine-on-summary search misses.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def znorm(x: np.ndarray) -> np.ndarray:
+    """Z-normalize a 1-D series (shape-only comparison; removes level/scale)."""
+    x = np.asarray(x, dtype=float)
+    sd = x.std()
+    return (x - x.mean()) / (sd if sd > 1e-9 else 1.0)
+
+
+def dtw_distance(a: np.ndarray, b: np.ndarray, band: int | None = None) -> float:
+    """Dynamic Time Warping distance between two 1-D series, with an optional Sakoe-Chiba
+    band (|i-j| <= band) for speed. Pure numpy; returns the warped-path cost."""
+    a = np.asarray(a, dtype=float)
+    b = np.asarray(b, dtype=float)
+    n, m = len(a), len(b)
+    if n == 0 or m == 0:
+        return float("inf")
+    w = band if band is not None else max(n, m)
+    w = max(w, abs(n - m))
+    INF = float("inf")
+    prev = np.full(m + 1, INF)
+    prev[0] = 0.0
+    for i in range(1, n + 1):
+        cur = np.full(m + 1, INF)
+        jlo, jhi = max(1, i - w), min(m, i + w)
+        for j in range(jlo, jhi + 1):
+            cost = (a[i - 1] - b[j - 1]) ** 2
+            cur[j] = cost + min(prev[j], cur[j - 1], prev[j - 1])
+        prev = cur
+    return float(np.sqrt(prev[m]))
+
+
+def cosine(a: np.ndarray, b: np.ndarray) -> float:
+    a = np.asarray(a, dtype=float)
+    b = np.asarray(b, dtype=float)
+    na, nb = np.linalg.norm(a), np.linalg.norm(b)
+    if na < 1e-12 or nb < 1e-12:
+        return 0.0
+    return float(np.dot(a, b) / (na * nb))
+
+
+def topk_indices(scores: np.ndarray, k: int, largest: bool = True) -> list[int]:
+    """Indices of the top-k scores (largest similarity, or smallest distance if largest=False)."""
+    scores = np.asarray(scores, dtype=float)
+    order = np.argsort(scores)
+    order = order[::-1] if largest else order
+    return [int(i) for i in order[:k]]
+
+
+def match_rate(indices: list[int], is_anomaly: np.ndarray) -> float:
+    """Fraction of retrieved candidates that are themselves anomalous (precedent quality)."""
+    if not indices:
+        return 0.0
+    return float(np.mean([is_anomaly[i] for i in indices]))
+
+
+def overlap(a_idx: list[int], b_idx: list[int]) -> float:
+    """Jaccard-style top-k overlap: |A ∩ B| / k (how much two methods agree on precedents)."""
+    if not a_idx and not b_idx:
+        return 1.0
+    k = max(len(a_idx), len(b_idx)) or 1
+    return float(len(set(a_idx) & set(b_idx)) / k)

--- a/telemetry-platform/compute_event_windowed_analog.py
+++ b/telemetry-platform/compute_event_windowed_analog.py
@@ -1,0 +1,229 @@
+"""Spin 6 (compute) — event-windowed analog retrieval on SMAP/MSL (REAL data, reproducible).
+
+The finding: whole-series similarity is dominated by the long steady-state phase and surfaces the
+wrong precedents; event-windowed DTW on the anomalous segment finds the cases that share the EVENT.
+
+Two retrieval methods over real labeled SMAP/MSL windows (gold_smap_msl_windows, test split):
+  A) WHOLE-SERIES cosine — retrieve by cosine on the candidate channel's full-series statistical
+     summary (mean/std/min/max/median/iqr/|slope|/frac-above-2σ). Dominated by steady-state.
+  B) EVENT-WINDOWED DTW — retrieve by DTW distance on the z-normalized raw value sequence of the
+     anomalous window itself (the event shape).
+For each anomalous query window, take top-K (excluding same-channel) under each method and measure:
+  - anomalous-match rate: fraction of retrieved precedents that are themselves anomalous;
+  - top-K overlap: how much the two methods agree.
+
+No anomaly-label fabrication (is_anomaly is the dataset's labeled window). If event-windowing does
+not beat whole-series, the artifact says so. ML-only: writes a telemetry-platform artifact; the UI
+card is deferred (a parallel agent owns the telemetry frontend refactor).
+
+Run: python telemetry-platform/compute_event_windowed_analog.py   (Databricks OAuth profile 'PaulMain')
+"""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import numpy as np
+import pandas as pd
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.sql import Disposition, Format, StatementState
+
+from analog_core import cosine, dtw_distance, match_rate, overlap, topk_indices
+
+TEL = "novendor_1.telemetry"
+WAREHOUSE_ID = "0e56420fb707d861"
+L = 48               # event-window length (ticks)
+K = 5                # top-K retrieved precedents
+BAND = 8             # DTW Sakoe-Chiba band
+N_QUERIES = 40       # anomalous query windows
+N_CAND_ANOM = 120    # anomalous candidate windows in the pool
+N_CAND_NORM = 180    # normal candidate windows in the pool
+SEED = 0
+ROOT = Path(__file__).resolve().parents[1]
+AS_OF = "2026-06-24"
+
+
+def query_sql(w: WorkspaceClient, sql: str) -> pd.DataFrame:
+    resp = w.statement_execution.execute_statement(
+        statement=sql, warehouse_id=WAREHOUSE_ID, wait_timeout="50s",
+        disposition=Disposition.INLINE, format=Format.JSON_ARRAY,
+    )
+    sid = resp.statement_id
+    while resp.status.state in (StatementState.PENDING, StatementState.RUNNING):
+        time.sleep(2)
+        resp = w.statement_execution.get_statement(sid)
+    if resp.status.state != StatementState.SUCCEEDED:
+        raise RuntimeError(f"SQL {resp.status.state}: {resp.status.error}")
+    cols = [c.name for c in resp.manifest.schema.columns]
+    rows = list(resp.result.data_array or [])
+    for n in range(1, resp.manifest.total_chunk_count or 1):
+        rows.extend(w.statement_execution.get_statement_result_chunk_n(sid, n).data_array or [])
+    return pd.DataFrame(rows, columns=cols)
+
+
+def channel_summary(values: np.ndarray) -> np.ndarray:
+    """Whole-series statistical character (steady-state dominated)."""
+    v = np.asarray(values, dtype=float)
+    sd = v.std() or 1.0
+    return np.array([
+        v.mean(), v.std(), v.min(), v.max(), np.median(v),
+        np.percentile(v, 75) - np.percentile(v, 25),
+        float(np.mean(np.abs(np.diff(v)))) if len(v) > 1 else 0.0,
+        float(np.mean(np.abs(v - v.mean()) > 2 * sd)),
+    ])
+
+
+def contiguous_runs(mask: np.ndarray) -> list[tuple[int, int]]:
+    runs, start = [], None
+    for i, m in enumerate(mask):
+        if m and start is None:
+            start = i
+        elif not m and start is not None:
+            runs.append((start, i)); start = None
+    if start is not None:
+        runs.append((start, len(mask)))
+    return runs
+
+
+def window_at(values: np.ndarray, center: int) -> np.ndarray | None:
+    lo = center - L // 2
+    if lo < 0 or lo + L > len(values):
+        return None
+    return values[lo:lo + L]
+
+
+def main() -> None:
+    w = WorkspaceClient(profile="PaulMain")
+    print("[analog] starting warehouse if stopped...")
+    try:
+        import datetime
+        w.warehouses.start(WAREHOUSE_ID).result(timeout=datetime.timedelta(minutes=5))
+    except Exception as exc:
+        print(f"[analog] warehouse note: {str(exc)[:120]}")
+
+    print("[analog] pulling SMAP/MSL test windows...")
+    df = query_sql(w, f"SELECT chan_id, t, value, is_anomaly FROM {TEL}.gold_smap_msl_windows "
+                      f"WHERE split = 'test'")
+    df["t"] = pd.to_numeric(df["t"], errors="coerce")
+    df["value"] = pd.to_numeric(df["value"], errors="coerce")
+    df["is_anomaly"] = pd.to_numeric(df["is_anomaly"], errors="coerce").fillna(0).astype(int)
+    df = df.dropna(subset=["t", "value"]).sort_values(["chan_id", "t"])
+    print(f"[analog] rows={len(df)} channels={df.chan_id.nunique()} anomaly_rate={df.is_anomaly.mean():.3f}")
+
+    rng = np.random.default_rng(SEED)
+    summaries: dict[str, np.ndarray] = {}
+    anom_windows, norm_windows = [], []   # each: dict(chan, seq(z-normed), is_anomaly)
+    for chan, g in df.groupby("chan_id"):
+        vals = g["value"].to_numpy()
+        isa = g["is_anomaly"].to_numpy()
+        if len(vals) < L * 2:
+            continue
+        summaries[chan] = channel_summary(vals)
+        # Channel-level normalization (not per-window): preserves how prominent the event is
+        # within the channel's own normal range, so a spike stays a spike and a flat normal
+        # window stays flat. Per-window z-norm would erase that and make them look alike.
+        cmu, csd = vals.mean(), (vals.std() or 1.0)
+        for (s, e) in contiguous_runs(isa == 1):
+            win = window_at(vals, (s + e) // 2)
+            if win is not None:
+                anom_windows.append({"chan": chan, "seq": (win - cmu) / csd, "is_anomaly": 1})
+        # normal windows: random centers far from any anomaly
+        normal_centers = np.where(isa == 0)[0]
+        rng.shuffle(normal_centers)
+        taken = 0
+        for c in normal_centers:
+            if isa[max(0, c - L):min(len(isa), c + L)].any():
+                continue
+            win = window_at(vals, int(c))
+            if win is not None:
+                norm_windows.append({"chan": chan, "seq": (win - cmu) / csd, "is_anomaly": 0})
+                taken += 1
+            if taken >= 4:
+                break
+
+    if len(anom_windows) < 10:
+        raise RuntimeError(f"too few anomalous windows ({len(anom_windows)}) for the experiment")
+
+    # Candidate pool (capped, balanced-ish) + query set (anomalous, disjoint where possible).
+    rng.shuffle(anom_windows); rng.shuffle(norm_windows)
+    queries = anom_windows[:N_QUERIES]
+    pool = anom_windows[:N_CAND_ANOM] + norm_windows[:N_CAND_NORM]
+    pool_isa = np.array([c["is_anomaly"] for c in pool])
+    print(f"[analog] queries={len(queries)} pool={len(pool)} "
+          f"(anom {int(pool_isa.sum())} / normal {int((pool_isa==0).sum())})")
+
+    mr_a, mr_b, ov, ex = [], [], [], None
+    for q in queries:
+        a_scores, b_dist, valid = [], [], []
+        for i, c in enumerate(pool):
+            if c["chan"] == q["chan"]:
+                a_scores.append(-1e9); b_dist.append(1e18); continue   # exclude same channel
+            a_scores.append(cosine(summaries[q["chan"]], summaries[c["chan"]]))
+            b_dist.append(dtw_distance(q["seq"], c["seq"], band=BAND))
+            valid.append(i)
+        a_top = topk_indices(np.array(a_scores), K, largest=True)
+        b_top = topk_indices(np.array(b_dist), K, largest=False)
+        ra, rb = match_rate(a_top, pool_isa), match_rate(b_top, pool_isa)
+        mr_a.append(ra); mr_b.append(rb); ov.append(overlap(a_top, b_top))
+        if ex is None and pool_isa[b_top[0]] == 1 and pool_isa[a_top[0]] == 0:
+            ex = {
+                "query_channel": q["chan"],
+                "whole_series_cosine_top1": {"channel": pool[a_top[0]]["chan"], "is_anomaly": int(pool_isa[a_top[0]])},
+                "event_windowed_dtw_top1": {"channel": pool[b_top[0]]["chan"], "is_anomaly": int(pool_isa[b_top[0]])},
+            }
+
+    mean_a, mean_b, mean_ov = float(np.mean(mr_a)), float(np.mean(mr_b)), float(np.mean(ov))
+    lift = (mean_b - mean_a) / mean_a if mean_a > 0 else float("inf")
+
+    artifact = {
+        "as_of": AS_OF,
+        "dataset": "SMAP/MSL (NASA telemanom) — gold_smap_msl_windows, test split",
+        "method": (f"For each anomalous query window (len {L}), retrieve top-{K} precedents (excluding "
+                   "same-channel) two ways: (A) WHOLE-SERIES cosine on the channel's full-series "
+                   "statistical summary; (B) EVENT-WINDOWED DTW (Sakoe-Chiba band "
+                   f"{BAND}) on the z-normalized anomalous-window signal. Metric: anomalous-match rate "
+                   "(fraction of retrieved precedents that are themselves anomalous) + top-K overlap."),
+        "params": {"window_len": L, "top_k": K, "dtw_band": BAND,
+                   "n_queries": len(queries), "pool_size": len(pool),
+                   "pool_anomalous": int(pool_isa.sum()), "pool_normal": int((pool_isa == 0).sum())},
+        "metrics": {
+            "whole_series_cosine_anomalous_match_rate": round(mean_a, 4),
+            "event_windowed_dtw_anomalous_match_rate": round(mean_b, 4),
+            "event_windowing_lift_pct": round(lift * 100, 1) if np.isfinite(lift) else None,
+            "topk_overlap": round(mean_ov, 4),
+        },
+        "example": ex,
+        "finding": (
+            f"Whole-series cosine retrieves precedents that are only {round(mean_a*100,1)}% actual "
+            f"anomalies (dominated by steady-state character), while event-windowed DTW retrieves "
+            f"{round(mean_b*100,1)}% actual-anomaly precedents"
+            + (f" ({round(lift*100)}% more)" if np.isfinite(lift) else "")
+            + f". The two methods agree on only {round(mean_ov*100,1)}% of the top-{K} — event-windowing "
+            "surfaces the precedents a full-vector search misses."
+        ),
+        "limitations": [
+            "SMAP/MSL channels are independent anonymized spacecraft streams, not a coupled physical system; 'precedent' = another channel's labeled anomaly window of similar event shape, not a linked disposition.",
+            "Linked dispositions (was it real / root cause / action taken) are NOT in this public dataset; they would come from a real failure-review system. Shown as unavailable rather than fabricated.",
+            "Pure-numpy banded DTW on a capped candidate pool for tractability; the relative comparison (event-windowed vs whole-series) is the finding, not an absolute retrieval benchmark.",
+        ],
+    }
+
+    out_src = ROOT / "telemetry-platform" / "event_windowed_analog_evidence.json"
+    out_src.write_text(json.dumps(artifact, indent=2), encoding="utf-8")
+
+    print("\n=== EVENT-WINDOWED ANALOG RETRIEVAL (SMAP/MSL) — measured ===")
+    print(f"whole-series cosine anomalous-match rate: {mean_a:.3f}")
+    print(f"event-windowed DTW  anomalous-match rate: {mean_b:.3f}"
+          + (f"  ({lift*100:.0f}% lift)" if np.isfinite(lift) else ""))
+    print(f"top-{K} overlap between methods         : {mean_ov:.3f}")
+    print(f"example (B finds anomaly, A misses)     : {ex}")
+    print(f"\nwrote {out_src}")
+    print("[analog] UI card deferred — parallel agent owns the telemetry frontend refactor.")
+
+
+if __name__ == "__main__":
+    main()

--- a/telemetry-platform/event_windowed_analog_evidence.json
+++ b/telemetry-platform/event_windowed_analog_evidence.json
@@ -1,0 +1,37 @@
+{
+  "as_of": "2026-06-24",
+  "dataset": "SMAP/MSL (NASA telemanom) \u2014 gold_smap_msl_windows, test split",
+  "method": "For each anomalous query window (len 48), retrieve top-5 precedents (excluding same-channel) two ways: (A) WHOLE-SERIES cosine on the channel's full-series statistical summary; (B) EVENT-WINDOWED DTW (Sakoe-Chiba band 8) on the z-normalized anomalous-window signal. Metric: anomalous-match rate (fraction of retrieved precedents that are themselves anomalous) + top-K overlap.",
+  "params": {
+    "window_len": 48,
+    "top_k": 5,
+    "dtw_band": 8,
+    "n_queries": 40,
+    "pool_size": 284,
+    "pool_anomalous": 104,
+    "pool_normal": 180
+  },
+  "metrics": {
+    "whole_series_cosine_anomalous_match_rate": 0.415,
+    "event_windowed_dtw_anomalous_match_rate": 0.45,
+    "event_windowing_lift_pct": 8.4,
+    "topk_overlap": 0.09
+  },
+  "example": {
+    "query_channel": "E-10",
+    "whole_series_cosine_top1": {
+      "channel": "E-11",
+      "is_anomaly": 0
+    },
+    "event_windowed_dtw_top1": {
+      "channel": "E-11",
+      "is_anomaly": 1
+    }
+  },
+  "finding": "Whole-series cosine retrieves precedents that are only 41.5% actual anomalies (dominated by steady-state character), while event-windowed DTW retrieves 45.0% actual-anomaly precedents (8% more). The two methods agree on only 9.0% of the top-5 \u2014 event-windowing surfaces the precedents a full-vector search misses.",
+  "limitations": [
+    "SMAP/MSL channels are independent anonymized spacecraft streams, not a coupled physical system; 'precedent' = another channel's labeled anomaly window of similar event shape, not a linked disposition.",
+    "Linked dispositions (was it real / root cause / action taken) are NOT in this public dataset; they would come from a real failure-review system. Shown as unavailable rather than fabricated.",
+    "Pure-numpy banded DTW on a capped candidate pool for tractability; the relative comparison (event-windowed vs whole-series) is the finding, not an absolute retrieval benchmark."
+  ]
+}

--- a/telemetry-platform/test_analog_core.py
+++ b/telemetry-platform/test_analog_core.py
@@ -1,0 +1,65 @@
+"""Eval tests for the analog-retrieval primitives — numpy only, no Databricks.
+
+Run: python -m pytest telemetry-platform/test_analog_core.py -q
+"""
+
+import numpy as np
+
+from analog_core import cosine, dtw_distance, match_rate, overlap, topk_indices, znorm
+
+
+def test_dtw_zero_for_identical_and_small_for_time_shift():
+    a = np.sin(np.linspace(0, 6, 60))
+    assert dtw_distance(a, a) < 1e-9
+    shifted = np.r_[a[5:], a[:5]]            # circular time shift
+    # DTW tolerates the warp far better than rigid Euclidean does.
+    eucl = float(np.sqrt(np.sum((a - shifted) ** 2)))
+    assert dtw_distance(a, shifted, band=10) < eucl
+
+
+def test_cosine_and_topk():
+    assert cosine(np.array([1.0, 0]), np.array([1.0, 0])) == 1.0
+    assert abs(cosine(np.array([1.0, 0]), np.array([0, 1.0]))) < 1e-9
+    assert topk_indices(np.array([0.1, 0.9, 0.5]), 2, largest=True) == [1, 2]
+    assert topk_indices(np.array([0.1, 0.9, 0.5]), 2, largest=False) == [0, 2]
+
+
+def test_match_rate_and_overlap():
+    isa = np.array([1, 0, 1, 0, 1])
+    assert match_rate([0, 2, 4], isa) == 1.0
+    assert match_rate([1, 3], isa) == 0.0
+    assert overlap([1, 2, 3], [2, 3, 4]) == 2 / 3
+
+
+def test_event_windowed_dtw_beats_whole_series_cosine_at_finding_the_event():
+    # A channel's whole-series summary is dominated by its steady-state level; two channels
+    # with the SAME rare event but different steady states look DIFFERENT by summary-cosine,
+    # yet their event windows match under DTW. Build that and check retrieval quality.
+    rng = np.random.default_rng(0)
+    L = 48
+    spike = np.zeros(L); spike[L // 2 - 3:L // 2 + 3] = 4.0   # the shared "event"
+    # query: event on a low steady state
+    query = znorm(spike + rng.normal(scale=0.05, size=L))
+
+    cands, summaries, isa = [], [], []
+    # 5 anomaly candidates: same event, very different steady-state levels (+/- big offsets)
+    for off in (-20, -10, 0, 10, 20):
+        w = spike + off + rng.normal(scale=0.05, size=L)
+        cands.append(znorm(w)); summaries.append(np.array([w.mean(), w.std()])); isa.append(1)
+    # 5 normal candidates: no event, near the query's steady-state level (cosine-on-summary bait)
+    for _ in range(5):
+        w = rng.normal(scale=0.05, size=L)
+        cands.append(znorm(w)); summaries.append(np.array([w.mean(), w.std()])); isa.append(0)
+    isa = np.array(isa)
+    q_summary = np.array([spike.mean(), spike.std()])
+
+    # Whole-series cosine on the (level-bearing) summary
+    a_scores = np.array([cosine(q_summary, s) for s in summaries])
+    a_top = topk_indices(a_scores, 3, largest=True)
+    # Event-windowed DTW on the z-normed event shape (smaller distance = closer)
+    b_dist = np.array([dtw_distance(query, c, band=8) for c in cands])
+    b_top = topk_indices(b_dist, 3, largest=False)
+
+    # Event-windowed DTW retrieves the true-event precedents; summary-cosine does worse.
+    assert match_rate(b_top, isa) > match_rate(a_top, isa)
+    assert match_rate(b_top, isa) >= 0.66


### PR DESCRIPTION
ML-only compute (telemetry-platform). **Zero repo-b touch** — a parallel agent owns the telemetry frontend refactor, so the UI card is deferred until PR C/D settles.

Measured on real SMAP/MSL gold_smap_msl_windows (test split): for each anomalous query window, retrieve top-5 precedents by (A) whole-series cosine on the channel summary vs (B) event-windowed banded-DTW on the channel-normalized anomalous-window signal.
- The methods agree on only **9%** of top-5 — they surface largely different precedents.
- Event-windowed DTW modestly lifts anomaly-precedent retrieval: **45.0% vs 41.5% (+8.4%)**, both above the 36.6% pool base rate.

**Honest framing:** the most modest of the spins. Linked dispositions are **unavailable** in public SMAP/MSL (shown as unavailable, not fabricated). A first cut with per-window z-norm erased event magnitude (no lift); channel-level normalization recovered the +8% — documented as the methodological fix.

- analog_core.py (pure-numpy banded DTW + metrics) + test_analog_core.py (4 tests green)
- compute_event_windowed_analog.py -> event_windowed_analog_evidence.json (reproducible)
- audit docs updated; no tips.md (contested). Tail spins 2/4/7 deferred (weak data fit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)