### PR TITLE
ci(#720): fix confluent CLI install path on GH runner

### DIFF
--- a/.github/workflows/confluent-broker-refresh.yml
+++ b/.github/workflows/confluent-broker-refresh.yml
@@ -47,9 +47,13 @@ jobs:
         run: pip install psycopg2-binary
 
       - name: Install confluent CLI
+        # Install to a user-writable dir — the runner's /usr/local/bin is not chmod-able
+        # without sudo ("Operation not permitted").
         run: |
-          curl -sL --http1.1 https://cnfl.io/cli | sh -s -- -b /usr/local/bin
-          confluent version
+          mkdir -p "$HOME/.local/bin"
+          curl -sL --http1.1 https://cnfl.io/cli | sh -s -- -b "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/confluent" version
 
       - name: Confluent login (service account key)
         # Non-fatal: if the key secrets are absent/invalid the login fails, but the


### PR DESCRIPTION
The installer can't chmod /usr/local/bin without sudo, aborting the job before the fail-closed refresh step. Install to $HOME/.local/bin + GITHUB_PATH instead. Follow-up to #347.