### PR TITLE
feat(telemetry): page header system + Overview hero (0009 Ticket 1)

### DIFF
--- a/docs/plans/01-shared-standards/design-system/component-contracts.md
+++ b/docs/plans/01-shared-standards/design-system/component-contracts.md
@@ -59,3 +59,19 @@ Every component type has a behavioral contract. If a component in any environmen
 - Must distinguish between: no permission (403), not found (404), server error (500), and network error
 - Must give the user a recovery path (retry, go back, contact support)
 - Never display a raw stack trace or API error message to end users
+
+## Page headers (telemetry header family)
+
+The telemetry environment uses one header family (`repo-b/src/components/telemetry/TelemetryPageHeader.tsx`)
+so every route shares a typographic system. Other environments may adopt the same contract.
+
+- Exactly one `<h1>` per page; an uppercase mono eyebrow precedes it with an accent bar.
+- Four variants by page role: `hero` (the environment's opening page only), `evidence` (evidence/lineage
+  surfaces), `standard` (analytical consoles), `compact` (operational consoles). Only one `hero` per env.
+- Title may be segmented for controlled emphasis; gradient/brand emphasis is limited to a meaningful
+  phrase, never the whole title.
+- The header neither fetches nor invents data — source/freshness/ids/timestamps/status and actions are
+  passed in by the caller and rendered in the `metadata`/`actions` slots; fail-closed states stay intact.
+- Titles must wrap cleanly and metadata rows stack without overflow at 390px / 1024px / desktop; title
+  and body text meet WCAG AA in dark mode.
+- Nested section headings keep using the standard heading primitive (`PageHeading`), not a second `<h1>`.

--- a/docs/plans/03-implementation-plans/active/0009-telemetry-page-header-system.md
+++ b/docs/plans/03-implementation-plans/active/0009-telemetry-page-header-system.md
@@ -1,0 +1,63 @@
+# Dispatch Record 0009 — Telemetry Page Header System Migration
+
+**Created:** 2026-06-24
+**Status:** IN PROGRESS — Ticket 1 (foundation + Overview hero) DONE + merged. Tickets 2–4 open.
+**Environment:** Telemetry Platform (`repo-b/src/app/lab/env/[envId]/telemetry/`, `repo-b/src/components/telemetry/`)
+**Owner:** lab-environment-winston (frontend support + QA verification)
+**ADO:** Epic #497 → Feature #721 "Telemetry Frontend Production-Readiness Refactor". Four focused User
+Stories for the migration (existing #693 and #722 do not cover it).
+**Deliverable type:** Frontend-only header system + per-route migration. **Risk:** Medium (affects every
+telemetry route; introduces editorial title typography on headers).
+
+> Discrepancy note: `docs/plans/02-environments/` does not exist — using the canonical
+> `docs/plans/telemetry-platform/`. The reference `launch_data_problem_header.jsx` is design-only and is
+> NOT imported.
+
+## Header architecture
+
+`repo-b/src/components/telemetry/TelemetryPageHeader.tsx` — one header family:
+
+- **Variants:** `hero` (Overview only), `evidence` (evidence/lineage), `standard` (models/factory),
+  `compact` (operational consoles).
+- **Props:** `eyebrow`, segmented `title` (typed `TitleSegment[]` with controlled `gradient` emphasis),
+  `description`, `metadata` slot, `actions` slot, optional hero `metrics` row.
+- **Typography:** hero/evidence titles use the existing editorial font (`var(--font-editorial)`,
+  Cormorant Garamond); compact/standard use `var(--font-display)` (Inter Tight); eyebrows, ids,
+  timestamps, metrics stay JetBrains Mono (`C.mono`). Colors stay on the `C` palette. Fonts are already
+  loaded globally via next/font in `app/layout.tsx` — no new font infra.
+- **Gradient** is limited to meaningful phrases — Overview's "Launch"/"Data", and at most one phrase on
+  selected evidence headers.
+- No fetching/state/invented metadata; callers pass existing values. `PageHeading` stays for nested
+  section headings; evidence cards are not globally restyled.
+
+## Tickets
+
+1. **Foundation + Overview proof — DONE.** Add `TelemetryPageHeader` + unit tests; migrate
+   `TelemetryOverview.tsx` to `hero` (copy + real Big Numbers preserved; "Launch"/"Data" gradient);
+   header-family entry in `component-contracts.md`. Screenshot-verified.
+2. **Operations — open.** `compact` on `MissionControlStream`, `ReplayConsole`, `stargate/StargateConsole`,
+   `RunsExplorer`, `SystemHealth`, `ControlTower`; standalone `Monitoring`/`SpikeInspector` `compact`
+   (embedded modes stay headerless). Preserve live verdicts, lag, controls, chips, timestamps, fail-closed
+   states in metadata/action slots.
+3. **Models & Factory — open.** `standard` on `ModelPerformance`, `RulCalibration`, `RegistryConsole`,
+   `Copilot`, `FactoryNcrIntelligence`, `factory-ml/FactoryMlConsole`. Convert RS console strips without
+   changing body data/controls/metrics/evidence-drawer work.
+4. **Evidence, lineage & final QA — open.** `evidence` on `metadata/MetricLineageExplorer`,
+   `metadata/TelemetryMetadataExplorer`, `GovernanceDashboard`, `HowItWorks`, `EvidenceCards`. Keep
+   metadata scope/freshness/generation-time/status/refresh intact. Add `tests/telemetry-page-headers.spec.ts`
+   visual-regression; update `design-adaptation.md`, `qa-checklist.md`, `eval-plan.md`, `next-session.md`,
+   `docs/tips.md`.
+
+Route wrappers, nav, APIs, DB contracts, page bodies unchanged. Remove only duplicate per-page top
+padding/background where needed for shell-aligned headers.
+
+## Acceptance
+
+- All 18 nav pages + the two retained standalone operational routes use the header family.
+- Overview is the only full `hero`; operational pages `compact`; evidence pages restrained; standard between.
+- Metadata, actions, fail-closed copy, shell, nav, data behavior unchanged.
+- Titles wrap cleanly + metadata rows stack without overflow at 390 / 1024 / desktop. Dark-mode text WCAG AA.
+- `npm run typecheck` · `npm run lint` · `npx vitest run src/components/telemetry` · `npm run build` ·
+  `npx playwright test tests/telemetry-page-headers.spec.ts`. Capture desktop/tablet/mobile evidence for
+  Overview, Mission Control, Model Performance, Metadata Explorer, Resume Evidence under
+  `telemetry-platform/docs/screenshots/header-system/`.

--- a/repo-b/src/components/telemetry/TelemetryOverview.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.tsx
@@ -1,55 +1,43 @@
 "use client";
 
-// Overview — the opening-argument page. A dominant thesis header states the idea once, then the
-// Spaceflight Bottleneck Map carries it as one large tabbed story module (Bottleneck Map / Cost to
+// Overview — the opening-argument page. A dominant editorial hero header states the idea once, then
+// the Spaceflight Bottleneck Map carries it as one large tabbed story module (Bottleneck Map / Cost to
 // LEO / Who Flies), with an editorial "Big Numbers" band and the Terran 1 event record. Static
 // public-data context module — no serving API, no KPI dashboard strip, no lineage CTA here.
 
-import { C, TelemetryPageShell, TelemetryThesisHeading } from "./primitives";
+import { C, TelemetryPageShell } from "./primitives";
+import { TelemetryPageHeader, type HeaderMetric } from "./TelemetryPageHeader";
 import BottleneckMap from "./context/BottleneckMap/BottleneckMap";
 import { computeBigNumbers } from "./context/BottleneckMap/data";
 
-// Brand fluorescent purple (--nv-purple-hot "wet reflect"); the marketing CSS var is
-// out of scope in the telemetry env, so the hex is inlined.
-const NV_PURPLE = "#B040FF";
-
-// Editorial "Big Numbers" band — inline stats under the thesis, not a card dashboard.
-function BigNumbers() {
-  return (
-    <div style={{ display: "flex", flexWrap: "wrap", gap: "26px 48px", marginTop: 24 }}>
-      {computeBigNumbers().map((b) => (
-        <div key={b.label}>
-          <div style={{ fontFamily: C.mono, fontSize: 10.5, letterSpacing: "0.12em", textTransform: "uppercase", color: C.faint, marginBottom: 5 }}>
-            {b.label}
-          </div>
-          <div style={{ fontFamily: C.mono, fontSize: 25, fontWeight: 700, letterSpacing: "-0.01em",
-            color: b.accent === "share" ? C.green : b.accent === "cost" ? C.amber : C.text }}>
-            {b.value}
-          </div>
-          <div style={{ fontFamily: C.sans, fontSize: 11.5, color: C.dim, marginTop: 3 }}>{b.sub}</div>
-        </div>
-      ))}
-    </div>
-  );
+// Big Numbers → header metric row; accent strings map to the C palette (share=green, cost=amber).
+function bigNumberMetrics(): HeaderMetric[] {
+  return computeBigNumbers().map((b) => ({
+    label: b.label,
+    value: b.value,
+    sub: b.sub,
+    accent: b.accent === "share" ? C.green : b.accent === "cost" ? C.amber : C.text,
+  }));
 }
 
 export default function TelemetryOverview() {
-  // Thesis-first: the dominant header states the argument once, Big Numbers sit under it, then the
-  // Spaceflight Bottleneck Map carries the story. Same copy and editorial layout as before.
+  // Thesis-first: the dominant hero states the argument once, Big Numbers sit under it, then the
+  // Spaceflight Bottleneck Map carries the story. Same copy and real Big Numbers as before — only the
+  // header now uses the shared editorial hero (Cormorant), with gradient on "Launch"/"Data".
   const heading = (
-    <TelemetryThesisHeading
+    <TelemetryPageHeader
+      variant="hero"
       eyebrow="Overview"
-      size={48}
-      title={
-        <>
-          Why <span style={{ color: NV_PURPLE, textShadow: `0 0 18px ${NV_PURPLE}99` }}>Launch</span> Became A{" "}
-          <span style={{ color: NV_PURPLE, textShadow: `0 0 18px ${NV_PURPLE}99` }}>Data</span> Problem
-        </>
-      }
-      blurb="Spaceflight moves by breaking what holds it back. First, reaching orbit. Then lowering the cost. Then flying again. Then building at scale. Now the hard part is speed of judgment: reading the telemetry, trusting the model, tracing the source, and acting before delay becomes risk."
-    >
-      <BigNumbers />
-    </TelemetryThesisHeading>
+      title={[
+        { text: "Why " },
+        { text: "Launch", gradient: true },
+        { text: " Became A " },
+        { text: "Data", gradient: true },
+        { text: " Problem" },
+      ]}
+      description="Spaceflight moves by breaking what holds it back. First, reaching orbit. Then lowering the cost. Then flying again. Then building at scale. Now the hard part is speed of judgment: reading the telemetry, trusting the model, tracing the source, and acting before delay becomes risk."
+      metrics={bigNumberMetrics()}
+    />
   );
 
   return (

--- a/repo-b/src/components/telemetry/TelemetryPageHeader.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetryPageHeader.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
+
+describe("TelemetryPageHeader", () => {
+  it("renders eyebrow, a single H1 from segmented title, and description", () => {
+    render(
+      <TelemetryPageHeader
+        variant="hero"
+        eyebrow="Overview"
+        title={[{ text: "Why " }, { text: "Launch", gradient: true }, { text: " Became A " }, { text: "Data", gradient: true }, { text: " Problem" }]}
+        description="A thesis sentence."
+      />
+    );
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1).toHaveTextContent("Why Launch Became A Data Problem");
+    expect(screen.getByText("A thesis sentence.")).toBeInTheDocument();
+  });
+
+  it("accepts a plain string title", () => {
+    render(<TelemetryPageHeader variant="standard" eyebrow="Model Evidence" title="Can you trust this model?" />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Can you trust this model?");
+  });
+
+  it("renders the hero metric row with values and accents", () => {
+    render(
+      <TelemetryPageHeader
+        variant="hero"
+        eyebrow="Overview"
+        title="T"
+        metrics={[{ label: "First orbit", value: "1957 – 2026", sub: "since" }, { label: "Cost", value: "$12k" }]}
+      />
+    );
+    expect(screen.getByText("First orbit")).toBeInTheDocument();
+    expect(screen.getByText("1957 – 2026")).toBeInTheDocument();
+    expect(screen.getByText("$12k")).toBeInTheDocument();
+  });
+
+  it("renders actions and metadata slots when provided", () => {
+    render(
+      <TelemetryPageHeader
+        variant="compact"
+        eyebrow="Stargate Live"
+        title="Printer telemetry stream"
+        actions={<button type="button">Start</button>}
+        metadata={<span>recorded capture</span>}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Start" })).toBeInTheDocument();
+    expect(screen.getByText("recorded capture")).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/TelemetryPageHeader.tsx
+++ b/repo-b/src/components/telemetry/TelemetryPageHeader.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import type { CSSProperties, ReactNode } from "react";
+import { C } from "./primitives";
+
+// ===========================================================================
+// Telemetry page header system. One header family for every telemetry route so
+// the pages scan as a typographic system:
+//   - hero      → Overview only: editorial (Cormorant) display title + metric row.
+//   - evidence  → evidence/lineage pages: editorial title, restrained.
+//   - standard  → models/factory consoles: Inter Tight title.
+//   - compact   → operational consoles: tighter Inter Tight title + live chips/actions.
+//
+// Fonts come from the global next/font CSS vars (set on <html> in app/layout.tsx):
+//   --font-editorial (Cormorant Garamond), --font-display (Inter Tight),
+//   --font-mono (JetBrains Mono). Colors stay on the telemetry `C` palette.
+//
+// No fetching, no state, no invented metadata — callers pass existing values into
+// the metadata/actions/metrics slots. Nested section headings keep using PageHeading.
+// ---------------------------------------------------------------------------
+
+// Brand fluorescent purple — gradient emphasis is limited to a meaningful phrase
+// (Overview's "Launch"/"Data", and at most one phrase on selected evidence headers).
+const NV_PURPLE = "#B040FF";
+
+export type HeaderVariant = "hero" | "compact" | "standard" | "evidence";
+
+/** A title is plain text or typed segments; a segment may be gradient-emphasized. */
+export type TitleSegment = { text: string; gradient?: boolean };
+export type HeaderTitle = string | TitleSegment[];
+
+export interface HeaderMetric {
+  label: string;
+  value: ReactNode;
+  sub?: ReactNode;
+  /** Accent for the value (e.g. C.green / C.amber). Defaults to C.text. */
+  accent?: string;
+}
+
+const FONT_EDITORIAL = "var(--font-editorial), Georgia, serif";
+const FONT_DISPLAY = "var(--font-display), 'Inter Tight', Inter, system-ui, sans-serif";
+
+// Per-variant title typography. Sizes use clamp() so titles wrap cleanly from
+// 390px → desktop without overflow.
+const TITLE_STYLE: Record<HeaderVariant, CSSProperties> = {
+  hero: {
+    fontFamily: FONT_EDITORIAL, fontWeight: 600,
+    fontSize: "clamp(2.4rem, 5.2vw, 3.25rem)", lineHeight: 1.05, letterSpacing: "0.002em",
+  },
+  evidence: {
+    fontFamily: FONT_EDITORIAL, fontWeight: 600,
+    fontSize: "clamp(1.7rem, 3.4vw, 2.15rem)", lineHeight: 1.1, letterSpacing: "0.004em",
+  },
+  standard: {
+    fontFamily: FONT_DISPLAY, fontWeight: 700,
+    fontSize: "clamp(1.45rem, 2.6vw, 1.9rem)", lineHeight: 1.12, letterSpacing: "-0.012em",
+  },
+  compact: {
+    fontFamily: FONT_DISPLAY, fontWeight: 700,
+    fontSize: "clamp(1.25rem, 2vw, 1.45rem)", lineHeight: 1.15, letterSpacing: "-0.01em",
+  },
+};
+
+const MARGIN_BOTTOM: Record<HeaderVariant, number> = { hero: 26, evidence: 24, standard: 22, compact: 18 };
+
+function renderTitle(title: HeaderTitle): ReactNode {
+  const segments: TitleSegment[] = typeof title === "string" ? [{ text: title }] : title;
+  return segments.map((seg, i) => {
+    if (!seg.gradient) return <span key={i}>{seg.text}</span>;
+    return (
+      <span key={i} style={{ color: NV_PURPLE, textShadow: `0 0 18px ${NV_PURPLE}99` }}>{seg.text}</span>
+    );
+  });
+}
+
+// Hero metric row — inline editorial stats under the thesis (not a card dashboard).
+function MetricRowStrip({ metrics }: { metrics: HeaderMetric[] }) {
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: "24px 48px", marginTop: 24 }}>
+      {metrics.map((m) => (
+        <div key={m.label}>
+          <div style={{ fontFamily: C.mono, fontSize: 10.5, letterSpacing: "0.12em", textTransform: "uppercase", color: C.faint, marginBottom: 5 }}>
+            {m.label}
+          </div>
+          <div style={{ fontFamily: C.mono, fontSize: 25, fontWeight: 700, letterSpacing: "-0.01em", color: m.accent || C.text }}>
+            {m.value}
+          </div>
+          {m.sub != null && <div style={{ fontFamily: C.sans, fontSize: 11.5, color: C.dim, marginTop: 3 }}>{m.sub}</div>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TelemetryPageHeader({
+  variant = "standard",
+  eyebrow,
+  title,
+  description,
+  metadata,
+  actions,
+  metrics,
+}: {
+  variant?: HeaderVariant;
+  eyebrow: string;
+  title: HeaderTitle;
+  description?: ReactNode;
+  /** Source/freshness strip, ids, timestamps, status chips — caller-provided. */
+  metadata?: ReactNode;
+  /** Right-aligned actions/controls/live chips. */
+  actions?: ReactNode;
+  /** Hero metric row (e.g. Overview Big Numbers). */
+  metrics?: HeaderMetric[];
+}) {
+  const isWide = variant === "hero" || variant === "evidence";
+  return (
+    <header style={{ marginBottom: MARGIN_BOTTOM[variant], maxWidth: isWide ? 880 : undefined }}>
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", flexWrap: "wrap", gap: 12 }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <span aria-hidden style={{ width: variant === "hero" ? 18 : 16, height: 2, borderRadius: 2, background: C.cyan, boxShadow: `0 0 8px ${C.cyan}aa` }} />
+            <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.16em", color: C.cyan, textTransform: "uppercase" }}>{eyebrow}</span>
+          </div>
+          <h1 style={{ ...TITLE_STYLE[variant], color: C.text, marginTop: variant === "hero" ? 12 : 9 }}>
+            {renderTitle(title)}
+          </h1>
+        </div>
+        {actions && <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", justifyContent: "flex-end", flexShrink: 0 }}>{actions}</div>}
+      </div>
+
+      {description && (
+        <p style={{ fontFamily: C.sans, fontSize: variant === "hero" ? 16 : 14.5, color: C.dim, lineHeight: 1.6, marginTop: variant === "hero" ? 16 : 13, maxWidth: 820 }}>
+          {description}
+        </p>
+      )}
+
+      {metadata && <div style={{ marginTop: 12 }}>{metadata}</div>}
+
+      {metrics && metrics.length > 0 && <MetricRowStrip metrics={metrics} />}
+    </header>
+  );
+}


### PR DESCRIPTION
**Dispatch 0009, Ticket 1** of the Telemetry Page Header System (Epic #497 → Feature #721).

Adds `TelemetryPageHeader` — one header family so every telemetry route shares a typographic system:
- **Variants:** `hero` (Overview only), `evidence`, `standard`, `compact`.
- **Typography:** hero/evidence titles use the existing editorial font (Cormorant, `var(--font-editorial)`); standard/compact use Inter Tight (`var(--font-display)`); eyebrows/ids/metrics stay JetBrains Mono. Colors stay on the `C` palette. Fonts were already loaded via next/font in `app/layout.tsx` — **no new font infra**.
- **Honest by construction:** no fetch/state/invented metadata — callers pass existing values into `metadata`/`actions`/`metrics` slots. Segmented title with controlled `gradient` emphasis (limited to Overview's "Launch"/"Data").

Migrates **`TelemetryOverview` → `hero`**: same copy + real Big Numbers, now an editorial serif headline. **Screenshot-verified** (Big Numbers, sidebar, Bottleneck Map all intact; no layout break).

Adds dispatch record `0009-telemetry-page-header-system.md` + a header-family entry in `component-contracts.md`. Nested section headings keep using `PageHeading`.

### Verification
`tsc` clean · `next lint` clean · `vitest` 6 tests (header 4 + Overview 2) pass · before/after screenshot of Overview reviewed.

Tickets 2–4 (operations `compact`, models/factory `standard`, evidence/lineage `evidence` + visual-regression spec + docs) are scoped in 0009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)