### PR TITLE
feat(telemetry): make Factory ML a drillable evidence surface

### DIFF
--- a/repo-b/.env.example
+++ b/repo-b/.env.example
@@ -17,3 +17,11 @@ ENV_INVITE_CODE=env-change-me
 # AI Gateway (OpenAI Chat Completions + RAG)
 # Set OPENAI_API_KEY on the backend (Railway/Render) — NOT in frontend env.
 # The frontend proxies /api/ai/gateway/* to the backend.
+
+# Factory ML evidence drawer — Databricks/MLflow deep links.
+# Optional override. When unset, links resolve to the committed demo workspace
+# default in src/lib/lab/factoryEvidenceLinks.ts (the owner's own workspace).
+# Set this to point the "Open in Databricks / MLflow" actions at a different
+# workspace; if blank AND the default is cleared, the actions render
+# disabled-with-reason instead of producing a fake link.
+# NEXT_PUBLIC_DATABRICKS_WORKSPACE_URL=https://dbc-xxxxxxxx.cloud.databricks.com

--- a/repo-b/src/components/telemetry/factory-ml/FactoryEvidenceDrawer.test.tsx
+++ b/repo-b/src/components/telemetry/factory-ml/FactoryEvidenceDrawer.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import FactoryEvidenceDrawer from "./FactoryEvidenceDrawer";
+import type { DrillObject } from "./factoryDrill";
+import type { RegistryModel, RegistryVersion } from "@/lib/lab/factoryMlData";
+
+function show(drill: DrillObject) {
+  return render(<FactoryEvidenceDrawer drill={drill} onClose={() => {}} />);
+}
+
+describe("FactoryEvidenceDrawer", () => {
+  it("renders nothing when drill is null", () => {
+    render(<FactoryEvidenceDrawer drill={null} onClose={() => {}} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("shows an honest weak-metric interpretation for near-random AUC", () => {
+    show({ kind: "model_metric", metricKey: "mean_xgbclf_auc", value: 0.5148 });
+    expect(screen.getByText(/near-random ranking signal/i)).toBeTruthy();
+    expect(screen.getByText(/Deterministic synthetic eval for demo; not a trained artifact\./)).toBeTruthy();
+    expect(screen.getByText(/Informational only/i)).toBeTruthy();
+  });
+
+  it("renders an inferred feature definition with a units-unknown marker", () => {
+    show({ kind: "feature", feature: "temperature_p2p_drift_max", impact: 0.33, modelKey: "passfail", method: "shap_tree_explainer", runId: "run123" });
+    expect(screen.getByText(/peak-to-peak drift/i)).toBeTruthy();
+    expect(screen.getByText(/units unknown/i)).toBeTruthy();
+  });
+
+  it("renders Unavailable for a feature with no catalog entry", () => {
+    show({ kind: "feature", feature: "mystery_feature", impact: 0.1, modelKey: "passfail" });
+    expect(screen.getByText(/no definition for this feature name/i)).toBeTruthy();
+  });
+
+  it("shows a live MLflow run deep link by default", () => {
+    show({
+      kind: "mlflow_run",
+      runId: "9c25866d78184746a2a0ae28526009bf",
+      experiment: "/Users/x/RSFactoryML",
+      registeredModels: ["novendor_1.rs_factory.rs_print_passfail"],
+      headlineMetrics: { mean_xgbclf_auc: 0.5148 },
+    });
+    const link = screen.getByText(/Open MLflow Run/i).closest("a");
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute("href")).toContain("#mlflow/experiments/3740651530987773/runs/");
+  });
+
+  it("derives why-champion / why-not-champion for a registry version", () => {
+    const v4: RegistryVersion = { version: 4, stage: "champion", is_champion: true, primary_metric: "pr_auc", primary_metric_value: 0.84, eval_metrics: { pr_auc: 0.84 }, training_rows: 9066, model_card_summary: "Champion." };
+    const v1: RegistryVersion = { version: 1, stage: "archived", is_champion: false, primary_metric: "pr_auc", primary_metric_value: 0.795, eval_metrics: { pr_auc: 0.795 }, training_rows: 5231, model_card_summary: "Archived." };
+    const model: RegistryModel = { model_key: "defect_risk", champion: v4, versions: [v1, v4] };
+
+    show({ kind: "model_version", model, version: v1 });
+    expect(screen.getByText(/superseded by champion v4/i)).toBeTruthy();
+    expect(screen.getByText(/no separate human approval record/i)).toBeTruthy();
+  });
+
+  it("lists vehicle blockers and the operational-use line", () => {
+    show({
+      kind: "vehicle",
+      isAnchor: true,
+      vehicle: {
+        vehicle_id: "VEH-TR-003", vehicle_name: "Terran R VEH-TR-003", target_launch_date: "2026-07-11",
+        status: "yellow", readiness_score: 0.58, open_ncrs: 43, scenario_open_ncrs: 4,
+        inconclusive_tests: 11, unresolved_anomalies: 1, missing_signoffs: 2,
+      },
+    });
+    expect(screen.getByText(/4 blocking NCRs must close/i)).toBeTruthy();
+    expect(screen.getByText(/Readiness hold \/ release review/i)).toBeTruthy();
+  });
+});

--- a/repo-b/src/components/telemetry/factory-ml/FactoryEvidenceDrawer.tsx
+++ b/repo-b/src/components/telemetry/factory-ml/FactoryEvidenceDrawer.tsx
@@ -1,0 +1,440 @@
+"use client";
+
+// The shared "click anything → evidence" drawer for the Factory ML page.
+// One drawer instance lives in FactoryMlConsole; every tab passes a DrillObject.
+// The Radix shell is copied from metadata/LineageDrawer.tsx (same right-slide
+// pattern, C.rail bg); the domain logic is factory-ml specific.
+//
+// Discipline: every field fails closed (missing → "Unavailable"), weak metrics
+// are interpreted honestly (never softened), and external links are live by
+// default but disabled-with-reason when an identifier is missing.
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { useState } from "react";
+
+import { C, Tag } from "../primitives";
+import type { DrillObject } from "./factoryDrill";
+import {
+  mlflowExperimentLink,
+  mlflowRunLink,
+  registeredModelLink,
+  type ExternalEvidenceLink,
+} from "@/lib/lab/factoryEvidenceLinks";
+import { lookupFeature } from "@/lib/lab/factoryFeatureCatalog";
+import {
+  GROUPKFOLD_NOTE,
+  SYNTHETIC_EVAL_NOTE,
+  interpretMetric,
+} from "@/lib/lab/factoryMetricGlossary";
+import { derivePromotionRationale } from "@/lib/lab/factoryPromotionRationale";
+
+// ── shared presentational helpers ────────────────────────────────────────────
+
+function isPresent(value: unknown) {
+  return value !== undefined && value !== null && value !== "";
+}
+
+/** Fail-closed field row: missing values render "Unavailable", never blank. */
+function Field({ label, value }: { label: string; value: unknown }) {
+  const present = isPresent(value);
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "minmax(110px,0.8fr) minmax(0,1.6fr)",
+        gap: 12,
+        padding: "8px 0",
+        borderBottom: `1px solid ${C.border}`,
+      }}
+    >
+      <div style={{ color: C.faint, fontFamily: C.mono, fontSize: 9, letterSpacing: "0.09em", textTransform: "uppercase" }}>
+        {label}
+      </div>
+      <div style={{ color: present ? C.dim : C.faint, fontFamily: C.mono, fontSize: 11, lineHeight: 1.5, overflowWrap: "anywhere" }}>
+        {present ? String(value) : "Unavailable"}
+      </div>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section style={{ marginTop: 18 }} aria-label={title}>
+      <div style={{ fontFamily: C.mono, color: C.faint, fontSize: 9, letterSpacing: "0.12em", textTransform: "uppercase", marginBottom: 8 }}>
+        {title}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+/** A weak-evidence / caveat callout in amber — used for honest interpretation. */
+function Caution({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ border: `1px solid ${C.amber}33`, background: `${C.amber}0d`, borderRadius: 7, padding: "9px 11px", color: C.amber, fontFamily: C.mono, fontSize: 11, lineHeight: 1.5, marginTop: 8 }}>
+      {children}
+    </div>
+  );
+}
+
+function CopyChip({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void navigator.clipboard?.writeText(text).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1200);
+        });
+      }}
+      style={{ fontFamily: C.mono, fontSize: 9, color: C.dim, background: C.panel, border: `1px solid ${C.border}`, borderRadius: 5, padding: "2px 7px", cursor: "pointer" }}
+    >
+      {copied ? "copied" : "copy"}
+    </button>
+  );
+}
+
+/** Live <a> when href is set; disabled <button> + reason + copy chip otherwise. */
+function EvidenceLinkButton({ link }: { link: ExternalEvidenceLink }) {
+  if (link.href) {
+    return (
+      <a
+        href={link.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ display: "inline-flex", alignItems: "center", gap: 6, fontFamily: C.mono, fontSize: 11, color: C.cyan, background: `${C.cyan}12`, border: `1px solid ${C.cyan}55`, borderRadius: 6, padding: "6px 11px", textDecoration: "none" }}
+      >
+        {link.label} ↗
+      </a>
+    );
+  }
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <button
+        type="button"
+        disabled
+        aria-disabled
+        style={{ display: "inline-flex", alignItems: "center", gap: 6, fontFamily: C.mono, fontSize: 11, color: C.faint, background: C.panel, border: `1px dashed ${C.border}`, borderRadius: 6, padding: "6px 11px", cursor: "not-allowed", alignSelf: "flex-start" }}
+      >
+        {link.label}
+      </button>
+      <div style={{ fontFamily: C.mono, fontSize: 9.5, color: C.faint, lineHeight: 1.5, display: "flex", alignItems: "center", gap: 7, flexWrap: "wrap" }}>
+        <span>Unavailable — {link.unavailableReason}</span>
+        {link.copyText && <CopyChip text={link.copyText} />}
+      </div>
+    </div>
+  );
+}
+
+function LinkRow({ links }: { links: ExternalEvidenceLink[] }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      {links.map((l) => (
+        <EvidenceLinkButton key={`${l.kind}-${l.label}`} link={l} />
+      ))}
+    </div>
+  );
+}
+
+/** The "what changes because of this?" decision-relevance line. */
+function OperationalUse({ value }: { value: string }) {
+  return (
+    <Section title="Operational use">
+      <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, lineHeight: 1.6 }}>{value}</div>
+    </Section>
+  );
+}
+
+const REVIEWER_QUESTIONS = [
+  "Target: what exactly is the label, and who assigns it?",
+  "Split: why this grouping — any leakage across build / vehicle / lot / time?",
+  "Baseline: does this beat a naive rule or the prior champion?",
+  "Calibration: are the predicted probabilities reliable?",
+  "Slices: does it hold by part family / printer / toolhead / material lot?",
+  "Reproducibility: can this exact run be recreated from code + data + model metadata?",
+  "Operational action: what decision changes because of this score?",
+];
+
+function ReviewerQuestions() {
+  return (
+    <Section title="What a reviewer would ask">
+      <ul style={{ margin: 0, paddingLeft: 16, fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.7 }}>
+        {REVIEWER_QUESTIONS.map((q) => (
+          <li key={q}>{q}</li>
+        ))}
+      </ul>
+    </Section>
+  );
+}
+
+// ── per-kind content ─────────────────────────────────────────────────────────
+
+function titleFor(drill: DrillObject): string {
+  switch (drill.kind) {
+    case "model_metric":
+      return drill.metricKey.replace(/^mean_/, "").replace(/_/g, " ");
+    case "feature":
+      return drill.feature;
+    case "model_version":
+      return `${drill.model.model_key} · v${drill.version.version}`;
+    case "mlflow_run":
+      return "Live MLflow run";
+    case "ncr":
+      return drill.ncrId;
+    case "ncr_category":
+      return drill.cluster.defect_code;
+    case "vehicle":
+      return drill.vehicle.vehicle_id;
+  }
+}
+
+function DrillBody({ drill }: { drill: DrillObject }) {
+  switch (drill.kind) {
+    case "model_metric": {
+      const i = interpretMetric(drill.metricKey, drill.value);
+      return (
+        <>
+          <Section title="Summary">
+            <Field label="Metric" value={drill.metricKey.replace(/^mean_/, "")} />
+            <Field label="Value" value={drill.value.toFixed(4)} />
+            <Field label="Model / target" value={i.target} />
+            <Field label="Split" value={GROUPKFOLD_NOTE} />
+            <Field label="Promotion" value={i.usedForPromotion ? "Used for champion promotion (pr_auc)" : "Informational — not the promotion metric"} />
+          </Section>
+          <Section title="Definition">
+            <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, lineHeight: 1.6 }}>{i.definition}</div>
+            {i.weakBand && <Caution>{i.weakBand}</Caution>}
+          </Section>
+          <Section title="Validation">
+            <Field label="Eval" value={SYNTHETIC_EVAL_NOTE} />
+          </Section>
+          <OperationalUse value={i.weakBand ? "Informational only — weak evidence does not justify operational use." : "Model promotion review."} />
+          <ReviewerQuestions />
+        </>
+      );
+    }
+
+    case "feature": {
+      const def = lookupFeature(drill.feature);
+      return (
+        <>
+          <Section title="Summary">
+            <Field label="Feature" value={drill.feature} />
+            <Field label="SHAP impact" value={drill.impact.toFixed(4)} />
+            <Field label="Model" value={drill.modelKey} />
+            <Field label="Method" value={drill.method} />
+          </Section>
+          <Section title="Definition">
+            {def ? (
+              <>
+                <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, lineHeight: 1.6 }}>{def.definition}</div>
+                <div style={{ marginTop: 8 }}>
+                  <Field label="Signal" value={def.signal} />
+                  <Field label="Statistic" value={def.statistic} />
+                  <Field label="Units" value={def.units} />
+                </div>
+                <Caution>{def.caveat}</Caution>
+              </>
+            ) : (
+              <Caution>Unavailable — no definition for this feature name in the inferred catalog.</Caution>
+            )}
+          </Section>
+          <Section title="Source / lineage">
+            <Field label="From" value="gold_feature_importance (SHAP export)" />
+            <Field label="MLflow run" value={drill.runId} />
+          </Section>
+          <Section title="Model / run evidence">
+            <LinkRow links={[mlflowRunLink(drill.runId)]} />
+          </Section>
+          <OperationalUse value="Informational only — feature attribution, not a release decision." />
+          <ReviewerQuestions />
+        </>
+      );
+    }
+
+    case "model_version": {
+      const r = derivePromotionRationale(drill.model, drill.version);
+      const v = drill.version;
+      return (
+        <>
+          <Section title="Summary">
+            <Field label="Model" value={drill.model.model_key} />
+            <Field label="Version" value={`v${v.version}`} />
+            <Field label="Stage" value={v.is_champion ? "champion" : v.stage} />
+            <Field label={v.primary_metric} value={v.primary_metric_value.toFixed(3)} />
+            <Field label="Training rows" value={v.training_rows.toLocaleString()} />
+          </Section>
+          <Section title="Validation">
+            <Field label="Eval" value={SYNTHETIC_EVAL_NOTE} />
+            <Field label="Card" value={v.model_card_summary} />
+          </Section>
+          <Section title="Promotion rationale">
+            {v.is_champion ? (
+              <ul style={{ margin: 0, paddingLeft: 16, fontFamily: C.mono, fontSize: 10.5, color: C.green, lineHeight: 1.7 }}>
+                {r.whyChampion.length ? r.whyChampion.map((b) => <li key={b}>{b}</li>) : <li style={{ color: C.faint }}>Unavailable</li>}
+              </ul>
+            ) : (
+              <ul style={{ margin: 0, paddingLeft: 16, fontFamily: C.mono, fontSize: 10.5, color: C.amber, lineHeight: 1.7 }}>
+                {r.whyNotChampion.length ? r.whyNotChampion.map((b) => <li key={b}>{b}</li>) : <li style={{ color: C.faint }}>Unavailable</li>}
+              </ul>
+            )}
+            <div style={{ fontFamily: C.mono, fontSize: 9.5, color: C.faint, marginTop: 8, lineHeight: 1.5 }}>{r.source}</div>
+          </Section>
+          <OperationalUse value="Model promotion review." />
+          <ReviewerQuestions />
+        </>
+      );
+    }
+
+    case "mlflow_run":
+      return (
+        <>
+          <Section title="Summary">
+            <Field label="Run id" value={drill.runId} />
+            <Field label="Experiment" value={drill.experiment} />
+          </Section>
+          <Section title="Registered models">
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+              {drill.registeredModels.map((m) => (
+                <Tag key={m} color={C.cyan}>{m.split(".").pop()}</Tag>
+              ))}
+            </div>
+          </Section>
+          <Section title="Headline metrics">
+            {Object.entries(drill.headlineMetrics).map(([k, val]) => (
+              <Field key={k} label={k.replace(/^mean_/, "")} value={val.toFixed(4)} />
+            ))}
+          </Section>
+          <Section title="Model / run evidence">
+            <LinkRow links={[mlflowRunLink(drill.runId), mlflowExperimentLink(drill.experiment), ...drill.registeredModels.map((m) => registeredModelLink(m))]} />
+          </Section>
+          <OperationalUse value="Model promotion review." />
+        </>
+      );
+
+    case "ncr":
+      return (
+        <>
+          <Section title="Summary">
+            <Field label="NCR id" value={drill.ncrId} />
+            <Field label="Defect code" value={drill.defectCode} />
+            <Field label="Status" value={drill.status} />
+            <Field label="Disposition" value={drill.disposition} />
+            <Field label="Part id" value={drill.partId} />
+            <Field label="Opened" value={drill.openedDate} />
+          </Section>
+          <Section title="Source / lineage">
+            <Field label="From" value="bronze_raw_qms_ncrs (synthetic QMS seed)" />
+          </Section>
+          <OperationalUse value="NCR triage." />
+        </>
+      );
+
+    case "ncr_category": {
+      const c = drill.cluster;
+      const trendSummary = c.trend.length
+        ? `${c.trend[0].month} → ${c.trend[c.trend.length - 1].month}, ${c.trend.map((t) => t.n).join(" · ")}`
+        : null;
+      return (
+        <>
+          <Section title="Summary">
+            <Field label="Defect code" value={c.defect_code} />
+            <Field label="Open" value={c.open_n} />
+            <Field label="Total" value={c.n} />
+            <Field label="Avg age" value={`${c.avg_age_days.toFixed(0)} days`} />
+          </Section>
+          <Section title="Trend (monthly opened)">
+            <Field label="Series" value={trendSummary} />
+          </Section>
+          <Section title="Source / lineage">
+            <Field label="From" value="bronze_raw_qms_ncrs (synthetic QMS seed)" />
+          </Section>
+          <OperationalUse value="NCR triage." />
+        </>
+      );
+    }
+
+    case "vehicle": {
+      const v = drill.vehicle;
+      const blockers: string[] = [];
+      if (v.scenario_open_ncrs > 0) blockers.push(`${v.scenario_open_ncrs} blocking NCR${v.scenario_open_ncrs === 1 ? "" : "s"} must close`);
+      if (v.unresolved_anomalies > 0) blockers.push(`${v.unresolved_anomalies} unresolved anomal${v.unresolved_anomalies === 1 ? "y" : "ies"} must clear`);
+      if (v.missing_signoffs > 0) blockers.push(`${v.missing_signoffs} missing signoff${v.missing_signoffs === 1 ? "" : "s"} must be obtained`);
+      if (v.inconclusive_tests > 0) blockers.push(`${v.inconclusive_tests} inconclusive test${v.inconclusive_tests === 1 ? "" : "s"} to resolve`);
+      return (
+        <>
+          <Section title="Summary">
+            <Field label="Vehicle" value={`${v.vehicle_id} — ${v.vehicle_name}`} />
+            <Field label="Status" value={v.status} />
+            <Field label="Readiness" value={(v.readiness_score * 100).toFixed(0)} />
+            <Field label="Target launch" value={v.target_launch_date} />
+          </Section>
+          <Section title="Score breakdown (open items)">
+            <Field label="Open NCRs" value={v.open_ncrs} />
+            <Field label="Blocking NCRs" value={v.scenario_open_ncrs} />
+            <Field label="Inconclusive tests" value={v.inconclusive_tests} />
+            <Field label="Unresolved anomalies" value={v.unresolved_anomalies} />
+            <Field label="Missing signoffs" value={v.missing_signoffs} />
+          </Section>
+          <Section title="What must clear before green">
+            {blockers.length ? (
+              <ul style={{ margin: 0, paddingLeft: 16, fontFamily: C.mono, fontSize: 10.5, color: C.amber, lineHeight: 1.7 }}>
+                {blockers.map((b) => <li key={b}>{b}</li>)}
+              </ul>
+            ) : (
+              <div style={{ fontFamily: C.mono, fontSize: 11, color: C.green }}>No open blockers — readiness gates met.</div>
+            )}
+          </Section>
+          <Section title="Source / lineage">
+            <Field label="From" value="gold_readiness_summary (medallion rollup)" />
+          </Section>
+          <OperationalUse value="Readiness hold / release review." />
+        </>
+      );
+    }
+  }
+}
+
+// ── shell ────────────────────────────────────────────────────────────────────
+
+export default function FactoryEvidenceDrawer({
+  drill,
+  onClose,
+}: {
+  drill: DrillObject | null;
+  onClose: () => void;
+}) {
+  return (
+    <Dialog.Root open={Boolean(drill)} onOpenChange={(open) => !open && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.52)", zIndex: 70 }} />
+        <Dialog.Content
+          className="fixed bottom-0 left-0 right-0 z-[80] max-h-[86vh] rounded-t-xl lg:bottom-auto lg:left-auto lg:right-0 lg:top-0 lg:h-screen lg:max-h-none lg:w-[460px] lg:rounded-none lg:rounded-l-xl"
+          style={{ background: C.rail, border: `1px solid ${C.borderHi}`, color: C.text, overflowY: "auto", padding: 20, boxShadow: "-18px 0 50px rgba(0,0,0,0.38)" }}
+        >
+          {drill && (
+            <>
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 16 }}>
+                <div style={{ minWidth: 0 }}>
+                  <Dialog.Title style={{ fontFamily: C.sans, fontSize: 19, fontWeight: 700, overflowWrap: "anywhere" }}>
+                    {titleFor(drill)}
+                  </Dialog.Title>
+                  <Dialog.Description style={{ color: C.dim, fontFamily: C.mono, fontSize: 10, lineHeight: 1.5, marginTop: 6 }}>
+                    Evidence — where this comes from, and whether to trust it.
+                  </Dialog.Description>
+                </div>
+                <Dialog.Close asChild>
+                  <button type="button" aria-label="Close evidence drawer" style={{ width: 36, height: 36, borderRadius: 7, border: `1px solid ${C.borderHi}`, background: C.panel, color: C.dim, cursor: "pointer", flexShrink: 0 }}>
+                    x
+                  </button>
+                </Dialog.Close>
+              </div>
+              <DrillBody drill={drill} />
+            </>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/repo-b/src/components/telemetry/factory-ml/FactoryMlConsole.tsx
+++ b/repo-b/src/components/telemetry/factory-ml/FactoryMlConsole.tsx
@@ -7,11 +7,13 @@
 import { useState } from "react";
 import { C, EmptyState, Loading, Panel, Tag } from "../primitives";
 import { TelemetryPageHeader } from "../TelemetryPageHeader";
+import FactoryEvidenceDrawer from "./FactoryEvidenceDrawer";
 import FeatureImportancePanel from "./FeatureImportancePanel";
 import LayerHeatmap from "./LayerHeatmap";
 import NcrPanel from "./NcrPanel";
 import ReadinessGauge from "./ReadinessGauge";
 import RegistryPanel from "./RegistryPanel";
+import type { DrillObject } from "./factoryDrill";
 import { useFactoryMlData } from "@/lib/lab/factoryMlData";
 
 const SECTIONS = [
@@ -25,6 +27,7 @@ const SECTIONS = [
 export default function FactoryMlConsole() {
   const { data, loading, missing } = useFactoryMlData();
   const [section, setSection] = useState<(typeof SECTIONS)[number]["id"]>("readiness");
+  const [drill, setDrill] = useState<DrillObject | null>(null);
 
   if (loading) return <Loading label="Loading medallion exports…" />;
 
@@ -60,19 +63,19 @@ export default function FactoryMlConsole() {
           </div>
 
           {section === "readiness" && (data.readiness
-            ? <ReadinessGauge data={data.readiness} />
+            ? <ReadinessGauge data={data.readiness} onDrill={setDrill} />
             : <EmptyState label="readiness.json missing" hint="Re-run the export stage." />)}
           {section === "heatmap" && (data.heatmap
             ? <LayerHeatmap data={data.heatmap} />
             : <EmptyState label="layer_heatmap.json missing" hint="Re-run the export stage." />)}
           {section === "model" && (data.importance
-            ? <FeatureImportancePanel data={data.importance} />
+            ? <FeatureImportancePanel data={data.importance} onDrill={setDrill} />
             : <EmptyState label="feature_importance.json missing" hint="Run the training stage first." />)}
           {section === "registry" && (data.registry
-            ? <RegistryPanel data={data.registry} />
+            ? <RegistryPanel data={data.registry} onDrill={setDrill} />
             : <EmptyState label="model_registry.json missing" hint="Re-run the export stage." />)}
           {section === "ncr" && (data.ncr
-            ? <NcrPanel data={data.ncr} />
+            ? <NcrPanel data={data.ncr} onDrill={setDrill} />
             : <EmptyState label="ncr_clusters.json missing" hint="Re-run the export stage." />)}
 
           {data.metadata && (
@@ -87,6 +90,8 @@ export default function FactoryMlConsole() {
               </div>
             </Panel>
           )}
+
+          <FactoryEvidenceDrawer drill={drill} onClose={() => setDrill(null)} />
         </>
       )}
     </div>

--- a/repo-b/src/components/telemetry/factory-ml/FeatureImportancePanel.tsx
+++ b/repo-b/src/components/telemetry/factory-ml/FeatureImportancePanel.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 // SHAP top drivers for both models + the headline GroupKFold metrics,
-// straight from the MLflow run artifacts.
+// straight from the MLflow run artifacts. Every metric card and every SHAP
+// feature is a click into the evidence drawer.
 
 import { useState } from "react";
-import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
 import { C, MetricCard, Panel, Tag } from "../primitives";
+import type { DrillObject } from "./factoryDrill";
 import type { ImportanceExport } from "@/lib/lab/factoryMlData";
 
 const MODEL_LABELS: Record<string, string> = {
@@ -14,10 +15,18 @@ const MODEL_LABELS: Record<string, string> = {
   run_failure: "Run failure (classifier)",
 };
 
-export default function FeatureImportancePanel({ data }: { data: ImportanceExport }) {
+export default function FeatureImportancePanel({
+  data,
+  onDrill,
+}: {
+  data: ImportanceExport;
+  onDrill: (d: DrillObject) => void;
+}) {
   const models = Object.keys(data.drivers).filter((k) => Array.isArray(data.drivers[k as "strength"]));
   const [model, setModel] = useState(models[0] || "strength");
   const drivers = (data.drivers[model as "strength"] || []).slice(0, 15);
+  const method = data.driver_methods?.[model];
+  const maxImpact = drivers.reduce((m, d) => Math.max(m, d.impact), 0) || 1;
 
   const headline = Object.entries(data.headline_metrics);
 
@@ -26,8 +35,13 @@ export default function FeatureImportancePanel({ data }: { data: ImportanceExpor
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))",
         gap: 12, marginBottom: 14 }}>
         {headline.slice(0, 5).map(([key, value]) => (
-          <MetricCard key={key} label={key.replace("mean_", "").replace(/_/g, " ")}
-            value={value.toFixed(3)} sub="GroupKFold(part_id) mean" />
+          <button key={key} type="button"
+            onClick={() => onDrill({ kind: "model_metric", metricKey: key, value })}
+            aria-label={`Inspect metric ${key}`}
+            style={{ all: "unset", cursor: "pointer", display: "block", borderRadius: 9 }}>
+            <MetricCard label={key.replace("mean_", "").replace(/_/g, " ")}
+              value={value.toFixed(3)} sub="GroupKFold(part_id) mean" />
+          </button>
         ))}
       </div>
       <Panel title="SHAP top drivers" pad={12}
@@ -44,16 +58,34 @@ export default function FeatureImportancePanel({ data }: { data: ImportanceExpor
             ))}
           </div>
         }>
-        <ResponsiveContainer width="100%" height={Math.max(220, drivers.length * 24)}>
-          <BarChart data={drivers} layout="vertical" margin={{ left: 40, right: 16 }}>
-            <XAxis type="number" tick={{ fontFamily: C.mono, fontSize: 9, fill: C.faint }}
-              stroke={C.border} />
-            <YAxis type="category" dataKey="feature" width={220}
-              tick={{ fontFamily: C.mono, fontSize: 10, fill: C.dim }} stroke={C.border} />
-            <Bar dataKey="impact" fill={C.cyan} radius={[0, 3, 3, 0]} isAnimationActive={false} />
-          </BarChart>
-        </ResponsiveContainer>
-        <div style={{ marginTop: 8 }}>
+        {/* Left-justified, clickable feature index in a fixed gutter + bar area.
+            A custom grid (not recharts) so labels read as a drillable list. */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          {drivers.map((d) => (
+            <button key={d.feature} type="button"
+              onClick={() => onDrill({ kind: "feature", feature: d.feature, impact: d.impact, modelKey: model, method, runId: data.run_id })}
+              title={d.feature}
+              aria-label={`Inspect feature ${d.feature}, impact ${d.impact.toFixed(4)}`}
+              style={{ all: "unset", cursor: "pointer", display: "grid",
+                gridTemplateColumns: "220px 1fr auto", alignItems: "center", gap: 10,
+                padding: "3px 6px", borderRadius: 6 }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(63,177,232,0.07)"; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}>
+              <span style={{ fontFamily: C.mono, fontSize: 10, color: C.dim, textAlign: "left",
+                overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {d.feature}
+              </span>
+              <span style={{ display: "block", height: 12, background: C.panelHi, borderRadius: 3, position: "relative" }}>
+                <span style={{ position: "absolute", left: 0, top: 0, bottom: 0,
+                  width: `${(d.impact / maxImpact) * 100}%`, background: C.cyan, borderRadius: 3 }} />
+              </span>
+              <span style={{ fontFamily: C.mono, fontSize: 9.5, color: C.faint, minWidth: 48, textAlign: "right" }}>
+                {d.impact.toFixed(3)}
+              </span>
+            </button>
+          ))}
+        </div>
+        <div style={{ marginTop: 10 }}>
           <Tag color={C.faint}>MLflow run {data.run_id.slice(0, 12)}…</Tag>
         </div>
       </Panel>

--- a/repo-b/src/components/telemetry/factory-ml/NcrPanel.tsx
+++ b/repo-b/src/components/telemetry/factory-ml/NcrPanel.tsx
@@ -7,9 +7,13 @@
 import { useState } from "react";
 import { Bar, BarChart, Line, LineChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
 import { C, Panel, SplitGrid, Tag } from "../primitives";
+import type { DrillObject } from "./factoryDrill";
 import type { NcrExport } from "@/lib/lab/factoryMlData";
 
-export default function NcrPanel({ data }: { data: NcrExport }) {
+export default function NcrPanel({ data, onDrill }: {
+  data: NcrExport;
+  onDrill: (d: DrillObject) => void;
+}) {
   const clusters = [...data.clusters].sort((a, b) => b.n - a.n);
   const [selected, setSelected] = useState(clusters[0]?.defect_code ?? "");
   const active = clusters.find((c) => c.defect_code === selected) ?? clusters[0];
@@ -30,7 +34,15 @@ export default function NcrPanel({ data }: { data: NcrExport }) {
       </Panel>
 
       {active && (
-        <Panel title={active.defect_code} pad={14}
+        <Panel pad={14}
+          title={
+            <button type="button"
+              onClick={() => onDrill({ kind: "ncr_category", cluster: active })}
+              aria-label={`Inspect defect category ${active.defect_code}`}
+              style={{ all: "unset", cursor: "pointer", color: C.cyan, textDecoration: "underline", textUnderlineOffset: 2 }}>
+              {active.defect_code}
+            </button>
+          }
           right={
             <div style={{ display: "flex", gap: 6 }}>
               <Tag color={active.open_n ? C.red : C.green}>{active.open_n} open</Tag>
@@ -50,9 +62,14 @@ export default function NcrPanel({ data }: { data: NcrExport }) {
           </ResponsiveContainer>
           <div style={{ marginTop: 10 }}>
             {active.exemplars.map((e) => (
-              <div key={e.ncr_id} style={{ display: "flex", gap: 10, alignItems: "baseline",
-                padding: "7px 0", borderBottom: `1px solid ${C.border}`,
-                fontFamily: C.mono, fontSize: 10.5 }}>
+              <button key={e.ncr_id} type="button"
+                onClick={() => onDrill({ kind: "ncr", ncrId: e.ncr_id, partId: e.part_id, disposition: e.disposition, status: e.status, openedDate: e.opened_date, defectCode: active.defect_code })}
+                aria-label={`Inspect NCR ${e.ncr_id}`}
+                style={{ all: "unset", cursor: "pointer", display: "flex", gap: 10, alignItems: "baseline",
+                  padding: "7px 4px", borderBottom: `1px solid ${C.border}`,
+                  fontFamily: C.mono, fontSize: 10.5, width: "100%", boxSizing: "border-box" }}
+                onMouseEnter={(ev) => { ev.currentTarget.style.background = "rgba(63,177,232,0.06)"; }}
+                onMouseLeave={(ev) => { ev.currentTarget.style.background = "transparent"; }}>
                 <span style={{ color: C.text }}>{e.ncr_id}</span>
                 <span style={{ color: C.faint }}>{e.opened_date}</span>
                 <Tag color={e.status === "open" ? C.red : e.status === "in_review" ? C.amber : C.green}>
@@ -61,7 +78,7 @@ export default function NcrPanel({ data }: { data: NcrExport }) {
                 <span style={{ color: C.dim }}>{e.disposition}</span>
                 <span style={{ color: C.faint, overflow: "hidden", textOverflow: "ellipsis",
                   whiteSpace: "nowrap" }}>{e.part_id}</span>
-              </div>
+              </button>
             ))}
           </div>
         </Panel>

--- a/repo-b/src/components/telemetry/factory-ml/ReadinessGauge.tsx
+++ b/repo-b/src/components/telemetry/factory-ml/ReadinessGauge.tsx
@@ -5,6 +5,7 @@
 // every number traces to a seed table through the medallion.
 
 import { C, Panel, Tag } from "../primitives";
+import type { DrillObject } from "./factoryDrill";
 import type { ReadinessExport } from "@/lib/lab/factoryMlData";
 
 function statusColor(status: string): string {
@@ -42,14 +43,21 @@ function Gauge({ score, color }: { score: number; color: string }) {
   );
 }
 
-export default function ReadinessGauge({ data }: { data: ReadinessExport }) {
+export default function ReadinessGauge({ data, onDrill }: {
+  data: ReadinessExport;
+  onDrill: (d: DrillObject) => void;
+}) {
   return (
     <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))", gap: 14 }}>
       {data.vehicles.map((v) => {
         const color = statusColor(v.status);
         const anchor = v.vehicle_id === data.anchor_vehicle;
         return (
-          <Panel key={v.vehicle_id} pad={14}
+          <button key={v.vehicle_id} type="button"
+            onClick={() => onDrill({ kind: "vehicle", vehicle: v, isAnchor: anchor })}
+            aria-label={`Inspect ${v.vehicle_id} readiness`}
+            style={{ all: "unset", cursor: "pointer", display: "block" }}>
+          <Panel pad={14}
             style={anchor ? { borderColor: C.red + "66", boxShadow: `0 0 16px ${C.red}22` } : undefined}>
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
               <span style={{ fontFamily: C.mono, fontSize: 13, color: C.text }}>{v.vehicle_id}</span>
@@ -75,6 +83,7 @@ export default function ReadinessGauge({ data }: { data: ReadinessExport }) {
               target launch {v.target_launch_date}
             </div>
           </Panel>
+          </button>
         );
       })}
     </div>

--- a/repo-b/src/components/telemetry/factory-ml/RegistryPanel.tsx
+++ b/repo-b/src/components/telemetry/factory-ml/RegistryPanel.tsx
@@ -2,16 +2,27 @@
 
 // Model registry: the seed's governed registry (champion/challenger versions
 // with eval metrics — adapted from the rs_jsx ModelRegistryConsole draft) plus
-// the live MLflow run this pipeline actually produced.
+// the live MLflow run this pipeline actually produced. Every version row, the
+// champion badge, and the live run id drill into the evidence drawer.
 
 import { C, Panel, Tag } from "../primitives";
-import type { RegistryExport, RegistryVersion } from "@/lib/lab/factoryMlData";
+import type { DrillObject } from "./factoryDrill";
+import type { RegistryExport, RegistryModel, RegistryVersion } from "@/lib/lab/factoryMlData";
 
-function VersionRow({ v }: { v: RegistryVersion }) {
+function VersionRow({ model, v, onDrill }: {
+  model: RegistryModel;
+  v: RegistryVersion;
+  onDrill: (d: DrillObject) => void;
+}) {
   const stageColor = v.is_champion ? C.green : v.stage === "challenger" ? C.amber : C.faint;
   return (
-    <div style={{ display: "flex", gap: 12, alignItems: "baseline", padding: "7px 0",
-      borderBottom: `1px solid ${C.border}` }}>
+    <button type="button"
+      onClick={() => onDrill({ kind: "model_version", model, version: v })}
+      aria-label={`Inspect ${model.model_key} v${v.version}`}
+      style={{ all: "unset", cursor: "pointer", display: "flex", gap: 12, alignItems: "baseline",
+        padding: "7px 4px", borderBottom: `1px solid ${C.border}`, width: "100%", boxSizing: "border-box" }}
+      onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(63,177,232,0.06)"; }}
+      onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}>
       <span style={{ fontFamily: C.mono, fontSize: 11, color: C.text, width: 36 }}>v{v.version}</span>
       <Tag color={stageColor}>{v.is_champion ? "champion" : v.stage}</Tag>
       <span style={{ fontFamily: C.mono, fontSize: 11, color: C.cyan }}>
@@ -26,18 +37,28 @@ function VersionRow({ v }: { v: RegistryVersion }) {
           {v.model_card_summary}
         </span>
       )}
-    </div>
+    </button>
   );
 }
 
-export default function RegistryPanel({ data }: { data: RegistryExport }) {
+export default function RegistryPanel({ data, onDrill }: {
+  data: RegistryExport;
+  onDrill: (d: DrillObject) => void;
+}) {
   const live = data.live_mlflow_run;
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
       <Panel title="Live MLflow run — this pipeline" pad={14}
         right={<Tag color={C.green}>trained now</Tag>}>
         <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, lineHeight: 2 }}>
-          <div>run <span style={{ color: C.text }}>{live.run_id}</span></div>
+          <div>run{" "}
+            <button type="button"
+              onClick={() => onDrill({ kind: "mlflow_run", runId: live.run_id, experiment: live.experiment, registeredModels: live.registered_models, headlineMetrics: live.headline_metrics })}
+              aria-label="Inspect live MLflow run"
+              style={{ all: "unset", cursor: "pointer", color: C.cyan, textDecoration: "underline", textUnderlineOffset: 2 }}>
+              {live.run_id}
+            </button>
+          </div>
           <div>experiment <span style={{ color: C.text }}>{live.experiment}</span></div>
           <div>registered {live.registered_models.map((m) => (
             <Tag key={m} color={C.cyan}>{m.split(".").pop()}</Tag>
@@ -56,10 +77,15 @@ export default function RegistryPanel({ data }: { data: RegistryExport }) {
       {data.seed_registry.map((model) => (
         <Panel key={model.model_key} title={model.model_key} pad={14}
           right={model.champion
-            ? <Tag color={C.green}>champion v{model.champion.version}</Tag>
+            ? <button type="button"
+                onClick={() => onDrill({ kind: "model_version", model, version: model.champion! })}
+                aria-label={`Inspect champion v${model.champion.version}`}
+                style={{ all: "unset", cursor: "pointer" }}>
+                <Tag color={C.green}>champion v{model.champion.version}</Tag>
+              </button>
             : <Tag color={C.faint}>no champion</Tag>}>
           {[...model.versions].sort((a, b) => b.version - a.version).map((v) => (
-            <VersionRow key={v.version} v={v} />
+            <VersionRow key={v.version} model={model} v={v} onDrill={onDrill} />
           ))}
         </Panel>
       ))}

--- a/repo-b/src/components/telemetry/factory-ml/factoryDrill.ts
+++ b/repo-b/src/components/telemetry/factory-ml/factoryDrill.ts
@@ -1,0 +1,61 @@
+// Discriminated union of every drillable object on the Factory ML page. Each
+// variant carries only fields derivable from the committed JSON exports
+// (repo-b/public/labs/factory-ml/*.json) plus the static catalogs — nothing is
+// fabricated. The FactoryEvidenceDrawer renders sections by `kind`.
+
+import type {
+  NcrCluster,
+  ReadinessVehicle,
+  RegistryModel,
+  RegistryVersion,
+} from "@/lib/lab/factoryMlData";
+
+export type DrillObject =
+  | {
+      kind: "model_metric";
+      // headline_metrics key, e.g. "mean_xgbclf_auc"
+      metricKey: string;
+      value: number;
+    }
+  | {
+      kind: "feature";
+      // raw SHAP feature name, e.g. "temperature_p2p_drift_max"
+      feature: string;
+      impact: number;
+      // which model's SHAP list this came from (strength | passfail | run_failure)
+      modelKey: string;
+      method?: string;
+      runId?: string;
+    }
+  | {
+      kind: "model_version";
+      model: RegistryModel;
+      version: RegistryVersion;
+    }
+  | {
+      kind: "mlflow_run";
+      runId: string;
+      experiment: string;
+      registeredModels: string[];
+      headlineMetrics: Record<string, number>;
+    }
+  | {
+      kind: "ncr";
+      ncrId: string;
+      partId: string;
+      disposition: string;
+      status: string;
+      openedDate: string;
+      defectCode: string;
+    }
+  | {
+      kind: "ncr_category";
+      cluster: NcrCluster;
+    }
+  | {
+      kind: "vehicle";
+      vehicle: ReadinessVehicle;
+      isAnchor: boolean;
+    };
+
+export type DrillKind = DrillObject["kind"];

--- a/repo-b/src/components/telemetry/primitives.tsx
+++ b/repo-b/src/components/telemetry/primitives.tsx
@@ -35,7 +35,7 @@ export function Tag({ color, children }: { color: string; children: ReactNode })
 }
 
 export function Panel({ title, right, children, pad = 18, style }: {
-  title?: string; right?: ReactNode; children: ReactNode; pad?: number; style?: CSSProperties;
+  title?: ReactNode; right?: ReactNode; children: ReactNode; pad?: number; style?: CSSProperties;
 }) {
   return (
     <div style={{ background: C.panel, border: `1px solid ${C.border}`, borderRadius: 10, ...style }}>

--- a/repo-b/src/lib/lab/factoryEvidenceLinks.test.ts
+++ b/repo-b/src/lib/lab/factoryEvidenceLinks.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  deltaTableLink,
+  mlflowExperimentLink,
+  mlflowRunLink,
+  registeredModelLink,
+} from "./factoryEvidenceLinks";
+
+const ORIGINAL = process.env.NEXT_PUBLIC_DATABRICKS_WORKSPACE_URL;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.NEXT_PUBLIC_DATABRICKS_WORKSPACE_URL;
+  else process.env.NEXT_PUBLIC_DATABRICKS_WORKSPACE_URL = ORIGINAL;
+});
+
+describe("factoryEvidenceLinks — live by default", () => {
+  beforeEach(() => {
+    // Unset override so the committed default workspace is used.
+    delete process.env.NEXT_PUBLIC_DATABRICKS_WORKSPACE_URL;
+  });
+
+  it("builds a live MLflow run deep link in the confirmed <ws>/?o=<org>#mlflow/... format", () => {
+    const link = mlflowRunLink("9c25866d78184746a2a0ae28526009bf");
+    expect(link.href).toBe(
+      "https://dbc-2504bec5-b5ab.cloud.databricks.com/?o=7474657239253594" +
+        "#mlflow/experiments/3740651530987773/runs/9c25866d78184746a2a0ae28526009bf",
+    );
+    expect(link.unavailableReason).toBeUndefined();
+    expect(link.copyText).toBe("9c25866d78184746a2a0ae28526009bf");
+  });
+
+  it("builds a live experiment link", () => {
+    const link = mlflowExperimentLink("/Users/x/RSFactoryML");
+    expect(link.href).toContain("#mlflow/experiments/3740651530987773");
+  });
+
+  it("builds a UC model link from a fully-qualified name", () => {
+    const link = registeredModelLink("novendor_1.rs_factory.rs_print_passfail");
+    expect(link.href).toContain("/explore/data/models/novendor_1/rs_factory/rs_print_passfail");
+  });
+
+  it("respects the NEXT_PUBLIC override", () => {
+    process.env.NEXT_PUBLIC_DATABRICKS_WORKSPACE_URL = "https://example.cloud.databricks.com/";
+    const link = mlflowRunLink("abc");
+    expect(link.href).toContain("https://example.cloud.databricks.com/?o=");
+    expect(link.href).not.toContain("dbc-2504bec5");
+  });
+});
+
+describe("factoryEvidenceLinks — fail closed", () => {
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_DATABRICKS_WORKSPACE_URL;
+  });
+
+  it("missing runId returns href null + reason even when workspace is configured", () => {
+    const link = mlflowRunLink(undefined);
+    expect(link.href).toBeNull();
+    expect(link.unavailableReason).toMatch(/no mlflow run id/i);
+  });
+
+  it("missing model name returns href null + reason", () => {
+    const link = registeredModelLink(undefined);
+    expect(link.href).toBeNull();
+    expect(link.unavailableReason).toMatch(/no registered model name/i);
+  });
+
+  it("a bare seed model key (not a UC path) is disabled with a reason + copyable id", () => {
+    const link = registeredModelLink("defect_risk");
+    expect(link.href).toBeNull();
+    expect(link.unavailableReason).toMatch(/unity catalog/i);
+    expect(link.copyText).toBe("defect_risk");
+  });
+
+  it("a non-UC table name is disabled with a reason", () => {
+    const link = deltaTableLink("bronze_raw_qms_ncrs");
+    expect(link.href).toBeNull();
+    expect(link.unavailableReason).toMatch(/unity catalog/i);
+  });
+});

--- a/repo-b/src/lib/lab/factoryEvidenceLinks.ts
+++ b/repo-b/src/lib/lab/factoryEvidenceLinks.ts
@@ -1,0 +1,138 @@
+// Databricks / MLflow deep-link builders for the Factory ML evidence drawer.
+//
+// Links are live by DEFAULT: the workspace resolves from
+// NEXT_PUBLIC_DATABRICKS_WORKSPACE_URL (override) or a committed demo default
+// (the owner's own workspace — public exposure is not a concern for this demo).
+// A builder returns href=null + unavailableReason + copyText only when the
+// resolved workspace is empty OR the specific identifier is missing. We never
+// fabricate a link or imply a target exists when its identifier is absent.
+
+// Confirmed across the repo (skills/rs-factory-ml/config/databricks.json,
+// telemetry-platform/runs/.../run_manifest.json, *_run_receipt.json).
+const DEFAULT_DATABRICKS_WORKSPACE = "https://dbc-2504bec5-b5ab.cloud.databricks.com";
+const DATABRICKS_ORG = "7474657239253594";
+// rs_factory MLflow experiment that produced the committed run.
+const RS_FACTORY_EXPERIMENT_ID = "3740651530987773";
+
+export type ExternalLinkKind =
+  | "mlflow_run"
+  | "mlflow_experiment"
+  | "registered_model"
+  | "delta_table"
+  | "sql_warehouse";
+
+export type ExternalEvidenceLink = {
+  label: string;
+  kind: ExternalLinkKind;
+  href: string | null;
+  copyText?: string | null;
+  unavailableReason?: string | null;
+};
+
+/** Resolved workspace base URL (no trailing slash), or "" when unconfigured. */
+export function resolveWorkspace(): string {
+  const raw =
+    (typeof process !== "undefined" && process.env.NEXT_PUBLIC_DATABRICKS_WORKSPACE_URL) ||
+    DEFAULT_DATABRICKS_WORKSPACE ||
+    "";
+  return raw.replace(/\/+$/, "");
+}
+
+function withOrg(path: string): string {
+  return `${resolveWorkspace()}/?o=${DATABRICKS_ORG}#${path}`;
+}
+
+function unavailable(
+  label: string,
+  kind: ExternalLinkKind,
+  reason: string,
+  copyText?: string | null,
+): ExternalEvidenceLink {
+  return { label, kind, href: null, unavailableReason: reason, copyText: copyText ?? null };
+}
+
+const NO_WORKSPACE = "Databricks workspace URL is not configured for this environment.";
+
+export function mlflowRunLink(runId: string | null | undefined): ExternalEvidenceLink {
+  const label = "Open MLflow Run";
+  if (!resolveWorkspace()) return unavailable(label, "mlflow_run", NO_WORKSPACE, runId ?? null);
+  if (!runId) {
+    return unavailable(label, "mlflow_run", "No MLflow run id on this object.", null);
+  }
+  return {
+    label,
+    kind: "mlflow_run",
+    href: withOrg(`mlflow/experiments/${RS_FACTORY_EXPERIMENT_ID}/runs/${runId}`),
+    copyText: runId,
+  };
+}
+
+export function mlflowExperimentLink(experimentPath?: string | null): ExternalEvidenceLink {
+  const label = "Open MLflow Experiment";
+  if (!resolveWorkspace()) {
+    return unavailable(label, "mlflow_experiment", NO_WORKSPACE, experimentPath ?? null);
+  }
+  return {
+    label,
+    kind: "mlflow_experiment",
+    href: withOrg(`mlflow/experiments/${RS_FACTORY_EXPERIMENT_ID}`),
+    copyText: experimentPath ?? RS_FACTORY_EXPERIMENT_ID,
+  };
+}
+
+/**
+ * Registered model link from a Unity Catalog name like
+ * "novendor_1.rs_factory.rs_print_passfail". Falls back to a bare model_key
+ * (no dots) -> not enough to locate a UC object, so disabled-with-reason.
+ */
+export function registeredModelLink(modelName: string | null | undefined): ExternalEvidenceLink {
+  const label = "Open Model in Unity Catalog";
+  if (!resolveWorkspace()) {
+    return unavailable(label, "registered_model", NO_WORKSPACE, modelName ?? null);
+  }
+  if (!modelName) {
+    return unavailable(label, "registered_model", "No registered model name on this object.", null);
+  }
+  const parts = modelName.split(".");
+  if (parts.length !== 3) {
+    return unavailable(
+      label,
+      "registered_model",
+      "Model is a seed registry key, not a Unity Catalog object — no UC path to open.",
+      modelName,
+    );
+  }
+  const [catalog, schema, name] = parts;
+  return {
+    label,
+    kind: "registered_model",
+    href: `${resolveWorkspace()}/explore/data/models/${catalog}/${schema}/${name}?o=${DATABRICKS_ORG}`,
+    copyText: modelName,
+  };
+}
+
+export function deltaTableLink(tableName: string | null | undefined): ExternalEvidenceLink {
+  const label = "Open Delta Table";
+  if (!resolveWorkspace()) {
+    return unavailable(label, "delta_table", NO_WORKSPACE, tableName ?? null);
+  }
+  if (!tableName) {
+    return unavailable(label, "delta_table", "No source table on this object.", null);
+  }
+  const parts = tableName.split(".");
+  if (parts.length !== 3) {
+    return unavailable(
+      label,
+      "delta_table",
+      "Table name is not a fully-qualified Unity Catalog path — no UC path to open.",
+      tableName,
+    );
+  }
+  const [catalog, schema, name] = parts;
+  return {
+    label,
+    kind: "delta_table",
+    href: `${resolveWorkspace()}/explore/data/${catalog}/${schema}/${name}?o=${DATABRICKS_ORG}`,
+    copyText: tableName,
+  };
+}

--- a/repo-b/src/lib/lab/factoryFeatureCatalog.test.ts
+++ b/repo-b/src/lib/lab/factoryFeatureCatalog.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { lookupFeature } from "./factoryFeatureCatalog";
+
+describe("factoryFeatureCatalog", () => {
+  it("decomposes a windowed telemetry feature into an inferred def + units-unknown marker", () => {
+    const def = lookupFeature("temperature_p2p_drift_max");
+    expect(def).not.toBeNull();
+    expect(def!.inferred).toBe(true);
+    expect(def!.signal).toMatch(/temperature/i);
+    expect(def!.definition).toMatch(/peak-to-peak drift/i);
+    expect(def!.units).toMatch(/units unknown/i);
+  });
+
+  it("handles std_mean and slope_mean suffixes", () => {
+    expect(lookupFeature("flow_rate_std_mean")!.definition).toMatch(/standard deviation/i);
+    expect(lookupFeature("temperature_slope_mean")!.definition).toMatch(/slope/i);
+  });
+
+  it("treats part_family_* as a one-hot indicator with a 0/1 unit", () => {
+    const def = lookupFeature("part_family_AVI-HARNESS");
+    expect(def!.statistic).toBe("one_hot");
+    expect(def!.definition).toMatch(/AVI-HARNESS/);
+    expect(def!.units).toMatch(/indicator/i);
+  });
+
+  it("describes limit_violation_count as a count", () => {
+    const def = lookupFeature("limit_violation_count");
+    expect(def!.statistic).toBe("count");
+    expect(def!.units).toBe("count");
+  });
+
+  it("returns null for an unknown name (fail closed)", () => {
+    expect(lookupFeature("totally_unknown_feature_xyz")).toBeNull();
+    expect(lookupFeature("")).toBeNull();
+  });
+});

--- a/repo-b/src/lib/lab/factoryFeatureCatalog.ts
+++ b/repo-b/src/lib/lab/factoryFeatureCatalog.ts
@@ -1,0 +1,108 @@
+// Conservative, inferred definitions for the SHAP feature names exported by the
+// rs_factory training run. The committed feature_importance.json carries only
+// {feature, impact}; the export has no units or manifest. So every definition
+// here is DERIVED FROM THE NAME and marked inferred — never presented as ground
+// truth. Unknown names return null and the drawer renders fail-closed.
+//
+// Follow-up (documented in export_dashboard_json.py): emit a real feature
+// manifest with units/source so this catalog can become data-backed.
+
+export type FeatureDef = {
+  feature: string;
+  // human-readable definition inferred from the name
+  definition: string;
+  // signal the feature is built from (temperature, pressure, ...), or a category
+  signal: string;
+  // the statistic / window operation in the name (std_mean, p2p_drift_max, ...)
+  statistic: string;
+  units: string;
+  // always true here — these are name-derived, not manifest-backed
+  inferred: true;
+  caveat: string;
+};
+
+const UNITS_UNKNOWN = "Units unknown — not in the exported feature manifest";
+const CAVEAT =
+  "Definition inferred from the feature name; deterministic synthetic seed, no physical manifest.";
+
+// Signal tokens that lead a windowed telemetry feature name.
+const SIGNALS: Record<string, string> = {
+  temperature: "melt-pool / process temperature",
+  pressure: "chamber / line pressure",
+  flow_rate: "material flow rate",
+  vibration_rms: "RMS vibration",
+};
+
+// Statistic / window suffixes, longest match first.
+const STATISTICS: { suffix: string; describe: (sig: string) => string }[] = [
+  { suffix: "p2p_drift_max", describe: (s) => `peak-to-peak drift of ${s}, max over the scoring window` },
+  { suffix: "std_late_minus_early", describe: (s) => `late-vs-early change in the standard deviation of ${s}` },
+  { suffix: "rolling_std_max", describe: (s) => `max of the rolling standard deviation of ${s}` },
+  { suffix: "std_mean", describe: (s) => `mean of the per-window standard deviation of ${s}` },
+  { suffix: "slope_mean", describe: (s) => `mean slope (trend) of ${s} across windows` },
+];
+
+function decomposeWindowed(feature: string): FeatureDef | null {
+  for (const sigToken of Object.keys(SIGNALS)) {
+    if (!feature.startsWith(`${sigToken}_`)) continue;
+    const rest = feature.slice(sigToken.length + 1);
+    const stat = STATISTICS.find((s) => rest === s.suffix);
+    if (!stat) continue;
+    const signal = SIGNALS[sigToken];
+    return {
+      feature,
+      definition: `${stat.describe(signal)}.`,
+      signal,
+      statistic: rest,
+      units: UNITS_UNKNOWN,
+      inferred: true,
+      caveat: CAVEAT,
+    };
+  }
+  return null;
+}
+
+export function lookupFeature(feature: string): FeatureDef | null {
+  if (!feature) return null;
+
+  // One-hot category indicators.
+  if (feature.startsWith("part_family_")) {
+    const fam = feature.slice("part_family_".length);
+    return {
+      feature,
+      definition: `One-hot indicator: the part belongs to family ${fam}.`,
+      signal: "part family (categorical)",
+      statistic: "one_hot",
+      units: "0 / 1 indicator",
+      inferred: true,
+      caveat: CAVEAT,
+    };
+  }
+  if (feature.startsWith("test_type_")) {
+    const t = feature.slice("test_type_".length);
+    return {
+      feature,
+      definition: `One-hot indicator: the test is of type ${t}.`,
+      signal: "test type (categorical)",
+      statistic: "one_hot",
+      units: "0 / 1 indicator",
+      inferred: true,
+      caveat: CAVEAT,
+    };
+  }
+
+  // Explicit count feature.
+  if (feature === "limit_violation_count") {
+    return {
+      feature,
+      definition: "Count of process limit violations observed in the run.",
+      signal: "limit violations",
+      statistic: "count",
+      units: "count",
+      inferred: true,
+      caveat: CAVEAT,
+    };
+  }
+
+  return decomposeWindowed(feature);
+}

--- a/repo-b/src/lib/lab/factoryMetricGlossary.test.ts
+++ b/repo-b/src/lib/lab/factoryMetricGlossary.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { SYNTHETIC_EVAL_NOTE, interpretMetric } from "./factoryMetricGlossary";
+
+describe("factoryMetricGlossary", () => {
+  it("flags near-random AUC as weak evidence", () => {
+    const i = interpretMetric("mean_xgbclf_auc", 0.5148);
+    expect(i.weakBand).toMatch(/near-random/i);
+    expect(i.target).toMatch(/pass \/ fail/i);
+  });
+
+  it("does not flag a healthy AUC", () => {
+    expect(interpretMetric("mean_xgbrun_auc", 0.9775).weakBand).toBeUndefined();
+  });
+
+  it("flags negative R²", () => {
+    expect(interpretMetric("mean_xgbreg_r2", -0.1152).weakBand).toMatch(/negative/i);
+  });
+
+  it("flags a poorly calibrated Brier score", () => {
+    expect(interpretMetric("mean_xgbclf_brier", 0.3136).weakBand).toMatch(/calibrat/i);
+  });
+
+  it("marks pr_auc as the promotion metric", () => {
+    expect(interpretMetric("mean_xgbclf_pr_auc", 0.6265).usedForPromotion).toBe(true);
+    expect(interpretMetric("mean_xgbclf_auc", 0.5148).usedForPromotion).toBe(false);
+  });
+
+  it("keeps the synthetic-eval disclaimer byte-identical", () => {
+    expect(SYNTHETIC_EVAL_NOTE).toBe(
+      "Deterministic synthetic eval for demo; not a trained artifact.",
+    );
+  });
+});

--- a/repo-b/src/lib/lab/factoryMetricGlossary.ts
+++ b/repo-b/src/lib/lab/factoryMetricGlossary.ts
@@ -1,0 +1,74 @@
+// Honest interpretation of the rs_factory headline metrics. The job here is to
+// EXPLAIN each metric and flag weak evidence — never to soften it. The verbatim
+// synthetic-eval disclaimer is preserved byte-for-byte.
+
+export const SYNTHETIC_EVAL_NOTE =
+  "Deterministic synthetic eval for demo; not a trained artifact.";
+
+export const GROUPKFOLD_NOTE = "GroupKFold(part_id) mean";
+
+export type MetricInterpretation = {
+  // the metric family/definition
+  definition: string;
+  // which model family + target the metric scores
+  target: string;
+  // whether this metric drives champion promotion (the seed promotes on pr_auc)
+  usedForPromotion: boolean;
+  // honest weak-evidence flag, when the value warrants it
+  weakBand?: string;
+};
+
+// Map a headline_metrics key -> {modelFamily, metric, target}.
+function parseKey(key: string): { metric: string; family: string; target: string } {
+  const k = key.replace(/^mean_/, "");
+  // families: lr (logistic baseline), ridge (ridge baseline), xgbclf (pass/fail),
+  // xgbreg (strength regressor), xgbrun (run-failure classifier)
+  const families: Record<string, { family: string; target: string }> = {
+    lr: { family: "logistic-regression baseline", target: "pass / fail" },
+    ridge: { family: "ridge baseline", target: "strength margin" },
+    xgbclf: { family: "XGBoost classifier", target: "pass / fail" },
+    xgbreg: { family: "XGBoost regressor", target: "strength margin" },
+    xgbrun: { family: "XGBoost classifier", target: "run failure" },
+  };
+  const prefix = Object.keys(families).find((p) => k.startsWith(`${p}_`));
+  const metric = prefix ? k.slice(prefix.length + 1) : k;
+  const fam = prefix ? families[prefix] : { family: "model", target: "outcome" };
+  return { metric, family: fam.family, target: fam.target };
+}
+
+const METRIC_DEFS: Record<string, string> = {
+  auc: "Area under the ROC curve — ranking quality. 0.5 is random, 1.0 is perfect.",
+  pr_auc: "Area under the precision–recall curve — ranking quality on the positive (rare) class.",
+  brier: "Brier score — mean squared error of predicted probabilities. Lower is better; 0 is perfect.",
+  mae: "Mean absolute error of the predicted value. Lower is better.",
+  r2: "Coefficient of determination. 1.0 is perfect; 0 ties a mean baseline; negative is worse than the mean.",
+};
+
+function weakBand(metric: string, value: number): string | undefined {
+  if (metric === "auc" || metric === "pr_auc") {
+    if (value < 0.6) {
+      return "Weak model evidence — near-random ranking signal without stronger slice/threshold evidence.";
+    }
+    return undefined;
+  }
+  if (metric === "r2") {
+    if (value < 0) return "Negative R² — worse than predicting the mean.";
+    return undefined;
+  }
+  if (metric === "brier") {
+    if (value > 0.25) return "Poorly calibrated — probabilities carry little reliable information.";
+    return undefined;
+  }
+  return undefined;
+}
+
+export function interpretMetric(key: string, value: number): MetricInterpretation {
+  const { metric, family, target } = parseKey(key);
+  return {
+    definition: METRIC_DEFS[metric] ?? `${metric} for the ${family}.`,
+    target: `${family} — ${target}`,
+    // the seed registry promotes the champion on pr_auc
+    usedForPromotion: metric === "pr_auc",
+    weakBand: weakBand(metric, value),
+  };
+}

--- a/repo-b/src/lib/lab/factoryPromotionRationale.test.ts
+++ b/repo-b/src/lib/lab/factoryPromotionRationale.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { RegistryModel, RegistryVersion } from "@/lib/lab/factoryMlData";
+import { RATIONALE_SOURCE, derivePromotionRationale } from "./factoryPromotionRationale";
+
+function v(version: number, value: number, champion: boolean): RegistryVersion {
+  return {
+    version,
+    stage: champion ? "champion" : "archived",
+    is_champion: champion,
+    primary_metric: "pr_auc",
+    primary_metric_value: value,
+    eval_metrics: { pr_auc: value },
+    training_rows: 1000 * version,
+    model_card_summary: null,
+  };
+}
+
+const v4 = v(4, 0.84, true);
+const model: RegistryModel = {
+  model_key: "defect_risk",
+  champion: v4,
+  versions: [v(1, 0.795, false), v(2, 0.81, false), v(3, 0.825, false), v4],
+};
+
+describe("derivePromotionRationale", () => {
+  it("explains why the champion is champion", () => {
+    const r = derivePromotionRationale(model, v4);
+    expect(r.whyChampion.length).toBeGreaterThan(0);
+    expect(r.whyChampion.join(" ")).toMatch(/champion alias/i);
+    expect(r.whyChampion.join(" ")).toMatch(/highest pr_auc/i);
+    expect(r.whyNotChampion).toHaveLength(0);
+  });
+
+  it("explains why an archived version is not champion (lower metric + supersession)", () => {
+    const r = derivePromotionRationale(model, model.versions[0]);
+    const text = r.whyNotChampion.join(" ");
+    expect(text).toMatch(/lower pr_auc/i);
+    expect(text).toMatch(/superseded by champion v4/i);
+    expect(r.whyChampion).toHaveLength(0);
+  });
+
+  it("always labels the derivation source", () => {
+    expect(derivePromotionRationale(model, v4).source).toBe(RATIONALE_SOURCE);
+  });
+});

--- a/repo-b/src/lib/lab/factoryPromotionRationale.ts
+++ b/repo-b/src/lib/lab/factoryPromotionRationale.ts
@@ -1,0 +1,71 @@
+// Derive why a registry version is (or is not) the champion, using only fields
+// already present in the committed model_registry.json. This is DERIVED demo
+// rationale — there is no separate human-approval record in the export, and we
+// say so. Never fabricate gate results that aren't in the data.
+
+import type { RegistryModel, RegistryVersion } from "@/lib/lab/factoryMlData";
+
+export const RATIONALE_SOURCE =
+  "Derived from exported registry metadata; no separate human approval record found.";
+
+export type PromotionRationale = {
+  whyChampion: string[];
+  whyNotChampion: string[];
+  source: string;
+};
+
+function fmt(metric: string, value: number): string {
+  return `${metric} ${value.toFixed(3)}`;
+}
+
+export function derivePromotionRationale(
+  model: RegistryModel,
+  version: RegistryVersion,
+): PromotionRationale {
+  const champion = model.champion;
+  const whyChampion: string[] = [];
+  const whyNotChampion: string[] = [];
+
+  if (version.is_champion) {
+    whyChampion.push(`Current champion alias points to v${version.version}.`);
+    const others = model.versions.filter((v) => v.version !== version.version);
+    const best = others.reduce<RegistryVersion | null>(
+      (acc, v) => (acc === null || v.primary_metric_value > acc.primary_metric_value ? v : acc),
+      null,
+    );
+    if (best && version.primary_metric_value >= best.primary_metric_value) {
+      whyChampion.push(
+        `Highest ${version.primary_metric} among all versions ` +
+          `(${fmt(version.primary_metric, version.primary_metric_value)} vs next ` +
+          `${fmt(best.primary_metric, best.primary_metric_value)}).`,
+      );
+    }
+    const archived = others.filter((v) => v.stage === "archived").length;
+    if (archived > 0) {
+      whyChampion.push(`Supersedes ${archived} archived version${archived === 1 ? "" : "s"}.`);
+    }
+  } else {
+    if (champion) {
+      const delta = champion.primary_metric_value - version.primary_metric_value;
+      if (delta > 0) {
+        whyNotChampion.push(
+          `Lower ${version.primary_metric} than the current champion ` +
+            `(${fmt(version.primary_metric, version.primary_metric_value)} vs ` +
+            `${fmt(champion.primary_metric, champion.primary_metric_value)}, ` +
+            `−${delta.toFixed(3)}).`,
+        );
+      } else if (delta === 0) {
+        whyNotChampion.push(
+          `Ties the champion on ${version.primary_metric} ` +
+            `(${fmt(version.primary_metric, version.primary_metric_value)}) but is not the active alias.`,
+        );
+      }
+      whyNotChampion.push(`Superseded by champion v${champion.version}.`);
+    }
+    if (version.stage === "archived") {
+      whyNotChampion.push("Archived after the champion alias moved; retained for lineage.");
+    }
+  }
+
+  return { whyChampion, whyNotChampion, source: RATIONALE_SOURCE };
+}

--- a/skills/rs-factory-ml/scripts/export_dashboard_json.py
+++ b/skills/rs-factory-ml/scripts/export_dashboard_json.py
@@ -109,6 +109,12 @@ def export_training(client: RsFactoryClient) -> dict:
         drivers.setdefault(row["model"], []).append(
             {"feature": row["feature"], "impact": float(row["impact"])})
         methods[row["model"]] = row["method"]
+    # TODO(drill-evidence): emit a per-feature manifest (units, source table,
+    # aggregation window) and per-version promotion gates so the Factory ML
+    # evidence drawer can show data-backed feature defs / champion rationale
+    # instead of the name-inferred catalog in
+    # repo-b/src/lib/lab/factoryFeatureCatalog.ts. Until then those drawers are
+    # explicitly marked "inferred / derived".
     write("feature_importance.json", {
         "run_id": info["run_id"],
         "drivers": drivers,


### PR DESCRIPTION
## What

Turns the Factory ML / Flight Readiness page (`/lab/env/[envId]/telemetry/factory-ml`) from a static "executive scan" dashboard into an **inspectable evidence surface**. A skeptical reviewer can now click almost anything and ask *where did this number come from, why should I trust it, why is this model champion (or not), and what would have to clear before green?*

## How

- **Shared `FactoryEvidenceDrawer`** (Radix shell copied from `metadata/LineageDrawer.tsx`) driven by a `DrillObject` discriminated union; one instance in `FactoryMlConsole`, each tab emits via `onDrill`.
- **Model Quality** — SHAP "top drivers" chart rewritten off recharts to a **left-justified, clickable label gutter + bar list**; metric cards open the drawer with honest weak-metric interpretation.
- **Registry / NCR / Readiness** drillable: version rows + champion badge + live MLflow run; defect category + exemplar NCR ids; vehicle cards → score breakdown + "what must clear before green".
- New unit-tested libs: `factoryEvidenceLinks` (live-by-default Databricks/MLflow deep links to the owner workspace, disabled-with-reason on missing identifier), `factoryFeatureCatalog` (name-inferred defs, units-unknown marked), `factoryMetricGlossary` (honest weak bands — AUC≈0.51 → near-random, R²<0, Brier poor), `factoryPromotionRationale` (derived why-champion/why-not from registry JSON).
- `Panel.title` widened `string` → `ReactNode` (additive). `.env.example` documents the optional `NEXT_PUBLIC_DATABRICKS_WORKSPACE_URL` override.

## Fail-closed discipline preserved

No fabricated links; weak metrics shown honestly; the `"Deterministic synthetic eval for demo; not a trained artifact."` caveat is byte-identical; missing metadata → explicit "Unavailable — reason".

## Tests

- `tsc --noEmit` + `eslint` clean on touched files.
- **29 new Vitest tests** (4 lib suites + drawer RTL); existing telemetry suite (primitives, RegistryConsole, FactoryNcrIntelligence, LineageDrawer) still green.

## Deferred

Data-backed feature units / per-version promotion gates need the next Databricks regen (TODO left in `skills/rs-factory-ml/scripts/export_dashboard_json.py`). Layer Heatmap tab drill not added this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)