### PR TITLE
security(#724): redact OpenAI key fragment from code-quality report

### DIFF
--- a/docs/ops-reports/code-quality/2026-03-21.md
+++ b/docs/ops-reports/code-quality/2026-03-21.md
@@ -167,7 +167,7 @@ The agent built significant features that align with the Meta Prompt directives 
 ## Improvement Recommendations
 
 ### Priority 1: CRITICAL — Rotate Exposed API Key
-`openaikey.txt` exists at repo root with a live OpenAI API key (`sk-proj-F6QN...`). While `.gitignore` lists it, the file is present in the working directory. Database credentials are also in `.env.local` files. **Action:** Rotate all exposed credentials immediately. Ensure `openaikey.txt` is not in git history (check with `git log --all -- openaikey.txt`).
+`openaikey.txt` exists at repo root with a live OpenAI API key (`sk-proj-REDACTED...`). While `.gitignore` lists it, the file is present in the working directory. Database credentials are also in `.env.local` files. **Action:** Rotate all exposed credentials immediately. Ensure `openaikey.txt` is not in git history (check with `git log --all -- openaikey.txt`).
 
 ### Priority 2: HIGH — Fix the Build-Then-Fix Loop
 37 of 76 commits (49%) are fixes for issues that should have been caught before committing. **Action:** Add pre-commit hooks:


### PR DESCRIPTION
Narrow redaction for ADO #724.

`docs/ops-reports/code-quality/2026-03-21.md` quoted a key fragment verbatim inside its own "rotate this key" finding. Replaced the fragment with `sk-proj-REDACTED`.

## Findings
- The tracked value was a **4-char prefix fragment + literal `...`** (`sk-proj-F6QN...`), not a recoverable key.
- Repo-wide secret scan (`sk-`/`AKIA`/`ghp_`/`gho_`/`xox`/`PRIVATE KEY` across all tracked files on main): **no other live secret**. The only other hit was `backend/app/services/telemetry_metadata.py:168`, which is itself a secret-detection regex (false positive).
- **No history rewrite** — a 4-char fragment doesn't justify rewriting shared history across active branches/worktrees.
- Key rotation handled out of band.

Single-file, one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)