### PR TITLE
fix(#720): broker refresh — no false 'gone' on auth failure + correct CI auth

### DIFF
--- a/.github/workflows/confluent-broker-refresh.yml
+++ b/.github/workflows/confluent-broker-refresh.yml
@@ -55,20 +55,18 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/confluent" version
 
-      - name: Confluent login (service account key)
-        # Non-fatal: if the key secrets are absent/invalid the login fails, but the
-        # refresh script must still run so it can fail CLOSED (write a 'stale' row with
-        # the reason) rather than the job aborting here and writing nothing.
+      - name: Confluent context (env-var auth, no interactive login)
+        # The Confluent CLI authenticates to Cloud via CONFLUENT_CLOUD_API_KEY/_SECRET env
+        # (already exported at job level) — `confluent login` is NOT a valid API-key auth mode
+        # and produced "no credentials found". We only need to pin the active environment.
+        # Non-fatal: if it fails, the refresh script still runs and fails CLOSED to 'stale'.
         continue-on-error: true
         run: |
           if [ -z "$CONFLUENT_CLOUD_API_KEY" ] || [ -z "$CONFLUENT_CLOUD_API_SECRET" ]; then
-            echo "Confluent API key secrets not set — skipping login; refresh will fail closed to 'stale'."
+            echo "Confluent API key secrets not set — refresh will fail closed to 'stale'."
             exit 0
           fi
-          confluent login --save
-        env:
-          CONFLUENT_CLOUD_API_KEY: ${{ secrets.CONFLUENT_CLOUD_API_KEY }}
-          CONFLUENT_CLOUD_API_SECRET: ${{ secrets.CONFLUENT_CLOUD_API_SECRET }}
+          confluent environment use "$CONFLUENT_ENV_ID" || true
 
       - name: Refresh broker row
         # The script itself fails closed: a failed Confluent probe → 'stale' + reason.

--- a/skills/confluent-stargate-lifecycle/scripts/refresh_broker_row.py
+++ b/skills/confluent-stargate-lifecycle/scripts/refresh_broker_row.py
@@ -42,10 +42,18 @@ FLINK_REGION = os.environ.get("CONFLUENT_FLINK_REGION", "us-east1")
 FLINK_POOLS = ["lfcp-22wznzq", "lfcp-v7pqqvj"]
 RUNNING_STATES = {"RUNNING", "PENDING", "DEGRADED"}
 REJECT_MARKERS = ("Bad Request", "Violations", "is not one of", "Error:", "Unauthorized", "Forbidden")
+# A genuine "this resource does not exist" — the ONLY signal that justifies 'gone'.
+# Anything else (auth, network, "no credentials found") is ambiguous → 'stale', never 'gone'.
+NOT_FOUND_MARKERS = ("not found", "does not exist", "resource was not found", "404")
 
 
 class CheckError(Exception):
     """A probe failed in a way that means we cannot trust the observed state."""
+
+
+class NotFoundError(CheckError):
+    """The resource genuinely does not exist (404) — distinct from an auth/network failure.
+    Only this justifies declaring the lane 'gone'."""
 
 
 def _utc_hhmm() -> str:
@@ -60,7 +68,10 @@ def _run(args: list[str]) -> str:
     )
     out = (proc.stdout or "") + (proc.stderr or "")
     if proc.returncode != 0 or any(m in out for m in REJECT_MARKERS):
-        raise CheckError(f"`confluent {' '.join(args)}` failed: {out.strip()[:300]}")
+        msg = f"`confluent {' '.join(args)}` failed: {out.strip()[:300]}"
+        if any(m in out.lower() for m in NOT_FOUND_MARKERS):
+            raise NotFoundError(msg)
+        raise CheckError(msg)
     return proc.stdout
 
 
@@ -80,26 +91,25 @@ def _json(args: list[str]):
 def probe_state() -> tuple[str, str]:
     """Return (status, reason) from observed Confluent facts. Raises CheckError if
     the state cannot be observed (caller turns that into a 'stale' row)."""
-    # Cluster existence
+    # Cluster existence. CRITICAL: only a genuine 404 (NotFoundError) means "gone".
+    # An auth/network failure (CheckError, e.g. "no credentials found") is ambiguous and
+    # must propagate → caller writes 'stale', NEVER a false 'gone'.
+    cluster_missing = False
     try:
         _json(["kafka", "cluster", "describe", CLUSTER_ID, "--environment", ENV_ID, "-o", "json"])
-        cluster_up = True
-    except CheckError:
-        cluster_up = False
+    except NotFoundError:
+        cluster_missing = True
+    # (other CheckError propagates out of probe_state → 'stale')
 
-    if not cluster_up:
-        # Confirm pools are also gone before declaring the lane fully torn down.
-        pools_present = False
+    if cluster_missing:
+        # Confirm pools are also genuinely gone (404) before declaring the lane torn down.
         for p in FLINK_POOLS:
             try:
                 _json(["flink", "compute-pool", "describe", p, "--environment", ENV_ID, "-o", "json"])
-                pools_present = True
-                break
-            except CheckError:
-                continue
-        if pools_present:
-            # Ambiguous: cluster unreachable but a pool answered — don't guess.
-            raise CheckError("cluster not found but a Flink pool still responds — ambiguous, not claiming a state")
+                # A pool still answers → ambiguous, don't claim a state.
+                raise CheckError("cluster 404 but a Flink pool still responds — ambiguous, not claiming a state")
+            except NotFoundError:
+                continue  # this pool is also gone — consistent with teardown
         return "gone", f"cluster + flink pools deleted · recreate from export · checked {_utc_hhmm()}"
 
     # Connectors

--- a/skills/confluent-stargate-lifecycle/scripts/test_refresh_broker_row.py
+++ b/skills/confluent-stargate-lifecycle/scripts/test_refresh_broker_row.py
@@ -45,6 +45,8 @@ graph_bind.write_row = _fake_write
 r.graph_bind.write_row = _fake_write
 
 
+_real_probe_state = r.probe_state  # save before tests 1–6 monkeypatch it
+
 def run_with_probe(probe):
     written.clear()
     r.probe_state = probe
@@ -84,6 +86,49 @@ check("observed teardown -> 'gone'", status == "gone")
 
 # 6. 'stale' is an accepted status for the DB writer (won't be rejected).
 check("graph_bind accepts 'stale' as a valid status", "stale" in graph_bind.VALID)
+
+# 7. REAL probe_state classification (the false-'gone' regression):
+#    an AUTH failure ("no credentials found") must NOT be read as 'gone' — it's ambiguous → stale.
+#    Only a genuine 404 on cluster AND pools yields 'gone'.
+import subprocess as _sp
+
+class _FakeProc:
+    def __init__(self, rc, out):
+        self.returncode = rc
+        self.stdout = out
+        self.stderr = ""
+
+_orig_run = _sp.run
+
+def _set_cli(rc, out):
+    # refresh_broker_row._run calls subprocess.run via the `subprocess` module object.
+    _sp.run = lambda *a, **k: _FakeProc(rc, out)
+
+def _reset_cli():
+    _sp.run = _orig_run
+
+# 7a. "no credentials found" on every call → ambiguous → CheckError → caller writes 'stale', NOT 'gone'.
+_set_cli(1, "Error: no credentials found")
+try:
+    st, _ = _real_probe_state()
+    outcome = ("returned", st)
+except r.CheckError:
+    outcome = ("raised", "CheckError")
+finally:
+    _reset_cli()
+check("auth failure is NOT classified 'gone'", outcome != ("returned", "gone"))
+check("auth failure raises CheckError (caller -> stale)", outcome == ("raised", "CheckError"))
+
+# 7b. genuine 404 on cluster AND both pools → 'gone'.
+_set_cli(1, "Error: resource was not found (404)")
+try:
+    st, _ = _real_probe_state()
+    outcome2 = st
+except r.CheckError:
+    outcome2 = "raised-checkerror"
+finally:
+    _reset_cli()
+check("genuine 404 on cluster + pools -> 'gone'", outcome2 == "gone")
 
 print("")
 if fails:


### PR DESCRIPTION
Live CI run wrote broker='gone' while the cluster was UP. Two bugs: (1) probe treated any cluster-describe error as 'missing' → false gone; now only a genuine 404 yields gone, auth/network failures → stale. (2) CI used invalid `confluent login` API-key mode ('no credentials found'); switched to env-var auth + environment use. Adds regression tests for both. Follow-up to #348.