### PR TITLE
Add telemetry stream Databricks provenance schema (10034)

### DIFF
--- a/docs/plans/03-implementation-plans/active/telemetry-confluent-databricks-supabase-lineage.md
+++ b/docs/plans/03-implementation-plans/active/telemetry-confluent-databricks-supabase-lineage.md
@@ -1,0 +1,143 @@
+# Telemetry Confluent → Databricks → Postgres Lineage Walkthrough
+
+**Status:** Active — Ticket 1 **blocked on owner-role apply** (schema written + dry-run validated)
+**Started:** 2026-06-24
+**Risk:** Medium (Ticket 1: additive schema; later tickets higher with consumer/Confluent access)
+**Linked build plan:** [Telemetry Platform Build](0003-telemetry-platform-build.md)
+**Related:** [Telemetry Metadata Explorer](telemetry-metadata-explorer.md) (visual lineage UI),
+[Event Streaming / BigQuery / GKE](0004-event-streaming-bigquery-gke.md) (raw-history sink)
+
+## Objective
+
+Make the telemetry environment prove how a displayed anomaly or triage record flows end to end:
+
+```
+Confluent Kafka  →  Databricks/Delta raw lake  →  Postgres serving slice  →  FastAPI  →  frontend lineage drawer
+                                                   (Lakebase in prod / Supabase local)
+```
+
+Plus the AI-triage lane (the Streaming Agent **explains** anomalies, it does not detect them):
+
+```
+stargate.printer.anomalies.v1  →  Paul_Streaming_Agent / stargate-anomaly-triage-gpt4o
+  →  stargate.printer.anomaly.triage.v1  →  Postgres triage projection  →  drawer
+```
+
+## Product truth (honesty boundary)
+
+- Confluent Kafka = live event transport, topic/partition/offset + schema proof.
+- Databricks/Delta = durable RAW/historical telemetry lake, model/eval/feature history.
+- Postgres serving slice (Databricks **Lakebase** managed Postgres via `TELEMETRY_DATABASE_URL` in
+  telemetry/prod; **Supabase** Postgres fallback locally) = latest rows, anomaly/triage summaries,
+  receipts, and **pointers** into the lake. **Not** the lake, not a raw warehouse.
+- Stargate is deterministic synthetic printer replay carried through real infrastructure — not live
+  physical rocket/printer telemetry. The deterministic stream/Flink/anomaly rules detect; the agent
+  triages. Missing lineage layers must **fail closed** with an explicit `*_unavailable` reason, never
+  faked.
+
+## Session Brief (Ticket 1)
+
+- **Requested work:** next slice of the Confluent + Databricks + Postgres telemetry lineage walkthrough.
+- **Routed plan:** this file.
+- **Environment:** Telemetry / Stargate.
+- **Shared standards touched:** Data/schema (additive migration, RLS, tenant scope). No AI-runtime,
+  design-system, or deployment change in this ticket.
+- **Expected source areas:** `repo-b/db/schema/`, `docs/plans/`, `tips.md`.
+- **Acceptance criteria:** see Ticket 1 below.
+- **Risk level:** Medium (additive DDL only).
+- **Out of scope:** consumer, routes, frontend, Confluent/Flink runtime, secrets.
+
+## Key context: 10033 already shipped the provenance core
+
+`repo-b/db/schema/10033_telemetry_kafka_stream_provenance.sql` (committed in `2ae69ce9`) already created
+`tel_stream_kafka_rows` (Kafka provenance: topic/partition/offset/schema-id, replay-safe UNIQUE on the
+Kafka coordinate) and `tel_stream_consumer_offsets`. Ticket 1 therefore does **not** recreate them — it
+**extends** them additively in `10034`. Rewriting the committed `10033` would violate the repo's
+additive / never-edit-shipped-migration convention.
+
+## Ticket order
+
+1. **Postgres provenance/serving schema — Databricks lake pointers + triage projection (additive `10034`).** ← in progress
+2. Durable Kafka serving-slice consumer (`backend/app/services/telemetry_stream_consumer.py`), default off
+   (`TELEMETRY_KAFKA_CONSUMER_ENABLED=false`); deterministic raw sampling (`kafka_offset % N`).
+3. Confluent Streaming Agent triage output → `stargate.printer.anomaly.triage.v1`; save reproducibility
+   artifacts under `infra/confluent/stargate/agents/`.
+4. FastAPI lineage/provenance routes (`/api/telemetry/stream/kafka/...`, `/api/telemetry/stream/lineage/anomaly/{id}`).
+5. Frontend Stargate lineage drawer: Kafka detection → AI triage → Databricks lake → Postgres serving row,
+   with explicit unavailable states.
+6. Confluent contract/catalog metadata hygiene.
+7. Runbook + verification script.
+8. Live replay / end-to-end rehearsal (with Flink pool start→stop→park-at-0-CFU cleanup).
+
+## Ticket 1 — implementation
+
+New additive migration `repo-b/db/schema/10034_telemetry_stream_databricks_pointers.sql`:
+
+- `ALTER TABLE tel_stream_kafka_rows` (all `ADD COLUMN IF NOT EXISTS`):
+  - `kafka_key`; source descriptors `source_system` (default `'confluent_kafka'`), `source_kind`,
+    `producer_version`; correlation ids `run_id`, `anomaly_id`, `triage_id`.
+  - Databricks lake pointers: `databricks_catalog/schema/table/path`, `delta_version`,
+    `delta_commit_timestamp`, `databricks_job_id/run_id/notebook_path`, `databricks_lineage_status`
+    (default `'not_available'`), `databricks_null_reason`.
+  - Extend `record_kind` CHECK (drop + re-add in one block) to
+    `telemetry_sample|telemetry|agg5s|anomaly|triage|dlq|execution|signal` — legacy values retained so
+    no existing row is rejected.
+  - Partial indexes on `anomaly_id`, `triage_id`, `(databricks_catalog, schema, table)`.
+  - Column comments disambiguating `run_id` (print/test run) vs `databricks_run_id` (Databricks job-run),
+    and documenting the fail-closed lineage status.
+- `ALTER TABLE tel_stream_consumer_offsets`: add `next_committed_offset`, `lag`, `status` (default
+  `'unknown'`), `null_reason`. PK unchanged.
+- New `tel_stream_triage_events` projection (PK `triage_id`, FK `kafka_row_id → tel_stream_kafka_rows`,
+  `requires_human_review` default `true`, `status` default `not_available`, same fail-closed Databricks
+  pointer block) + RLS tenant policy + indexes + table comment.
+- Trailing `DO $$` verification: triage table + RLS, 11 Databricks pointer columns present, CHECK admits
+  `'triage'`, and defaults (`databricks_lineage_status = not_available`, `requires_human_review = true`).
+
+### Acceptance criteria
+
+- Additive migration `10034` exists; `tel_stream_kafka_rows` carries the Databricks pointer block;
+  `tel_stream_triage_events` exists with RLS; `tel_stream_consumer_offsets` gains lag/status receipts.
+- Kafka idempotency UNIQUE (from 10033) still rejects a replayed `(env, business, topic, partition,
+  offset)`.
+- `databricks_lineage_status` defaults to `not_available`; no fake offsets or Delta pointers inserted.
+- No destructive change; existing telemetry frontend/API/Stargate SSE untouched; no Confluent/Flink
+  runtime change; no secrets.
+
+## Discovery note — Databricks Stargate mapping
+
+`novendor_1.telemetry.*` Delta tables are the **separate NASA C-MAPSS/SMAP/IMS ML lane**, not the
+Stargate printer stream. No concrete Delta table is mapped to the Stargate stream yet, so the lake
+pointers fail closed (`databricks_lineage_status = 'not_available'`,
+`databricks_null_reason = 'databricks_table_mapping_not_configured'`). A follow-up ticket should connect
+known Delta tables once a Stargate→Delta mapping exists.
+
+## Session update — 2026-06-24 (Ticket 1)
+
+**Done:** migration `repo-b/db/schema/10034_telemetry_stream_databricks_pointers.sql` written; active
+plan + `docs/tips.md` lessons added (tips.md merge conflict was already resolved upstream this session).
+
+**Tests run:**
+- `node repo-b/db/schema/apply.js --files 10034 --dry-run` → PASS (39 statements; `DO $$` blocks split
+  whole).
+- Live apply against Lakebase (`TELEMETRY_DATABASE_URL`, Railway `authentic-sparkle`) → **FAILED at
+  statement 1**: `ERROR 42501 must be owner of table tel_stream_kafka_rows`.
+
+**Blocker (apply):** the Lakebase `tel_*` tables are owned by the human Databricks role
+`paulmalmquist@gmail.com`. The only reachable credential is the runtime `telemetry_app` role
+(`rolsuper=false`, `rolcreaterole=false`, member of only itself, **not** a member of the owner role —
+no `SET ROLE` path). DDL therefore cannot run as `telemetry_app`. **`10034` must be applied as the
+owner**, either via the Databricks SQL editor authenticated as `paulmalmquist@gmail.com` (paste the
+file; confirm the trailing `DO $$` NOTICE), or with an owner connection string passed to
+`node repo-b/db/schema/apply.js --files 10034` (then revoke). I did **not** fabricate a successful
+apply and did **not** create fallback/duplicate tables.
+
+**Pre-apply state captured (read-only, as `telemetry_app`):** on Lakebase, `tel_stream_kafka_rows` has
+no `databricks_*` columns, `tel_stream_triage_events` does not exist, and the `record_kind` CHECK is the
+legacy `('telemetry','anomaly','agg5s')` — exactly what `10034` extends. Confirmed `tel_stream_*` tables
+are absent on Supabase (`to_regclass` → null), so Supabase is the wrong target.
+
+**Ticket 1 status:** **blocked** — schema complete and dry-run validated; live apply + post-apply
+verification pending owner-role access. Do **not** start Ticket 2 until `10034` is applied and verified.
+
+**Risks/unknowns:** owner credential is the interactive Databricks human login (not in Railway/Vercel/
+Supabase). No Stargate→Delta mapping yet (pointers stay `not_available`).

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -3038,6 +3038,32 @@ Hierarchy + board hygiene decisions:
 - ADO state discipline for coding agents: `Active` at start, `Resolved` when code/tests/evidence are ready, `Closed` only when the PR is merged and deploy/smoke is verified. A local-only pass never closes a work item. Every session also appends an ADO discussion comment (branch/commit/PR, files, tests, evidence, risks, next item) — a bare state change is not an audit trail.
 - If the Azure DevOps CLI is unavailable or unauthenticated during intake, stop before coding and emit an "ADO Unavailable Blocker" note with the exact command and error. Do not silently proceed; proceed only on an explicit, marked user exception.
 
+### RS MLOps team board is the control tower for RS/telemetry work (2026-06-24)
+
+- The `Novendor` project is already on the Agile process. Do not recreate it or change the shared `Novendor Team` board.
+- RS Analytics and telemetry work uses the dedicated `RS MLOps` team, scoped to `Novendor\RS-Analytics` with child areas included. The existing Epic/Feature/Story hierarchy remains authoritative; team boards are views over those same work items.
+- The source of truth is `scripts/azure-devops/rs-mlops-control-tower.json`; apply it with `setup-rs-mlops-control-tower.ps1`. Always run `-DryRun`, then `-Backup`, before `-Apply`, and finish with `-Verify`.
+- Board columns carry the detailed MLOps lifecycle while work-item states remain `New`, `Active`, `Resolved`, and `Closed`. `Verified` maps to `Resolved`; `Done` maps to `Closed`.
+- Azure Boards requires the outgoing/Closed column to be last. The live order therefore ends `Verified → Blocked → Done`; the originally proposed `Done → Blocked` order is not accepted by the API.
+- Azure DevOps plan names reject `/`, so the live Delivery Plan is `RS - Winston MLOps Delivery Plan`.
+- Swimlane placement is explicit. Azure Boards does not move cards to a swimlane based on tags.
+- Test Plans remain represented by linked `Test Case` work items until a dedicated ADO PAT and license are confirmed. Service hooks remain disabled until the `Agent Ready` polling flow is stable.
+
+## Confluent Cloud CLI Management (2026-06-24)
+
+CLI quirks (`confluent` CLI v4.60 on Windows). Owned by `skills/confluent-stargate-lifecycle/`.
+
+- **Exit 0 does not mean success.** `confluent flink compute-pool update --max-cfu 0` returns exit code 0 while *rejecting* the argument in stdout: `Error: Bad Request: Violations [MaxCfu is not one of 5, 10, 20, 30, 40, 50: 0]`. Never trust the exit code alone — scan output for rejection markers (`Bad Request`, `Violations`, `is not one of`). This silently produced a false "parked at 0 CFU" cost claim before it was caught.
+- **Flink pools cannot be parked at 0 CFU.** `--max-cfu` only accepts `{5, 10, 20, 30, 40, 50}`. There is no scale-to-zero for a compute pool. CFU-hours bill on *running statements*, not on the pool's `max_cfu` ceiling, so an idle pool (no running statements) costs nothing — to stop Flink billing, `confluent flink statement stop <name>`, don't lower the ceiling.
+- **`flink statement list` prepends a notice line to stdout** before the JSON: `No Flink endpoint is specified, defaulting to public endpoint: https://flink.us-east1.gcp.confluent.cloud`. Piping straight into `ConvertFrom-Json` fails with "Error parsing NaN value". Strip everything before the first `[`/`{` first.
+- **Flink commands need cloud + region.** `confluent flink statement list` errors with "no cloud provider and region selected" unless you pass `--cloud gcp --region us-east1` (the Stargate lane's region).
+- **Stopping serving ≠ deleting topics.** Deleting connectors + stopping Flink statements stops the *active* costs losslessly — topics, their data, and Schema Registry subjects survive. Topics are cluster-scoped and only disappear when you delete the Kafka cluster. Schema Registry is environment-scoped and *may* survive a cluster delete, but export before relying on it.
+- **`cluster_0` (lkc-gqpvvyv) is STANDARD, not Dedicated** — it bills a flat hourly base, not CKU-hours. CKU/CKU-hour billing is Dedicated-only. Read the real cluster type (`confluent kafka cluster describe`) before writing any cost message; don't hardcode "CKU".
+- **Connectors: delete, don't pause.** A paused managed connector keeps accruing task-hour charges. `confluent connect cluster delete <id>` to actually stop the cost.
+- **PowerShell empty-array trap (not Confluent-specific but bites here):** a function that does `return @()` can hand back `$null` because PS unwraps empty arrays through `return`. Wrap the *call site* in `@(...)` before reading `.Count`, and wrap `ConvertFrom-Json` results in `@()` since an empty `[]` deserializes to `$null`.
+- **CI cannot use the interactive `confluent login`.** A scheduled GitHub Action needs a service-account **API key** (`confluent api-key create --resource cloud --service-account sa-…`), passed as `CONFLUENT_CLOUD_API_KEY`/`_SECRET` env, then `confluent login --save`. A machine email/password works but exposes full-account creds in CI — prefer the scoped service account.
+- **Age a status row from its own `as_of_ts`; never trust a stored "fresh" as still-current.** A row re-stamped on a fixed cadence (e.g. a 15-min refresh job) must be aged client-side: if `now − as_of_ts` exceeds ~2× the cadence, render it STALE regardless of the stored status. This keeps the surface honest if the writer stops, with no extra signal. Pair it with a *fail-closed writer*: when the periodic check itself fails, write an explicit `stale`/`check_failed` state — do **not** re-write the last good state as if freshly verified (that would launder a stale value into a fresh-looking one).
+
 ### After a feature merges to main, do a docs-only "presentation hardening" pass before the next layer (2026-06-02)
 
 When a multi-phase feature crosses from active build to production-shipped (merged to `main`, deployed, smoke-verified), freeze the win as portfolio artifacts *before* starting the next phase — it's cheap insurance against the demo decaying into "depends on the author's memory." Two docs carry it: a **reviewer runbook** (`telemetry-platform/REVIEWER_DEMO.md` — login/auth flow, exact production routes, a timed click-through script, the **exact expected evidence values** so a reviewer can confirm groundedness, what NOT to claim, and known caveats) and a **2-minute portfolio proof** (`telemetry-platform/docs/portfolio-proof.md` — problem → architecture → proof points → applied-AI controls → routes → tests → "what this demonstrates", pasteable into a recruiter message). Keep it docs-only (no runtime changes); reference the screenshots already in the repo rather than regenerating; pin the real IDs/metrics so the artifact and the live system can't silently drift. Do this on a clean branch off `main` in an isolated `git worktree` so an unrelated dirty primary working tree is never disturbed. Caveats a portfolio reviewer needs stated up front: public-analog-data-only (no proprietary / no physical root cause / no safety disposition), manual deploys (Railway/Vercel don't auto-deploy on push — state deploy↔main parity), auth-gated UI, and any legacy branch-name mismatch already merged.
@@ -4100,66 +4126,28 @@ Inventory of the real data behind the telemetry env (full per-surface contracts 
   and print only the password *length*, never the value. Login form on `/login` uses
   `input[autocomplete=username]` (type=text, not `type=email`) + `input[type=password]` + a "Sign in" submit.
 
-## Telemetry evidence layer + Stargate bridge (Story #707)
+## Telemetry Databricks pipeline — running, inspecting, and judging the ML
 
-- **Evidence-card pattern.** A claim-proof card fetches one real endpoint, then branches:
-  `error → ErrorState`, `!data → Loading`, `data.null_reason → EmptyState/ErrorState`, else render. Never
-  fabricate a number — render only fields present in the response, and give each card its own fail-closed
-  sub-state so one missing source doesn't blank the whole card. Cards live in
-  `repo-b/src/components/telemetry/*EvidenceCard.tsx` and compose onto one page (`/telemetry/evidence`)
-  behind a single nav entry.
-- **Claim-proof matrix.** `claim_coverage_matrix.md` maps each resume claim to: current status (evidence-backed)
-  · `file:symbol` · what can be said live · what must NOT be overclaimed · required follow-up. Keep it current
-  as claims improve or fail. It is the guardrail the cards and demo talk-track must not exceed.
-- **Capture-replay labeling (non-negotiable).** The Stargate stream is *recorded capture replayed through the
-  real Kafka/SSE bridge*, not a live printer. Every control/label says "recorded capture" (e.g. the button is
-  "Start recorded capture"); the restart endpoint returns `source: recorded_capture`. Never imply live data.
-- **Judgment-artifact framing.** The strongest evidence is an honest negative result already in the repo: the
-  256-d autoencoder anomaly detector is degenerate (F1 = the all-positive baseline because the train threshold
-  sits below the test-error floor), so the champion is rolling-MAD and the AE vector is repurposed for
-  retrieval. Surface that as "built the obvious thing → measured → found the break → shipped the fix," not as a
-  working detector. Same for honest pointwise F1 (0.313) shown beside the inflated point-adjusted (0.645).
-- **Stargate bridge deploy gotcha (cost me a 503).** The shared backend mounts `/stargate/*` behind
-  `STARGATE_BRIDGE_ENABLED`, but `main.py`'s lifespan did NOT set `app.state.stargate_bridge` (only
-  `create_app`'s lifespan did) — so `/stargate/stream` returned 503 ("reconnecting" forever) in prod. The fix
-  is to mirror `create_app`'s init (preload fixture + `replay_capture_forever`) inside `main.py`'s lifespan,
-  gated on the same flag. In prod `NEXT_PUBLIC_STARGATE_BRIDGE_URL` points at the **main backend**
-  (authentic-sparkle), so the bridge ships with the main image — `railway up` from the **clean main worktree**
-  (`C:/Projects/Consulting_app-rs-demos`), then poll `/version` until the git_sha flips, then curl
-  `/stargate/health` (expect `msgs_in_per_sec > 0`) + `POST /stargate/replay/cycle` (expect 200).
-- **Production smoke gotchas.** (1) A live SSE page never reaches Playwright `networkidle` — use
-  `domcontentloaded` + `waitForSelector`, not `networkidle`, on `/telemetry/stargate`. (2) The login button
-  renders "SIGN IN" (CSS uppercase); a `text=Sign in` click can miss — submit with
-  `page.press("input[type=password]", "Enter")` instead. (3) The backend root `GET /version` is not under the
-  `/api/telemetry` catch-all, so the frontend reads it through a dedicated `/api/version` proxy route handler.
+Lessons from running the full `novendor_1.telemetry` pipeline (probe → anomaly → RUL → promote → score →
+fused → NCR corpus/clustering/forecast) on serverless and reviewing it for ML quality.
 
-## Conformal lower-bound RUL (Phase 2, Story #716)
+**Running notebooks remotely (no new client):**
+- Auth: set `DATABRICKS_PAT` or drop the gitignored repo-root `claude_token.txt`; `telemetry-platform/databricks/_bootstrap.py:get_client()` reads it. Host `dbc-2504bec5-b5ab`, catalog `novendor_1.telemetry`, warehouse `0e56420fb707d861`, MLflow exp `3740651530987773`.
+- Use `_jobs.py` (`upload_notebook` + `run_notebook_and_wait`, serverless, polls every 15 s) — see the `08_*`…`16_*` drivers. A reusable runner that also cancels-on-timeout and appends to a `run_manifest.json` is `telemetry-platform/runs/*/runner.py`.
+- The PowerShell tool does NOT persist env vars between calls — persist the PAT via the `claude_token.txt` fallback (gitignored by `*token*.txt`), or inline `$env:DATABRICKS_PAT=…` per invocation.
+- Read-only inspector pattern: `DatabricksClient.execute_sql` + `search_mlflow_runs` + UC REST. The UC alias field is `version` (e.g. `GET /api/2.1/unity-catalog/models/{full}/aliases/champion` → `.version`), **not** `version_num`; the registered-models *list* endpoint returns empty `aliases`.
+- **Workspace drifts from repo source.** Deployed notebooks differed from `notebooks/*.py` for 6/8 here, and the live champion had been built by stale code (only point-adjusted metrics). Always back up workspace source (`/api/2.0/workspace/export`) before re-uploading, and treat the repo as the only source of truth.
 
-- **Split conformal in ~30 lines, no heavy deps.** Pure numpy in `telemetry-platform/conformal_core.py`:
-  nonconformity quantile = `ceil((n+1)(1-alpha))/n` empirical quantile (finite-sample valid); two-sided
-  `[pred±qhat]`; one-sided lower = `pred - quantile(over-prediction residuals)`. Keep the math in a
-  Databricks-free module so the eval test runs without credentials.
-- **Calibration exchangeability is the whole game.** C-MAPSS test units truncate at a *varied* point in life, so
-  their last-cycle RUL spans a wide range. Calibrating on held-out TRAIN units' *last* cycles (all near-failure,
-  small RUL) breaks exchangeability and badly under-covers — **measured PICP 0.44 vs a 0.90 target**. Calibrate
-  on a random *operational* cycle per held-out unit (matching the score-at-an-arbitrary-point distribution) and
-  PICP recovers to **~0.86**. Report measured PICP honestly; near-nominal-but-under is a real result, not
-  something to hide.
-- **Lower-bound safety gating.** For a go/no-go, clear a unit on the calibrated **lower bound** of remaining
-  life, never the point estimate. The demo moment is the disagreement count: N units look GO on the point
-  estimate but the lower bound demands REVIEW/NO-GO.
-- **Databricks pull without a PAT.** `auth_gate.py` only checks `DATABRICKS_PAT`/`claude_token.txt`, but the CLI
-  and SDK authenticate via the OAuth profile in `~/.databrickscfg`. Use
-  `WorkspaceClient(profile='PaulMain').statement_execution.execute_statement(warehouse_id=…, disposition=INLINE,
-  format=JSON_ARRAY)`, page chunks via `get_statement_result_chunk_n`, start the serverless warehouse on demand.
-  Early-cycle rolling / rate-of-change gold features are NaN until their window fills — impute with train-median
-  (medians from fit rows only, no leakage).
-- **Evidence-artifact pattern for ML results.** Persist computed metrics as a committed JSON (in
-  `telemetry-platform/` plus a copy under `repo-b/src/lib/telemetry/`), import it into a card, and label it
-  "computed evidence artifact · not live serving" with `as_of` + the calibration-split description. Real numbers,
-  reproducible, never claimed as live.
+**threadpoolctl "Exception ignored on calling ctypes callback … 'NoneType' has no attribute 'split'":**
+- Root cause on DBR Python 3.12: bundled `libgomp` reports `version: null` and **threadpoolctl 2.2.0** doesn't guard against it. **Non-fatal** introspection noise — fit/predict return finite, correct results; the warning is intermittent and off the result path. Fix only if the noise bothers you: notebook-scoped `%pip install "threadpoolctl>=3.1.0"` (3.x guards `version=None`); never change the global cluster image. Prove non-fatality before any package change.
 
-## Relativity / aerospace telemetry surfaces — the three-question rule (Story #717)
+**Judging the ML (notebook success ≠ done):**
+- **Point-adjusted F1 inflates ~2×.** SMAP/MSL MAD reported 0.639 point-adjusted vs 0.309 honest point-wise. Lead with honest/affiliation metrics (the pipeline logs both + a fail-closed gate).
+- **Watch for the always-positive baseline.** Fused PCA-256 and the autoencoder both hit f1=0.757 with fn=0 — that's exactly the all-positive baseline (2·p·1/(1+p)). A 99th-pctl-of-*train* threshold under the min *test* reconstruction error → constant classifier. Always compute the trivial baseline.
+- **RMSE can hide the dangerous failure mode.** RUL GBM wins RMSE (20.3 vs 21.7) but loses PHM (1423 vs 1036) and predicts LATE 58% of the time (optimistic on near-failure units). For asymmetric-cost targets, make the gate PHM-/late-rate-aware, not RMSE-only; check error-by-regime.
+- **Negative control = cheapest leakage test.** Shuffle training labels, refit; RMSE should collapse to naive (here 41.65 ≈ naive 41.71 → no leakage). Add naive baselines (train-mean/median) — a model that can't beat them isn't skillful (RUL beats them ~2×; the NCR drift forecast only ties / loses on MAPE).
+- **Clustering: measure family purity, don't tune to the answer.** MiniLM→UMAP→HDBSCAN recovered 3/6 synthetic families cleanly, split 2, scattered 1, and missed the engineered *declining* trend (slopes didn't cross −0.35). Add a "needs human review" bucket + family-level trend rather than lowering thresholds.
+- **Curated replay feeds overstate recall.** `gold_replay_feed_scored` showed fn=0 (100% recall) because it's a curated D-4 fixture; the honest test recall is 0.30. And the `anomaly_score` display column is uncalibrated (10⁰–10¹³) — gate on the binary `model_pred`, clamp the score for UI.
 
 When building any Relativity / aerospace telemetry feature, every technical surface should answer three
 questions, or it reads as an isolated demo rather than part of one argument:
@@ -4229,3 +4217,11 @@ claims as fact unless sourced; keep era framing general (access → cost → reu
 - **Fail-closed UI is load-bearing copy.** Every `null_reason` string (`model_not_promoted`, `no_upstream_edges_in_catalog`, `metadata_graph_unreachable`, "Unavailable reason", governance N=0 reason) and every honesty label ("recorded capture", "not live serving", honest-F1 dual labels, GO/REVIEW/NO_GO) is a constant a refactor may MOVE but never edit or strengthen. The card `.test.tsx` files assert these exact strings — they ARE the behavior-preservation safety net; run `vitest run src/components/telemetry` before merging.
 - **One token system per file.** `rsTokens` (RS demo palette) had accent hexes byte-identical to `C`, so unifying was a one-file recolor (point `RS` at `C`, keep only the RS-specific teal/violet/blue chart hexes) — zero layout change. Cheaper and safer than swapping `RsPanel`→`Panel` (different radius/size) across files.
 - **Production-refactor gotchas.** (1) A *near*-duplicate (6px vs 8px dot glow, 9.5px vs 9px label) is NOT an exact-swap dedup — folding it normalizes pixels, which is a visual change to screenshot-gate, not a free behavior-preserving win. (2) This repo is edited by multiple concurrent agents in one checkout — work in a `git worktree` off `origin/main` + junction `node_modules`; see the concurrent-agent memory. (3) When a squash-merged commit lingers on a follow-up branch, `git rebase origin/main` drops it so the next PR diff stays clean.
+
+**Telemetry stream lineage / Lakebase DDL ownership (Ticket 1, 10034):**
+- **`tel_*` serving tables live on Databricks Lakebase, not Supabase.** They were migrated off Supabase to Lakebase (managed Postgres) via `TELEMETRY_DATABASE_URL`. Supabase no longer has them — `to_regclass('public.tel_stream_kafka_rows')` returns `null` on the Supabase `DATABASE_URL`. Never apply `tel_*` migrations against Supabase; you'll get "relation does not exist."
+- **The runtime `telemetry_app` role is DML-scoped and is NOT the table owner**, so `apply.js` DDL (`ALTER TABLE` / `DROP CONSTRAINT` / `CREATE TABLE`) fails with `SQLSTATE 42501 must be owner of table ...`. The Lakebase `tel_*` tables are owned by the human Databricks identity `paulmalmquist@gmail.com`. **DDL migrations to `tel_*` must be run as that owner** — Databricks SQL editor authenticated as the human, or an owner connection string — not the Railway `authentic-sparkle` `TELEMETRY_DATABASE_URL` (that's `telemetry_app`). This is the same family of limit as "Lakebase telemetry_app can't CREATE partitions."
+- **Where the creds actually live:** `TELEMETRY_DATABASE_URL` is on **Railway `authentic-sparkle`** (read via `railway variables --service authentic-sparkle --kv`), not on any Vercel project. Backend `DATABASE_URL` (Supabase) is on the **`consulting-app`** Vercel project (serves novendor.ai), and several values export as empty strings from `vercel env pull` (sensitive/encrypted) — pull is unreliable for secrets; Railway `--kv` is the dependable source for the telemetry URL.
+- **Architecture line to hold:** Databricks/Delta is the durable RAW telemetry lake; Lakebase/Postgres is the serving/provenance slice (latest rows, anomaly/triage summaries, receipts, and *pointers* into the lake). Do **not** copy full raw Kafka telemetry into Postgres — persist a deterministic sample (`kafka_offset % sample_rate = 0`) plus anomalies, agg5s, triage, DLQ, and offset receipts in full.
+- **Fail closed on missing lineage.** No concrete Databricks Delta table is mapped to the Stargate *printer* stream (`novendor_1.telemetry.*` is the separate NASA C-MAPSS/SMAP/IMS ML lane). So Databricks pointer columns default `databricks_lineage_status='not_available'` with `databricks_null_reason='databricks_table_mapping_not_configured'`. Never fabricate a Delta pointer or a Kafka offset.
+- **10033 already shipped the Kafka-provenance core** (`tel_stream_kafka_rows` + `tel_stream_consumer_offsets` + the replay-safe `UNIQUE (env_id, business_id, kafka_topic, kafka_partition, kafka_offset)`). Lake pointers + triage came as **additive `10034`** (next free number after committed `10033`) — extend committed migrations, never rewrite them. `apply.js`'s SQL splitter respects `DO $$ ... $$` dollar-quoting, so multi-statement `DO` blocks (drop+re-add CHECK, RLS policy, verification) stay intact under `--files N`.

--- a/repo-b/db/schema/10034_telemetry_stream_databricks_pointers.sql
+++ b/repo-b/db/schema/10034_telemetry_stream_databricks_pointers.sql
@@ -1,0 +1,182 @@
+-- 10034_telemetry_stream_databricks_pointers.sql
+-- Telemetry Platform: additive lineage extension to the Stargate Kafka serving slice shipped in
+-- 10033_telemetry_kafka_stream_provenance.sql. Adds (1) Databricks/Delta lake pointer columns so a
+-- served row can name the raw-lake table/version it corresponds to, (2) the AI-triage record kinds +
+-- correlation ids, and (3) a tel_stream_triage_events projection the lineage drawer/route read.
+--
+-- Architecture / honesty boundary:
+--   Databricks/Delta is the DURABLE RAW telemetry lake. The Postgres serving slice — backed by
+--   Databricks Lakebase (managed Postgres, TELEMETRY_DATABASE_URL) in telemetry/prod and Supabase
+--   Postgres locally where that URL is unset — holds only the serving/provenance slice: latest rows,
+--   anomaly/triage summaries, receipts, and POINTERS into the lake. It is NOT the lake. No raw Kafka
+--   stream is copied here in full; raw telemetry is deterministically sampled (kafka_offset % N) by the
+--   consumer. No concrete Databricks Delta table is mapped to the Stargate printer stream yet, so the
+--   lake pointers fail closed: databricks_lineage_status defaults to 'not_available'. We never fabricate
+--   a Delta pointer or a Kafka offset.
+--
+-- Additive + idempotent only. Re-runnable. Does not rewrite 10033, does not drop data, does not change
+-- any committed primary key. Owning module: Telemetry Platform.
+
+-- ── tel_stream_kafka_rows: Kafka extras + source descriptors + correlation ids + Databricks pointers ──
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS kafka_key            text;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS source_system        text NOT NULL DEFAULT 'confluent_kafka';
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS source_kind          text;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS producer_version     text;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS run_id               text;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS anomaly_id           text;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS triage_id            text;
+-- Databricks/Delta lake pointers — name the raw-lake object a served row came from. Fail-closed by default.
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS databricks_catalog        text;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS databricks_schema         text;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS databricks_table          text;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS databricks_path           text;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS delta_version             bigint;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS delta_commit_timestamp    timestamptz;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS databricks_job_id         text;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS databricks_run_id         text;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS databricks_notebook_path  text;
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS databricks_lineage_status text NOT NULL DEFAULT 'not_available';
+ALTER TABLE tel_stream_kafka_rows ADD COLUMN IF NOT EXISTS databricks_null_reason    text;
+
+-- Extend record_kind. The legacy values (telemetry, agg5s, anomaly) stay in the allowed set so the new
+-- CHECK can never reject an existing committed row; the lineage chain adds telemetry_sample, triage,
+-- dlq, execution, signal. Drop + re-add in one transaction so the table is never left without a CHECK.
+DO $$
+BEGIN
+    ALTER TABLE tel_stream_kafka_rows DROP CONSTRAINT IF EXISTS tel_stream_kafka_rows_record_kind_chk;
+    ALTER TABLE tel_stream_kafka_rows ADD  CONSTRAINT tel_stream_kafka_rows_record_kind_chk
+        CHECK (record_kind IN (
+            'telemetry_sample', 'telemetry', 'agg5s', 'anomaly', 'triage', 'dlq', 'execution', 'signal'
+        ));
+END $$;
+
+-- Provenance/lineage lookup paths (tenant-scoped, partial — these ids are usually null on a raw sample).
+CREATE INDEX IF NOT EXISTS idx_tel_stream_kafka_rows_anomaly
+    ON tel_stream_kafka_rows (env_id, business_id, anomaly_id)
+    WHERE anomaly_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_tel_stream_kafka_rows_triage
+    ON tel_stream_kafka_rows (env_id, business_id, triage_id)
+    WHERE triage_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_tel_stream_kafka_rows_databricks
+    ON tel_stream_kafka_rows (env_id, business_id, databricks_catalog, databricks_schema, databricks_table)
+    WHERE databricks_table IS NOT NULL;
+
+COMMENT ON COLUMN tel_stream_kafka_rows.run_id IS
+  'Print/test run id from the telemetry payload — the manufacturing run. NOT the Databricks job-run id (see databricks_run_id).';
+COMMENT ON COLUMN tel_stream_kafka_rows.databricks_run_id IS
+  'Databricks job-RUN id that produced/refreshed the linked Delta object. NOT the print/test run_id.';
+COMMENT ON COLUMN tel_stream_kafka_rows.databricks_lineage_status IS
+  'Linkage state to the Databricks/Delta raw lake: available | not_available. Explicit only — never inferred. Defaults not_available; set databricks_null_reason when not available (e.g. databricks_table_mapping_not_configured).';
+COMMENT ON COLUMN tel_stream_kafka_rows.databricks_null_reason IS
+  'Why the Databricks lake pointer is absent when databricks_lineage_status = not_available (e.g. databricks_table_mapping_not_configured, databricks_lineage_unavailable). Null when status = available.';
+
+-- ── tel_stream_consumer_offsets: lag + status receipts (PK unchanged from 10033) ──────────────────────
+ALTER TABLE tel_stream_consumer_offsets ADD COLUMN IF NOT EXISTS next_committed_offset bigint;
+ALTER TABLE tel_stream_consumer_offsets ADD COLUMN IF NOT EXISTS lag                   bigint;
+ALTER TABLE tel_stream_consumer_offsets ADD COLUMN IF NOT EXISTS status                text NOT NULL DEFAULT 'unknown';
+ALTER TABLE tel_stream_consumer_offsets ADD COLUMN IF NOT EXISTS null_reason           text;
+COMMENT ON COLUMN tel_stream_consumer_offsets.status IS
+  'Fail-closed consumer health: ok | lagging | stalled | unknown. Defaults unknown until a runner reports.';
+
+-- ── tel_stream_triage_events: AI-triage projection for the lineage drawer / triage routes ─────────────
+CREATE TABLE IF NOT EXISTS tel_stream_triage_events (
+    triage_id              text PRIMARY KEY,
+    env_id                 text NOT NULL,
+    business_id            uuid NOT NULL,
+    -- Correlation back to the upstream detection event + manufacturing context.
+    anomaly_id             text,
+    printer_id             text,
+    print_job_id           text,
+    run_id                 text,                              -- print/test run id, not a Databricks run id
+    -- Triage output (the Streaming Agent explains; it is NOT the detector). status fails closed.
+    severity               text,                              -- low | medium | high | critical | null
+    status                 text NOT NULL DEFAULT 'not_available',  -- ok | not_available
+    incident_summary       text,
+    likely_cause           text,
+    leading_indicators     jsonb NOT NULL DEFAULT '[]'::jsonb,
+    recommended_action     text,
+    confidence             text,                              -- low | medium | high
+    requires_human_review  boolean NOT NULL DEFAULT true,
+    null_reason            text,
+    -- Kafka provenance of the triage record itself (the triage topic coordinate).
+    kafka_row_id           uuid REFERENCES tel_stream_kafka_rows(id),
+    kafka_topic            text,
+    kafka_partition        integer,
+    kafka_offset           bigint,
+    -- Databricks/Delta lake pointer for the triage record (fail-closed, same contract as above).
+    databricks_catalog        text,
+    databricks_schema         text,
+    databricks_table          text,
+    delta_version             bigint,
+    databricks_lineage_status text NOT NULL DEFAULT 'not_available',
+    databricks_null_reason    text,
+    created_at             timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_tel_stream_triage_events_tail
+    ON tel_stream_triage_events (env_id, business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_tel_stream_triage_events_anomaly
+    ON tel_stream_triage_events (env_id, business_id, anomaly_id)
+    WHERE anomaly_id IS NOT NULL;
+ALTER TABLE tel_stream_triage_events ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+    CREATE POLICY tel_stream_triage_events_tenant ON tel_stream_triage_events
+        USING (env_id = current_setting('app.env_id', true))
+        WITH CHECK (env_id = current_setting('app.env_id', true));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+COMMENT ON TABLE tel_stream_triage_events IS
+  'Telemetry Platform: AI-triage projection over the Stargate anomaly-triage topic (stargate.printer.anomaly.triage.v1). The Streaming Agent EXPLAINS upstream anomaly events; it is not the detector. status/severity fail closed (not_available). Databricks pointers fail closed until a Delta mapping is configured. Postgres serving slice (Lakebase in prod / Supabase locally), not the raw lake. Owning module: Telemetry Platform.';
+COMMENT ON COLUMN tel_stream_triage_events.databricks_lineage_status IS
+  'Linkage to the Databricks/Delta raw lake: available | not_available. Explicit only — never inferred. Defaults not_available.';
+
+-- ── verification ─────────────────────────────────────────────────────────────────────────────────────
+DO $$
+DECLARE
+    n_triage_rls int;
+    n_db_cols    int;
+    chk_admits   boolean;
+    lineage_def  text;
+    review_def   text;
+BEGIN
+    -- (a) triage table exists with RLS on
+    SELECT count(*) INTO n_triage_rls FROM pg_tables
+      WHERE schemaname = 'public' AND tablename = 'tel_stream_triage_events' AND rowsecurity = true;
+
+    -- (b) Databricks pointer columns landed on tel_stream_kafka_rows (expect all 11)
+    SELECT count(*) INTO n_db_cols FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'tel_stream_kafka_rows'
+        AND column_name IN (
+            'databricks_catalog','databricks_schema','databricks_table','databricks_path','delta_version',
+            'delta_commit_timestamp','databricks_job_id','databricks_run_id','databricks_notebook_path',
+            'databricks_lineage_status','databricks_null_reason');
+
+    -- (c) the new record_kind CHECK admits 'triage'
+    SELECT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'tel_stream_kafka_rows_record_kind_chk'
+          AND pg_get_constraintdef(oid) LIKE '%''triage''%'
+    ) INTO chk_admits;
+
+    -- (d) defaults: databricks_lineage_status = not_available, requires_human_review = true
+    SELECT column_default INTO lineage_def FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='tel_stream_kafka_rows' AND column_name='databricks_lineage_status';
+    SELECT column_default INTO review_def FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='tel_stream_triage_events' AND column_name='requires_human_review';
+
+    IF n_triage_rls <> 1 THEN
+        RAISE EXCEPTION 'telemetry 10034 incomplete: tel_stream_triage_events missing or RLS off (% of 1)', n_triage_rls;
+    END IF;
+    IF n_db_cols <> 11 THEN
+        RAISE EXCEPTION 'telemetry 10034 incomplete: % of 11 Databricks pointer columns on tel_stream_kafka_rows', n_db_cols;
+    END IF;
+    IF NOT chk_admits THEN
+        RAISE EXCEPTION 'telemetry 10034 incomplete: record_kind CHECK does not admit triage';
+    END IF;
+    IF lineage_def IS NULL OR lineage_def NOT LIKE '%not_available%' THEN
+        RAISE EXCEPTION 'telemetry 10034 incomplete: databricks_lineage_status default is % (expected not_available)', lineage_def;
+    END IF;
+    IF review_def IS NULL OR review_def NOT LIKE '%true%' THEN
+        RAISE EXCEPTION 'telemetry 10034 incomplete: requires_human_review default is % (expected true)', review_def;
+    END IF;
+
+    RAISE NOTICE 'telemetry 10034 ready (triage table + RLS, 11 Databricks pointer cols, record_kind admits triage, defaults verified)';
+END $$;


### PR DESCRIPTION
## Summary
Ticket 1 of the Confluent → Databricks → Postgres telemetry lineage walkthrough. Additive migration `10034_telemetry_stream_databricks_pointers.sql` extends the **already-committed** `10033` Stargate Kafka serving slice with:
- **Databricks/Delta lake pointer columns** on `tel_stream_kafka_rows` (catalog/schema/table/path, delta_version, commit_ts, job/run/notebook, `databricks_lineage_status` default `not_available`, `databricks_null_reason`) — fail-closed.
- **Extended `record_kind`** CHECK: adds `telemetry_sample|triage|dlq|execution|signal`, keeps legacy `telemetry|agg5s|anomaly` so no existing row is rejected (drop+re-add in one block).
- **Correlation ids** (`run_id`, `anomaly_id`, `triage_id`) + Kafka extras (`kafka_key`, source descriptors) + partial provenance indexes.
- **lag/status receipts** on `tel_stream_consumer_offsets` (`next_committed_offset`, `lag`, `status`, `null_reason`).
- New **`tel_stream_triage_events`** projection (PK `triage_id`, FK → `tel_stream_kafka_rows`, `requires_human_review` default `true`, RLS tenant policy, fail-closed Databricks pointers).

## Why `10034` extends committed `10033` instead of editing it
The migration this ticket originally specified (`10033`, with `tel_stream_kafka_rows` + `tel_stream_consumer_offsets` + the replay-safe Kafka-coordinate UNIQUE) **already exists and is committed**. Rewriting a shipped migration violates the repo's additive/idempotent convention, so `10034` `ALTER`s the committed tables and adds the triage table.

## Migration apply status — NOT YET APPLIED (owner-role blocker)
Live apply against Lakebase failed: `ERROR 42501 must be owner of table tel_stream_kafka_rows`. The Lakebase `tel_*` tables are owned by the human Databricks role `paulmalmquist@gmail.com`; the runtime `telemetry_app` role (the only CLI-reachable credential) is DML-scoped (`rolsuper=false`, not a member of the owner role, no `SET ROLE`). **`10034` must be applied as the owner** — Databricks SQL editor as the human, or an owner connection string passed to `node repo-b/db/schema/apply.js --files 10034` — then run the post-apply verification.

**Do not merge until `10034` is applied and verified against the Lakebase target.**

## Verification output
- `node repo-b/db/schema/apply.js --files 10034 --dry-run` → PASS (39 statements; `DO $$` blocks split whole).
- Pre-apply state (read-only, Lakebase): no `databricks_*` cols, no triage table, legacy 3-value `record_kind` CHECK — exactly what `10034` extends. `tel_stream_*` absent on Supabase.
- The migration's trailing `DO $$` self-verifies: triage table + RLS, 11 Databricks columns, CHECK admits `triage`, defaults (`databricks_lineage_status=not_available`, `requires_human_review=true`).

## Scope
Schema + plan + tips only. **No** consumer / routes / frontend / Confluent-Flink runtime changes. No secrets.

## Follow-up
Ticket 2 — durable Kafka serving-slice consumer (`backend/app/services/telemetry_stream_consumer.py`), default-off (`TELEMETRY_KAFKA_CONSUMER_ENABLED=false`), deterministic sampling (`kafka_offset % sample_rate = 0`), `stargate.printer.anomaly.triage.v1` support, no faked Databricks linkage. **Only after `10034` is applied + verified.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)