### PR TITLE
feat(telemetry): evidence/lineage → evidence header + spec + docs (0009 Ticket 4)

### DIFF
--- a/docs/plans/03-implementation-plans/active/0009-telemetry-page-header-system.md
+++ b/docs/plans/03-implementation-plans/active/0009-telemetry-page-header-system.md
@@ -1,7 +1,7 @@
 # Dispatch Record 0009 — Telemetry Page Header System Migration
 
 **Created:** 2026-06-24
-**Status:** IN PROGRESS — Ticket 1 (foundation + Overview hero) DONE + merged. Tickets 2–4 open.
+**Status:** COMPLETE — all 4 tickets merged (#335 foundation+hero, #338 operations→compact, #339 models/factory→standard, evidence/lineage→evidence). `TelemetryPageHeader` leads every telemetry route; Overview is the only hero. `tests/telemetry-page-headers.spec.ts` + docs added. Optional follow-up: header-system multi-viewport screenshot set under `telemetry-platform/docs/screenshots/header-system/`.
 **Environment:** Telemetry Platform (`repo-b/src/app/lab/env/[envId]/telemetry/`, `repo-b/src/components/telemetry/`)
 **Owner:** lab-environment-winston (frontend support + QA verification)
 **ADO:** Epic #497 → Feature #721 "Telemetry Frontend Production-Readiness Refactor". Four focused User

--- a/docs/plans/telemetry-platform/design-adaptation.md
+++ b/docs/plans/telemetry-platform/design-adaptation.md
@@ -15,3 +15,13 @@ Will record, per `01-shared-standards/design-system/`:
 - Any component-contract additions needed for the trace viewer or the go/no-go indicator — if a new
   pattern is legitimate, update `01-shared-standards/design-system/component-contracts.md` rather than
   copy-pasting a one-off variant.
+
+## Page header system (dispatch 0009)
+
+Every telemetry route uses the shared `TelemetryPageHeader` family (one `<h1>` + mono eyebrow):
+`hero` (Overview only — editorial Cormorant title, gradient on "Launch"/"Data", Big Numbers row),
+`evidence` (evidence/lineage — editorial, restrained), `standard` (models/factory — Inter Tight),
+`compact` (operational consoles — tight Inter Tight + live chips/controls). Titles use
+`var(--font-editorial)` / `var(--font-display)`; eyebrows/ids/metrics stay JetBrains Mono; colors stay
+on the `C` palette. The header carries no data — callers pass existing values into metadata/actions/metrics
+slots; fail-closed states are untouched. Nested section headings keep using `PageHeading`.

--- a/docs/plans/telemetry-platform/eval-plan.md
+++ b/docs/plans/telemetry-platform/eval-plan.md
@@ -63,3 +63,7 @@ curl -s "http://localhost:8000/monitoring?env_id=<env>" | jq '{psi, anomaly_rate
 
 - [ ] `/score` returns score + go/no-go + model_version + run_id + persistence receipt + attribution.
 - [ ] `/monitoring` returns a PSI value.
+
+## Page header system (dispatch 0009)
+- [ ] `tests/telemetry-page-headers.spec.ts`: one `<h1>` + correct eyebrow/title per variant (hero/compact/standard/evidence) across representative pages, under chromium + webkit projects.
+- [ ] No header migration changed any metric, claim, null_reason, or fail-closed string (asserted by the existing per-component vitest suites, which stay green).

--- a/docs/plans/telemetry-platform/next-session.md
+++ b/docs/plans/telemetry-platform/next-session.md
@@ -94,3 +94,11 @@ seed-pack behavior, and template key. Do not add a standalone RS Factory environ
 
 The prior telemetry-only optional items remain tracked in `backlog.md` and
 `release-readiness.md`; they are not part of the RS Factory generator work.
+
+> **Shipped (2026-06-24) — Telemetry Page Header System (dispatch 0009, all 4 tickets):** PRs #335 (foundation
+> + Overview hero), #338 (operations → compact), #339 (models/factory → standard), + evidence/lineage →
+> evidence. `TelemetryPageHeader` (hero/evidence/standard/compact) now leads every telemetry route; Overview
+> is the only hero (editorial Cormorant). Added `tests/telemetry-page-headers.spec.ts` + doc updates
+> (component-contracts, design-adaptation, qa-checklist, eval-plan, tips). All behavior-preserving; live
+> data/chips/fail-closed in header slots. Remaining optional polish: header-system multi-viewport screenshot
+> set under `telemetry-platform/docs/screenshots/header-system/`; deeper console component-splits (maintainability only).

--- a/docs/plans/telemetry-platform/qa-checklist.md
+++ b/docs/plans/telemetry-platform/qa-checklist.md
@@ -30,3 +30,9 @@ Will cover, per `docs/plans/_templates/qa-checklist-template.md`:
 - [x] Desktop, drawer/trace, and mobile screenshots are stored under
   `docs/evidence/telemetry-metadata-explorer/`.
 - [ ] Repeat endpoint and browser smoke after deployment.
+
+## Page header system (dispatch 0009)
+- [ ] Every nav page + the two standalone operational routes use the `TelemetryPageHeader` family; Overview is the only `hero`.
+- [ ] Each page has exactly one `<h1>`; titles wrap cleanly and metadata/actions stack without overflow at 390 / 1024 / desktop.
+- [ ] Live verdicts/lag/controls/chips/timestamps and fail-closed copy still render (now in header slots); dark-mode title + body text meet WCAG AA.
+- [ ] `npx playwright test tests/telemetry-page-headers.spec.ts` green; header-system screenshots captured (Overview, Mission Control, Model Performance, Metadata Explorer, Resume Evidence).

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4266,3 +4266,29 @@ claims as fact unless sourced; keep era framing general (access → cost → reu
 - **Adding a telemetry sidebar group is data-only** in `telemetryNav.ts` (add to `TelemetryNavGroup` union + `TELEMETRY_NAV_GROUPS` + `TELEMETRY_NAV`); the sidebar auto-renders. BUT `TelemetrySidebar.tsx` has a `GROUP_ACCENT: Record<TelemetryNavGroup, string>` — a new group breaks tsc until you add its accent. Nested slugs like `data-engineering/grain` work directly through `telemetryHref`/`isTelemetryItemActive` (the parent overview item also highlights on child routes — acceptable).
 - **Old-route compatibility = server `redirect()`** from `next/navigation` in each old page.tsx (Next 14, env params via `await params`). The wrapping layout still renders, so also strip its shell wrap (`AdeLayout` → `return <>{children}</>`) since the redirect short-circuits anyway.
 - **vitest unhandled-rejection guard fails "fail-closed" tests** that mock a fetch with `mockRejectedValue` (already-rejected promise rejects before the component's `.catch` attaches; the rejection fires post-teardown via the timer and is attributed to the test). Fix: mirror the repo pattern — `mockResolvedValue(null)` and make the component treat a null/falsy fetch result as the fail-closed state too (real `apiFetch` can both throw AND the test can resolve-null). One branch, both paths covered, no rejection.
+
+## Telemetry page header system (dispatch 0009, 2026-06-24)
+
+- **One header family across a 20-route env.** `TelemetryPageHeader` with four role-based variants
+  (`hero` opening page only · `evidence` evidence/lineage · `standard` analytical · `compact` operational)
+  makes every route scan as one typographic system. Migrate page-by-page (one ticket per role group),
+  each with tsc + the page's vitest + a screenshot, so a bad swap is caught before merge.
+- **Reuse the env's already-loaded fonts.** Cormorant (`--font-editorial`) + Inter Tight (`--font-display`)
+  + JetBrains Mono were already wired via next/font in `app/layout.tsx` and exposed as CSS vars on `<html>`
+  — the header references the vars; no new font infra. Editorial serif for hero/evidence titles, Inter
+  Tight for standard/compact, mono for eyebrows/ids/metrics; colors stay on the `C` palette.
+- **The header carries no data.** It exposes `metadata`/`actions`/`metrics` slots; callers move their
+  EXISTING live chips/lag/verdict/controls/source-strips into those slots verbatim (preserve onClick,
+  disabled, live state, and every string). Fail-closed states and copy never change in a header migration.
+- **Migrating a header ≠ touching the body.** For RS consoles (Registry, Factory/NCR, Mission Control)
+  swap only the top strip to the header; keep the RS body, charts, drawers, and honesty copy. For a page
+  whose error/empty branch returns BEFORE the header (e.g. MetadataExplorer), the header won't show in
+  that state — that's fine; cover it with the component's unit test, not a data-dependent screenshot.
+- **Parallel subagents per file work well for a mechanical, well-specified swap** with strict
+  "byte-identical strings, run tsc+test+lint" rules — but always re-run a CENTRAL tsc+lint+vitest after,
+  because a `next lint` run issued mid-edit by one agent will report a transient parse error in a file
+  another agent is still writing (it resolves once both finish).
+- **Local screenshot harness for env pages:** dev server with `PLAYWRIGHT_BYPASS_AUTH=1` (admin session →
+  env access) + `BOS_API_ORIGIN=<railway backend>` so `/api/telemetry/*` proxies to real data; junction
+  `node_modules` into the worktree; Playwright at 1440×900, env `telemetry-demo`. The playwright.config
+  webServer already sets `PLAYWRIGHT_BYPASS_AUTH=1` for `tests/*.spec.ts`.

--- a/repo-b/src/components/telemetry/EvidenceCards.tsx
+++ b/repo-b/src/components/telemetry/EvidenceCards.tsx
@@ -7,7 +7,8 @@
 // PLAN_DIVERGENCE_REVIEW.md. Nothing here is seeded: every value is fetched or an
 // explicit unavailable state; the Stargate capture is labeled recorded.
 
-import { C, TelemetryThesisHeading } from "./primitives";
+import { C } from "./primitives";
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
 import DataCollectionCard from "./DataCollectionCard";
 import ModelEvidenceCard from "./ModelEvidenceCard";
 import RulConformalCard from "./RulConformalCard";
@@ -21,10 +22,11 @@ import DeploymentReceiptCard from "./DeploymentReceiptCard";
 
 function Lead() {
   return (
-    <TelemetryThesisHeading
+    <TelemetryPageHeader
+      variant="evidence"
       eyebrow="Resume-Claim Evidence"
       title="Every claim, mapped to a live proof"
-      blurb="Each card binds to a real endpoint and fails closed when a source is missing — no seeded numbers. Honest by construction: the autoencoder is shown as the judgment artifact it is (the rolling-MAD detector is the champion), RUL is point-prediction until conformal intervals land, and the live stream is labeled recorded capture, not a live printer."
+      description="Each card binds to a real endpoint and fails closed when a source is missing — no seeded numbers. Honest by construction: the autoencoder is shown as the judgment artifact it is (the rolling-MAD detector is the champion), RUL is point-prediction until conformal intervals land, and the live stream is labeled recorded capture, not a live printer."
     />
   );
 }

--- a/repo-b/src/components/telemetry/GovernanceDashboard.tsx
+++ b/repo-b/src/components/telemetry/GovernanceDashboard.tsx
@@ -7,9 +7,10 @@ import {
   type SecurityPosture, type PostureControl, type McpToolsResponse,
 } from "@/lib/telemetry/copilot-api";
 import {
-  C, Tag, Panel, MetricCard, Loading, ErrorState, PageHeading, DisclosureFooter,
+  C, Tag, Panel, MetricCard, Loading, ErrorState, DisclosureFooter,
   StatGrid, SplitGrid, ScrollTable, ResponsiveSwap, RowCard,
 } from "./primitives";
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
 
 const pct = (x: number | null | undefined) => (x == null ? null : `${Math.round(x * 100)}%`);
 const ms = (x: number | null | undefined) => (x == null ? null : `${x}ms`);
@@ -51,9 +52,9 @@ export default function GovernanceDashboard() {
   }, []);
 
   const head = (
-    <PageHeading eyebrow="Evidence &amp; Lineage · Trust Center"
+    <TelemetryPageHeader variant="evidence" eyebrow="Evidence &amp; Lineage · Trust Center"
       title="Trust Center — why you can trust the AI layer"
-      blurb="AI governance, security posture, model governance, and audit receipts in one place. Every number is aggregated from real logged copilot interactions and a real eval run — nothing is hardcoded. Where a metric is not available, it says so." />
+      description="AI governance, security posture, model governance, and audit receipts in one place. Every number is aggregated from real logged copilot interactions and a real eval run — nothing is hardcoded. Where a metric is not available, it says so." />
   );
   if (err) return <>{head}<ErrorState message={err} /></>;
   if (!g) return <>{head}<Loading label="Loading governance metrics…" /></>;

--- a/repo-b/src/components/telemetry/HowItWorks.tsx
+++ b/repo-b/src/components/telemetry/HowItWorks.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { C, PageHeading, DisclosureFooter } from "./primitives";
+import { C, DisclosureFooter } from "./primitives";
+import { TelemetryPageHeader } from "./TelemetryPageHeader";
 import TelemetryArchitectureMap, { KnownLimitationsPanel } from "./TelemetryArchitectureMap";
 
 // "How This Works" — the telemetry system-architecture exhibit. A faithful React port of the
@@ -14,10 +15,11 @@ import TelemetryArchitectureMap, { KnownLimitationsPanel } from "./TelemetryArch
 export default function HowItWorks({ envId }: { envId: string }) {
   return (
     <div>
-      <PageHeading
+      <TelemetryPageHeader
+        variant="evidence"
         eyebrow="System Architecture"
         title="Winston Telemetry Platform"
-        blurb="Data · ML · Streaming · Serving · Governance — a truth-bounded map of the whole platform. Click a lane to read it; click a node for the plain-English story: what it is, which system runs it, whether it is real-and-live, real-over-synthetic, committed evidence, optional, or planned — and a link to the live surface where one exists."
+        description="Data · ML · Streaming · Serving · Governance — a truth-bounded map of the whole platform. Click a lane to read it; click a node for the plain-English story: what it is, which system runs it, whether it is real-and-live, real-over-synthetic, committed evidence, optional, or planned — and a link to the live surface where one exists."
       />
 
       <TelemetryArchitectureMap envId={envId} />

--- a/repo-b/src/components/telemetry/metadata/MetricLineageExplorer.tsx
+++ b/repo-b/src/components/telemetry/metadata/MetricLineageExplorer.tsx
@@ -22,11 +22,11 @@ import {
   EmptyState,
   Loading,
   MetricCard,
-  PageHeading,
   Panel,
   StatGrid,
   Tag,
 } from "../primitives";
+import { TelemetryPageHeader } from "../TelemetryPageHeader";
 import LineageDrawer from "./LineageDrawer";
 
 function formatTs(value?: string | null) {
@@ -62,10 +62,11 @@ export default function MetricLineageExplorer({ envId }: { envId: string }) {
   }, [envId, reload]);
 
   const heading = (
-    <PageHeading
+    <TelemetryPageHeader
+      variant="evidence"
       eyebrow="Evidence & Lineage"
       title="Metric Lineage Explorer"
-      blurb="Every governed metric, traced to its source. Click a metric to see its full upstream chain (gold to silver to bronze to source) with freshness and owner. Lineage is read live from the telemetry metadata catalog; a metric with no cataloged source shows 'No lineage yet' rather than implying provenance."
+      description="Every governed metric, traced to its source. Click a metric to see its full upstream chain (gold to silver to bronze to source) with freshness and owner. Lineage is read live from the telemetry metadata catalog; a metric with no cataloged source shows 'No lineage yet' rather than implying provenance."
     />
   );
 

--- a/repo-b/src/components/telemetry/metadata/TelemetryMetadataExplorer.tsx
+++ b/repo-b/src/components/telemetry/metadata/TelemetryMetadataExplorer.tsx
@@ -27,6 +27,7 @@ import {
   type TelemetryMetadataNode,
 } from "@/lib/telemetry/metadata";
 import { C, EmptyState, Panel, Tag } from "../primitives";
+import { TelemetryPageHeader } from "../TelemetryPageHeader";
 import MetadataDetailDrawer from "./MetadataDetailDrawer";
 import MetadataGraphNode, {
   type MetadataFlowNode,
@@ -339,43 +340,13 @@ export default function TelemetryMetadataExplorer({ envId }: { envId: string }) 
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-      <header
-        style={{
-          border: `1px solid ${C.border}`,
-          background: C.panel,
-          borderRadius: 11,
-          padding: 18,
-        }}
-      >
-        <div style={{ display: "flex", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
-          <div>
-            <div
-              style={{
-                color: C.cyan,
-                fontFamily: C.mono,
-                fontSize: 10,
-                letterSpacing: "0.13em",
-                textTransform: "uppercase",
-              }}
-            >
-              RS Telemetry / Control Plane
-            </div>
-            <h1
-              style={{
-                color: C.text,
-                fontFamily: C.sans,
-                fontSize: 27,
-                fontWeight: 750,
-                marginTop: 6,
-              }}
-            >
-              Telemetry Metadata Explorer
-            </h1>
-            <p style={{ color: C.dim, fontSize: 14, lineHeight: 1.5, marginTop: 7 }}>
-              Schemas, feeds, lineage, and consumers for the RS Telemetry environment
-            </p>
-          </div>
-          <div style={{ display: "flex", alignItems: "flex-start", gap: 8, flexWrap: "wrap" }}>
+      <TelemetryPageHeader
+        variant="evidence"
+        eyebrow="RS Telemetry / Control Plane"
+        title="Telemetry Metadata Explorer"
+        description="Schemas, feeds, lineage, and consumers for the RS Telemetry environment"
+        actions={
+          <>
             <StatusPill graph={graph} />
             <Tag color={freshnessSummary(graph) === "fresh" ? C.green : C.amber}>
               {freshnessSummary(graph)}
@@ -398,52 +369,62 @@ export default function TelemetryMetadataExplorer({ envId }: { envId: string }) 
             >
               {loading ? "Refreshing..." : "Refresh"}
             </button>
+          </>
+        }
+        metadata={
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+            {[
+              ["Route environment", envId],
+              ["Serving data scope", graph.env_id ?? TELEMETRY_DEMO_ENV_ID],
+              ["Generated", formatTimestamp(graph.generated_at)],
+            ].map(([label, value]) => (
+              <div
+                key={label}
+                style={{
+                  border: `1px solid ${C.border}`,
+                  borderRadius: 7,
+                  background: C.panelHi,
+                  padding: "10px 11px",
+                  minWidth: 0,
+                }}
+              >
+                <div
+                  style={{
+                    color: C.faint,
+                    fontFamily: C.mono,
+                    fontSize: 8,
+                    letterSpacing: "0.1em",
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {label}
+                </div>
+                <div
+                  style={{
+                    color: C.text,
+                    fontFamily: C.mono,
+                    fontSize: 11,
+                    marginTop: 5,
+                    overflowWrap: "anywhere",
+                  }}
+                >
+                  {value}
+                </div>
+              </div>
+            ))}
           </div>
-        </div>
+        }
+      />
 
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3" style={{ marginTop: 16 }}>
-          {[
-            ["Route environment", envId],
-            ["Serving data scope", graph.env_id ?? TELEMETRY_DEMO_ENV_ID],
-            ["Generated", formatTimestamp(graph.generated_at)],
-          ].map(([label, value]) => (
-            <div
-              key={label}
-              style={{
-                border: `1px solid ${C.border}`,
-                borderRadius: 7,
-                background: C.panelHi,
-                padding: "10px 11px",
-                minWidth: 0,
-              }}
-            >
-              <div
-                style={{
-                  color: C.faint,
-                  fontFamily: C.mono,
-                  fontSize: 8,
-                  letterSpacing: "0.1em",
-                  textTransform: "uppercase",
-                }}
-              >
-                {label}
-              </div>
-              <div
-                style={{
-                  color: C.text,
-                  fontFamily: C.mono,
-                  fontSize: 11,
-                  marginTop: 5,
-                  overflowWrap: "anywhere",
-                }}
-              >
-                {value}
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-[minmax(220px,1fr)_repeat(4,minmax(130px,0.55fr))_auto]" style={{ marginTop: 16, alignItems: "end" }}>
+      <div
+        style={{
+          border: `1px solid ${C.border}`,
+          background: C.panel,
+          borderRadius: 11,
+          padding: 18,
+        }}
+      >
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-[minmax(220px,1fr)_repeat(4,minmax(130px,0.55fr))_auto]" style={{ alignItems: "end" }}>
           <label style={{ display: "flex", flexDirection: "column", gap: 5 }}>
             <span
               style={{
@@ -495,7 +476,7 @@ export default function TelemetryMetadataExplorer({ envId }: { envId: string }) 
             Clear
           </button>
         </div>
-      </header>
+      </div>
 
       {graph.warnings.length > 0 && (
         <Panel

--- a/repo-b/tests/telemetry-page-headers.spec.ts
+++ b/repo-b/tests/telemetry-page-headers.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+// Telemetry page header system (dispatch 0009). Asserts the shared TelemetryPageHeader family is in
+// place across the variant spectrum: each page has exactly one <h1>, the right eyebrow, and the
+// expected title — independent of backend data (these headers render even when the body fails closed).
+// Runs under both projects (chromium Desktop + webkit iPhone), so it doubles as a wrap/viewport check.
+
+const ENV_ID = "telemetry-demo";
+const base = (slug: string) => `/lab/env/${ENV_ID}/telemetry${slug ? `/${slug}` : ""}`;
+
+test.beforeEach(async ({ context, baseURL }) => {
+  if (!baseURL) throw new Error("baseURL missing");
+  const url = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo_lab_session", value: "active", domain: url.hostname, path: "/", httpOnly: true, sameSite: "Lax" },
+  ]);
+});
+
+// One representative page per variant; header renders regardless of backend availability.
+const PAGES: { slug: string; eyebrow: string; title: string; variant: string }[] = [
+  { slug: "", eyebrow: "Overview", title: "Why Launch Became A Data Problem", variant: "hero" },
+  { slug: "stargate", eyebrow: "Stargate Live", title: "Printer telemetry stream", variant: "compact" },
+  { slug: "model-performance", eyebrow: "Model Performance", title: "Champions, metrics, and promotion gates", variant: "standard" },
+  { slug: "evidence", eyebrow: "Resume-Claim Evidence", title: "Every claim, mapped to a live proof", variant: "evidence" },
+];
+
+for (const p of PAGES) {
+  test(`${p.variant} header renders with one h1 + eyebrow on /${p.slug || "(overview)"}`, async ({ page }) => {
+    await page.goto(base(p.slug));
+    // Exactly one page-level heading.
+    const h1s = page.getByRole("heading", { level: 1 });
+    await expect(h1s).toHaveCount(1);
+    await expect(h1s.first()).toHaveText(new RegExp(p.title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    // The mono eyebrow precedes it.
+    await expect(page.getByText(p.eyebrow, { exact: true }).first()).toBeVisible();
+  });
+}


### PR DESCRIPTION
**Dispatch 0009, Ticket 4 — completes the header system.** Migrates `EvidenceCards`, `GovernanceDashboard`, `HowItWorks`, `metadata/MetricLineageExplorer`, `metadata/TelemetryMetadataExplorer` to `TelemetryPageHeader` variant `evidence`.

- Editorial header leads each page; metadata scope/freshness/generated-at/status + refresh control moved **verbatim** into the header `metadata`/`actions` slots.
- ReactFlow graphs, drawers, posture/PROVES panels, and fail-closed states (`metadata_graph_unreachable`, `no_upstream_edges_in_catalog`, governance N=0) unchanged.

Adds **`tests/telemetry-page-headers.spec.ts`** (one `<h1>` + correct eyebrow/title per variant across hero/compact/standard/evidence, under chromium + webkit projects). Docs: 0009 → COMPLETE; header-system sections added to `component-contracts` (Ticket 1), `design-adaptation`, `qa-checklist`, `eval-plan`, `next-session`, and `tips.md`.

With this, **all 20 telemetry routes share the header family; Overview is the only hero.**

### Verification
`tsc` clean · `next lint` clean · `vitest` 33 files / 132 tests · screenshots (Evidence editorial header + all 10 cards; Metadata Explorer fail-closes on local data by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)