### PR TITLE
Fix Stargate schema registry exports

### DIFF
--- a/docs/plans/03-implementation-plans/active/telemetry-confluent-databricks-supabase-lineage.md
+++ b/docs/plans/03-implementation-plans/active/telemetry-confluent-databricks-supabase-lineage.md
@@ -141,3 +141,14 @@ verification pending owner-role access. Do **not** start Ticket 2 until `10034` 
 
 **Risks/unknowns:** owner credential is the interactive Databricks human login (not in Railway/Vercel/
 Supabase). No Stargate→Delta mapping yet (pointers stay `not_available`).
+
+## Cleanup — Stargate schema exports (2026-06-24)
+
+Before Ticket 4: the 4 files under `infra/confluent/stargate/schemas/` held a Confluent CLI **error
+dump**, not schemas (born corrupted in `1de9b66e`). Root cause: the lifecycle `export` action ran
+`confluent schema-registry schema describe … -o json 2>&1 > file`, but `schema describe` has **no `-o`
+flag**, so the error was redirected into the file. Regenerated all 4 from live Schema Registry
+(env `env-vwkk2z`) into clean `{subject, version, id, schemaType, schema}` JSON — JSON-type subjects
+embed the parsed schema, the PROTOBUF telemetry subject embeds the raw `.proto` text. Fixed the exporter
+in `skills/confluent-stargate-lifecycle/scripts/lifecycle.ps1` so future exports don't re-corrupt.
+Validated: valid JSON, no CLI error strings, expected subjects/ids. Schema-artifact cleanup only.

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4292,3 +4292,9 @@ claims as fact unless sourced; keep era framing general (access → cost → reu
   env access) + `BOS_API_ORIGIN=<railway backend>` so `/api/telemetry/*` proxies to real data; junction
   `node_modules` into the worktree; Playwright at 1440×900, env `telemetry-demo`. The playwright.config
   webServer already sets `PLAYWRIGHT_BYPASS_AUTH=1` for `tests/*.spec.ts`.
+
+**Schema Registry exports — validate after export; don't blind-redirect stderr:**
+- **`confluent schema-registry schema describe` has NO `-o`/`--output json` flag** (unlike `kafka cluster/topic describe` and `flink compute-pool describe`, which do). Passing `-o json` errors; a blind `… -o json 2>&1 > file.json` writes the CLI error dump INTO the file. This silently corrupted all 4 `infra/confluent/stargate/schemas/*-value.json` at birth — they looked exported but contained `Error: unknown shorthand flag: 'o'`.
+- **`describe` prints a human `Schema ID:/Type:/Schema:` block, not JSON.** To make a `.json` artifact: capture stdout only (no `2>&1`), parse out id/type, and emit `{subject, version, id, schemaType, schema}`. **JSON**-type subjects embed the parsed schema object; **PROTOBUF/AVRO** subjects embed the raw schema text as a string (the protobuf telemetry subject's body is a `.proto`, not JSON — don't `JSON.parse` it).
+- **Always validate exported schema JSON before committing:** `json.load` each file AND grep for `Error:`, `Usage:`, `failed`, `Unauthorized`, `Forbidden`. (Note `confluent` alone is a false-positive grep: real Avro schemas contain `io.confluent.connect.*` annotation keys.)
+- **Never hand-write a schema export when live Schema Registry is reachable** — query it (`confluent schema-registry schema list` / `describe --subject … --version latest`) so the artifact matches the registered subject/id exactly.

--- a/infra/confluent/stargate/schemas/sample_data_stock_trades-value.json
+++ b/infra/confluent/stargate/schemas/sample_data_stock_trades-value.json
@@ -1,26 +1,47 @@
-Error: unknown shorthand flag: 'o' in -o
-Usage:
-  confluent schema-registry schema describe [id] [flags]
-
-Examples:
-Describe the schema with ID "1337".
-
-  $ confluent schema-registry schema describe 1337
-
-Describe the schema with subject "payments" and version "latest".
-
-  $ confluent schema-registry schema describe --subject payments --version latest
-
-Flags:
-      --subject string                    Subject of the schema.
-      --version string                    Version of the schema. Can be a specific version or "latest".
-      --show-references                   Display the entire schema graph, including references.
-      --context string                    CLI context name.
-      --environment string                Environment ID.
-      --schema-registry-endpoint string   The URL of the Schema Registry cluster.
-
-Global Flags:
-  -h, --help            Show help for this command.
-      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
-  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
-
+{
+  "subject": "sample_data_stock_trades-value",
+  "version": "latest",
+  "id": 100001,
+  "schemaType": "JSON",
+  "schema": {
+    "type": "object",
+    "title": "ksql.StockTrade",
+    "connect.parameters": {
+      "io.confluent.connect.avro.field.doc.account": "Simulated accounts assigned to the trade",
+      "io.confluent.connect.avro.field.doc.quantity": "A simulated random quantity of the trade",
+      "io.confluent.connect.avro.field.doc.symbol": "Simulated stock symbols",
+      "io.confluent.connect.avro.record.doc": "Defines a hypothetical stock trade using some known test stock symbols.",
+      "io.confluent.connect.avro.field.doc.price": "A simulated random trade price in pennies",
+      "io.confluent.connect.avro.field.doc.userid": "The simulated user who executed the trade",
+      "io.confluent.connect.avro.field.doc.side": "A simulated trade side (buy or sell or short)"
+    },
+    "properties": {
+      "symbol": {
+        "type": "string",
+        "connect.index": 2
+      },
+      "side": {
+        "type": "string",
+        "connect.index": 0
+      },
+      "quantity": {
+        "type": "integer",
+        "connect.index": 1,
+        "connect.type": "int32"
+      },
+      "price": {
+        "type": "integer",
+        "connect.index": 3,
+        "connect.type": "int32"
+      },
+      "userid": {
+        "type": "string",
+        "connect.index": 5
+      },
+      "account": {
+        "type": "string",
+        "connect.index": 4
+      }
+    }
+  }
+}

--- a/infra/confluent/stargate/schemas/stargate.printer.anomalies.v1-value.json
+++ b/infra/confluent/stargate/schemas/stargate.printer.anomalies.v1-value.json
@@ -1,26 +1,83 @@
-Error: unknown shorthand flag: 'o' in -o
-Usage:
-  confluent schema-registry schema describe [id] [flags]
-
-Examples:
-Describe the schema with ID "1337".
-
-  $ confluent schema-registry schema describe 1337
-
-Describe the schema with subject "payments" and version "latest".
-
-  $ confluent schema-registry schema describe --subject payments --version latest
-
-Flags:
-      --subject string                    Subject of the schema.
-      --version string                    Version of the schema. Can be a specific version or "latest".
-      --show-references                   Display the entire schema graph, including references.
-      --context string                    CLI context name.
-      --environment string                Environment ID.
-      --schema-registry-endpoint string   The URL of the Schema Registry cluster.
-
-Global Flags:
-  -h, --help            Show help for this command.
-      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
-  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
-
+{
+  "subject": "stargate.printer.anomalies.v1-value",
+  "version": "latest",
+  "id": 100005,
+  "schemaType": "JSON",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "arm_vibration_g": {
+        "connect.index": 5,
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "connect.type": "float64",
+            "type": "number"
+          }
+        ]
+      },
+      "layer": {
+        "connect.index": 2,
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "connect.type": "int32",
+            "type": "number"
+          }
+        ]
+      },
+      "melt_pool_temp_c": {
+        "connect.index": 4,
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "connect.type": "float64",
+            "type": "number"
+          }
+        ]
+      },
+      "print_job_id": {
+        "connect.index": 3,
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "printer_id": {
+        "connect.index": 0,
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "ts_us": {
+        "connect.index": 1,
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "connect.type": "int64",
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "title": "Record",
+    "type": "object"
+  }
+}

--- a/infra/confluent/stargate/schemas/stargate.printer.telemetry.agg5s.v1-value.json
+++ b/infra/confluent/stargate/schemas/stargate.printer.telemetry.agg5s.v1-value.json
@@ -1,26 +1,84 @@
-Error: unknown shorthand flag: 'o' in -o
-Usage:
-  confluent schema-registry schema describe [id] [flags]
-
-Examples:
-Describe the schema with ID "1337".
-
-  $ confluent schema-registry schema describe 1337
-
-Describe the schema with subject "payments" and version "latest".
-
-  $ confluent schema-registry schema describe --subject payments --version latest
-
-Flags:
-      --subject string                    Subject of the schema.
-      --version string                    Version of the schema. Can be a specific version or "latest".
-      --show-references                   Display the entire schema graph, including references.
-      --context string                    CLI context name.
-      --environment string                Environment ID.
-      --schema-registry-endpoint string   The URL of the Schema Registry cluster.
-
-Global Flags:
-  -h, --help            Show help for this command.
-      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
-  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
-
+{
+  "subject": "stargate.printer.telemetry.agg5s.v1-value",
+  "version": "latest",
+  "id": 100004,
+  "schemaType": "JSON",
+  "schema": {
+    "additionalProperties": false,
+    "properties": {
+      "avg_temp_c": {
+        "connect.index": 3,
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "connect.type": "float64",
+            "type": "number"
+          }
+        ]
+      },
+      "max_vibration_g": {
+        "connect.index": 4,
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "connect.type": "float64",
+            "type": "number"
+          }
+        ]
+      },
+      "n": {
+        "connect.index": 5,
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "connect.type": "int64",
+            "type": "number"
+          }
+        ]
+      },
+      "printer_id": {
+        "connect.index": 0,
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "window_end_ms": {
+        "connect.index": 2,
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "connect.type": "int64",
+            "type": "number"
+          }
+        ]
+      },
+      "window_start_ms": {
+        "connect.index": 1,
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "connect.type": "int64",
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "title": "Record",
+    "type": "object"
+  }
+}

--- a/infra/confluent/stargate/schemas/stargate.printer.telemetry.v1-value.json
+++ b/infra/confluent/stargate/schemas/stargate.printer.telemetry.v1-value.json
@@ -1,26 +1,7 @@
-Error: unknown shorthand flag: 'o' in -o
-Usage:
-  confluent schema-registry schema describe [id] [flags]
-
-Examples:
-Describe the schema with ID "1337".
-
-  $ confluent schema-registry schema describe 1337
-
-Describe the schema with subject "payments" and version "latest".
-
-  $ confluent schema-registry schema describe --subject payments --version latest
-
-Flags:
-      --subject string                    Subject of the schema.
-      --version string                    Version of the schema. Can be a specific version or "latest".
-      --show-references                   Display the entire schema graph, including references.
-      --context string                    CLI context name.
-      --environment string                Environment ID.
-      --schema-registry-endpoint string   The URL of the Schema Registry cluster.
-
-Global Flags:
-  -h, --help            Show help for this command.
-      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
-  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
-
+{
+  "subject": "stargate.printer.telemetry.v1-value",
+  "version": "latest",
+  "id": 100003,
+  "schemaType": "PROTOBUF",
+  "schema": "syntax = \"proto3\";\npackage stargate.v1;\n\nmessage StargateTelemetry {\n  string printer_id = 1;\n  int64 ts_us = 2;\n  uint32 layer = 3;\n  string print_job_id = 4;\n  double x = 5;\n  double y = 6;\n  double z = 7;\n  double melt_pool_temp_c = 8;\n  double deposition_rate_kg_hr = 9;\n  double arm_vibration_g = 10;\n  optional double laser_power_w = 11;\n}\n"
+}

--- a/skills/confluent-stargate-lifecycle/scripts/lifecycle.ps1
+++ b/skills/confluent-stargate-lifecycle/scripts/lifecycle.ps1
@@ -164,14 +164,29 @@ function Do-Export {
   }
   Say "exported $($topicNames.Count) topics" 'Green'
 
-  # schema subjects (latest version each)
+  # schema subjects (latest version each).
+  # NOTE: `schema describe` does NOT support `-o json` (unlike the cluster/topic/pool describe
+  # commands above). Passing it errors, and a blind `2>&1 > file` writes the CLI error dump INTO the
+  # schema file. So: capture stdout only (no 2>&1) and parse the human "Schema ID:/Type:/Schema:"
+  # output into a clean {subject, version, id, schemaType, schema} doc. JSON schemas embed the parsed
+  # object; PROTOBUF/AVRO embed the raw schema text as a string. A bad/empty describe is skipped, never
+  # written. (Re-corrupting these files is exactly the bug fix/stargate-schema-exports addressed.)
   $subs = & confluent schema-registry subject list --environment $ENV_ID -o json 2>&1 | ConvertFrom-Json
   $subjNames = @()
   foreach ($s in $subs) {
-    $subjNames += $s.subject
     $safe = ($s.subject -replace '[^\w\.\-]','_')
-    & confluent schema-registry schema describe --subject $s.subject --version latest --environment $ENV_ID -o json 2>&1 |
-      Out-File -Encoding utf8 (Join-Path $IacDir 'schemas' "$safe.json")
+    $raw = & confluent schema-registry schema describe --subject $s.subject --version latest --environment $ENV_ID 2>$null
+    $text = ($raw -join "`n")
+    if ($text -match 'Error:|Usage:' -or [string]::IsNullOrWhiteSpace($text)) {
+      Say "  skipped schema $($s.subject) (describe returned no schema)" 'Yellow'; continue
+    }
+    $id   = if ($text -match 'Schema ID:\s*(\d+)') { [int]$Matches[1] } else { $null }
+    $type = if ($text -match 'Type:\s*(\w+)')      { $Matches[1] }       else { $null }
+    $body = if ($text -match '(?s)Schema:\s*\n(.*)$') { $Matches[1].Trim() } else { '' }
+    $schema = if ($type -eq 'JSON') { $body | ConvertFrom-Json } else { $body }  # proto/avro: raw text
+    $doc = [ordered]@{ subject = $s.subject; version = 'latest'; id = $id; schemaType = $type; schema = $schema }
+    $doc | ConvertTo-Json -Depth 50 | Out-File -Encoding utf8 (Join-Path $IacDir 'schemas' "$safe.json")
+    $subjNames += $s.subject
   }
   Say "exported $($subjNames.Count) schema subjects" 'Green'
 


### PR DESCRIPTION
## Summary
Pre-Ticket-4 cleanup: the schema export files under `infra/confluent/stargate/schemas/` contained a **Confluent CLI error dump**, not schemas. Regenerated them from live Schema Registry and fixed the exporter that produced the corruption. Schema-artifact cleanup only.

## Corrupted files (all 4 — born corrupted in `1de9b66e`)
Each held `Error: unknown shorthand flag: 'o' in -o` + CLI usage text instead of a schema:
- `sample_data_stock_trades-value.json`
- `stargate.printer.telemetry.v1-value.json`
- `stargate.printer.telemetry.agg5s.v1-value.json`
- `stargate.printer.anomalies.v1-value.json`

(There is no `stargate.printer.dlq.v1-value.json` — the DLQ topic carries raw bytes, no value schema.)

## Root cause
The lifecycle `export` action (`skills/confluent-stargate-lifecycle/scripts/lifecycle.ps1`) ran:
`confluent schema-registry schema describe … -o json 2>&1 > file.json`
But `schema describe` has **no `-o`/`--output` flag** (unlike the cluster/topic/pool `describe` commands). The flag errored, and `2>&1` redirected the CLI error into the schema file.

## Subjects regenerated (from live SR, env `env-vwkk2z`)
| Subject | ID | Type |
|---|---|---|
| sample_data_stock_trades-value | 100001 | JSON |
| stargate.printer.telemetry.v1-value | 100003 (latest=v2) | PROTOBUF |
| stargate.printer.telemetry.agg5s.v1-value | 100004 | JSON |
| stargate.printer.anomalies.v1-value | 100005 | JSON |

Each file is now `{subject, version, id, schemaType, schema}` — JSON subjects embed the parsed schema object; the PROTOBUF telemetry subject embeds the raw `.proto` text as a string.

## CLI command shape
```
confluent schema-registry schema describe --subject <subject> --version latest
# (NO -o flag; stdout parsed into id/type/schema — never 2>&1 into the file)
```
Also fixed `lifecycle.ps1` to use this shape so future exports don't re-corrupt.

## Validation
- Every file parses as valid JSON.
- No file contains `Error:`, `Usage:`, `failed`, `Unauthorized`, `Forbidden`. (The substring `confluent` appears only as legitimate `io.confluent.connect.avro.*` annotation keys in the Avro sample schema.)
- Each file carries the expected `subject`/`id`/`schemaType`/`schema`; all 4 expected subjects represented.
- `git diff --check` clean.

## No secrets
The OpenAI/cluster keys are never in these files. The only secret-pattern matches in the diff are **deletions** of the old error-dump help text. No API keys, tokens, connection strings, or CLI config committed.

## Scope
Schema artifacts + the exporter script + plan/tips notes. **No** backend routes, frontend drawer, consumer logic, topic-name, or Ticket-4 changes. The unrelated Stargate scoring-lane work was left untouched.

## Next
Ticket 4 — FastAPI lineage/provenance routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)