### PR TITLE
feat(telemetry): fold ADE into a composed Data Engineering section (Phase 1)

### DIFF
--- a/docs/adr/automated-data-engineering/0002-surface-portability.md
+++ b/docs/adr/automated-data-engineering/0002-surface-portability.md
@@ -61,3 +61,24 @@ The second mount is the test: if adding ADE to another environment takes more th
 mount wiring (regex entry + link), the core leaked environment assumptions and this ADR
 gets a follow-up. Also check at PR 1 review that grep for "telemetry" and "RS" inside the
 core package returns nothing.
+
+## Follow-up (2026-06-24) — composed telemetry mount
+
+The standalone `/lab/env/[envId]/automated-data-engineering` mount read as its own
+environment (its own left rail) and presented a generic tool/connector/receipt inventory
+rather than data engineering. The telemetry environment now presents ADE through a
+**composed** mount instead: a `Data Engineering` group in the telemetry sidebar
+(`/lab/env/[envId]/telemetry/data-engineering/*`) whose data-semantics pages (grain,
+relationships, lineage, pipelines/quality) reuse the telemetry **metadata catalog**, and
+whose agent/governance pages (Agent Workbench, Run Autopsy, Source & Platform Map) read the
+portable ADE endpoints (`/api/ade/*`). The old standalone routes now 307-redirect into the
+new section.
+
+This **does not change** the ADR decision: the ADE core package
+(`repo-b/src/components/automated-data-engineering/`, its lib, and the backend route) is
+**unchanged and still portable** — the composition lives entirely in the telemetry package
+(`repo-b/src/components/telemetry/data-engineering/`), which is allowed to import the ADE
+lib. The grep-for-"telemetry"-in-core test still holds. The standalone domain route remains
+the portability contract for future environment mounts (a non-redirecting mount re-adds its
+own route/link); only telemetry, which has a richer metadata layer to compose with,
+redirects today.

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/audit/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/audit/page.tsx
@@ -1,9 +1,10 @@
-"use client";
+import { redirect } from "next/navigation";
 
-import { useParams } from "next/navigation";
-import AuditDashboard from "@/components/automated-data-engineering/AuditDashboard";
-
-export default function AdeAuditPage() {
-  const { envId } = useParams<{ envId: string }>();
-  return <AuditDashboard envId={envId} />;
+export default async function AdeAuditRedirect({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  redirect(`/lab/env/${envId}/telemetry/data-engineering/autopsy`);
 }

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/connectors/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/connectors/page.tsx
@@ -1,7 +1,10 @@
-"use client";
+import { redirect } from "next/navigation";
 
-import ConnectorMap from "@/components/automated-data-engineering/ConnectorMap";
-
-export default function AdeConnectorsPage() {
-  return <ConnectorMap />;
+export default async function AdeConnectorsRedirect({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  redirect(`/lab/env/${envId}/telemetry/data-engineering/sources`);
 }

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/layout.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/layout.tsx
@@ -1,15 +1,8 @@
-import AdeShell from "@/components/automated-data-engineering/AdeShell";
-
-// Full-bleed control room. The lab shell yields full-bleed for
-// /automated-data-engineering (isDomainRoute), and AdeShell carries its dark
-// palette inline, so no theme pinning is needed here.
-export default function AdeLayout({
-  children,
-  params,
-}: {
-  children: React.ReactNode;
-  params: { envId: string };
-}) {
-  const { envId } = params;
-  return <AdeShell envId={envId}>{children}</AdeShell>;
+// The telemetry mount of ADE is superseded by the composed Data Engineering section under
+// /telemetry/data-engineering. Every page in this segment now redirects there, so this layout no
+// longer wraps anything in AdeShell — it just passes children through (the redirect short-circuits
+// the render). The portable AdeShell component is unchanged and still available for a future
+// standalone mount in another environment. See ADR 0002 follow-up.
+export default function AdeLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
 }

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/page.tsx
@@ -1,9 +1,13 @@
-"use client";
+import { redirect } from "next/navigation";
 
-import { useParams } from "next/navigation";
-import AdeOverview from "@/components/automated-data-engineering/AdeOverview";
-
-export default function AdeOverviewPage() {
-  const { envId } = useParams<{ envId: string }>();
-  return <AdeOverview envId={envId} />;
+// The standalone ADE mount is superseded by the composed telemetry Data Engineering section.
+// The portable ADE package (components/lib/backend) is unchanged and still mountable elsewhere;
+// only this telemetry mount redirects. See ADR 0002 follow-up.
+export default async function AdeOverviewRedirect({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  redirect(`/lab/env/${envId}/telemetry/data-engineering`);
 }

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/playbooks/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/playbooks/page.tsx
@@ -1,7 +1,10 @@
-"use client";
+import { redirect } from "next/navigation";
 
-import PlaybooksPanel from "@/components/automated-data-engineering/PlaybooksPanel";
-
-export default function AdePlaybooksPage() {
-  return <PlaybooksPanel />;
+export default async function AdePlaybooksRedirect({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  redirect(`/lab/env/${envId}/telemetry/data-engineering`);
 }

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/runs/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/runs/page.tsx
@@ -1,10 +1,10 @@
-"use client";
+import { redirect } from "next/navigation";
 
-import { useParams } from "next/navigation";
-import ReceiptsFeed from "@/components/automated-data-engineering/ReceiptsFeed";
-
-// Route segment stays /runs; the user-facing label is "Execution Receipts".
-export default function AdeReceiptsPage() {
-  const { envId } = useParams<{ envId: string }>();
-  return <ReceiptsFeed envId={envId} />;
+export default async function AdeRunsRedirect({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  redirect(`/lab/env/${envId}/telemetry/data-engineering/autopsy`);
 }

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/skills/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/skills/page.tsx
@@ -1,7 +1,10 @@
-"use client";
+import { redirect } from "next/navigation";
 
-import SkillRegistryTable from "@/components/automated-data-engineering/SkillRegistryTable";
-
-export default function AdeSkillsPage() {
-  return <SkillRegistryTable />;
+export default async function AdeSkillsRedirect({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  redirect(`/lab/env/${envId}/telemetry/data-engineering/workbench`);
 }

--- a/repo-b/src/app/lab/env/[envId]/automated-data-engineering/workflows/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/automated-data-engineering/workflows/page.tsx
@@ -1,9 +1,10 @@
-"use client";
+import { redirect } from "next/navigation";
 
-import { useParams } from "next/navigation";
-import WorkflowCatalog from "@/components/automated-data-engineering/WorkflowCatalog";
-
-export default function AdeWorkflowsPage() {
-  const { envId } = useParams<{ envId: string }>();
-  return <WorkflowCatalog envId={envId} />;
+export default async function AdeWorkflowsRedirect({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  redirect(`/lab/env/${envId}/telemetry/data-engineering`);
 }

--- a/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/autopsy/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/autopsy/page.tsx
@@ -1,0 +1,10 @@
+import RunAutopsy from "@/components/telemetry/data-engineering/RunAutopsy";
+
+export default async function DataEngineeringAutopsyPage({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  return <RunAutopsy envId={envId} />;
+}

--- a/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/grain/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/grain/page.tsx
@@ -1,0 +1,10 @@
+import DataMapGrain from "@/components/telemetry/data-engineering/DataMapGrain";
+
+export default async function DataEngineeringGrainPage({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  return <DataMapGrain envId={envId} />;
+}

--- a/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/page.tsx
@@ -1,0 +1,10 @@
+import DataEngineeringOverview from "@/components/telemetry/data-engineering/DataEngineeringOverview";
+
+export default async function DataEngineeringPage({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  return <DataEngineeringOverview envId={envId} />;
+}

--- a/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/pipelines/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/pipelines/page.tsx
@@ -1,0 +1,10 @@
+import PipelinesQuality from "@/components/telemetry/data-engineering/PipelinesQuality";
+
+export default async function DataEngineeringPipelinesPage({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  return <PipelinesQuality envId={envId} />;
+}

--- a/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/relationships/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/relationships/page.tsx
@@ -1,0 +1,10 @@
+import RelationshipsLineage from "@/components/telemetry/data-engineering/RelationshipsLineage";
+
+export default async function DataEngineeringRelationshipsPage({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  return <RelationshipsLineage envId={envId} />;
+}

--- a/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/sources/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/sources/page.tsx
@@ -1,0 +1,10 @@
+import SourcePlatformMap from "@/components/telemetry/data-engineering/SourcePlatformMap";
+
+export default async function DataEngineeringSourcesPage({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  return <SourcePlatformMap envId={envId} />;
+}

--- a/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/workbench/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/telemetry/data-engineering/workbench/page.tsx
@@ -1,0 +1,10 @@
+import AgentWorkbench from "@/components/telemetry/data-engineering/AgentWorkbench";
+
+export default async function DataEngineeringWorkbenchPage({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  return <AgentWorkbench envId={envId} />;
+}

--- a/repo-b/src/components/telemetry/TelemetrySidebar.tsx
+++ b/repo-b/src/components/telemetry/TelemetrySidebar.tsx
@@ -21,6 +21,7 @@ const GROUP_ACCENT: Record<TelemetryNavGroup, string> = {
   "Factory & Quality": C.amber,
   "Evidence & Lineage": C.green,
   "Agent Operations": "#f472b6",
+  "Data Engineering": "#a855f7",
 };
 
 // Grouped navigation rail. Rendered in the desktop rail and inside the mobile

--- a/repo-b/src/components/telemetry/data-engineering/AgentWorkbench.tsx
+++ b/repo-b/src/components/telemetry/data-engineering/AgentWorkbench.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  getSkillRegistry,
+  type SkillRegistryResponse,
+  type SkillSummary,
+} from "@/lib/automated-data-engineering/api";
+import {
+  C,
+  EmptyState,
+  InlineCode,
+  Loading,
+  MetricCard,
+  PageHeading,
+  Panel,
+  SelectField,
+  StatGrid,
+  StatusDot,
+  Tag,
+  TelemetrySection,
+  TelemetryStatusBanner,
+} from "../primitives";
+
+// Agent Workbench — the "propose" mode. It frames the live, governed MCP skill registry as the three
+// things AI is allowed to do over the data fabric: Observe (read-only), Propose (produce an artifact),
+// and Execute-with-guardrails (a write that requires confirmation). Skills come from /api/ade/skill-
+// registry (the real registry). Phase 1 shows the full registry; an aerospace-data-engineering default
+// view is declared next-phase, not faked.
+
+type Capability = "observe" | "propose" | "execute";
+
+const CAP_META: Record<Capability, { label: string; blurb: string; color: string }> = {
+  observe: { label: "Observe", blurb: "Read-only: profile sources, read grain/freshness, inspect lineage. No side effects.", color: C.cyan },
+  propose: { label: "Propose", blurb: "Produce an artifact or change for review — a mapping, feature, contract, or PR.", color: C.green },
+  execute: { label: "Execute · guardrails", blurb: "A write that fails closed until explicitly confirmed.", color: C.amber },
+};
+
+function classify(skill: SkillSummary): Capability {
+  if (skill.confirmation_required) return "execute";
+  if (skill.side_effect_class === "read" || skill.permission === "read") return "observe";
+  return "propose";
+}
+
+export default function AgentWorkbench({ envId }: { envId: string }) {
+  // envId is accepted for route symmetry; the skill registry is environment-agnostic (platform core).
+  void envId;
+  const [registry, setRegistry] = useState<SkillRegistryResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [moduleFilter, setModuleFilter] = useState("");
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    let live = true;
+    getSkillRegistry()
+      .then((r) => { if (live) setRegistry(r); })
+      .catch((e) => { if (live) setError(e instanceof Error ? e.message : String(e)); });
+    return () => { live = false; };
+  }, []);
+
+  const buckets = useMemo(() => {
+    const out: Record<Capability, number> = { observe: 0, propose: 0, execute: 0 };
+    for (const t of registry?.tools ?? []) out[classify(t)] += 1;
+    return out;
+  }, [registry]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return (registry?.tools ?? [])
+      .filter((t) => (!moduleFilter || t.module === moduleFilter))
+      .filter((t) => (!q || `${t.name} ${t.description} ${t.skill_tags.join(" ")}`.toLowerCase().includes(q)))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [registry, moduleFilter, query]);
+
+  const heading = (
+    <PageHeading
+      eyebrow="Mode · Agent Workbench"
+      title="Agent Workbench"
+      blurb="What AI is allowed to do over the data fabric, governed. Every skill declares its permission, side-effect class, and whether it needs confirmation before it can run — so the boundary between observing, proposing, and executing is explicit, not implied."
+    />
+  );
+
+  if (error && !registry) {
+    return <>{heading}<TelemetryStatusBanner tone="error">Skill registry unavailable — {error}.</TelemetryStatusBanner></>;
+  }
+  if (!registry) return <>{heading}<Loading label="Loading skill registry…" /></>;
+  if (registry.null_reason) {
+    return <>{heading}<EmptyState label="Skill registry unavailable" hint={`null_reason: ${registry.null_reason}`} /></>;
+  }
+
+  return (
+    <>
+      {heading}
+
+      <TelemetryStatusBanner tone="info">
+        Showing the full governed skill registry ({registry.tools.length} skills · {registry.modules.length}{" "}
+        modules). An aerospace-data-engineering scoped default view (profile, infer-grain, validate-join,
+        generate-contract, propose-feature) is declared next-phase work.
+      </TelemetryStatusBanner>
+
+      <StatGrid cols={3} style={{ marginTop: 16 }}>
+        {(Object.keys(CAP_META) as Capability[]).map((cap) => (
+          <MetricCard key={cap} label={CAP_META[cap].label} value={buckets[cap]} sub={CAP_META[cap].blurb} accent={CAP_META[cap].color} />
+        ))}
+      </StatGrid>
+
+      <TelemetrySection
+        label="Governed skills"
+        right={
+          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+            <input
+              type="search"
+              aria-label="Search skills"
+              placeholder="Search skills…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              style={{ minHeight: 34, borderRadius: 7, border: `1px solid ${C.borderHi}`, background: C.panelHi, color: C.text, padding: "0 11px", fontFamily: C.mono, fontSize: 11 }}
+            />
+            <SelectField value={moduleFilter} onChange={setModuleFilter} ariaLabel="Filter by module">
+              <option value="">All modules</option>
+              {registry.modules.map((m) => (
+                <option key={m.module} value={m.module}>{m.module} ({m.tool_count})</option>
+              ))}
+            </SelectField>
+          </div>
+        }
+      >
+        {filtered.length === 0 ? (
+          <EmptyState label="No skills match" hint="Clear the search or module filter." />
+        ) : (
+          <Panel pad={0}>
+            <div style={{ maxHeight: 560, overflowY: "auto" }}>
+              {filtered.map((t) => {
+                const cap = classify(t);
+                return (
+                  <div key={t.name} style={{ display: "flex", alignItems: "flex-start", gap: 12, padding: "11px 16px", borderBottom: `1px solid ${C.border}` }}>
+                    <StatusDot color={CAP_META[cap].color} size={7} />
+                    <div style={{ minWidth: 0, flex: 1 }}>
+                      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                        <InlineCode color={C.text}>{t.name}</InlineCode>
+                        <Tag color={CAP_META[cap].color}>{CAP_META[cap].label}</Tag>
+                        {t.confirmation_required && <Tag color={C.amber}>confirm required</Tag>}
+                      </div>
+                      <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.dim, lineHeight: 1.5, marginTop: 5 }}>{t.description}</div>
+                    </div>
+                    <span style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, whiteSpace: "nowrap" }}>{t.module}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </Panel>
+        )}
+      </TelemetrySection>
+    </>
+  );
+}

--- a/repo-b/src/components/telemetry/data-engineering/DataEngineeringOverview.test.tsx
+++ b/repo-b/src/components/telemetry/data-engineering/DataEngineeringOverview.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/telemetry/api", () => ({
+  TELEMETRY_DEMO_ENV_ID: "telemetry-demo",
+  TELEMETRY_DEMO_BUSINESS_ID: "biz-1",
+}));
+
+const getMetadataGraph = vi.fn();
+vi.mock("@/lib/telemetry/metadata", async (orig) => ({
+  ...(await orig<typeof import("@/lib/telemetry/metadata")>()),
+  getMetadataGraph: (...args: unknown[]) => getMetadataGraph(...args),
+}));
+
+const getSkillRegistry = vi.fn(() => Promise.resolve({ tools: [], modules: [], null_reason: null }));
+const getReceipts = vi.fn(() => Promise.resolve({ runs: [], null_reason: null }));
+vi.mock("@/lib/automated-data-engineering/api", () => ({
+  getSkillRegistry: () => getSkillRegistry(),
+  getReceipts: () => getReceipts(),
+}));
+
+import DataEngineeringOverview from "./DataEngineeringOverview";
+
+const graph = {
+  generated_at: "2026-06-24T00:00:00Z",
+  status: "ok",
+  warnings: [],
+  nodes: [
+    { id: "s1", label: "Sensor readings", kind: "table", layer: "source", confidence: "explicit", status: "fresh", metadata: { grain: "ts x channel x run" } },
+  ],
+  edges: [],
+  stats: { source_count: 1, bronze_count: 0, silver_count: 0, gold_count: 0, metric_count: 0, model_count: 0, dashboard_count: 0, edge_count: 0, unavailable_count: 0 },
+};
+
+describe("DataEngineeringOverview", () => {
+  beforeEach(() => getMetadataGraph.mockReset());
+
+  it("names the two operating modes once the catalog loads", async () => {
+    getMetadataGraph.mockResolvedValue(graph);
+    render(<DataEngineeringOverview envId="env-1" />);
+    expect(await screen.findByText("Agent Workbench")).toBeInTheDocument();
+    expect(screen.getByText("Run Autopsy")).toBeInTheDocument();
+    expect(screen.getByText("Tables with grain")).toBeInTheDocument();
+  });
+
+  it("fails closed (no substitute counts) when the metadata catalog is unavailable", async () => {
+    // Same render branch as a 404 from the endpoint: no usable graph -> fail-closed banner,
+    // not a substitute number. (Resolve-null mirrors the proven MetricLineageExplorer pattern.)
+    getMetadataGraph.mockResolvedValue(null);
+    render(<DataEngineeringOverview envId="env-1" />);
+    expect(await screen.findByText(/Metadata catalog unavailable/)).toBeInTheDocument();
+    expect(screen.getByText(/metadata_graph_unreachable/)).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/data-engineering/DataEngineeringOverview.tsx
+++ b/repo-b/src/components/telemetry/data-engineering/DataEngineeringOverview.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+import {
+  TELEMETRY_DEMO_BUSINESS_ID,
+  TELEMETRY_DEMO_ENV_ID,
+} from "@/lib/telemetry/api";
+import {
+  getMetadataGraph,
+  type TelemetryMetadataGraph,
+} from "@/lib/telemetry/metadata";
+import {
+  getReceipts,
+  getSkillRegistry,
+  type ReceiptsResponse,
+  type SkillRegistryResponse,
+} from "@/lib/automated-data-engineering/api";
+import {
+  C,
+  Loading,
+  MetricCard,
+  PageHeading,
+  Panel,
+  StatGrid,
+  StatusDot,
+  Tag,
+  TelemetrySection,
+  TelemetryStatusBanner,
+} from "../primitives";
+
+// Data Engineering — the landing/control room. Composition surface: the data-semantics counts come
+// from the live telemetry metadata catalog (/api/telemetry/metadata/graph) and the governance counts
+// come from the portable ADE endpoints (/api/ade/*). It re-presents real data and routes the two
+// operating modes (Agent Workbench, Run Autopsy). No new backend, no fabricated values.
+
+const CHAIN = ["Source", "Bronze", "Silver", "Gold", "Metric", "Model / AI", "Receipt"];
+
+function deBase(envId: string) {
+  return `/lab/env/${envId}/telemetry/data-engineering`;
+}
+
+function countWithGrain(graph: TelemetryMetadataGraph): number {
+  return graph.nodes.filter((n) => {
+    const grain = n.metadata?.grain;
+    return typeof grain === "string" && grain.trim().length > 0;
+  }).length;
+}
+
+function openRisks(graph: TelemetryMetadataGraph): number {
+  return graph.nodes.filter(
+    (n) => n.status === "stale" || n.status === "missing" || n.status === "quarantined",
+  ).length;
+}
+
+function ModeCard({
+  envId,
+  slug,
+  eyebrow,
+  title,
+  blurb,
+  bullets,
+}: {
+  envId: string;
+  slug: string;
+  eyebrow: string;
+  title: string;
+  blurb: string;
+  bullets: string[];
+}) {
+  return (
+    <Link href={`${deBase(envId)}/${slug}`} style={{ textDecoration: "none" }}>
+      <div
+        style={{
+          background: C.panel,
+          border: `1px solid ${C.border}`,
+          borderRadius: 11,
+          padding: 18,
+          height: "100%",
+        }}
+      >
+        <div style={{ fontFamily: C.mono, fontSize: 10, letterSpacing: "0.14em", color: C.cyan, textTransform: "uppercase" }}>
+          {eyebrow}
+        </div>
+        <div style={{ fontFamily: C.sans, fontSize: 19, fontWeight: 700, color: C.text, marginTop: 7 }}>{title}</div>
+        <p style={{ fontFamily: C.sans, fontSize: 13, color: C.dim, lineHeight: 1.55, marginTop: 8 }}>{blurb}</p>
+        <div style={{ display: "flex", flexDirection: "column", gap: 7, marginTop: 13 }}>
+          {bullets.map((b) => (
+            <div key={b} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <StatusDot color={C.cyan} size={5} glow={false} />
+              <span style={{ fontFamily: C.mono, fontSize: 12, color: C.text }}>{b}</span>
+            </div>
+          ))}
+        </div>
+        <div style={{ fontFamily: C.mono, fontSize: 11, color: C.cyan, marginTop: 14 }}>Open {title} →</div>
+      </div>
+    </Link>
+  );
+}
+
+export default function DataEngineeringOverview({ envId }: { envId: string }) {
+  const [graph, setGraph] = useState<TelemetryMetadataGraph | null>(null);
+  const [registry, setRegistry] = useState<SkillRegistryResponse | null>(null);
+  const [receipts, setReceipts] = useState<ReceiptsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    getMetadataGraph(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID, envId)
+      .then((g) => { if (!live) return; if (g) setGraph(g); else setError("metadata_graph_unreachable"); })
+      .catch((e) => { if (live) setError(e instanceof Error ? e.message : String(e)); });
+    // Governance counts are non-blocking: a failure degrades a card, not the page.
+    getSkillRegistry().then((r) => { if (live) setRegistry(r); }).catch(() => {});
+    getReceipts(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID)
+      .then((r) => { if (live) setReceipts(r); }).catch(() => {});
+    return () => { live = false; };
+  }, [envId]);
+
+  const heading = (
+    <PageHeading
+      eyebrow="Data Fabric · Control Room"
+      title="Automated Data Engineering"
+      blurb="The governed layer between operational telemetry and trusted AI. It maps every source's grain, declares which relationships are real, traces lineage from raw signal to metric and model, and leaves an audit receipt before any dashboard, feature, or AI answer is allowed to depend on the data. Read-only — it shows what the fabric is, not a simulation of it."
+    />
+  );
+
+  if (error && !graph) {
+    return (
+      <>
+        {heading}
+        <TelemetryStatusBanner tone="error">
+          Metadata catalog unavailable — {error}. Data-semantics counts below are withheld; this is the
+          fail-closed state, not a substitute number.
+        </TelemetryStatusBanner>
+      </>
+    );
+  }
+  if (!graph) return <>{heading}<Loading label="Loading fabric state…" /></>;
+
+  const withGrain = countWithGrain(graph);
+  const risks = openRisks(graph);
+
+  return (
+    <>
+      {heading}
+
+      {/* The two operating modes, named and separated. */}
+      <TelemetrySection label="Two ways to work the fabric">
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <ModeCard
+            envId={envId}
+            slug="workbench"
+            eyebrow="Mode · Propose"
+            title="Agent Workbench"
+            blurb="Where AI does governed data-engineering work: observe source contracts and grain, propose mappings/joins/features, and execute read-only or confirmation-gated actions. Every skill declares its permission and side-effect class before it runs."
+            bullets={["Observe — profile, grain, freshness", "Propose — joins, features, contracts", "Execute — read-only or confirmation-gated"]}
+          />
+          <ModeCard
+            envId={envId}
+            slug="autopsy"
+            eyebrow="Mode · Inspect"
+            title="Run Autopsy"
+            blurb="The after-the-fact view: what ran, what it cost, what it refused, and the receipt that proves it. Failures, refusals, and stale inputs surface here rather than being hidden."
+            bullets={["Receipts — what ran, by whom, when", "Governance — success, grounding, cost", "Refusals — fail-closed, not silent"]}
+          />
+        </div>
+      </TelemetrySection>
+
+      {/* Source-to-Outcome Chain — the spine the whole surface defends. */}
+      <TelemetrySection label="Source-to-outcome chain">
+        <Panel>
+          <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 8 }}>
+            {CHAIN.map((stage, i) => (
+              <div key={stage} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <span style={{ fontFamily: C.mono, fontSize: 11, color: C.text, border: `1px solid ${C.borderHi}`, borderRadius: 6, padding: "5px 10px", background: C.panelHi }}>
+                  {stage}
+                </span>
+                {i < CHAIN.length - 1 && (
+                  <svg width="12" height="10" viewBox="0 0 12 10" aria-hidden>
+                    <path d="M1 5h9M7 1.5L10.5 5 7 8.5" stroke={C.faint} strokeWidth="1.2" fill="none" strokeLinecap="round" />
+                  </svg>
+                )}
+              </div>
+            ))}
+          </div>
+          <p style={{ fontFamily: C.sans, fontSize: 13, color: C.dim, lineHeight: 1.55, marginTop: 14, maxWidth: 760 }}>
+            Each node carries a declared grain and primary key; each edge is a typed, confidence-rated
+            relationship. A metric or feature is only trustworthy when its full upstream chain is fresh and
+            its joins are declared — not assumed.
+          </p>
+        </Panel>
+      </TelemetrySection>
+
+      {/* Honest, real counts. */}
+      <TelemetrySection label="Fabric at a glance">
+        <StatGrid cols={4}>
+          <Link href={`${deBase(envId)}/grain`} style={{ textDecoration: "none" }}>
+            <MetricCard label="Sources mapped" value={graph.stats.source_count} sub="declared in catalog" />
+          </Link>
+          <Link href={`${deBase(envId)}/grain`} style={{ textDecoration: "none" }}>
+            <MetricCard label="Tables with grain" value={withGrain} sub={`of ${graph.nodes.length} catalog nodes`} />
+          </Link>
+          <Link href={`${deBase(envId)}/relationships`} style={{ textDecoration: "none" }}>
+            <MetricCard label="Relationships" value={graph.stats.edge_count} sub="typed · confidence-rated" />
+          </Link>
+          <Link href={`${deBase(envId)}/pipelines`} style={{ textDecoration: "none" }}>
+            <MetricCard
+              label="Open data risks"
+              value={risks}
+              sub="stale · missing · quarantined"
+              accent={risks > 0 ? C.amber : C.green}
+            />
+          </Link>
+        </StatGrid>
+        <StatGrid cols={3} style={{ marginTop: 12 }}>
+          <Link href={`${deBase(envId)}/workbench`} style={{ textDecoration: "none" }}>
+            <MetricCard
+              label="Governed skills"
+              value={registry ? (registry.null_reason ? "—" : registry.tools.length) : "…"}
+              sub={registry?.null_reason ? `null_reason: ${registry.null_reason}` : "typed, permissioned"}
+            />
+          </Link>
+          <Link href={`${deBase(envId)}/autopsy`} style={{ textDecoration: "none" }}>
+            <MetricCard
+              label="Execution receipts"
+              value={receipts ? (receipts.null_reason ? "—" : receipts.runs.length) : "…"}
+              sub={receipts?.null_reason ? `null_reason: ${receipts.null_reason}` : "audit trail"}
+            />
+          </Link>
+          <Link href={`${deBase(envId)}/sources`} style={{ textDecoration: "none" }}>
+            <MetricCard label="Source & platform" value="map" sub="declared connector status" />
+          </Link>
+        </StatGrid>
+      </TelemetrySection>
+
+      <div style={{ marginTop: 16 }}>
+        <Tag color={C.amber}>honest scope</Tag>
+        <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, marginLeft: 10 }}>
+          Grain, lineage, and relationships come from the live telemetry metadata catalog. Join-safety
+          classification, the guided investigation scenario, and an aerospace-scoped skill view are
+          declared next-phase work — not shown as if they exist.
+        </span>
+      </div>
+    </>
+  );
+}

--- a/repo-b/src/components/telemetry/data-engineering/DataMapGrain.tsx
+++ b/repo-b/src/components/telemetry/data-engineering/DataMapGrain.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  TELEMETRY_DEMO_BUSINESS_ID,
+  TELEMETRY_DEMO_ENV_ID,
+} from "@/lib/telemetry/api";
+import {
+  getMetadataGraph,
+  metadataVisualLane,
+  type MetadataVisualLane,
+  type TelemetryMetadataGraph,
+  type TelemetryMetadataNode,
+} from "@/lib/telemetry/metadata";
+import {
+  C,
+  EmptyState,
+  Loading,
+  PageHeading,
+  Panel,
+  ResponsiveSwap,
+  RowCard,
+  ScrollTable,
+  StatusDot,
+  Tag,
+  TelemetryStatusBanner,
+} from "../primitives";
+import MetadataDetailDrawer from "../metadata/MetadataDetailDrawer";
+
+// Data Map & Grain — the catalog of telemetry sources/tables with the one thing a skeptical data
+// person asks first: at what grain does each table live, and what is its key? Reuses the live metadata
+// catalog; the full "source contract" (columns, quality checks, references) opens in the shared
+// MetadataDetailDrawer. Grain that is not declared reads "not declared" — never invented.
+
+const LANE_LABEL: Record<MetadataVisualLane, string> = {
+  source: "Source", bronze: "Bronze", silver: "Silver", gold: "Gold",
+  metric: "Metric", consumer: "Consumer", model: "Model", runtime: "Runtime / AI",
+};
+const LANE_ORDER: MetadataVisualLane[] = ["source", "bronze", "silver", "gold", "metric", "consumer", "model", "runtime"];
+
+function str(value: unknown): string | null {
+  if (typeof value === "string" && value.trim()) return value;
+  if (typeof value === "number") return String(value);
+  return null;
+}
+
+function fkCount(value: unknown): number {
+  if (Array.isArray(value)) return value.length;
+  if (typeof value === "string" && value.trim()) return 1;
+  return 0;
+}
+
+function statusColor(status?: string): string {
+  if (status === "fresh") return C.green;
+  if (status === "missing") return C.red;
+  if (status === "stale" || status === "quarantined") return C.amber;
+  return C.faint;
+}
+
+function Unavailable() {
+  return <span style={{ color: C.faint }}>not declared</span>;
+}
+
+export default function DataMapGrain({ envId }: { envId: string }) {
+  const [graph, setGraph] = useState<TelemetryMetadataGraph | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    getMetadataGraph(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID, envId)
+      .then((g) => { if (live) setGraph(g); })
+      .catch((e) => { if (live) setError(e instanceof Error ? e.message : String(e)); });
+    return () => { live = false; };
+  }, [envId]);
+
+  const grouped = useMemo(() => {
+    if (!graph) return [] as { lane: MetadataVisualLane; nodes: TelemetryMetadataNode[] }[];
+    const byLane = new Map<MetadataVisualLane, TelemetryMetadataNode[]>();
+    for (const node of graph.nodes) {
+      const lane = metadataVisualLane(node);
+      (byLane.get(lane) ?? byLane.set(lane, []).get(lane)!).push(node);
+    }
+    return LANE_ORDER
+      .map((lane) => ({ lane, nodes: (byLane.get(lane) ?? []).sort((a, b) => a.label.localeCompare(b.label)) }))
+      .filter((g) => g.nodes.length > 0);
+  }, [graph]);
+
+  const heading = (
+    <PageHeading
+      eyebrow="Data Map · Grain"
+      title="Data Map & Grain"
+      blurb="Every source and table the fabric knows about, with its declared grain and key. Grain is the guardrail against false precision — it stops an analyst (or an AI) from joining 10 Hz sensor data straight to part-level defects and reporting fake exactness. Click a row for the full source contract."
+    />
+  );
+
+  const selected = graph?.nodes.find((n) => n.id === selectedId) ?? null;
+
+  if (error && !graph) {
+    return <>{heading}<TelemetryStatusBanner tone="error">Metadata catalog unavailable — {error}.</TelemetryStatusBanner></>;
+  }
+  if (!graph) return <>{heading}<Loading label="Loading catalog…" /></>;
+  if (graph.nodes.length === 0) {
+    return <>{heading}<EmptyState label="No catalog nodes" hint="The telemetry metadata response was empty." /></>;
+  }
+
+  return (
+    <>
+      {heading}
+      {graph.warnings.length > 0 && (
+        <TelemetryStatusBanner tone="warn">
+          {graph.warnings.map((w) => w.message).join(" · ")}
+        </TelemetryStatusBanner>
+      )}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 16, marginTop: 16 }}>
+        {grouped.map(({ lane, nodes }) => (
+          <Panel
+            key={lane}
+            title={`${LANE_LABEL[lane]} · ${nodes.length}`}
+            pad={0}
+          >
+            <ResponsiveSwap
+              desktop={
+                <ScrollTable minWidth={780}>
+                  <table style={{ width: "100%", borderCollapse: "collapse" }}>
+                    <thead>
+                      <tr>
+                        {["Object", "Grain", "Primary key", "FKs", "Owner", "Freshness", "Status"].map((h) => (
+                          <th key={h} style={{ textAlign: "left", padding: "10px 14px", fontFamily: C.mono, fontSize: 9, letterSpacing: "0.1em", textTransform: "uppercase", color: C.faint, borderBottom: `1px solid ${C.border}` }}>
+                            {h}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {nodes.map((node) => {
+                        const m = node.metadata ?? {};
+                        const grain = str(m.grain);
+                        const pk = str(m.primary_key);
+                        const owner = str(m.owner);
+                        const fresh = str(m.freshness_as_of) ?? str(m.last_refreshed) ?? str(m.last_updated_at);
+                        return (
+                          <tr
+                            key={node.id}
+                            onClick={() => setSelectedId(node.id)}
+                            style={{ cursor: "pointer", borderBottom: `1px solid ${C.border}` }}
+                          >
+                            <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 12, color: C.text }}>{node.label}</td>
+                            <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: grain ? C.dim : C.faint }}>{grain ?? <Unavailable />}</td>
+                            <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: pk ? C.dim : C.faint }}>{pk ?? <Unavailable />}</td>
+                            <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: C.dim }}>{fkCount(m.foreign_keys) || "—"}</td>
+                            <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: owner ? C.dim : C.faint }}>{owner ?? <Unavailable />}</td>
+                            <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: fresh ? C.dim : C.faint }}>{fresh ?? <Unavailable />}</td>
+                            <td style={{ padding: "10px 14px" }}>
+                              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontFamily: C.mono, fontSize: 11, color: statusColor(node.status) }}>
+                                <StatusDot color={statusColor(node.status)} size={6} />
+                                {node.status ?? "unknown"}
+                              </span>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </ScrollTable>
+              }
+              mobile={
+                <div style={{ display: "flex", flexDirection: "column", gap: 10, padding: 12 }}>
+                  {nodes.map((node) => {
+                    const m = node.metadata ?? {};
+                    return (
+                      <RowCard
+                        key={node.id}
+                        title={node.label}
+                        onClick={() => setSelectedId(node.id)}
+                        tags={<Tag color={statusColor(node.status)}>{node.status ?? "unknown"}</Tag>}
+                        fields={[
+                          { label: "Grain", value: str(m.grain) ?? <Unavailable /> },
+                          { label: "Primary key", value: str(m.primary_key) ?? <Unavailable /> },
+                          { label: "Owner", value: str(m.owner) ?? <Unavailable /> },
+                          { label: "FKs", value: fkCount(m.foreign_keys) || "—" },
+                        ]}
+                      />
+                    );
+                  })}
+                </div>
+              }
+            />
+          </Panel>
+        ))}
+      </div>
+
+      <MetadataDetailDrawer
+        node={selected}
+        nodes={graph.nodes}
+        edges={graph.edges}
+        onClose={() => setSelectedId(null)}
+      />
+    </>
+  );
+}

--- a/repo-b/src/components/telemetry/data-engineering/PipelinesQuality.tsx
+++ b/repo-b/src/components/telemetry/data-engineering/PipelinesQuality.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  TELEMETRY_DEMO_BUSINESS_ID,
+  TELEMETRY_DEMO_ENV_ID,
+} from "@/lib/telemetry/api";
+import {
+  getMetadataGraph,
+  metadataVisualLane,
+  type MetadataStatus,
+  type TelemetryMetadataGraph,
+  type TelemetryMetadataNode,
+} from "@/lib/telemetry/metadata";
+import {
+  C,
+  EmptyState,
+  Loading,
+  MetricCard,
+  PageHeading,
+  Panel,
+  StatGrid,
+  StatusDot,
+  Tag,
+  TelemetrySection,
+  TelemetryStatusBanner,
+} from "../primitives";
+
+// Pipelines & Quality — the medallion (source -> bronze -> silver -> gold) with the freshness/quality
+// state of each stage. IMPORTANT (per plan): this derives stage health from the catalog node `status`
+// the metadata endpoint already exposes (which the backend computes from pipeline/DQ state). It does
+// NOT claim a direct tel_pipeline_status / tel_dq_assertions frontend feed — that dedicated feed is a
+// follow-up. Anything unknown fails closed; no fabricated "all green" board.
+
+const MEDALLION = [
+  { lane: "source", label: "Source", note: "adapters / capture" },
+  { lane: "bronze", label: "Bronze", note: "append-only landing" },
+  { lane: "silver", label: "Silver", note: "deduped / conformed" },
+  { lane: "gold", label: "Gold", note: "aggregated / served" },
+] as const;
+
+function worstStatus(nodes: TelemetryMetadataNode[]): MetadataStatus {
+  if (nodes.some((n) => n.status === "missing")) return "missing";
+  if (nodes.some((n) => n.status === "quarantined")) return "quarantined";
+  if (nodes.some((n) => n.status === "stale")) return "stale";
+  if (nodes.some((n) => n.status === "fresh")) return "fresh";
+  return "unknown";
+}
+
+function statusColor(status: MetadataStatus): string {
+  if (status === "fresh") return C.green;
+  if (status === "missing") return C.red;
+  if (status === "stale" || status === "quarantined") return C.amber;
+  return C.faint;
+}
+
+export default function PipelinesQuality({ envId }: { envId: string }) {
+  const [graph, setGraph] = useState<TelemetryMetadataGraph | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    getMetadataGraph(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID, envId)
+      .then((g) => { if (live) setGraph(g); })
+      .catch((e) => { if (live) setError(e instanceof Error ? e.message : String(e)); });
+    return () => { live = false; };
+  }, [envId]);
+
+  const stages = useMemo(() => {
+    if (!graph) return [];
+    return MEDALLION.map((stage) => {
+      const nodes = graph.nodes.filter((n) => metadataVisualLane(n) === stage.lane);
+      return { ...stage, nodes, status: worstStatus(nodes) };
+    });
+  }, [graph]);
+
+  const risks = useMemo(
+    () => (graph?.nodes ?? []).filter((n) => n.status === "stale" || n.status === "missing" || n.status === "quarantined"),
+    [graph],
+  );
+
+  const heading = (
+    <PageHeading
+      eyebrow="Pipelines · Quality"
+      title="Pipelines & Quality"
+      blurb="The medallion path each signal travels, and whether every stage is fresh. A downstream metric is only as trustworthy as the weakest stage feeding it — stale, missing, or quarantined stages surface here rather than being smoothed over."
+    />
+  );
+
+  if (error && !graph) {
+    return <>{heading}<TelemetryStatusBanner tone="error">Pipeline/quality state unavailable — {error}.</TelemetryStatusBanner></>;
+  }
+  if (!graph) return <>{heading}<Loading label="Loading pipeline state…" /></>;
+
+  return (
+    <>
+      {heading}
+
+      <TelemetryStatusBanner tone="info">
+        Stage health is derived from catalog node status (computed server-side from pipeline and
+        data-quality state). A dedicated pipeline-run and DQ-assertion feed to the frontend is a
+        follow-up; until then, unknown stages read &ldquo;unknown,&rdquo; never &ldquo;passing.&rdquo;
+      </TelemetryStatusBanner>
+
+      <TelemetrySection label="Medallion flow">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {stages.map((stage, i) => (
+            <Panel key={stage.lane} pad={15}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                <span style={{ fontFamily: C.mono, fontSize: 10, letterSpacing: "0.12em", color: C.faint, textTransform: "uppercase" }}>
+                  {i + 1} · {stage.label}
+                </span>
+                <Tag color={statusColor(stage.status)}>{stage.status}</Tag>
+              </div>
+              <div style={{ fontFamily: C.sans, fontSize: 26, fontWeight: 600, color: C.text, marginTop: 8 }}>{stage.nodes.length}</div>
+              <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, marginTop: 4 }}>{stage.note}</div>
+            </Panel>
+          ))}
+        </div>
+      </TelemetrySection>
+
+      <StatGrid cols={4} style={{ marginTop: 4 }}>
+        <MetricCard label="Fresh" value={graph.nodes.filter((n) => n.status === "fresh").length} sub="catalog nodes" accent={C.green} />
+        <MetricCard label="Stale" value={graph.nodes.filter((n) => n.status === "stale").length} sub="past freshness window" accent={graph.nodes.some((n) => n.status === "stale") ? C.amber : undefined} />
+        <MetricCard label="Quarantined" value={graph.nodes.filter((n) => n.status === "quarantined").length} sub="failed a DQ check" accent={graph.nodes.some((n) => n.status === "quarantined") ? C.amber : undefined} />
+        <MetricCard label="Missing" value={graph.nodes.filter((n) => n.status === "missing").length} sub="no data / metadata" accent={graph.nodes.some((n) => n.status === "missing") ? C.red : undefined} />
+      </StatGrid>
+
+      <TelemetrySection label="Open data risks">
+        {risks.length === 0 ? (
+          <EmptyState label="No open data risks reported" hint="Every catalog node is fresh, or its status is unknown (shown above) — no stage is being silently treated as passing." />
+        ) : (
+          <Panel pad={0}>
+            {risks.map((node) => (
+              <div key={node.id} style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap", padding: "10px 16px", borderBottom: `1px solid ${C.border}` }}>
+                <StatusDot color={statusColor(node.status ?? "unknown")} size={7} />
+                <span style={{ fontFamily: C.mono, fontSize: 12, color: C.text }}>{node.label}</span>
+                <Tag color={C.faint}>{node.layer ?? metadataVisualLane(node)}</Tag>
+                <span style={{ marginLeft: "auto" }}><Tag color={statusColor(node.status ?? "unknown")}>{node.status ?? "unknown"}</Tag></span>
+              </div>
+            ))}
+          </Panel>
+        )}
+      </TelemetrySection>
+    </>
+  );
+}

--- a/repo-b/src/components/telemetry/data-engineering/RelationshipsLineage.tsx
+++ b/repo-b/src/components/telemetry/data-engineering/RelationshipsLineage.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  TELEMETRY_DEMO_BUSINESS_ID,
+  TELEMETRY_DEMO_ENV_ID,
+} from "@/lib/telemetry/api";
+import {
+  getMetadataGraph,
+  type MetadataConfidence,
+  type TelemetryMetadataGraph,
+  type TelemetryMetadataNode,
+} from "@/lib/telemetry/metadata";
+import {
+  C,
+  EmptyState,
+  Loading,
+  PageHeading,
+  Panel,
+  StatGrid,
+  MetricCard,
+  StatusDot,
+  Tag,
+  TelemetrySection,
+  TelemetryStatusBanner,
+} from "../primitives";
+import LineageDrawer from "../metadata/LineageDrawer";
+
+// Relationships & Lineage — the declared, typed edges between catalog objects (with confidence) plus
+// the full upstream trace for any node via the shared LineageDrawer. Phase 1 shows what relationships
+// EXIST and how confident the catalog is in each; it does NOT yet render a safe/unsafe/bridge join
+// VERDICT — that classification is declared next-phase work and labeled as such, not faked.
+
+function confidenceColor(c: MetadataConfidence): string {
+  if (c === "explicit") return C.green;
+  if (c === "inferred") return C.amber;
+  return C.faint; // unknown
+}
+
+function humanize(value: string) {
+  return value.replace(/_/g, " ");
+}
+
+export default function RelationshipsLineage({ envId }: { envId: string }) {
+  const [graph, setGraph] = useState<TelemetryMetadataGraph | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [traceId, setTraceId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    getMetadataGraph(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID, envId)
+      .then((g) => { if (live) setGraph(g); })
+      .catch((e) => { if (live) setError(e instanceof Error ? e.message : String(e)); });
+    return () => { live = false; };
+  }, [envId]);
+
+  const nodeMap = useMemo(
+    () => new Map((graph?.nodes ?? []).map((n) => [n.id, n] as const)),
+    [graph],
+  );
+
+  const byConfidence = useMemo(() => {
+    const counts: Record<MetadataConfidence, number> = { explicit: 0, inferred: 0, unknown: 0 };
+    for (const e of graph?.edges ?? []) counts[e.confidence] += 1;
+    return counts;
+  }, [graph]);
+
+  // Traceable focus nodes: metrics + gold tables (where "where did this come from?" matters most).
+  const traceable = useMemo(
+    () => (graph?.nodes ?? [])
+      .filter((n) => n.kind === "metric" || n.layer === "gold")
+      .sort((a, b) => a.label.localeCompare(b.label)),
+    [graph],
+  );
+
+  const heading = (
+    <PageHeading
+      eyebrow="Relationships · Lineage"
+      title="Relationships & Lineage"
+      blurb="Which objects connect to which, how, and with what confidence — plus the full upstream trace behind any metric or gold table. A relationship the catalog can't vouch for is marked inferred or unknown, not presented as fact."
+    />
+  );
+
+  const traceNode: TelemetryMetadataNode | null = traceId ? nodeMap.get(traceId) ?? null : null;
+
+  if (error && !graph) {
+    return <>{heading}<TelemetryStatusBanner tone="error">Metadata catalog unavailable — {error}.</TelemetryStatusBanner></>;
+  }
+  if (!graph) return <>{heading}<Loading label="Loading relationships…" /></>;
+
+  return (
+    <>
+      {heading}
+
+      <TelemetryStatusBanner tone="info">
+        Join-safety classification (safe · bridge-required · blocked) and recommended bridge paths are
+        next-phase work. Today this surface shows declared relationships and the catalog&rsquo;s confidence
+        in each — not a safety verdict.
+      </TelemetryStatusBanner>
+
+      <StatGrid cols={4} style={{ marginTop: 16 }}>
+        <MetricCard label="Relationships" value={graph.edges.length} sub="typed edges" />
+        <MetricCard label="Explicit" value={byConfidence.explicit} sub="cataloged & confirmed" accent={C.green} />
+        <MetricCard label="Inferred" value={byConfidence.inferred} sub="derived, lower confidence" accent={byConfidence.inferred ? C.amber : undefined} />
+        <MetricCard label="Unknown" value={byConfidence.unknown} sub="confidence not established" accent={byConfidence.unknown ? C.amber : undefined} />
+      </StatGrid>
+
+      <TelemetrySection label="Declared relationships">
+        {graph.edges.length === 0 ? (
+          <EmptyState label="No relationships cataloged" hint="The metadata catalog returned no edges for this scope." />
+        ) : (
+          <Panel pad={0}>
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              {graph.edges.map((edge) => {
+                const src = nodeMap.get(edge.source);
+                const tgt = nodeMap.get(edge.target);
+                return (
+                  <div key={edge.id} style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap", padding: "11px 16px", borderBottom: `1px solid ${C.border}` }}>
+                    <span style={{ fontFamily: C.mono, fontSize: 12, color: C.text }}>{src?.label ?? edge.source}</span>
+                    <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontFamily: C.mono, fontSize: 10, color: C.faint, textTransform: "uppercase", letterSpacing: "0.06em" }}>
+                      <svg width="14" height="9" viewBox="0 0 14 9" aria-hidden><path d="M1 4.5h11M9 1.5l3 3-3 3" stroke={C.faint} strokeWidth="1.1" fill="none" strokeLinecap="round" /></svg>
+                      {humanize(edge.relationship)}
+                    </span>
+                    <span style={{ fontFamily: C.mono, fontSize: 12, color: C.text }}>{tgt?.label ?? edge.target}</span>
+                    <span style={{ marginLeft: "auto" }}>
+                      <Tag color={confidenceColor(edge.confidence)}>{edge.confidence}</Tag>
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </Panel>
+        )}
+      </TelemetrySection>
+
+      <TelemetrySection label="Trace lineage">
+        <Panel>
+          <p style={{ fontFamily: C.sans, fontSize: 13, color: C.dim, lineHeight: 1.55, marginBottom: 12 }}>
+            Pick a metric or gold table to see its complete upstream chain — source → bronze → silver → gold →
+            metric — with freshness at every hop. Nodes with no cataloged source fail closed.
+          </p>
+          {traceable.length === 0 ? (
+            <EmptyState label="Nothing traceable yet" hint="No metrics or gold tables are cataloged for this scope." />
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+              {traceable.map((n) => (
+                <button
+                  key={n.id}
+                  type="button"
+                  onClick={() => setTraceId(n.id)}
+                  style={{ display: "inline-flex", alignItems: "center", gap: 7, cursor: "pointer", fontFamily: C.mono, fontSize: 11, color: C.text, background: C.panelHi, border: `1px solid ${C.borderHi}`, borderRadius: 7, padding: "7px 11px" }}
+                >
+                  <StatusDot color={n.status === "fresh" ? C.green : n.status === "missing" ? C.red : C.amber} size={6} />
+                  {n.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </Panel>
+      </TelemetrySection>
+
+      <LineageDrawer
+        node={traceNode}
+        nodes={graph.nodes}
+        edges={graph.edges}
+        generatedAt={graph.generated_at}
+        onClose={() => setTraceId(null)}
+      />
+    </>
+  );
+}

--- a/repo-b/src/components/telemetry/data-engineering/RunAutopsy.tsx
+++ b/repo-b/src/components/telemetry/data-engineering/RunAutopsy.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  TELEMETRY_DEMO_BUSINESS_ID,
+  TELEMETRY_DEMO_ENV_ID,
+} from "@/lib/telemetry/api";
+import {
+  getGovernanceStats,
+  getReceipts,
+  type GovernanceStatsResponse,
+  type ReceiptsResponse,
+} from "@/lib/automated-data-engineering/api";
+import {
+  C,
+  EmptyState,
+  InlineCode,
+  Loading,
+  MetricCard,
+  PageHeading,
+  Panel,
+  ScrollTable,
+  StatGrid,
+  Tag,
+  TelemetrySection,
+  TelemetryStatusBanner,
+} from "../primitives";
+
+// Run Autopsy — the "inspect" mode. After-the-fact view of what the fabric actually did: governed
+// AI-decision aggregates (/api/ade/governance-stats) and execution receipts (/api/ade/runs), both real
+// and tenant-scoped. NO-GO: never seed or backfill receipts. If empty, show the honest empty state and
+// name the action that would create the first one. null_reason is rendered verbatim.
+
+function fmtTime(value?: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  return Number.isNaN(d.valueOf()) ? value : d.toLocaleString();
+}
+
+function statusColor(status: string): string {
+  const s = status.toLowerCase();
+  if (s === "ok" || s === "success" || s === "succeeded") return C.green;
+  if (s === "error" || s === "failed" || s === "refused" || s === "blocked") return C.red;
+  return C.amber;
+}
+
+export default function RunAutopsy({ envId }: { envId: string }) {
+  void envId;
+  const [receipts, setReceipts] = useState<ReceiptsResponse | null>(null);
+  const [gov, setGov] = useState<GovernanceStatsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    getReceipts(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID)
+      .then((r) => { if (live) setReceipts(r); })
+      .catch((e) => { if (live) setError(e instanceof Error ? e.message : String(e)); });
+    getGovernanceStats(TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID)
+      .then((g) => { if (live) setGov(g); })
+      .catch(() => {});
+    return () => { live = false; };
+  }, []);
+
+  const heading = (
+    <PageHeading
+      eyebrow="Mode · Run Autopsy"
+      title="Run Autopsy"
+      blurb="What ran, what it cost, what it refused, and the receipt that proves it. Failures and refusals are surfaced here, not hidden — an empty trail is shown as empty, never padded with examples."
+    />
+  );
+
+  if (error && !receipts) {
+    return <>{heading}<TelemetryStatusBanner tone="error">Audit read path unavailable — {error}.</TelemetryStatusBanner></>;
+  }
+  if (!receipts) return <>{heading}<Loading label="Reading audit trail…" /></>;
+
+  return (
+    <>
+      {heading}
+
+      {/* Governance aggregate — honest nulls when nothing is logged. */}
+      <TelemetrySection label="Governance (30-day window)">
+        {gov == null ? (
+          <Loading label="Loading governance stats…" />
+        ) : gov.null_reason ? (
+          <EmptyState label="Governance stats unavailable" hint={`null_reason: ${gov.null_reason}`} />
+        ) : (
+          <StatGrid cols={4}>
+            <MetricCard label="AI decisions" value={gov.total_decisions} sub={`${gov.successful} ok · ${gov.failed} failed`} />
+            <MetricCard
+              label="Success rate"
+              value={gov.success_rate != null ? `${Math.round(gov.success_rate * 100)}%` : "—"}
+              sub={gov.success_rate != null ? "of logged decisions" : "no decisions logged"}
+              accent={gov.success_rate != null && gov.success_rate >= 0.9 ? C.green : undefined}
+            />
+            <MetricCard
+              label="Avg grounding"
+              value={gov.avg_grounding_score != null ? gov.avg_grounding_score.toFixed(2) : "—"}
+              sub={`${gov.high_grounding} high · ${gov.low_grounding} low`}
+            />
+            <MetricCard label="Top tool" value={gov.top_tools[0]?.tool_name ?? "—"} sub={gov.top_tools[0] ? `${gov.top_tools[0].call_count} calls` : "no tool calls logged"} />
+          </StatGrid>
+        )}
+      </TelemetrySection>
+
+      {/* Execution receipts — fail-closed, no seeding. */}
+      <TelemetrySection
+        label="Execution receipts"
+        right={<Tag color={C.faint}>{receipts.null_reason ? "unavailable" : `${receipts.runs.length} recorded`}</Tag>}
+      >
+        {receipts.null_reason ? (
+          <EmptyState label="Audit read unavailable" hint={`null_reason: ${receipts.null_reason}`} />
+        ) : receipts.runs.length === 0 ? (
+          <EmptyState
+            label="No receipts yet"
+            hint="The audit read path responded but no governed executions are recorded for this scope. Run a governed MCP tool from the Agent Workbench to record the first receipt — none are seeded or fabricated here."
+          />
+        ) : (
+          <Panel pad={0}>
+            <ScrollTable minWidth={720}>
+              <table style={{ width: "100%", borderCollapse: "collapse" }}>
+                <thead>
+                  <tr>
+                    {["Tool", "Status", "Permission", "Latency", "Actor", "When"].map((h) => (
+                      <th key={h} style={{ textAlign: "left", padding: "10px 14px", fontFamily: C.mono, fontSize: 9, letterSpacing: "0.1em", textTransform: "uppercase", color: C.faint, borderBottom: `1px solid ${C.border}` }}>{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {receipts.runs.map((r, i) => (
+                    <tr key={`${r.tool_name}-${i}`} style={{ borderBottom: `1px solid ${C.border}` }}>
+                      <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 12, color: C.text }}>{r.tool_name}</td>
+                      <td style={{ padding: "10px 14px" }}><Tag color={statusColor(r.status)}>{r.status}</Tag></td>
+                      <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: C.dim }}>{r.permission_mode}</td>
+                      <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: C.dim }}>{r.latency_ms != null ? `${r.latency_ms} ms` : "—"}</td>
+                      <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: C.dim }}>{r.actor ?? "—"}</td>
+                      <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: C.dim }}>{fmtTime(r.created_at)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </ScrollTable>
+          </Panel>
+        )}
+      </TelemetrySection>
+
+      <div style={{ marginTop: 14 }}>
+        <InlineCode color={C.faint}>
+          Source: app.audit_events (receipts) + ai_decision_audit_log (governance), tenant-scoped. Read-only.
+        </InlineCode>
+      </div>
+    </>
+  );
+}

--- a/repo-b/src/components/telemetry/data-engineering/SourcePlatformMap.tsx
+++ b/repo-b/src/components/telemetry/data-engineering/SourcePlatformMap.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  getConnectorLifecycle,
+  type ConnectorLifecycleResponse,
+  type ConnectorLifecycleRow,
+} from "@/lib/automated-data-engineering/api";
+import {
+  C,
+  EmptyState,
+  InlineCode,
+  Loading,
+  PageHeading,
+  Panel,
+  StatusDot,
+  Tag,
+  TelemetryStatusBanner,
+} from "../primitives";
+
+// Source & Platform Map — the providers the fabric knows about, what ROLE each plays, and its declared
+// status + derived lifecycle state. Reuses /api/ade/connector-lifecycle (declared inventory + real
+// read-only validators). No fake validation: a provider only reads "read-validated" when a validator
+// actually ran; everything else shows its declared floor and the reason.
+
+// One-line role per provider — explains WHY it's in the fabric, not just its status.
+function roleFor(provider: string): string {
+  const p = provider.toLowerCase();
+  if (p.includes("kafka") || p.includes("confluent")) return "Streaming telemetry ingestion";
+  if (p.includes("supabase") || p.includes("postgres")) return "Serving · audit · metadata store";
+  if (p.includes("databricks")) return "Model training · feature engineering · notebooks";
+  if (p.includes("github")) return "Pull requests · evidence";
+  if (p.includes("azure devops") || p.includes("devops")) return "Ticket / work-item intake";
+  if (p.includes("vercel")) return "Frontend app hosting";
+  if (p.includes("railway")) return "Backend service hosting";
+  if (p.includes("bigquery") || p.includes("google cloud")) return "Warehouse export target";
+  if (p.includes("openai") || p.includes("claude") || p.includes("gemma") || p.includes("model provider")) return "AI model runtime";
+  if (p.includes("microsoft graph") || p.includes("outlook")) return "Email / calendar sync";
+  if (p.includes("git ")) return "Local repository tools";
+  return "Platform connector";
+}
+
+function statusColor(status: string): string {
+  if (status === "live") return C.green;
+  if (status === "script") return C.amber;
+  if (status === "stub") return C.cyan;
+  return C.red; // missing
+}
+
+function stateColor(state: string): string {
+  if (state === "read_validated") return C.green;
+  if (state === "credential_pending" || state === "validating") return C.cyan;
+  if (state === "degraded") return C.amber;
+  if (state === "blocked") return C.red;
+  if (state === "retired") return C.faint;
+  return C.dim; // declared, discovered
+}
+
+function ConnectorCard({ row }: { row: ConnectorLifecycleRow }) {
+  return (
+    <Panel pad={15}>
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 10 }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontFamily: C.sans, fontSize: 15, fontWeight: 600, color: C.text }}>{row.provider}</div>
+          <div style={{ fontFamily: C.mono, fontSize: 11, color: C.cyan, marginTop: 4 }}>{roleFor(row.provider)}</div>
+        </div>
+        <Tag color={statusColor(row.declared_status)}>{row.declared_status}</Tag>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 12 }}>
+        <StatusDot color={stateColor(row.state)} size={7} />
+        <span style={{ fontFamily: C.mono, fontSize: 11, color: stateColor(row.state) }}>{row.state.replace(/_/g, " ")}</span>
+        <span style={{ marginLeft: "auto" }}><Tag color={C.faint}>risk · {row.risk_tier}</Tag></span>
+      </div>
+
+      {row.receipt ? (
+        <div style={{ marginTop: 10, fontFamily: C.mono, fontSize: 11, color: row.receipt.outcome === "ok" ? C.green : C.amber, lineHeight: 1.5 }}>
+          {row.receipt.outcome === "ok" ? "✓ " : "• "}{row.receipt.detail ?? row.receipt.outcome}
+          {row.receipt.checked && <div style={{ color: C.faint, fontSize: 10, marginTop: 3 }}>{row.receipt.checked}</div>}
+        </div>
+      ) : row.null_reason ? (
+        <div style={{ marginTop: 10, fontFamily: C.mono, fontSize: 11, color: C.dim }}>
+          Not validated — {row.null_reason}
+        </div>
+      ) : null}
+
+      <div style={{ marginTop: 12, fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.5 }}>
+        mode · {row.mode}
+      </div>
+      <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.dim, lineHeight: 1.5, marginTop: 5 }}>{row.reason}</div>
+      {row.evidence_path && (
+        <div style={{ marginTop: 8 }}>
+          <InlineCode color={C.faint}>evidence: {row.evidence_path}</InlineCode>
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+export default function SourcePlatformMap({ envId }: { envId: string }) {
+  void envId;
+  const [data, setData] = useState<ConnectorLifecycleResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    getConnectorLifecycle(true)
+      .then((d) => { if (live) setData(d); })
+      .catch((e) => { if (live) setError(e instanceof Error ? e.message : String(e)); });
+    return () => { live = false; };
+  }, []);
+
+  const heading = (
+    <PageHeading
+      eyebrow="Inventory · Source & Platform"
+      title="Source & Platform Map"
+      blurb="Every source and platform the fabric depends on, with the role it plays and its declared status. A safe read-only validator may promote a connector to read-validated; connectors with no validator stay at their declared floor and say why. No provider is written to."
+    />
+  );
+
+  if (error && !data) {
+    return <>{heading}<TelemetryStatusBanner tone="error">Connector inventory unavailable — {error}.</TelemetryStatusBanner></>;
+  }
+  if (!data) return <>{heading}<Loading label="Loading source & platform map…" /></>;
+  if (data.null_reason) {
+    return <>{heading}<EmptyState label="Connector inventory unavailable" hint={`null_reason: ${data.null_reason}`} /></>;
+  }
+
+  return (
+    <>
+      {heading}
+      <TelemetryStatusBanner tone="info">
+        Status is declared (live · script · stub · missing); lifecycle state is derived read-only.
+        Read-validated means a safe validator actually ran — not an inference from configuration.
+      </TelemetryStatusBanner>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3" style={{ marginTop: 16 }}>
+        {data.connectors.map((row) => (
+          <ConnectorCard key={row.provider} row={row} />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/repo-b/src/components/telemetry/telemetryNav.test.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.test.ts
@@ -5,8 +5,8 @@ import {
   telemetryHref,
 } from "./telemetryNav";
 
-describe("telemetry navigation structure (6-section redesign)", () => {
-  it("exposes exactly the six redesign sections in order", () => {
+describe("telemetry navigation structure (6-section redesign + Data Engineering)", () => {
+  it("exposes the redesign sections in order, with Data Engineering last", () => {
     expect(TELEMETRY_NAV_GROUPS).toEqual([
       "Overview",
       "Operations",
@@ -14,10 +14,11 @@ describe("telemetry navigation structure (6-section redesign)", () => {
       "Factory & Quality",
       "Evidence & Lineage",
       "Agent Operations",
+      "Data Engineering",
     ]);
   });
 
-  it("assigns every nav item to one of the six declared groups", () => {
+  it("assigns every nav item to one of the declared groups", () => {
     for (const item of TELEMETRY_NAV) {
       expect(TELEMETRY_NAV_GROUPS).toContain(item.group);
     }
@@ -31,6 +32,13 @@ describe("telemetry navigation structure (6-section redesign)", () => {
         "calibration",
         "control-tower",
         "copilot",
+        "data-engineering",
+        "data-engineering/autopsy",
+        "data-engineering/grain",
+        "data-engineering/pipelines",
+        "data-engineering/relationships",
+        "data-engineering/sources",
+        "data-engineering/workbench",
         "evidence",
         "factory",
         "factory-ml",
@@ -76,6 +84,32 @@ describe("telemetry navigation structure (6-section redesign)", () => {
         "/lab/env/env-1/telemetry/metadata",
         "env-1",
         "metadata",
+      ),
+    ).toBe(true);
+  });
+
+  it("registers the seven Data Engineering items under their group", () => {
+    const slugs = TELEMETRY_NAV.filter((n) => n.group === "Data Engineering").map((n) => n.slug);
+    expect(slugs).toEqual([
+      "data-engineering",
+      "data-engineering/grain",
+      "data-engineering/relationships",
+      "data-engineering/pipelines",
+      "data-engineering/workbench",
+      "data-engineering/autopsy",
+      "data-engineering/sources",
+    ]);
+  });
+
+  it("builds and recognizes a nested data-engineering route", () => {
+    expect(telemetryHref("env-1", "data-engineering/grain")).toBe(
+      "/lab/env/env-1/telemetry/data-engineering/grain",
+    );
+    expect(
+      isTelemetryItemActive(
+        "/lab/env/env-1/telemetry/data-engineering/grain",
+        "env-1",
+        "data-engineering/grain",
       ),
     ).toBe(true);
   });

--- a/repo-b/src/components/telemetry/telemetryNav.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.ts
@@ -17,7 +17,8 @@ export type TelemetryNavGroup =
   | "Models & Intelligence"
   | "Factory & Quality"
   | "Evidence & Lineage"
-  | "Agent Operations";
+  | "Agent Operations"
+  | "Data Engineering";
 
 export type TelemetryNavItem = {
   slug: string;
@@ -62,6 +63,18 @@ export const TELEMETRY_NAV: TelemetryNavItem[] = [
 
   // Section 6 — Agent Operations (approved execution)
   { slug: "control-tower", label: "Agent Control Tower", icon: "M8 1l6 3v4c0 3-2.5 5.5-6 7-3.5-1.5-6-4-6-7V4zM8 5v6M5 8h6", group: "Agent Operations" },
+
+  // Section 7 — Data Engineering (the governed fabric between operational data and trusted AI).
+  // Composed surface: data-semantics pages reuse the telemetry metadata catalog; the agent/governance
+  // pages read the portable ADE endpoints (/api/ade/*). Replaces the old standalone
+  // /automated-data-engineering domain route (which now redirects here).
+  { slug: "data-engineering", label: "Data Engineering", icon: "M3 3h4v4H3zM9 9h4v4H9zM7 5h2M5 7v2M11 7V5M9 11H7", group: "Data Engineering" },
+  { slug: "data-engineering/grain", label: "Data Map & Grain", icon: "M2 3h12v3H2zM2 8h12v3H2zM2 13h7v1H2z", group: "Data Engineering" },
+  { slug: "data-engineering/relationships", label: "Relationships & Lineage", icon: "M4 2v12M4 6h6M4 11h5M10 4v4M9 9v3", group: "Data Engineering" },
+  { slug: "data-engineering/pipelines", label: "Pipelines & Quality", icon: "M2 8h3l2-4 2 8 2-4h3", group: "Data Engineering" },
+  { slug: "data-engineering/workbench", label: "Agent Workbench", icon: "M8 1l2 4 4 1-3 3 1 4-4-2-4 2 1-4-3-3 4-1z", group: "Data Engineering" },
+  { slug: "data-engineering/autopsy", label: "Run Autopsy", icon: "M3 2h8l2 2v10H3zM5 6h6M5 9h6M5 12h4", group: "Data Engineering" },
+  { slug: "data-engineering/sources", label: "Source & Platform Map", icon: "M3 3h4v4H3zM9 3h4v4H9zM3 9h4v4H3zM9 9h4v4H9z", group: "Data Engineering" },
 ];
 
 export const TELEMETRY_NAV_GROUPS: TelemetryNavGroup[] = [
@@ -71,6 +84,7 @@ export const TELEMETRY_NAV_GROUPS: TelemetryNavGroup[] = [
   "Factory & Quality",
   "Evidence & Lineage",
   "Agent Operations",
+  "Data Engineering",
 ];
 
 export function telemetryHref(envId: string, slug: string): string {


### PR DESCRIPTION
## Why
The "Automated Data Engineering" page read like its own environment (own left rail) and presented a generic tool/connector/receipt inventory rather than *data engineering*. This reframes it into a governed **Data Engineering** section inside the telemetry sidebar, with two clearly-named modes: **Agent Workbench** (observe / propose / execute-with-guardrails) and **Run Autopsy** (receipts, governance, refusals).

Phase 1 = information-architecture + product framing. It re-presents data that already exists and re-routes existing endpoints — no new backends, validators, or semantic engines.

## What
- **New telemetry sidebar group** `Data Engineering` → Overview · Data Map & Grain · Relationships & Lineage · Pipelines & Quality · Agent Workbench · Run Autopsy · Source & Platform Map. Renders inside `TelemetryShell` (no second rail).
- **Data-semantics pages reuse the live telemetry metadata catalog** (`getMetadataGraph`) + `MetadataDetailDrawer` / `LineageDrawer`.
- **Agent/governance pages read the portable ADE endpoints** (`/api/ade/*`) with telemetry primitives.
- **Old `/automated-data-engineering/*` routes 307-redirect** into the new homes.

## Honesty / fail-closed (preserved)
- Every `null_reason` verbatim; metadata failure shows a fail-closed banner, not a substitute count.
- **No seeded receipts** — empty Run Autopsy names the action that creates the first one.
- No fake validation; join-safety, the guided scenario, the aerospace skill filter, and a dedicated pipeline/DQ feed are labeled **next-phase**.

## Portability (ADR 0002 honored)
ADE core package untouched & still portable; composition lives in the telemetry package. ADR 0002 gets a composed-mount follow-up note.

## Verification
- `tsc` clean for new/changed files (only stale `.next/types` + pre-existing historyrhymes test errors remain).
- ESLint 0 errors on touched files (inline-style warnings = documented telemetry palette convention).
- Tests green: `telemetryNav` + `DataEngineeringOverview` (render + fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)