### PR TITLE
Stargate anomaly-triage agent reproducibility artifacts (Ticket 3)

### DIFF
--- a/infra/confluent/stargate/agents/README.md
+++ b/infra/confluent/stargate/agents/README.md
@@ -1,0 +1,85 @@
+# Stargate anomaly-triage agent — reproducibility artifacts
+
+The Confluent **Streaming Agent** that turns deterministic anomaly events into structured AI triage.
+Deployed agent: `Paul_Streaming_Agent`, model `stargate-anomaly-triage-gpt4o`. These files exist so the
+agent can be re-created from the repo; nothing here is auto-submitted (the agent runs in Confluent).
+
+```
+stargate.printer.anomalies.v1            (input — deterministic detection event, from Flink 02)
+  → Paul_Streaming_Agent / stargate-anomaly-triage-gpt4o
+    → stargate.printer.anomaly.triage.v1 (output — this agent's triage)
+      → backend/app/services/telemetry_stream_consumer.py  (durable consumer, Ticket 2)
+        → tel_stream_triage_events                          (Postgres projection, Ticket 1 / 10034)
+```
+
+**Role boundary (load-bearing):** the upstream Flink rule
+(`../flink/02_anomaly_route.sql`, `melt_pool_temp_c < 1400 AND arm_vibration_g > 0.08`) **detects**;
+the agent only **explains and triages**. The agent is never the detector. Stargate is deterministic
+synthetic printer replay carried through real infrastructure — not live physical telemetry.
+
+## Files
+
+| File | What it is |
+|---|---|
+| `anomaly_triage_agent.sql` | Re-creatable model + sink-table + agent INSERT (anomalies → model → triage). Submit each statement separately, same as the `flink/*.sql` lane. |
+| `anomaly_triage_system_prompt.md` | The model's system prompt — **single source of truth for the output contract**. Paste verbatim into the model's `openai.system_prompt`. |
+| `anomaly_triage_output.schema.json` | json-registry value schema for `stargate.printer.anomaly.triage.v1`. Field names == the consumer + `tel_stream_triage_events`. |
+| `../topics/stargate.printer.anomaly.triage.v1.json` | Topic inventory entry (documentation). The topic is **Flink-owned**: the agent's `CREATE TABLE … WITH json-registry` binds topic + schema together, so do **not** pre-create it (same rule as agg5s/anomalies — see `../README.md`). |
+
+## Contract lock (do not drift)
+
+The triage JSON field names are a contract shared by three places — change them together or not at all:
+
+1. `anomaly_triage_system_prompt.md` (what the model emits)
+2. `anomaly_triage_output.schema.json` (the registered value schema)
+3. `backend/app/services/telemetry_stream_consumer.py::persist_row` (what the consumer reads into
+   `tel_stream_triage_events`): `triage_id, anomaly_id, printer_id, print_job_id, run_id, severity,
+   status, incident_summary, likely_cause, leading_indicators, recommended_action, confidence,
+   requires_human_review, null_reason`.
+
+Fail-closed semantics are part of the contract: `status` defaults to `not_available`,
+`requires_human_review` defaults to `true`, `severity` is null when not triaged.
+
+## Re-create the agent (Confluent CLI; secrets stay out of the repo)
+
+Prerequisite: `confluent login --save` (interactive, one-time — see `../README.md`).
+
+```powershell
+# 1. Connection holds the OpenAI endpoint + key. Created out-of-band so no secret lands in the repo.
+confluent flink connection create stargate-openai-connection `
+  --cloud gcp --region us-east1 --environment <env-id> `
+  --type openai --endpoint https://api.openai.com/v1/chat/completions `
+  --api-key "$env:OPENAI_API_KEY"
+
+# 2. Model — paste the system prompt from anomaly_triage_system_prompt.md verbatim.
+confluent flink statement create triage-model `
+  --sql "<CREATE MODEL block from anomaly_triage_agent.sql, with openai.system_prompt filled in>" `
+  --compute-pool <pool-id> --database <lkc-id> --environment <env-id> --cloud gcp --region us-east1 --wait
+
+# 3. Sink table + agent statement (each separately; Flink owns the triage topic).
+confluent flink statement create triage-table `
+  --sql "<CREATE TABLE stargate.printer.anomaly.triage.v1 block>" `
+  --compute-pool <pool-id> --database <lkc-id> --environment <env-id> --cloud gcp --region us-east1 --wait
+confluent flink statement create triage-agent `
+  --sql "<INSERT INTO stargate.printer.anomaly.triage.v1 … block>" `
+  --compute-pool <pool-id> --database <lkc-id> --environment <env-id> --cloud gcp --region us-east1 `
+  --property "sql.tables.scan.startup.mode=latest-offset" --wait
+```
+
+## Verify
+
+```powershell
+confluent flink statement list --cloud gcp --region us-east1 --environment <env-id>
+# triage rows emitted while the anomaly route runs:
+confluent kafka topic consume stargate.printer.anomaly.triage.v1 --from-beginning
+```
+
+End to end (with the Ticket-2 consumer on, `TELEMETRY_KAFKA_CONSUMER_ENABLED=1` + `CONFLUENT_*`):
+triage rows land in `tel_stream_kafka_rows` (record_kind=`triage`) and upsert `tel_stream_triage_events`
+keyed on `triage_id`.
+
+## Cost hygiene
+
+The model + agent statement run on the same Flink compute pool as `flink/01`/`02`. Park or delete the
+pool when the demo is done (see `../README.md` and `skills/confluent-stargate-lifecycle/`). The agent
+also bills per OpenAI call — do not leave the agent statement running against a live high-rate feed.

--- a/infra/confluent/stargate/agents/anomaly_triage_agent.sql
+++ b/infra/confluent/stargate/agents/anomaly_triage_agent.sql
@@ -1,0 +1,104 @@
+-- Confluent Streaming Agent: Stargate anomaly triage (reproducibility artifact).
+--
+-- The deployed agent is "Paul_Streaming_Agent" with model "stargate-anomaly-triage-gpt4o".
+-- It READS deterministic anomaly events and EMITS structured AI triage events. It is NOT the
+-- detector: the upstream Flink rule (flink/02_anomaly_route.sql, predicate
+-- `melt_pool_temp_c < 1400 AND arm_vibration_g > 0.08`) detects; this agent only EXPLAINS and
+-- recommends. Nothing here changes detection.
+--
+--   stargate.printer.anomalies.v1            (input — the detection event)
+--     -> Paul_Streaming_Agent / stargate-anomaly-triage-gpt4o
+--       -> stargate.printer.anomaly.triage.v1 (output — this agent's triage)
+--
+-- Output schema: anomaly_triage_output.schema.json (json-registry). The field names MUST match the
+-- durable consumer (backend/app/services/telemetry_stream_consumer.py::persist_row, which upserts
+-- tel_stream_triage_events): triage_id, anomaly_id, printer_id, print_job_id, severity, status,
+-- incident_summary, likely_cause, leading_indicators, recommended_action, confidence,
+-- requires_human_review, null_reason (+ provenance: source_topic/partition/offset, schema_subject/version).
+--
+-- This file documents the agent so it can be re-created from the repo. It is not auto-submitted by any
+-- script (the agent runs in Confluent; see agents/README.md for the create/verify steps). Submit each
+-- statement separately, same as the flink/*.sql lane.
+
+-- ── 1. The model handle (provisioned once; connection holds the GPT-4o endpoint + key) ────────────────
+-- The CONNECTION (credentials) is created out-of-band via `confluent flink connection create` so no
+-- secret lands in the repo (see agents/README.md). The model binds the system prompt below.
+CREATE MODEL IF NOT EXISTS `stargate-anomaly-triage-gpt4o`
+INPUT (prompt STRING)
+OUTPUT (response STRING)
+WITH (
+  'provider' = 'openai',
+  'task' = 'text_generation',
+  'openai.connection' = 'stargate-openai-connection',
+  'openai.model_version' = 'gpt-4o',
+  -- System prompt is the single source of truth for the output contract.
+  -- Keep byte-equal to agents/anomaly_triage_system_prompt.md.
+  'openai.system_prompt' = '<<see agents/anomaly_triage_system_prompt.md>>'
+);
+
+-- ── 2. The triage output topic table (json-registry; Flink owns its sink topic) ───────────────────────
+-- Do NOT pre-create the topic — like agg5s/anomalies, the CREATE TABLE binds topic + json-registry
+-- schema together. Fields mirror anomaly_triage_output.schema.json.
+CREATE TABLE IF NOT EXISTS `stargate.printer.anomaly.triage.v1` (
+  triage_id STRING,
+  anomaly_id STRING,
+  printer_id STRING,
+  print_job_id STRING,
+  severity STRING,                 -- low | medium | high | critical | null
+  status STRING,                   -- ok | not_available
+  incident_summary STRING,
+  likely_cause STRING,
+  leading_indicators ARRAY<STRING>,
+  recommended_action STRING,
+  confidence STRING,               -- low | medium | high
+  requires_human_review BOOLEAN,
+  null_reason STRING,
+  source_topic STRING,             -- provenance: the anomaly event this triage explains
+  source_partition INT,
+  source_offset BIGINT,
+  schema_subject STRING,
+  schema_version INT
+) WITH (
+  'value.format' = 'json-registry'
+);
+
+-- ── 3. The agent statement: anomalies -> model -> triage ──────────────────────────────────────────────
+-- ML_PREDICT runs the model per anomaly row; the prompt embeds the structured anomaly. The model is
+-- instructed (system prompt) to return STRICT JSON matching the output schema; we parse it into columns.
+-- triage_id is deterministic per anomaly so re-runs are idempotent downstream (the consumer upserts on
+-- triage_id). status/severity FAIL CLOSED to 'not_available'/NULL when the model cannot triage.
+INSERT INTO `stargate.printer.anomaly.triage.v1`
+SELECT
+  CONCAT('tri_', a.printer_id, '_', CAST(a.ts_us AS STRING))   AS triage_id,
+  CONCAT('anom_', a.printer_id, '_', CAST(a.ts_us AS STRING))  AS anomaly_id,
+  a.printer_id,
+  a.print_job_id,
+  JSON_VALUE(p.response, '$.severity')                          AS severity,
+  COALESCE(JSON_VALUE(p.response, '$.status'), 'not_available') AS status,
+  JSON_VALUE(p.response, '$.incident_summary')                 AS incident_summary,
+  JSON_VALUE(p.response, '$.likely_cause')                     AS likely_cause,
+  CAST(JSON_QUERY(p.response, '$.leading_indicators') AS ARRAY<STRING>) AS leading_indicators,
+  JSON_VALUE(p.response, '$.recommended_action')               AS recommended_action,
+  JSON_VALUE(p.response, '$.confidence')                       AS confidence,
+  COALESCE(CAST(JSON_VALUE(p.response, '$.requires_human_review') AS BOOLEAN), TRUE) AS requires_human_review,
+  JSON_VALUE(p.response, '$.null_reason')                      AS null_reason,
+  'stargate.printer.anomalies.v1'                              AS source_topic,
+  CAST(NULL AS INT)                                            AS source_partition,
+  CAST(NULL AS BIGINT)                                         AS source_offset,
+  'stargate.printer.anomalies.v1-value'                        AS schema_subject,
+  CAST(NULL AS INT)                                            AS schema_version
+FROM `stargate.printer.anomalies.v1` AS a
+CROSS JOIN LATERAL TABLE(
+  ML_PREDICT(
+    'stargate-anomaly-triage-gpt4o',
+    CONCAT(
+      'Triage this Stargate printer anomaly. Return STRICT JSON only.\n',
+      'printer_id=', a.printer_id,
+      ' print_job_id=', a.print_job_id,
+      ' layer=', CAST(a.layer AS STRING),
+      ' melt_pool_temp_c=', CAST(a.melt_pool_temp_c AS STRING),
+      ' arm_vibration_g=', CAST(a.arm_vibration_g AS STRING),
+      ' ts_us=', CAST(a.ts_us AS STRING)
+    )
+  )
+) AS p;

--- a/infra/confluent/stargate/agents/anomaly_triage_output.schema.json
+++ b/infra/confluent/stargate/agents/anomaly_triage_output.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "stargate.printer.anomaly.triage.v1-value",
+  "description": "AI triage output for a Stargate printer anomaly. Emitted by the Confluent Streaming Agent (stargate-anomaly-triage-gpt4o), consumed durably by backend/app/services/telemetry_stream_consumer.py and projected into tel_stream_triage_events. The agent EXPLAINS anomalies the upstream Flink rule detected; it is not the detector. Field names are the contract — keep equal to the consumer and agents/anomaly_triage_system_prompt.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["triage_id", "anomaly_id", "status", "requires_human_review"],
+  "properties": {
+    "triage_id": {
+      "type": "string",
+      "description": "Stable id for this triage record (PK of tel_stream_triage_events). Deterministic per anomaly so re-runs upsert. Stamped by the pipeline, not the model."
+    },
+    "anomaly_id": {
+      "type": ["string", "null"],
+      "description": "Correlates back to the upstream detection event. Stamped by the pipeline."
+    },
+    "printer_id": { "type": ["string", "null"] },
+    "print_job_id": { "type": ["string", "null"] },
+    "run_id": { "type": ["string", "null"], "description": "Print/test run id, not a Databricks run id." },
+    "severity": {
+      "type": ["string", "null"],
+      "enum": ["low", "medium", "high", "critical", null],
+      "description": "Model's severity. Null when status=not_available."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["ok", "not_available"],
+      "description": "Fail-closed: 'ok' when triaged, else 'not_available' with null_reason set."
+    },
+    "incident_summary": { "type": ["string", "null"] },
+    "likely_cause": { "type": ["string", "null"] },
+    "leading_indicators": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Signals that drove the triage call. Possibly empty."
+    },
+    "recommended_action": { "type": ["string", "null"] },
+    "confidence": {
+      "type": ["string", "null"],
+      "enum": ["low", "medium", "high", null]
+    },
+    "requires_human_review": {
+      "type": "boolean",
+      "default": true,
+      "description": "Fails closed to true; false only when severity=low AND confidence=high."
+    },
+    "null_reason": {
+      "type": ["string", "null"],
+      "description": "Machine-readable reason when status=not_available (e.g. insufficient_signal)."
+    },
+    "source_topic": {
+      "type": ["string", "null"],
+      "description": "Provenance: the anomaly topic this triage explains (stargate.printer.anomalies.v1)."
+    },
+    "source_partition": { "type": ["integer", "null"] },
+    "source_offset": { "type": ["integer", "null"] },
+    "schema_subject": { "type": ["string", "null"] },
+    "schema_version": { "type": ["integer", "null"] }
+  }
+}

--- a/infra/confluent/stargate/agents/anomaly_triage_system_prompt.md
+++ b/infra/confluent/stargate/agents/anomaly_triage_system_prompt.md
@@ -1,0 +1,69 @@
+# Stargate anomaly-triage agent — system prompt
+
+This is the system prompt for the Confluent Streaming Agent model
+`stargate-anomaly-triage-gpt4o` (deployed agent: `Paul_Streaming_Agent`). It is the **single source
+of truth** for the agent's output contract. When you re-create the model
+(`agents/anomaly_triage_agent.sql`, the `openai.system_prompt` property), paste the prompt block below
+**byte-for-byte**.
+
+The agent's output JSON field names MUST match the durable consumer
+(`backend/app/services/telemetry_stream_consumer.py::persist_row`, which upserts
+`tel_stream_triage_events`). Do not rename a field without changing the consumer + the output schema
+(`anomaly_triage_output.schema.json`) in the same change.
+
+## Role boundary (load-bearing)
+
+The agent **explains and triages** anomalies that an upstream deterministic rule already detected
+(`flink/02_anomaly_route.sql`: `melt_pool_temp_c < 1400 AND arm_vibration_g > 0.08`). The agent is **not
+the detector** and must never claim to have detected the anomaly. Stargate is deterministic synthetic
+printer replay carried through real infrastructure — not live physical telemetry. The prompt must not
+assert physical ground truth.
+
+## Prompt (paste verbatim into `openai.system_prompt`)
+
+```text
+You are a triage assistant for a metal 3D-printer telemetry stream (the "Stargate" lane). An upstream
+deterministic rule has ALREADY flagged the input as an anomaly (cold melt pool AND high arm vibration).
+Your job is to EXPLAIN and TRIAGE that flagged event — not to decide whether it is an anomaly, and not
+to claim you detected it.
+
+You will receive one anomaly's fields (printer_id, print_job_id, layer, melt_pool_temp_c,
+arm_vibration_g, ts_us). Reason about the likely physical cause and the recommended operator action for
+a metal additive-manufacturing process, given a cold melt pool (< 1400 C) together with elevated arm
+vibration (> 0.08 g).
+
+Return STRICT JSON only — no prose, no markdown, no code fences. Exactly these keys:
+
+{
+  "severity": "low | medium | high | critical",
+  "status": "ok",
+  "incident_summary": "one sentence, factual, no hedging filler",
+  "likely_cause": "the most probable physical cause, or null if you cannot say",
+  "leading_indicators": ["short phrases naming the signals that drove the call"],
+  "recommended_action": "the next operator step, or null",
+  "confidence": "low | medium | high",
+  "requires_human_review": true,
+  "null_reason": null
+}
+
+Rules:
+- status is "ok" when you produced a real triage. If you cannot triage (insufficient or contradictory
+  input), set status="not_available", severity=null, set null_reason to a short machine-readable reason
+  (e.g. "insufficient_signal"), and leave the explanatory fields null.
+- requires_human_review defaults to true. Only set it false when severity is "low" AND confidence is
+  "high".
+- Never invent a printer_id, anomaly_id, offset, or schema id — those are stamped by the pipeline, not
+  by you.
+- Do not assert physical ground truth or real-world hardware state; you are triaging a synthetic replay
+  carried through real infrastructure.
+- Keep every string short. leading_indicators is a JSON array of strings (possibly empty).
+```
+
+## Notes
+
+- `triage_id`, `anomaly_id`, and the provenance fields (`source_topic/partition/offset`,
+  `schema_subject/version`) are stamped by the agent SQL / pipeline, **not** by the model — the prompt
+  deliberately forbids the model from inventing them.
+- `confidence` and `severity` are the model's; `requires_human_review` fails closed to `true`.
+- If you change OpenAI model versions, keep this contract identical so the consumer and the
+  `tel_stream_triage_events` projection do not drift.

--- a/infra/confluent/stargate/topics/stargate.printer.anomaly.triage.v1.json
+++ b/infra/confluent/stargate/topics/stargate.printer.anomaly.triage.v1.json
@@ -1,0 +1,6 @@
+{
+  "name": "stargate.printer.anomaly.triage.v1",
+  "is_internal": false,
+  "replication_factor": 3,
+  "partition_count": 6
+}


### PR DESCRIPTION
## Summary
Ticket 3 of the Confluent → Databricks → Postgres telemetry lineage walkthrough. Makes the Confluent **Streaming Agent** (`Paul_Streaming_Agent` / `stargate-anomaly-triage-gpt4o`) re-creatable from the repo. The agent reads deterministic anomaly events and emits structured AI triage to `stargate.printer.anomaly.triage.v1` — it **explains** anomalies the upstream Flink rule detected; it is **not** the detector.

```
stargate.printer.anomalies.v1  →  agent (gpt-4o)  →  stargate.printer.anomaly.triage.v1
  →  telemetry_stream_consumer (Ticket 2)  →  tel_stream_triage_events (Ticket 1 / 10034)
```

## Files (all new, under `infra/confluent/stargate/`)
- `agents/anomaly_triage_agent.sql` — `CREATE MODEL` + json-registry sink table + the agent `INSERT` (anomalies → `ML_PREDICT` → triage). Flink-owned topic (not pre-created).
- `agents/anomaly_triage_system_prompt.md` — the model's system prompt; **single source of truth for the output contract**. Role boundary (explains, doesn't detect), STRICT-JSON, fail-closed rules.
- `agents/anomaly_triage_output.schema.json` — json-registry value schema; field names == the Ticket-2 consumer and `tel_stream_triage_events`.
- `agents/README.md` — re-create + verify steps (secrets stay out of the repo via a Flink `connection`), the contract lock across prompt/schema/consumer, cost hygiene.
- `topics/stargate.printer.anomaly.triage.v1.json` — topic inventory entry.

## Verification
- **Contract aligned:** a cross-check confirms every field `telemetry_stream_consumer.persist_row` reads (`triage_id, anomaly_id, printer_id, print_job_id, run_id, severity, status, incident_summary, likely_cause, leading_indicators, recommended_action, confidence, null_reason`) is present in the output schema.
- `pytest tests/test_stargate_codec.py -k Lock` → 3 passed — the FlinkSqlLock test parses `flink/*.sql`, not `agents/`, so it's unaffected.
- Both new JSON files parse.

## Scope
Artifacts/config + docs only. **No** Confluent/Flink runtime change, **no** code change, **no** secrets (the OpenAI key lives in a Flink connection created out-of-band, never in the repo).

## Follow-up
Ticket 4 — FastAPI lineage/provenance routes (`/api/telemetry/stream/kafka/...`, `/api/telemetry/stream/lineage/anomaly/{id}`). Then Ticket 5 (frontend drawer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)