### PR TITLE
docs(telemetry): divergence proof package (re-land after branch collision)

### DIFF
--- a/DIVERGENCE_FINDINGS_DEMO_SCRIPT.md
+++ b/DIVERGENCE_FINDINGS_DEMO_SCRIPT.md
@@ -1,0 +1,122 @@
+# Divergence Findings — Demo Script
+
+> Companion to `PLAN_DIVERGENCE_REVIEW.md` (the audit) and `claim_coverage_matrix.md` (the
+> claim→proof matrix). This is the **presentation** layer: what to click, what to say, what **not** to
+> claim, and the answers to the sharp questions. Built to make the story impossible to miss and hard to
+> overclaim.
+
+## The one-sentence thesis
+
+> Launch became a data problem because modern operations depend on **collecting, scoring, trusting, and
+> acting on** telemetry fast enough to improve the next test/build/launch action. This demo proves that
+> pattern with **honest ML findings**: conservative uncertainty changes calls; regime mismatch breaks
+> naive detectors; out-of-envelope inputs abstain; lead-lag separates root cause from coupled symptoms;
+> analog retrieval is useful but modest; and unsupported ideas are rejected instead of fabricated.
+
+## The six beats (the spine of every walkthrough)
+
+1. **Uncertainty changes the call** — conformal lower-bound RUL go/no-go *(Spin 3, LIVE)*
+2. **Regime mismatch breaks naive anomaly detection** — FD004 regime-conditioning *(Spin 1, LIVE)*
+3. **Out-of-envelope inputs should abstain before scoring** — competence envelope *(Spin 5, LIVE)*
+4. **Lead-lag separates root cause from coupled symptoms** — sensor attribution *(Spin 2, compute)*
+5. **Analog retrieval is real but modest, not magic** — event-windowed DTW *(Spin 6, compute)*
+6. **Unsupported ideas are rejected, not fabricated** — feature-completeness gate *(Spin 4, declined)*
+
+## Access
+
+- **URL:** `https://novendor.ai`
+- **Login:** use the **scoped reviewer credential** (username `telemetry`) — *never* the admin login in a
+  demo context. Password in `docs/reference/ENV_KEYS.md`.
+- **Telemetry env:** `/lab/env/dc82d39d-9be2-49b0-a01d-c7181b13a8b6/telemetry`
+- **Pages used:** `…/telemetry` (Overview), `…/telemetry/stargate`, `…/telemetry/evidence`,
+  `…/telemetry/model-performance`, `…/telemetry/system-health`.
+
+---
+
+## 5-minute walkthrough (the three live findings)
+
+| Step | Click | Say | Don't claim |
+|---|---|---|---|
+| 0 | **Overview** (`/telemetry`) | "Why launch became a data problem — access, cost, reuse, scale, and now *data velocity*. Everything below is real-or-explicitly-unavailable." | Don't quote a "live printer" volume — Stargate is recorded capture. |
+| 1 | **Stargate Live** → click **Start recorded capture** | "Protobuf over Kafka, windowed, anomalies routed to their own topic, ring-buffered — recorded test-stand capture replayed through the real bridge. The baseline is a rolling-MAD scorer, not an LSTM." | Not a live printer; not an LSTM. |
+| 2 | **Evidence** → **Conformal RUL** card | "In a go/no-go you clear on the *worst case* — the calibrated lower bound. **15 of 100 units look GO on the point estimate but the lower bound flags them.** PICP 0.86 at a 0.90 target — measured, slightly under." | PICP is ~0.86, not "guaranteed 90%"; intervals are marginal, FD001-only. |
+| 3 | **Evidence** → **Regime Anomaly** card | "The obvious global detector flags ~100% of *healthy* points in 5 of 6 operating regimes — its error is **entirely** explained by regime (η²=1.0). Regime-conditioning cuts the worst-regime false alarms **100%→10% (90% reduction)**. This is the degenerate-autoencoder story, fixed." | Global baseline is the single-mode assumption (a real naive baseline, not a strawman); FD004 has no anomaly labels — metric is false-positives on healthy rows. |
+| 4 | **Evidence** → **Competence Envelope** card | "Before scoring, ask: is this input inside the model's trained envelope? FD001-trained envelope holds for its own units (**98.9% in**) but **90.5% of FD004 is out-of-envelope → abstain**. Drift, flipped upstream." | Gates the *input distribution*, not correctness; "abstain/review/within trained scope", never "safe/certified"; FD004 is a regime-shift stress test, not hot-fire. |
+
+Close: "Three findings, all live, all honest about what's measured vs unavailable."
+
+---
+
+## 10-minute walkthrough (add the two compute findings + the trust layer)
+
+Do the 5-minute path, then:
+
+5. **Model Performance / Registry** — "Promotion is a fail-closed gate on *honest* metrics (event recall,
+   affiliation F1), not the inflated point-adjusted F1. Champion is rolling-MAD; the 256-d autoencoder is
+   shown as a measured judgment artifact, not a working detector."
+6. **Lead-lag attribution (Spin 2 — compute, talk-track + artifact)** — "On the coupled C-MAPSS engine,
+   channel-level attribution is redundant: **14 of 15 sensors deviate at failure (93% co-move)**. Onset
+   timing pins **sensors 9, 14, 11** as the consistent leads (~80 cycles of lead time); downstream sensors
+   lag by ~11 cycles. That's how a failure board narrows root cause." *(Artifact:
+   `telemetry-platform/lead_lag_attribution_evidence.json`. UI card pending the frontend refactor.)*
+7. **Event-windowed analog retrieval (Spin 6 — compute)** — "Whole-series cosine and event-windowed DTW
+   agree on only **9%** of precedents; event-windowing lifts anomaly-precedent retrieval **+8%**. Real, but
+   **modest, not magic** — and linked dispositions aren't in public data, so I show that as unavailable, not
+   fabricated." *(Artifact: `telemetry-platform/event_windowed_analog_evidence.json`.)*
+8. **System Health / Trust** — "Drift PSI bands, governed-metric catalog (provenance + freshness, not
+   auto-derived lineage), and the copilot that refuses out-of-scope and post-validates its own numbers."
+
+---
+
+## 20-minute walkthrough (the full case)
+
+Do the 10-minute path, then add the **methodology + honesty** layer:
+
+- **Data Collection card** — the data types a test/build/launch program depends on, each tied to the
+  decision it changes (framework, labeled not-live).
+- **Pipeline / Feature Contract** — real Databricks/PySpark medallion, no-look-ahead (`ROWS BETWEEN n
+  PRECEDING`), grouped-by-unit walk-forward with a **passing label-shuffle leakage control**.
+- **One Known Anomaly Walkthrough** — score → ranked contributing channels → GO/REVIEW/NO-GO → lineage.
+- **AI evidence** — one grounded answer + one refusal + visible audit log.
+- **Deployment receipt** — live backend `/version` SHA + frontend build + CI gates.
+- **Spin 4 — the rejection (say this out loud):** "I tried a feature-completeness go/no-go gate. The data
+  shape doesn't support it — there's no multi-rate/late-arriving signal in these public datasets, and I
+  wouldn't fabricate one. So it's **declined**, not faked. That decision is itself the point: the platform
+  rejects unsupported ideas instead of overbuilding a chart."
+- **The negative results as judgment artifacts:** the degenerate autoencoder (built→measured→broke→fixed
+  via Spin 1), point-adjusted vs honest F1, and the first conformal calibration that under-covered (0.44)
+  until I fixed the calibration set. "These are the things a skeptic can't dismiss as borrowed."
+
+---
+
+## What NOT to claim (hard guardrails)
+
+- **Not** Relativity's production system — the same *operating pattern*, honestly scoped.
+- **Not** a live printer — Stargate is recorded capture replayed through the real bridge.
+- **Not** a working autoencoder detector — it's degenerate; the champion is rolling-MAD; the 256-d vector
+  is for retrieval.
+- **Not** "calibrated 90% coverage" — measured PICP **~0.86**, slightly under, on FD001 single-condition.
+- **Not** "safe"/"certified" for the envelope — "within trained scope" / "abstain/review".
+- **Not** "beats baseline forecasting" — the NCR forecast ties naive; don't center it.
+- **Not** auto-derived lineage — a governed *catalog* with provenance + freshness.
+- **Not** "event-windowed retrieval is a breakthrough" — it's a **modest +8%**, with dispositions
+  unavailable.
+- **Not** Brier for telemetry — that's probabilistic-forecasting work, not this slice.
+
+## Gotcha answers (the sharp questions)
+
+- **"Isn't the regime baseline a strawman?"** — No: it's the single-operating-mode assumption — the real
+  FD001→FD004 generalization failure. A model that explicitly models all six conditions also works; the
+  point is operating-condition awareness is *required*, and per-regime normalization is the scalable way.
+- **"FD004 has no anomaly labels — what are you measuring?"** — False positives on *healthy* (high-RUL)
+  rows, grouped fit/eval by unit. It's false-alarm rate, not detection recall — and I say so.
+- **"Why is PICP under 0.90?"** — Honest: split conformal with a modest calibration set; a first cut on
+  near-failure rows under-covered at 0.44, fixed by calibrating on operational-cycle rows. Reported as
+  measured, not dressed up.
+- **"Is C-MAPSS rocket data?"** — No — simulated turbofan / spacecraft analogs. Transferable *patterns*,
+  framed as such. The hot-fire framing is the *thesis*, the datasets are honest analogs.
+- **"Where's the lead-lag / analog UI?"** — Compute is shipped + reproducible; the cards are deferred
+  behind a concurrent frontend refactor, wired onto the new evidence-card contract next (no recomputation
+  in the frontend — they read the committed artifacts).
+- **"Did you fabricate anything to fill the matrix?"** — No — Spin 4 was declined for lack of supporting
+  data. That's the tell that the rest is real.

--- a/DIVERGENCE_RECEIPTS_MANIFEST.md
+++ b/DIVERGENCE_RECEIPTS_MANIFEST.md
@@ -1,0 +1,105 @@
+# Divergence Receipts Manifest
+
+> Every receipt behind the divergence program: PRs, ADO stories, reproducible artifacts, tests, prod
+> surfaces, and the handoff notes for the two compute-only findings whose UI cards are deferred behind a
+> concurrent frontend refactor. Pairs with `PLAN_DIVERGENCE_REVIEW.md`, `claim_coverage_matrix.md`, and
+> `DIVERGENCE_FINDINGS_DEMO_SCRIPT.md`.
+
+## Finding ledger
+
+| Finding | Status | PR | ADO | Reproducible artifact | Eval test | Prod page |
+|---|---|---|---|---|---|---|
+| **Spin 1** regime-conditioned anomaly | **LIVE + verified** | #314 | #718 | `telemetry-platform/regime_anomaly_evidence.json` (+ `compute_regime_anomaly.py`, `regime_core.py`) | `test_regime_core.py` (3) | `/telemetry/evidence` → RegimeAnomalyCard |
+| **Spin 2** sensor lead-lag attribution | **compute shipped · card deferred** | #331 | #726 | `telemetry-platform/lead_lag_attribution_evidence.json` (+ `compute_lead_lag_attribution.py`, `lead_lag_core.py`) | `test_lead_lag_core.py` (5) | — (artifact only) |
+| **Spin 3** conformal lower-bound RUL | **LIVE + verified** | #308 | #716 | `telemetry-platform/rul_conformal_evidence.json` (+ `compute_rul_conformal.py`, `conformal_core.py`) | `test_conformal_core.py` (4) | `/telemetry/evidence` → RulConformalCard |
+| **Spin 4** feature-completeness gate | **declined — not feasible without fabricated data** | — | — | — (no artifact; intentional) | — | — |
+| **Spin 5** pre-test competence envelope | **LIVE + verified** | #316 | #719 | `telemetry-platform/competence_envelope_evidence.json` (+ `compute_competence_envelope.py`, `envelope_core.py`) | `test_envelope_core.py` (3) | `/telemetry/evidence` → CompetenceEnvelopeCard |
+| **Spin 6** event-windowed analog retrieval | **compute shipped · card deferred** | #327 | #723 | `telemetry-platform/event_windowed_analog_evidence.json` (+ `compute_event_windowed_analog.py`, `analog_core.py`) | `test_analog_core.py` (4) | — (artifact only) |
+| **Spin 7** grouped walk-forward | RUL already grouped-by-unit (leakage control passes); anomaly version null by construction | (#308 RUL) | (#716) | `rul_conformal_evidence.json` (grouped split) | — | — |
+| **Derived A** degenerate autoencoder | surfaced + **fixed by Spin 1** | #305 / #314 | #707 / #718 | `regime_anomaly_evidence.json` | — | evidence page |
+| **Derived B** honest vs point-adjusted F1 | already in the system | (pre-existing) | — | `eval_honest_metrics.py` / `honest_metrics_result.json` | — | model-performance |
+
+## Measured values (the unfakeable numbers)
+
+- **Spin 1:** worst-regime false-positive **100% → 10.2% (90% reduction)**; mean **84.3% → 5.7%**;
+  recon-error variance explained by regime **η² 1.0 → 0.0**; per-regime FP `[1,1,1,0.06,1,1] → [0.07,0.05,0.10,0.03,0.08,0.02]`.
+- **Spin 2:** median **14 of 15** sensors deviate at failure (**93%** co-move); lead sensors **sensor_9**
+  (onset freq 0.86, median lead 86.5 cyc), **sensor_14** (0.88, 81.0), **sensor_11** (1.0, 76.5); median
+  downstream lag **11 cycles**.
+- **Spin 3:** **PICP 0.86** at a 0.90 target; lower-bound coverage 0.85; mean interval width 56 cycles;
+  point RMSE 20.96; **15/100** units flip GO→REVIEW/NO-GO on the lower bound; 22 units disagree.
+- **Spin 5:** FD001 held-out **98.9% in-envelope**; FD004 **90.5% out-of-envelope** (+1.5% near); τ=61.6;
+  example FD001 unit 85 d²=18.2 → SCORE, FD004 unit 83 d² ≫ τ → ABSTAIN.
+- **Spin 6:** whole-series cosine **41.5%** vs event-windowed DTW **45.0%** anomalous-match (**+8.4%**),
+  top-5 overlap **9%**, pool base rate 36.6%.
+
+## All divergence PRs (merged to main)
+
+#305 (Phase 1 evidence cards + Stargate Start + `/api/version` proxy) · #306 (`main.py` bridge init) ·
+#307 (docs/tips wrap) · #308 (Spin 3 conformal RUL) · #309 (newscope narrative) · #310 (Overview heading) ·
+#311 (Big Numbers inline) · #314 (Spin 1 regime anomaly) · #316 (Spin 5 competence envelope) ·
+#327 (Spin 6 analog compute) · #331 (Spin 2 lead-lag compute).
+
+> Note: **#321** was a redundant no-op duplicate of a parallel agent's PR A (#320) — 0-line merge, main
+> verified clean (single primitive export set). Recorded for honesty; no impact.
+
+## ADO
+
+Epic **#497** (RS-Analytics) → Feature **#691** (telemetry redesign). Stories all **Closed**: #707 (Phase 1),
+#716 (Spin 3), #717 (newscope), #718 (Spin 1), #719 (Spin 5), #723 (Spin 6), #726 (Spin 2).
+Refactor (parallel agent): Feature #721, Story #722 (my no-op PR A).
+
+## Tests
+
+- **ML eval (pure-numpy, CI-safe, run locally):** `test_conformal_core` (4) · `test_regime_core` (3) ·
+  `test_envelope_core` (3) · `test_analog_core` (4) · `test_lead_lag_core` (5) = **19 green**.
+- **Frontend card tests (CI):** `RulConformalCard`, `RegimeAnomalyCard`, `CompetenceEnvelopeCard`, the six
+  Phase-1 cards, `StargateConsole`, `telemetryNav` — green at each merge.
+- **Backend (CI):** `test_stargate_bridge.py` (15, incl. `POST /stargate/replay/cycle`).
+
+## Screenshots / receipts (local, untracked)
+
+`repo-b/_smoke_shots/`: `evidence.png`, `conformal_evidence.png`, `regime_card.png`, `envelope_card.png`,
+`stargate_live_after.png`, `overview_top.png`, `newscope_evidence.png`. Each prod-smoked via a throwaway
+Playwright `.cjs` (deleted after run; password read by length only).
+
+---
+
+## Card handoff notes — for the frontend refactor agent (Spin 2 & Spin 6)
+
+**Do not recompute in the frontend.** Both cards render a committed JSON artifact, exactly like the three
+live cards (`RulConformalCard` etc.). The pattern: copy the artifact from `telemetry-platform/` into
+`repo-b/src/lib/telemetry/`, `import` it, type it, fail closed if fields are missing, render onto the new
+`TelemetryEvidenceCard` contract (`sourceStatus: "computed"`), and add to `EvidenceCards.tsx` after the
+Competence Envelope card. **Preserve the values and caveat strings byte-identical from the JSON.**
+
+### Spin 2 — "Lead-Lag Root Cause" card
+- **Artifact:** `telemetry-platform/lead_lag_attribution_evidence.json` → copy to
+  `repo-b/src/lib/telemetry/leadLagAttributionEvidence.json`.
+- **Reference shape:** mirror `RegimeAnomalyCard.tsx` (metric strip + ranked table + finding + limitations).
+- **Render:** `metrics.median_sensors_deviating_at_failure` / `channel_attribution_redundancy_pct` (the
+  "93% redundant" headline), `metrics.lead_sensors` (9/14/11), `metrics.median_downstream_lag_cycles` (11);
+  `sensor_ranking[]` table (sensor · onset_frequency · median_lead_cycles); `example`; `finding`.
+- **Caveats to preserve (verbatim from `limitations`):** "C-MAPSS is simulated… pattern, not ground-truth
+  subsystem wiring"; "onset is a threshold-crossing, not a calibrated change-point"; "lead-lag narrows
+  root-cause search, it does not assign physical cause."
+- **Tags:** `computed evidence artifact · not live serving` + dataset tag. **thesisRole:** "lead-lag
+  separates root cause from coupled symptoms."
+
+### Spin 6 — "Event-Windowed Analog Retrieval" card
+- **Artifact:** `telemetry-platform/event_windowed_analog_evidence.json` → copy to
+  `repo-b/src/lib/telemetry/eventWindowedAnalogEvidence.json`.
+- **Reference shape:** mirror `RulConformalCard.tsx`.
+- **Render:** `metrics.whole_series_cosine_anomalous_match_rate` (41.5%) vs
+  `metrics.event_windowed_dtw_anomalous_match_rate` (45.0%), `metrics.event_windowing_lift_pct` (+8.4%),
+  `metrics.topk_overlap` (9%); `params`; `example`; `finding`.
+- **Caveats to preserve (do NOT oversell):** present as **modest** (+8%, not a breakthrough); "linked
+  dispositions are unavailable in public data — shown as unavailable, not fabricated"; "relative method
+  comparison, not an absolute retrieval benchmark."
+- **Tags:** `computed evidence artifact · not live serving`. **thesisRole:** "analog retrieval is real but
+  modest, not magic." **claimBoundary:** the +8% is measured, modest, and disposition-free.
+
+### Guardrails for both
+- No `null_reason` strings changed; computed-artifact label required ("not live serving").
+- The cards are *additive* to the evidence page — they do not alter the three live findings.
+- After wiring, prod-smoke the evidence page (the cards render real artifact values) and screenshot.

--- a/PLAN_DIVERGENCE_REVIEW.md
+++ b/PLAN_DIVERGENCE_REVIEW.md
@@ -383,3 +383,30 @@ SMAP/MSL streams):
 
 Remaining tail: Spin 4 (completeness — needs multi-rate data, would be simulated) and Spin 7-anomaly
 (grouped split — likely null on a fixed-K per-channel rule). Both weak/optional.
+
+---
+
+## FINAL STATUS — divergence program complete (wrap)
+
+All seven original spins + derived A/B are addressed. The six-beat story:
+1. **Uncertainty changes the call** (Spin 3) · 2. **Regime mismatch breaks naive detection** (Spin 1) ·
+3. **Out-of-envelope inputs abstain** (Spin 5) · 4. **Lead-lag separates root cause from coupling** (Spin 2) ·
+5. **Analog retrieval is real but modest** (Spin 6) · 6. **Unsupported ideas are rejected, not fabricated** (Spin 4).
+
+| Spin | Final status | Headline |
+|---|---|---|
+| 1 regime-conditioned anomaly | **LIVE + verified** | worst-regime FP 100%→10.2% (90% reduction); η² 1.0→0 — fixes the degenerate AE |
+| 2 sensor lead-lag attribution | **compute shipped · UI card deferred** | 14/15 sensors deviate at failure (93% redundant); leads 9/14/11; ~11-cycle downstream lag |
+| 3 conformal lower-bound RUL | **LIVE + verified** | PICP 0.86 @ 0.90; 15/100 units flip on the lower bound |
+| 4 feature-completeness gate | **declined — not feasible without fabricated data** | no multi-rate/late-arriving signal in public data; rejected, not faked |
+| 5 pre-test competence envelope | **LIVE + verified** | FD001 98.9% in-envelope; FD004 90.5% out → abstain |
+| 6 event-windowed analog retrieval | **compute shipped · UI card deferred** | modest +8% lift, 9% precedent overlap — real, not magic |
+| 7 grouped walk-forward | **done (RUL) / null-by-construction (anomaly)** | RUL grouped-by-unit + leakage control passes |
+| A degenerate autoencoder | **surfaced + fixed by Spin 1** | built→measured→broke→fixed judgment artifact |
+| B honest vs point-adjusted F1 | **already in the system** | gate uses affiliation/event metrics, not inflated F1 |
+
+Three findings (1/3/5) are **live + prod-verified** on `/telemetry/evidence`; two (2/6) are **compute
+shipped** with reproducible artifacts and eval tests, UI cards deferred behind a concurrent frontend
+refactor (handoff notes in `DIVERGENCE_RECEIPTS_MANIFEST.md`). Spin 4 is **declined for lack of supporting
+data** — the tell that the rest is real. Demo walkthroughs: `DIVERGENCE_FINDINGS_DEMO_SCRIPT.md`.
+**No further ML expansion** — the package is intentionally tight.

--- a/claim_coverage_matrix.md
+++ b/claim_coverage_matrix.md
@@ -100,3 +100,17 @@ identify sensors **9/14/11** as the consistent leads (~80 cycles lead time), dow
 cycles**. **Must NOT overclaim:** C-MAPSS is simulated; onset is a threshold-crossing, not a calibrated
 change-point; lead-lag narrows root-cause search, it does not assign physical cause. ML-only; UI card
 deferred (parallel agent owns the telemetry frontend).
+
+---
+
+## FINAL STATE (divergence wrap)
+
+- **LIVE + verified** on `/telemetry/evidence`: Spin 1 (regime anomaly), Spin 3 (conformal RUL), Spin 5
+  (competence envelope). Cards read committed artifacts; no seeded-as-live values.
+- **Compute shipped · UI card deferred** (handoff in `DIVERGENCE_RECEIPTS_MANIFEST.md`): Spin 2 (lead-lag
+  attribution) and Spin 6 (event-windowed analog retrieval). Reproducible artifacts + eval tests; cards
+  wired onto the new evidence-card contract after the concurrent frontend refactor lands.
+- **Spin 4 (feature-completeness): NOT FEASIBLE without a fabricated scenario** — declined, not faked.
+- **Spin 6 stays MODEST** (+8% lift), never oversold; linked dispositions are unavailable, shown as such.
+- Nothing in this matrix is weakened: every claim is live-verified, compute-reproducible, or honestly
+  declined. The degenerate autoencoder remains a **liability/judgment artifact**, not a working detector.

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4292,3 +4292,29 @@ claims as fact unless sourced; keep era framing general (access → cost → reu
   env access) + `BOS_API_ORIGIN=<railway backend>` so `/api/telemetry/*` proxies to real data; junction
   `node_modules` into the worktree; Playwright at 1440×900, env `telemetry-demo`. The playwright.config
   webServer already sets `PLAYWRIGHT_BYPASS_AUTH=1` for `tests/*.spec.ts`.
+## Finalizing an evidence program into a proof package (divergence wrap)
+
+- **Distinguish live vs compute-only findings explicitly.** A finding is "LIVE + verified" only if a card
+  on a prod page reads its committed artifact AND it was prod-smoked with a screenshot. "Compute shipped"
+  = reproducible artifact + eval test landed, but no UI yet. Never blur the two in the matrix or demo — a
+  reviewer trusts the distinction more than a uniform "done".
+- **Refusing a fabricated spin is a feature, not a gap.** When the data shape doesn't support an idea
+  (e.g. a feature-completeness gate with no multi-rate/late-arriving data), DECLINE it and say so out loud.
+  "We didn't fabricate Spin 4" earns more credibility than another overbuilt chart. Record the rejection in
+  the plan + matrix as a first-class outcome.
+- **Turn negative results into presentation-ready proof.** The strongest demo beats are "built the obvious
+  thing → measured → found the break → shipped the fix": the degenerate autoencoder (fixed via regime
+  conditioning), the conformal calibration that under-covered at 0.44 until the calibration set was fixed,
+  point-adjusted vs honest F1. Package each as a judgment artifact with the before/after number.
+- **Card handoff notes for a parallel frontend agent.** When ML compute lands but the frontend is being
+  refactored by someone else: copy the artifact `telemetry-platform/*_evidence.json` →
+  `repo-b/src/lib/telemetry/*.json`, render onto the evidence-card contract (`sourceStatus: "computed"`,
+  label "not live serving"), mirror an existing card (RulConformal/RegimeAnomaly), and **preserve the
+  values + caveat strings byte-identical — no recomputation in the frontend.** Put the notes in a repo-root
+  manifest, not in their component dir (avoid touching contested files).
+- **Three demo lengths.** Author a 5/10/20-minute walkthrough with what-to-click / what-to-say /
+  what-NOT-to-claim / gotcha-answers. The "what not to claim" + "gotcha answers" sections are what keep a
+  live demo honest under a sharp interviewer; write them before the demo, not during.
+- **Keep the package tight.** Once the strong findings are live and the story is clear, STOP expanding ML.
+  A robustness sweep is intellectually good but strategically weaker than a story that's impossible to
+  miss; queue it behind "demo script is tight", not ahead of it.


### PR DESCRIPTION
Re-lands the divergence proof package. The original PR #346 branch (`docs/divergence-proof-package`) was overwritten on origin by a concurrent `fold ADE` commit during a parallel-agent branch collision, so #346 merged the ADE feature under this title and **my docs never landed**. This cherry-picks the original docs commit onto current main (unique branch, isolated worktree — no contested files touched).

Docs only: DIVERGENCE_FINDINGS_DEMO_SCRIPT.md + DIVERGENCE_RECEIPTS_MANIFEST.md (new) + final-status appends to PLAN_DIVERGENCE_REVIEW.md / claim_coverage_matrix.md + a divergence-wrap tips.md section (kept alongside the parallel agent's tips append). No ML, no card code, no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)