### PR TITLE
feat(telemetry): sensor lead-lag attribution compute (Spin 2, Story #726)

### DIFF
--- a/PLAN_DIVERGENCE_REVIEW.md
+++ b/PLAN_DIVERGENCE_REVIEW.md
@@ -361,3 +361,25 @@ refactor). Measured on real SMAP/MSL `gold_smap_msl_windows` (test split, 509,55
 
 Remaining tail spins (2 subsystem lead-lag, 4 completeness, 7 anomaly grouped-split) have weak data fit
 on the independent SMAP/MSL streams (would need simulation or yield null results) — deferred/optional.
+
+---
+
+## Status — Spin 2 (compute) shipped (sensor lead-lag attribution, Story #726)
+
+ML-only (telemetry-platform; UI card deferred — parallel agent owns the telemetry frontend). On real
+C-MAPSS **FD001** (15 active sensors on one coupled engine, 100 units; better fit than the independent
+SMAP/MSL streams):
+- **Channel-level attribution is redundant:** at failure a median of **14 of 15 sensors deviate (93%
+  co-move)** — they all measure the same degrading engine.
+- **Onset timing finds the root signal:** sensors **9, 14, 11** consistently lead (onset in 86–100% of
+  units, ~76–87 cycles of lead time); cross-correlation shows downstream sensors **lag the lead by a
+  median of 11 cycles**. The lead sensors are the root signal; the rest are downstream responders —
+  exactly how a failure-review board narrows root cause.
+- reproducible: `compute_lead_lag_attribution.py` → `lead_lag_attribution_evidence.json`; pure-numpy
+  `lead_lag_core.py` with `test_lead_lag_core.py` (5 tests, numpy-only/CI-safe).
+- honest: C-MAPSS is simulated; onset is a threshold-crossing, not a calibrated change-point; lead-lag
+  narrows root-cause search, it does not assign physical cause.
+- card deferred to avoid colliding with the parallel frontend refactor.
+
+Remaining tail: Spin 4 (completeness — needs multi-rate data, would be simulated) and Spin 7-anomaly
+(grouped split — likely null on a fixed-K per-channel rule). Both weak/optional.

--- a/claim_coverage_matrix.md
+++ b/claim_coverage_matrix.md
@@ -90,3 +90,13 @@ event-windowing modestly lifts anomaly-precedent retrieval to **45.0% vs 41.5% (
 overclaim:** this is the most modest finding; **linked dispositions are unavailable** in public data (shown
 as unavailable, not fabricated); it is a relative method comparison, not an absolute retrieval benchmark.
 ML-only so far — the UI card is **deferred** (parallel agent owns the telemetry frontend refactor).
+
+---
+
+**Status (Spin 2 compute — sensor lead-lag attribution, Story #726):** The **Channel divergence /
+attribution** row gets a coupled-system finding on real C-MAPSS FD001. Channel-level attribution is
+redundant (median **14/15** sensors deviate at failure, 93% co-move); onset timing + cross-correlation
+identify sensors **9/14/11** as the consistent leads (~80 cycles lead time), downstream sensors lag **~11
+cycles**. **Must NOT overclaim:** C-MAPSS is simulated; onset is a threshold-crossing, not a calibrated
+change-point; lead-lag narrows root-cause search, it does not assign physical cause. ML-only; UI card
+deferred (parallel agent owns the telemetry frontend).

--- a/telemetry-platform/compute_lead_lag_attribution.py
+++ b/telemetry-platform/compute_lead_lag_attribution.py
@@ -1,0 +1,203 @@
+"""Spin 2 (compute) — subsystem/sensor lead-lag attribution on C-MAPSS FD001 (REAL data).
+
+The finding: under physical coupling (the 21 sensors all measure the SAME degrading engine),
+channel-level attribution at failure is redundant — many sensors deviate together. Onset timing
+and cross-correlation lag separate the sensors that move FIRST (the root signal) from the
+downstream responders. This maps onto how a real failure-review board reasons about root cause.
+
+Why C-MAPSS (not SMAP/MSL): C-MAPSS sensors are a coupled physical system over a unit's life, so
+lead-lag is meaningful. SMAP/MSL channels are independent anonymized streams where it is not.
+
+Method (per unit, sorted by cycle):
+  - onset cycle per sensor = first cycle the (smoothed) sensor stays > k-sigma from its early-life
+    baseline; lead-time = failure_cycle - onset_cycle.
+  - count_deviating at the last cycle = the channel-level redundancy at failure.
+Aggregate: per-sensor median lead-time + onset frequency -> the consistent LEAD sensors; cross-
+correlation lag between the lead sensor and the others -> how far downstream sensors lag.
+
+ML-only: writes a telemetry-platform artifact; UI card deferred (parallel agent owns the frontend).
+
+Run: python telemetry-platform/compute_lead_lag_attribution.py   (Databricks OAuth profile 'PaulMain')
+"""
+
+import json
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import numpy as np
+import pandas as pd
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.sql import Disposition, Format, StatementState
+
+from lead_lag_core import count_deviating, cross_correlation_lag, onset_index
+
+TEL = "novendor_1.telemetry"
+WAREHOUSE_ID = "0e56420fb707d861"
+SENSORS = [f"sensor_{i}" for i in range(1, 22)]
+BASELINE_N = 25       # early-life cycles defining each sensor's nominal baseline
+K_SIGMA = 4.0         # deviation threshold (matches the anomaly detector's K)
+MAX_LAG = 30          # cross-correlation search (cycles)
+SEED = 0
+ROOT = Path(__file__).resolve().parents[1]
+AS_OF = "2026-06-24"
+
+
+def query_sql(w: WorkspaceClient, sql: str) -> pd.DataFrame:
+    resp = w.statement_execution.execute_statement(
+        statement=sql, warehouse_id=WAREHOUSE_ID, wait_timeout="50s",
+        disposition=Disposition.INLINE, format=Format.JSON_ARRAY,
+    )
+    sid = resp.statement_id
+    while resp.status.state in (StatementState.PENDING, StatementState.RUNNING):
+        time.sleep(2)
+        resp = w.statement_execution.get_statement(sid)
+    if resp.status.state != StatementState.SUCCEEDED:
+        raise RuntimeError(f"SQL {resp.status.state}: {resp.status.error}")
+    cols = [c.name for c in resp.manifest.schema.columns]
+    rows = list(resp.result.data_array or [])
+    for n in range(1, resp.manifest.total_chunk_count or 1):
+        rows.extend(w.statement_execution.get_statement_result_chunk_n(sid, n).data_array or [])
+    return pd.DataFrame(rows, columns=cols)
+
+
+def main() -> None:
+    w = WorkspaceClient(profile="PaulMain")
+    print("[lead-lag] starting warehouse if stopped...")
+    try:
+        import datetime
+        w.warehouses.start(WAREHOUSE_ID).result(timeout=datetime.timedelta(minutes=5))
+    except Exception as exc:
+        print(f"[lead-lag] warehouse note: {str(exc)[:120]}")
+
+    print("[lead-lag] pulling FD001 train sensor trajectories from silver_cmapss...")
+    cols = ", ".join(["unit", "cycle"] + SENSORS)
+    df = query_sql(w, f"SELECT {cols} FROM {TEL}.silver_cmapss "
+                      f"WHERE subset = 'FD001' AND split = 'train'")
+    for c in ["unit", "cycle"] + SENSORS:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+    df = df.dropna(subset=SENSORS).sort_values(["unit", "cycle"])
+
+    active = [s for s in SENSORS if df[s].std() > 1e-6]
+    print(f"[lead-lag] units={df.unit.nunique()} active_sensors={len(active)} "
+          f"(dropped {len(SENSORS)-len(active)} constant)")
+
+    lead_times = defaultdict(list)     # sensor -> list of (failure_cycle - onset_cycle) over units
+    onset_count = defaultdict(int)     # sensor -> # units where it had an onset
+    deviating_at_failure = []          # per unit: how many active sensors deviated by the last cycle
+    n_units = 0
+    per_unit_traj: dict[int, dict[str, np.ndarray]] = {}
+
+    for unit, g in df.groupby("unit"):
+        g = g.sort_values("cycle")
+        if len(g) < BASELINE_N + 10:
+            continue
+        n_units += 1
+        failure_cycle = len(g) - 1
+        vals = g[active].to_numpy()
+        deviating_at_failure.append(count_deviating(vals, BASELINE_N, K_SIGMA))
+        traj = {}
+        for j, s in enumerate(active):
+            series = vals[:, j]
+            traj[s] = series
+            oi = onset_index(series, BASELINE_N, K_SIGMA)
+            if oi is not None:
+                lead_times[s].append(failure_cycle - oi)
+                onset_count[s] += 1
+        per_unit_traj[int(unit)] = traj
+
+    # Rank sensors by consistency (onset frequency) then median lead-time.
+    ranked = []
+    for s in active:
+        freq = onset_count[s] / n_units
+        med_lead = float(np.median(lead_times[s])) if lead_times[s] else 0.0
+        ranked.append({"sensor": s, "onset_frequency": round(freq, 3),
+                       "median_lead_cycles": round(med_lead, 1)})
+    # Lead = high frequency AND high lead-time.
+    ranked.sort(key=lambda r: (r["onset_frequency"] >= 0.6, r["median_lead_cycles"]), reverse=True)
+    lead_sensors = [r["sensor"] for r in ranked if r["onset_frequency"] >= 0.6][:3]
+
+    median_redundant = float(np.median(deviating_at_failure))
+
+    # Cross-correlation lag: the top lead sensor vs every other active sensor, median over units.
+    lag_to_downstream = {}
+    if lead_sensors:
+        lead = lead_sensors[0]
+        for s in active:
+            if s == lead:
+                continue
+            lags = [cross_correlation_lag(t[lead], t[s], MAX_LAG)
+                    for t in per_unit_traj.values() if lead in t and s in t]
+            if lags:
+                lag_to_downstream[s] = float(np.median(lags))
+    downstream_lags = [v for v in lag_to_downstream.values() if v > 0]
+    median_downstream_lag = float(np.median(downstream_lags)) if downstream_lags else None
+
+    # Example unit: show the redundant count + the lead sensor's lead-time.
+    ex_unit = next(iter(per_unit_traj))
+    ex_vals = df[df.unit == ex_unit].sort_values("cycle")[active].to_numpy()
+    ex = {
+        "unit": ex_unit,
+        "sensors_deviating_at_failure": int(count_deviating(ex_vals, BASELINE_N, K_SIGMA)),
+        "active_sensors": len(active),
+        "lead_sensor": lead_sensors[0] if lead_sensors else None,
+        "lead_sensor_lead_cycles": (
+            int(np.median(lead_times[lead_sensors[0]])) if lead_sensors and lead_times[lead_sensors[0]] else None),
+    }
+
+    artifact = {
+        "as_of": AS_OF,
+        "dataset": "C-MAPSS FD001 (single condition; 21 sensors on one coupled engine over its life)",
+        "source_table": f"{TEL}.silver_cmapss (subset=FD001, split=train)",
+        "method": (f"Per unit: per-sensor onset = first cycle the smoothed sensor stays > {K_SIGMA}-sigma "
+                   f"from its first-{BASELINE_N}-cycle baseline; lead-time = failure_cycle - onset. "
+                   "count_deviating at the last cycle = channel-level redundancy. Lead sensors = onset "
+                   "frequency >= 0.6 ranked by median lead-time; cross-correlation lag of downstream "
+                   "sensors vs the top lead sensor (positive = downstream follows the lead)."),
+        "n_units": n_units, "n_active_sensors": len(active),
+        "metrics": {
+            "median_sensors_deviating_at_failure": median_redundant,
+            "channel_attribution_redundancy_pct": round(median_redundant / len(active) * 100, 1),
+            "lead_sensors": lead_sensors,
+            "median_downstream_lag_cycles": median_downstream_lag,
+        },
+        "sensor_ranking": ranked,
+        "example": ex,
+        "finding": (
+            f"On the coupled FD001 engine, channel-level attribution is redundant: at failure a median "
+            f"of {median_redundant:.0f} of {len(active)} sensors are deviating "
+            f"({round(median_redundant/len(active)*100)}% co-move). Onset timing identifies the "
+            f"sensors that move FIRST — {', '.join(lead_sensors) if lead_sensors else 'none'} consistently "
+            f"lead (onset in >=60% of units"
+            + (f", median {int(np.median(lead_times[lead_sensors[0]]))} cycles of lead time" if lead_sensors and lead_times[lead_sensors[0]] else "")
+            + ")"
+            + (f"; downstream sensors lag the lead by a median of {median_downstream_lag:.0f} cycles" if median_downstream_lag else "")
+            + ". The lead sensors are the root signal; the rest are downstream responders."
+        ),
+        "limitations": [
+            "C-MAPSS is simulated turbofan degradation; the lead-lag structure is a pattern, not ground-truth subsystem wiring.",
+            "Onset is a threshold-crossing on the raw sensor, not a calibrated change-point test; it is a transparent first-line attribution.",
+            "Lead-lag identifies which sensors move first, not the physical cause; it narrows root-cause search, it does not assign blame.",
+        ],
+    }
+
+    out_src = ROOT / "telemetry-platform" / "lead_lag_attribution_evidence.json"
+    out_src.write_text(json.dumps(artifact, indent=2), encoding="utf-8")
+
+    print("\n=== SENSOR LEAD-LAG ATTRIBUTION (FD001) — measured ===")
+    print(f"units {n_units} | active sensors {len(active)}")
+    print(f"median sensors deviating at failure: {median_redundant:.0f} of {len(active)} "
+          f"({median_redundant/len(active)*100:.0f}% redundant)")
+    print(f"lead sensors (onset-freq>=0.6, by lead-time): {lead_sensors}")
+    print(f"median downstream lag vs lead: {median_downstream_lag} cycles")
+    print(f"top-5 ranking: {ranked[:5]}")
+    print(f"\nwrote {out_src}")
+    print("[lead-lag] UI card deferred — parallel agent owns the telemetry frontend refactor.")
+
+
+if __name__ == "__main__":
+    main()

--- a/telemetry-platform/lead_lag_attribution_evidence.json
+++ b/telemetry-platform/lead_lag_attribution_evidence.json
@@ -1,0 +1,108 @@
+{
+  "as_of": "2026-06-24",
+  "dataset": "C-MAPSS FD001 (single condition; 21 sensors on one coupled engine over its life)",
+  "source_table": "novendor_1.telemetry.silver_cmapss (subset=FD001, split=train)",
+  "method": "Per unit: per-sensor onset = first cycle the smoothed sensor stays > 4.0-sigma from its first-25-cycle baseline; lead-time = failure_cycle - onset. count_deviating at the last cycle = channel-level redundancy. Lead sensors = onset frequency >= 0.6 ranked by median lead-time; cross-correlation lag of downstream sensors vs the top lead sensor (positive = downstream follows the lead).",
+  "n_units": 100,
+  "n_active_sensors": 15,
+  "metrics": {
+    "median_sensors_deviating_at_failure": 14.0,
+    "channel_attribution_redundancy_pct": 93.3,
+    "lead_sensors": [
+      "sensor_9",
+      "sensor_14",
+      "sensor_11"
+    ],
+    "median_downstream_lag_cycles": 11.0
+  },
+  "sensor_ranking": [
+    {
+      "sensor": "sensor_9",
+      "onset_frequency": 0.86,
+      "median_lead_cycles": 86.5
+    },
+    {
+      "sensor": "sensor_14",
+      "onset_frequency": 0.88,
+      "median_lead_cycles": 81.0
+    },
+    {
+      "sensor": "sensor_11",
+      "onset_frequency": 1.0,
+      "median_lead_cycles": 76.5
+    },
+    {
+      "sensor": "sensor_4",
+      "onset_frequency": 1.0,
+      "median_lead_cycles": 74.0
+    },
+    {
+      "sensor": "sensor_12",
+      "onset_frequency": 1.0,
+      "median_lead_cycles": 72.5
+    },
+    {
+      "sensor": "sensor_13",
+      "onset_frequency": 0.97,
+      "median_lead_cycles": 70.0
+    },
+    {
+      "sensor": "sensor_7",
+      "onset_frequency": 1.0,
+      "median_lead_cycles": 68.0
+    },
+    {
+      "sensor": "sensor_8",
+      "onset_frequency": 0.93,
+      "median_lead_cycles": 64.0
+    },
+    {
+      "sensor": "sensor_15",
+      "onset_frequency": 1.0,
+      "median_lead_cycles": 61.5
+    },
+    {
+      "sensor": "sensor_20",
+      "onset_frequency": 1.0,
+      "median_lead_cycles": 59.5
+    },
+    {
+      "sensor": "sensor_21",
+      "onset_frequency": 1.0,
+      "median_lead_cycles": 57.5
+    },
+    {
+      "sensor": "sensor_17",
+      "onset_frequency": 0.99,
+      "median_lead_cycles": 54.0
+    },
+    {
+      "sensor": "sensor_2",
+      "onset_frequency": 0.98,
+      "median_lead_cycles": 52.0
+    },
+    {
+      "sensor": "sensor_3",
+      "onset_frequency": 0.99,
+      "median_lead_cycles": 46.0
+    },
+    {
+      "sensor": "sensor_6",
+      "onset_frequency": 0.04,
+      "median_lead_cycles": 123.5
+    }
+  ],
+  "example": {
+    "unit": 1,
+    "sensors_deviating_at_failure": 14,
+    "active_sensors": 15,
+    "lead_sensor": "sensor_9",
+    "lead_sensor_lead_cycles": 86
+  },
+  "finding": "On the coupled FD001 engine, channel-level attribution is redundant: at failure a median of 14 of 15 sensors are deviating (93% co-move). Onset timing identifies the sensors that move FIRST \u2014 sensor_9, sensor_14, sensor_11 consistently lead (onset in >=60% of units, median 86 cycles of lead time); downstream sensors lag the lead by a median of 11 cycles. The lead sensors are the root signal; the rest are downstream responders.",
+  "limitations": [
+    "C-MAPSS is simulated turbofan degradation; the lead-lag structure is a pattern, not ground-truth subsystem wiring.",
+    "Onset is a threshold-crossing on the raw sensor, not a calibrated change-point test; it is a transparent first-line attribution.",
+    "Lead-lag identifies which sensors move first, not the physical cause; it narrows root-cause search, it does not assign blame."
+  ]
+}

--- a/telemetry-platform/lead_lag_core.py
+++ b/telemetry-platform/lead_lag_core.py
@@ -1,0 +1,72 @@
+"""Pure lead-lag / subsystem-attribution primitives (numpy only — CI-safe).
+
+Shared by compute_lead_lag_attribution.py (real C-MAPSS data) and test_lead_lag_core.py.
+The finding: under physical coupling (all sensors measure the same degrading engine), counting
+which channels deviate at failure is redundant — many co-move. Onset timing + cross-correlation
+lag separate the sensors that move FIRST (the root signal) from the downstream responders.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def smooth(x: np.ndarray, w: int = 5) -> np.ndarray:
+    """Causal moving average (past-only) to denoise an onset signal."""
+    x = np.asarray(x, dtype=float)
+    if w <= 1 or len(x) < w:
+        return x
+    k = np.ones(w) / w
+    pad = np.concatenate([np.full(w - 1, x[0]), x])
+    return np.convolve(pad, k, mode="valid")
+
+
+def onset_index(series: np.ndarray, baseline_n: int, k_sigma: float, persist: int = 3) -> int | None:
+    """First index where the (smoothed) series stays > k_sigma from its early-life baseline for
+    `persist` consecutive points. None if it never does. Baseline = first `baseline_n` points."""
+    s = smooth(np.asarray(series, dtype=float))
+    if len(s) <= baseline_n + persist:
+        return None
+    mu, sd = s[:baseline_n].mean(), (s[:baseline_n].std() or 1.0)
+    dev = np.abs(s - mu) > k_sigma * sd
+    run = 0
+    for i in range(baseline_n, len(s)):
+        run = run + 1 if dev[i] else 0
+        if run >= persist:
+            return i - persist + 1
+    return None
+
+
+def cross_correlation_lag(a: np.ndarray, b: np.ndarray, max_lag: int) -> int:
+    """Lag L (in samples) maximizing correlation of b shifted against a, over [-max_lag, max_lag].
+    Positive L => b follows a by L (a leads). Series are z-normalized first."""
+    a = np.asarray(a, dtype=float); b = np.asarray(b, dtype=float)
+    a = (a - a.mean()) / (a.std() or 1.0)
+    b = (b - b.mean()) / (b.std() or 1.0)
+    n = min(len(a), len(b))
+    a, b = a[:n], b[:n]
+    best_lag, best_corr = 0, -np.inf
+    for lag in range(-max_lag, max_lag + 1):
+        # positive lag => b follows a by `lag` (a leads): correlate a[i] with b[i+lag].
+        if lag >= 0:
+            x, y = a[:n - lag], b[lag:]
+        else:
+            x, y = a[-lag:], b[:n + lag]
+        if len(x) < 3:
+            continue
+        c = float(np.mean(x * y))
+        if c > best_corr:
+            best_corr, best_lag = c, lag
+    return best_lag
+
+
+def count_deviating(values: np.ndarray, baseline_n: int, k_sigma: float) -> int:
+    """How many of the LAST few points exceed k_sigma from baseline (channel-level attribution
+    'redundancy' at failure: many coupled sensors flag at once)."""
+    n_dev = 0
+    for col in range(values.shape[1]):
+        s = smooth(values[:, col])
+        mu, sd = s[:baseline_n].mean(), (s[:baseline_n].std() or 1.0)
+        if np.abs(s[-1] - mu) > k_sigma * sd:
+            n_dev += 1
+    return n_dev

--- a/telemetry-platform/test_lead_lag_core.py
+++ b/telemetry-platform/test_lead_lag_core.py
@@ -1,0 +1,47 @@
+"""Eval tests for the lead-lag primitives — numpy only, no Databricks.
+
+Run: python -m pytest telemetry-platform/test_lead_lag_core.py -q
+"""
+
+import numpy as np
+
+from lead_lag_core import count_deviating, cross_correlation_lag, onset_index, smooth
+
+
+def test_onset_detects_a_step_change():
+    x = np.r_[np.zeros(60), np.ones(40) * 5.0]   # flat baseline, then a sustained jump at 60
+    idx = onset_index(x, baseline_n=30, k_sigma=3.0, persist=3)
+    assert idx is not None and 58 <= idx <= 64
+
+
+def test_onset_none_when_flat():
+    x = np.random.default_rng(0).normal(scale=0.1, size=120)
+    assert onset_index(x, baseline_n=30, k_sigma=5.0) is None
+
+
+def test_cross_correlation_recovers_known_lag():
+    rng = np.random.default_rng(0)
+    a = np.cumsum(rng.normal(size=200))
+    lag = 7
+    b = np.r_[np.zeros(lag), a[:-lag]]            # b follows a by 7 (a leads)
+    assert abs(cross_correlation_lag(a, b, max_lag=20) - lag) <= 1
+
+
+def test_lead_sensor_onsets_before_downstream():
+    # Lead sensor jumps at t=50; a coupled downstream sensor responds later at t=70.
+    lead = np.r_[np.zeros(50), np.ones(70) * 4.0]
+    downstream = np.r_[np.zeros(70), np.ones(50) * 4.0]
+    o_lead = onset_index(lead, 30, 3.0)
+    o_down = onset_index(downstream, 30, 3.0)
+    assert o_lead is not None and o_down is not None and o_lead < o_down
+
+
+def test_count_deviating_flags_many_coupled_sensors_at_failure():
+    # 5 coupled sensors all drift up by the end (channel attribution is redundant -> counts ~all).
+    rng = np.random.default_rng(0)
+    ramp = np.linspace(0, 6, 120)
+    vals = np.column_stack([ramp + rng.normal(scale=0.1, size=120) for _ in range(5)])
+    assert count_deviating(vals, baseline_n=30, k_sigma=3.0) == 5
+    # a flat sensor added -> still only the 5 drifters flagged
+    flat = rng.normal(scale=0.1, size=(120, 1))
+    assert count_deviating(np.hstack([vals, flat]), baseline_n=30, k_sigma=3.0) == 5


### PR DESCRIPTION
ML-only compute (telemetry-platform). **No repo-b / no backend / no contested files** — a parallel agent owns the telemetry frontend refactor + stargate tests + promote/train notebooks.

On real C-MAPSS **FD001** (the 21 sensors measure one coupled engine over its life, so lead-lag is meaningful — unlike independent SMAP/MSL streams):
- **Channel-level attribution is redundant:** at failure a median of **14 of 15 sensors deviate (93% co-move)**.
- **Onset timing finds the root signal:** sensors **9, 14, 11** consistently lead (onset in 86–100% of units, ~76–87 cycles of lead time); cross-correlation shows downstream sensors **lag the lead by a median of 11 cycles**.
- The lead sensors are the root signal; the rest are downstream responders — how a failure-review board narrows root cause.

**Honest:** C-MAPSS is simulated; onset is a threshold-crossing, not a calibrated change-point; lead-lag narrows root-cause search, it does not assign physical cause.

- lead_lag_core.py (pure-numpy, CI-safe) + test_lead_lag_core.py (5 tests green)
- compute_lead_lag_attribution.py → lead_lag_attribution_evidence.json (reproducible)
- audit docs updated. Tail spins 4/7 weak/optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)