### PR TITLE
feat(telemetry): models & factory consoles → standard page header (0009 Ticket 3)

### DIFF
--- a/repo-b/src/components/telemetry/Copilot.tsx
+++ b/repo-b/src/components/telemetry/Copilot.tsx
@@ -7,6 +7,7 @@ import {
   type DraftReportResponse, type DispositionResult,
 } from "@/lib/telemetry/copilot-api";
 import { C, Tag, Panel, Loading } from "./primitives";
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
 
 export interface ReportContext { runKey: string; fireTick: number; channel?: string }
 
@@ -414,16 +415,19 @@ export function CopilotWorkbench({ envId }: { envId: string }) {
 
   return (
     <>
-      <div style={{ marginBottom: 18 }}>
-        <div style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.14em", color: C.cyan, textTransform: "uppercase" }}>Test Intelligence</div>
-        <h1 style={{ fontFamily: C.sans, fontSize: 24, fontWeight: 700, color: C.text, margin: "6px 0 0" }}>Test Intelligence Copilot</h1>
-        <p style={{ fontFamily: C.sans, fontSize: 13.5, color: C.dim, lineHeight: 1.55, marginTop: 8, maxWidth: 760 }}>
-          Grounded AI analysis over telemetry runs, model outputs, prediction receipts, and monitoring
-          evidence. Not an open-ended chatbot — a fixed set of supported questions, answered only from
-          recorded platform evidence, with refusals enforced before the model is called. Public NASA
-          aerospace analog data. Answers are draft analysis for human review.
-        </p>
-      </div>
+      <TelemetryPageHeader
+        variant="standard"
+        eyebrow="Test Intelligence"
+        title="Test Intelligence Copilot"
+        description={
+          <>
+            Grounded AI analysis over telemetry runs, model outputs, prediction receipts, and monitoring
+            evidence. Not an open-ended chatbot — a fixed set of supported questions, answered only from
+            recorded platform evidence, with refusals enforced before the model is called. Public NASA
+            aerospace analog data. Answers are draft analysis for human review.
+          </>
+        }
+      />
 
       <Panel title="Ask about this run" right={<Tag color={C.cyan}>run smap_msl:D-4:test</Tag>}>
         <div style={{ display: "flex", gap: 8 }}>

--- a/repo-b/src/components/telemetry/FactoryNcrIntelligence.tsx
+++ b/repo-b/src/components/telemetry/FactoryNcrIntelligence.tsx
@@ -14,6 +14,7 @@ import {
 
 import { SplitGrid, StatGrid } from "./primitives";
 import { RS, RS_MONO, RS_SANS, RsPanel, RsChip, RsKpi } from "./rsTokens";
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
 import {
   getNcr, TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID,
   type NcrResponse, type NcrCluster, type NcrBacklogRow,
@@ -166,24 +167,28 @@ export default function FactoryNcrIntelligence() {
     <div style={{ minHeight: "100vh", width: "100%", padding: 12, background: RS.bg,
       fontFamily: RS_SANS, color: RS.text }}>
       {/* header */}
-      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 12,
-        padding: "0 4px 12px" }}>
-        <div>
-          <div style={{ color: RS.faint, fontSize: 11, letterSpacing: "0.18em" }}>TELEMETRY LAB</div>
-          <div style={{ fontSize: 13, letterSpacing: "0.14em" }}>FACTORY · NCR INTELLIGENCE</div>
-        </div>
-        <RsChip color={RS.cyan}>pipeline: embed → UMAP → HDBSCAN → c-TF-IDF</RsChip>
-        {prov && (
-          <RsChip color={isDatabricks ? RS.green : RS.amber}>
-            {isDatabricks
-              ? `DATABRICKS · mlflow ${(prov.cluster_mlflow_run_id ?? "").slice(0, 8)}`
-              : "LOCAL FALLBACK — not a Databricks run"}
-          </RsChip>
-        )}
-        <div style={{ marginLeft: "auto", color: RS.faint, fontFamily: RS_MONO, fontSize: 11 }}>
-          window: 16-week corpus · batch pipeline mirror (not live)
-        </div>
-      </div>
+      <TelemetryPageHeader
+        variant="standard"
+        eyebrow="TELEMETRY LAB"
+        title="FACTORY · NCR INTELLIGENCE"
+        actions={
+          <>
+            <RsChip color={RS.cyan}>pipeline: embed → UMAP → HDBSCAN → c-TF-IDF</RsChip>
+            {prov && (
+              <RsChip color={isDatabricks ? RS.green : RS.amber}>
+                {isDatabricks
+                  ? `DATABRICKS · mlflow ${(prov.cluster_mlflow_run_id ?? "").slice(0, 8)}`
+                  : "LOCAL FALLBACK — not a Databricks run"}
+              </RsChip>
+            )}
+          </>
+        }
+        metadata={
+          <div style={{ color: RS.faint, fontFamily: RS_MONO, fontSize: 11 }}>
+            window: 16-week corpus · batch pipeline mirror (not live)
+          </div>
+        }
+      />
 
       {/* KPI tiles — all real derivations; absent values say so */}
       <StatGrid cols={4} style={{ paddingBottom: 12 }}>

--- a/repo-b/src/components/telemetry/ModelPerformance.tsx
+++ b/repo-b/src/components/telemetry/ModelPerformance.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import {
   getModelPerformance, type ModelRun, TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID,
 } from "@/lib/telemetry/api";
-import { C, Tag, Panel, Loading, ErrorState, PageHeading, DisclosureFooter, ScrollTable } from "./primitives";
+import { C, Tag, Panel, Loading, ErrorState, DisclosureFooter, ScrollTable } from "./primitives";
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
 
 function metric(m: ModelRun, k: string): string {
   const v = (m.metrics || {})[k];
@@ -90,8 +91,8 @@ export default function ModelPerformance() {
       .catch((e) => setError(String(e)));
   }, []);
 
-  const heading = <PageHeading eyebrow="Model Performance" title="Champions, metrics, and promotion gates"
-    blurb="Exact metrics from the registry-backed serving API, no hardcoded numbers. Baseline vs stronger model side by side, with the promotion decision shown honestly." />;
+  const heading = <TelemetryPageHeader variant="standard" eyebrow="Model Performance" title="Champions, metrics, and promotion gates"
+    description="Exact metrics from the registry-backed serving API, no hardcoded numbers. Baseline vs stronger model side by side, with the promotion decision shown honestly." />;
   if (error) return <>{heading}<ErrorState message={error} /></>;
   if (!models) return <>{heading}<Loading label="Loading model metrics…" /></>;
   if (nullReason) return <>{heading}<ErrorState message={nullReason} /></>;

--- a/repo-b/src/components/telemetry/RegistryConsole.tsx
+++ b/repo-b/src/components/telemetry/RegistryConsole.tsx
@@ -12,6 +12,7 @@ import {
   TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID,
 } from "@/lib/telemetry/api";
 import { RS, RS_MONO, RS_SANS, RsChip, RsPanel } from "./rsTokens";
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
 
 const PSI_WARN = 0.15;
 
@@ -184,17 +185,22 @@ export default function RegistryConsole() {
   return (
     <div style={{ minHeight: "100vh", width: "100%", padding: 12, background: RS.bg,
       fontFamily: RS_SANS, color: RS.text }}>
-      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 12, padding: "0 4px 12px" }}>
-        <div>
-          <div style={{ color: RS.faint, fontSize: 11, letterSpacing: "0.18em" }}>TELEMETRY LAB</div>
-          <div style={{ fontSize: 13, letterSpacing: "0.14em" }}>MODEL REGISTRY · PROMOTION CONTROL</div>
-        </div>
-        <RsChip color={RS.cyan}>registry: unity_catalog · novendor_1.telemetry</RsChip>
-        <RsChip color={RS.teal}>aliases: champion / challenger</RsChip>
-        <div style={{ marginLeft: "auto", fontFamily: RS_MONO, fontSize: 11, color: RS.faint }}>
-          promotion = alias update · fail closed · display-only console
-        </div>
-      </div>
+      <TelemetryPageHeader
+        variant="standard"
+        eyebrow="TELEMETRY LAB"
+        title="MODEL REGISTRY · PROMOTION CONTROL"
+        actions={
+          <>
+            <RsChip color={RS.cyan}>registry: unity_catalog · novendor_1.telemetry</RsChip>
+            <RsChip color={RS.teal}>aliases: champion / challenger</RsChip>
+          </>
+        }
+        metadata={
+          <div style={{ fontFamily: RS_MONO, fontSize: 11, color: RS.faint }}>
+            promotion = alias update · fail closed · display-only console
+          </div>
+        }
+      />
 
       {error && (
         <RsPanel><div style={{ padding: 16, fontFamily: RS_MONO, fontSize: 12, color: RS.red }}>

--- a/repo-b/src/components/telemetry/RulCalibration.tsx
+++ b/repo-b/src/components/telemetry/RulCalibration.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { C, Tag, Panel, MetricCard, StatGrid, SplitGrid, PageHeading, DisclosureFooter } from "./primitives";
+import { C, Tag, Panel, MetricCard, StatGrid, SplitGrid, DisclosureFooter } from "./primitives";
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
 import {
   CALIBRATION_EVIDENCE as E,
   CALIBRATION_TRAJECTORY as TRAJ,
@@ -86,11 +87,12 @@ export default function RulCalibration() {
 
   return (
     <div style={{ maxWidth: 1180, margin: "0 auto" }}>
-      <PageHeading
+      <TelemetryPageHeader
+        variant="standard"
         eyebrow="Telemetry · Calibration"
         title="RUL Calibration"
-        blurb="CNN-LSTM FD001 champion with split-conformal uncertainty intervals. For one engine trajectory: how predicted RUL evolves toward failure, how wide the calibrated 80% and 90% intervals are, and where a late prediction would have been dangerous."
-        right={
+        description="CNN-LSTM FD001 champion with split-conformal uncertainty intervals. For one engine trajectory: how predicted RUL evolves toward failure, how wide the calibrated 80% and 90% intervals are, and where a late prediction would have been dangerous."
+        actions={
           <div style={{ display: "flex", gap: 6, flexWrap: "wrap", justifyContent: "flex-end" }}>
             <Tag color={C.green}>Champion: CNN-LSTM</Tag>
             <Tag color={C.green}>Gate: Passed</Tag>

--- a/repo-b/src/components/telemetry/factory-ml/FactoryMlConsole.tsx
+++ b/repo-b/src/components/telemetry/factory-ml/FactoryMlConsole.tsx
@@ -5,7 +5,8 @@
 // provenance footer pinning every number to a seed build sha and run id.
 
 import { useState } from "react";
-import { C, EmptyState, Loading, PageHeading, Panel, Tag } from "../primitives";
+import { C, EmptyState, Loading, Panel, Tag } from "../primitives";
+import { TelemetryPageHeader } from "../TelemetryPageHeader";
 import FeatureImportancePanel from "./FeatureImportancePanel";
 import LayerHeatmap from "./LayerHeatmap";
 import NcrPanel from "./NcrPanel";
@@ -31,11 +32,12 @@ export default function FactoryMlConsole() {
 
   return (
     <div>
-      <PageHeading
+      <TelemetryPageHeader
+        variant="standard"
         eyebrow="Factory ML"
         title="Flight-readiness analytics"
-        blurb="Databricks medallion over the deterministic factory seed: bronze landings reconciled to the build manifest, window features along the layer axis, a gold feature store joined to QMS outcomes, and XGBoost models tracked in MLflow. Served as committed exports — every number is reviewable."
-        right={data.metadata && (
+        description="Databricks medallion over the deterministic factory seed: bronze landings reconciled to the build manifest, window features along the layer axis, a gold feature store joined to QMS outcomes, and XGBoost models tracked in MLflow. Served as committed exports — every number is reviewable."
+        actions={data.metadata && (
           <Tag color={C.cyan}>build {data.metadata.seed_build_sha.slice(0, 10)}</Tag>
         )}
       />


### PR DESCRIPTION
**Dispatch 0009, Ticket 3.** Migrates `ModelPerformance`, `RulCalibration`, `RegistryConsole`, `Copilot`, `FactoryNcrIntelligence`, `factory-ml/FactoryMlConsole` to `TelemetryPageHeader` variant `standard`.

- Header copy **byte-identical**; top-strip controls/chips/metrics-summaries → `actions`, source/status lines → `metadata`.
- RS consoles (Registry, Factory/NCR) keep their RS bodies, charts, cluster drawers, and honesty copy ("promotion = alias update · fail closed", "batch pipeline mirror (not live)", synthetic-deterministic, "committed JSON, not a live Databricks query", honest-F1 dual labels) **unchanged**.

### Verification
`tsc` clean · `next lint` clean · `vitest` 33 files / 132 tests · **screenshots** of Registry + Factory/NCR reviewed — standard header leads, slots intact, RS bodies preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)