### PR TITLE
feat(telemetry): operations consoles → compact page header (0009 Ticket 2)

### DIFF
--- a/repo-b/src/components/telemetry/ControlTower.tsx
+++ b/repo-b/src/components/telemetry/ControlTower.tsx
@@ -9,7 +9,6 @@ import {
   Loading,
   MetricCard,
   Panel,
-  PageHeading,
   SplitGrid,
   StatGrid,
   Tag,
@@ -30,6 +29,7 @@ import {
   verifyReceipt,
   warmGemma,
 } from "@/lib/telemetry/controlTower-api";
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
 
 // Truth label: every panel says where its data comes from. Never imply live execution over a fixture.
 function TruthLabel({ kind }: { kind: "fixture" | "staged" | "live" | "cold" | "unavailable" }) {
@@ -190,11 +190,12 @@ export default function ControlTower() {
 
   return (
     <div style={{ padding: 24, background: C.bg, minHeight: "100%", color: C.text }}>
-      <PageHeading
+      <TelemetryPageHeader
+        variant="compact"
         eyebrow="Telemetry · Go/No-Go"
         title="Agent Control Tower"
-        blurb="Test-telemetry go/no-go with a sensitivity-aware model router, an enforced human approval gate, and a tamper-evident signed decision receipt. Sensitive / ITAR-demo-tagged triage routes only to the in-boundary Gemma private tier (or fails closed) — an ITAR-aware routing posture, not a compliance claim."
-        right={<TruthLabel kind="staged" />}
+        description="Test-telemetry go/no-go with a sensitivity-aware model router, an enforced human approval gate, and a tamper-evident signed decision receipt. Sensitive / ITAR-demo-tagged triage routes only to the in-boundary Gemma private tier (or fails closed) — an ITAR-aware routing posture, not a compliance claim."
+        actions={<TruthLabel kind="staged" />}
       />
 
       {error && <div style={{ marginBottom: 16 }}><ErrorState message={error} /></div>}

--- a/repo-b/src/components/telemetry/MissionControlStream.tsx
+++ b/repo-b/src/components/telemetry/MissionControlStream.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/telemetry/stream";
 import { SplitGrid } from "./primitives";
 import { RS, RS_MONO, RS_SANS, RsChip, RsPanel } from "./rsTokens";
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
 
 const WINDOW_S = 120;
 const MAX_STRIPS = 4;
@@ -166,41 +167,46 @@ export default function MissionControlStream() {
       )}
 
       {/* Header */}
-      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 12, padding: "0 4px 12px" }}>
-        <div>
-          <div style={{ color: RS.faint, fontSize: 11, letterSpacing: "0.18em" }}>TELEMETRY LAB</div>
-          <div style={{ fontSize: 13, letterSpacing: "0.14em" }}>MISSION CONTROL · LIVE STREAM</div>
-        </div>
-        <RsChip color={RS.cyan}>run: iss_live:stream</RsChip>
-        <RsChip color={chip.color}>{chip.label}</RsChip>
-        {champion && <RsChip color={RS.violet}>model: {champion}</RsChip>}
-        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 14 }}>
-          <span style={{ color: RS.dim, fontFamily: RS_MONO, fontSize: 11 }}>
-            ingest lag {lag.ingestLagS != null ? `${lag.ingestLagS.toFixed(1)}s` : "—"}
-            {" · "}client lag {lag.clientLagS != null ? `${lag.clientLagS.toFixed(1)}s` : "—"}
-          </span>
-          <span style={{ color: verdict.color, border: `1px solid ${verdict.color}`,
-            background: `${verdict.color}18`, fontFamily: RS_MONO, fontWeight: 700,
-            padding: "4px 12px", borderRadius: 4, fontSize: 13 }}>
-            {verdict.text}
-          </span>
-          <button type="button" onClick={handleStart} disabled={starting}
-            title="Start (or restart) the live ingest worker on the backend"
-            style={{ fontFamily: RS_MONO, fontSize: 11, fontWeight: 700, padding: "4px 12px",
-              borderRadius: 4, cursor: starting ? "default" : "pointer",
-              color: starting ? RS.faint : RS.bg,
-              background: starting ? "transparent" : RS.green,
-              border: `1px solid ${starting ? RS.line : RS.green}` }}>
-            {starting ? "Starting…" : "Start stream"}
-          </button>
-          <button type="button" onClick={() => setHold((h) => !h)}
-            style={{ fontFamily: RS_MONO, fontSize: 11, padding: "4px 10px", borderRadius: 4,
-              cursor: "pointer", color: hold ? RS.bg : RS.dim,
-              background: hold ? RS.amber : "transparent", border: `1px solid ${RS.line}` }}>
-            {hold ? "Resume" : "Hold"}
-          </button>
-        </div>
-      </div>
+      <TelemetryPageHeader
+        variant="compact"
+        eyebrow="TELEMETRY LAB"
+        title="MISSION CONTROL · LIVE STREAM"
+        metadata={
+          <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 12 }}>
+            <RsChip color={RS.cyan}>run: iss_live:stream</RsChip>
+            <RsChip color={chip.color}>{chip.label}</RsChip>
+            {champion && <RsChip color={RS.violet}>model: {champion}</RsChip>}
+          </div>
+        }
+        actions={
+          <>
+            <span style={{ color: RS.dim, fontFamily: RS_MONO, fontSize: 11 }}>
+              ingest lag {lag.ingestLagS != null ? `${lag.ingestLagS.toFixed(1)}s` : "—"}
+              {" · "}client lag {lag.clientLagS != null ? `${lag.clientLagS.toFixed(1)}s` : "—"}
+            </span>
+            <span style={{ color: verdict.color, border: `1px solid ${verdict.color}`,
+              background: `${verdict.color}18`, fontFamily: RS_MONO, fontWeight: 700,
+              padding: "4px 12px", borderRadius: 4, fontSize: 13 }}>
+              {verdict.text}
+            </span>
+            <button type="button" onClick={handleStart} disabled={starting}
+              title="Start (or restart) the live ingest worker on the backend"
+              style={{ fontFamily: RS_MONO, fontSize: 11, fontWeight: 700, padding: "4px 12px",
+                borderRadius: 4, cursor: starting ? "default" : "pointer",
+                color: starting ? RS.faint : RS.bg,
+                background: starting ? "transparent" : RS.green,
+                border: `1px solid ${starting ? RS.line : RS.green}` }}>
+              {starting ? "Starting…" : "Start stream"}
+            </button>
+            <button type="button" onClick={() => setHold((h) => !h)}
+              style={{ fontFamily: RS_MONO, fontSize: 11, padding: "4px 10px", borderRadius: 4,
+                cursor: "pointer", color: hold ? RS.bg : RS.dim,
+                background: hold ? RS.amber : "transparent", border: `1px solid ${RS.line}` }}>
+              {hold ? "Resume" : "Hold"}
+            </button>
+          </>
+        }
+      />
 
       {startMsg && (
         <div style={{ padding: "0 4px 8px", fontFamily: RS_MONO, fontSize: 11,

--- a/repo-b/src/components/telemetry/ReplayConsole.tsx
+++ b/repo-b/src/components/telemetry/ReplayConsole.tsx
@@ -4,9 +4,10 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { getReplayFeed, type ReplayFeed, type ReplayTick } from "@/lib/telemetry/api";
 import { computeReplayDiagnostics } from "@/lib/telemetry/replayDiagnostics";
 import {
-  C, Panel, Loading, ErrorState, PageHeading, DisclosureFooter, SplitGrid,
+  C, Panel, Loading, ErrorState, DisclosureFooter, SplitGrid,
   Stat, StatGrid, MetricRow, StatusDot, Tag,
 } from "./primitives";
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
 import ReplayForensicsDrawer from "./ReplayForensicsDrawer";
 
 const W = 900, H = 280, PAD = 28;
@@ -58,8 +59,8 @@ export default function ReplayConsole() {
   const diag = useMemo(() => (feed ? computeReplayDiagnostics(feed) : null), [feed]);
 
   const heading = (
-    <PageHeading eyebrow="Replay test feed · NASA SMAP/MSL analog" title="Hot-fire-style replay → automated go/no-go"
-      blurb="Replays a recorded run from the public SMAP/MSL anomaly baseline in accelerated time, framed as a hot-fire-style operational flow. The promoted anomaly model scores each tick; when it detects off-nominal behavior the verdict flips on its own. Nothing here is hand-authored; the flag is the model's output. Open the forensics drawer to inspect the signal, model evidence, verdict policy, operator action, and lineage." />
+    <TelemetryPageHeader variant="compact" eyebrow="Replay test feed · NASA SMAP/MSL analog" title="Hot-fire-style replay → automated go/no-go"
+      description="Replays a recorded run from the public SMAP/MSL anomaly baseline in accelerated time, framed as a hot-fire-style operational flow. The promoted anomaly model scores each tick; when it detects off-nominal behavior the verdict flips on its own. Nothing here is hand-authored; the flag is the model's output. Open the forensics drawer to inspect the signal, model evidence, verdict policy, operator action, and lineage." />
   );
   if (error) return <>{heading}<ErrorState message={error} /></>;
   if (!feed) return <>{heading}<Loading label="Loading replay feed…" /></>;

--- a/repo-b/src/components/telemetry/RunsExplorer.tsx
+++ b/repo-b/src/components/telemetry/RunsExplorer.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react";
 import { getRuns, type TestRun, TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID } from "@/lib/telemetry/api";
-import { C, Tag, Panel, Loading, ErrorState, PageHeading, DisclosureFooter, ResponsiveSwap, RowCard } from "./primitives";
+import { C, Tag, Panel, Loading, ErrorState, DisclosureFooter, ResponsiveSwap, RowCard } from "./primitives";
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
 
 export default function RunsExplorer() {
   const [runs, setRuns] = useState<TestRun[] | null>(null);
@@ -12,8 +13,8 @@ export default function RunsExplorer() {
     getRuns(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID).then(setRuns).catch((e) => setError(String(e)));
   }, []);
 
-  const heading = <PageHeading eyebrow="Test Run Explorer" title="Ingested test runs"
-    blurb="Every run ingested into the lakehouse and exposed to the serving layer: SMAP/MSL anomaly channels (go/no-go) and C-MAPSS RUL units, with dataset, unit/channel, and row counts." />;
+  const heading = <TelemetryPageHeader variant="compact" eyebrow="Test Run Explorer" title="Ingested test runs"
+    description="Every run ingested into the lakehouse and exposed to the serving layer: SMAP/MSL anomaly channels (go/no-go) and C-MAPSS RUL units, with dataset, unit/channel, and row counts." />;
   if (error) return <>{heading}<ErrorState message={error} /></>;
   if (!runs) return <>{heading}<Loading label="Loading test runs…" /></>;
 

--- a/repo-b/src/components/telemetry/SystemHealth.tsx
+++ b/repo-b/src/components/telemetry/SystemHealth.tsx
@@ -5,7 +5,8 @@
 // already real_backend and fail closed; this composes them (embedded, no duplicate chrome) under
 // section dividers. Finer Data/Models/Agents/Infrastructure quadranting + RS polish is a later phase.
 
-import { C, DisclosureFooter, PageHeading } from "./primitives";
+import { C, DisclosureFooter } from "./primitives";
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
 import Monitoring from "./Monitoring";
 import SpikeInspector from "./SpikeInspector";
 
@@ -24,10 +25,11 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 export default function SystemHealth({ envId }: { envId: string }) {
   return (
     <>
-      <PageHeading
+      <TelemetryPageHeader
+        variant="compact"
         eyebrow="Operations"
         title="System Health"
-        blurb="One operational view: data freshness and drift, model serving health, and the analyzer's findings. Real serving reads only — each panel fails closed (a dash or an explicit null_reason), never a fabricated value."
+        description="One operational view: data freshness and drift, model serving health, and the analyzer's findings. Real serving reads only — each panel fails closed (a dash or an explicit null_reason), never a fabricated value."
       />
 
       <SectionLabel>Data &amp; infrastructure — drift, serving, stream health</SectionLabel>

--- a/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
+++ b/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
@@ -7,7 +7,8 @@
 
 import dynamic from "next/dynamic";
 import { useEffect, useMemo, useState } from "react";
-import { C, EmptyState, MetricCard, PageHeading, Panel, RowCard, SplitGrid, Tag } from "../primitives";
+import { C, EmptyState, MetricCard, Panel, RowCard, SplitGrid, Tag } from "../primitives";
+import { TelemetryPageHeader } from "../TelemetryPageHeader";
 import DlqPanel from "./DlqPanel";
 import TempVibrationChart from "./TempVibrationChart";
 import { useStargateStream } from "@/lib/lab/stargateStream";
@@ -97,10 +98,11 @@ export default function StargateConsole() {
   if (!stream.configured) {
     return (
       <div>
-        <PageHeading
+        <TelemetryPageHeader
+          variant="compact"
           eyebrow="Stargate Live"
           title="Printer telemetry stream"
-          blurb="Protobuf telemetry over Kafka, windowed in flight, anomalies routed to their own topic."
+          description="Protobuf telemetry over Kafka, windowed in flight, anomalies routed to their own topic."
         />
         <EmptyState
           label="Stargate bridge URL is not configured for this deployment."
@@ -112,12 +114,13 @@ export default function StargateConsole() {
 
   return (
     <div>
-      <PageHeading
+      <TelemetryPageHeader
+        variant="compact"
         eyebrow="Stargate Live"
         title="Printer telemetry stream"
-        blurb="The live proof of the thesis: historical launch progress created more data than judgment could keep up with. The modern answer is governed streaming + model evidence + lineage + operator-facing actions. This is recorded test-stand capture replayed through real streaming infrastructure — protobuf over Kafka, windowed in flight, anomalies routed to their own topic, ring-buffered in the bridge with no database in the hot path. Recorded capture, not a live printer."
-        right={
-          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", justifyContent: "flex-end" }}>
+        description="The live proof of the thesis: historical launch progress created more data than judgment could keep up with. The modern answer is governed streaming + model evidence + lineage + operator-facing actions. This is recorded test-stand capture replayed through real streaming infrastructure — protobuf over Kafka, windowed in flight, anomalies routed to their own topic, ring-buffered in the bridge with no database in the hot path. Recorded capture, not a live printer."
+        actions={
+          <>
             {startMsg && <span style={{ fontFamily: C.mono, fontSize: 10, color: C.red }}>{startMsg}</span>}
             {isCapture && (
               <button type="button" onClick={startRecordedCapture} disabled={starting}
@@ -131,7 +134,7 @@ export default function StargateConsole() {
             )}
             <Tag color={stream.connected ? C.green : C.red}>{stream.connected ? "stream live" : "reconnecting"}</Tag>
             <Tag color={badge.color}>{badge.label}</Tag>
-          </div>
+          </>
         }
       />
 


### PR DESCRIPTION
**Dispatch 0009, Ticket 2.** Migrates the six operational consoles to `TelemetryPageHeader` variant `compact`: `MissionControlStream`, `ReplayConsole`, `stargate/StargateConsole`, `RunsExplorer`, `SystemHealth`, `ControlTower`.

- Header copy preserved **byte-identical**; live controls/chips/lag/verdict moved into the header `actions` slot and status/source strips into `metadata` (verbatim — onClick/disabled/live state preserved).
- SystemHealth's embedded Monitoring/Spike sections stay headerless.
- Bodies, charts, SSE/stream, fail-closed states, predicate `temp<1400°C ∧ vib>0.08g`, and capture-honesty copy unchanged.

### Verification
`tsc` clean · `next lint` clean · `vitest` 32 files / 128 tests pass · **screenshots** of Stargate + Mission Control reviewed — compact headers, actions/metadata intact, no body change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)