### PR TITLE
Telemetry FastAPI lineage/provenance routes (Ticket 4)

### DIFF
--- a/backend/app/routes/telemetry.py
+++ b/backend/app/routes/telemetry.py
@@ -412,3 +412,63 @@ def mcp_check(req: McpCheckRequest):
         }
     except Exception as exc:  # noqa: BLE001
         raise _to_http(exc)
+
+
+# ── Stream lineage / provenance (Ticket 4) ──────────────────────────────────────────────────────────
+# Read-only contract over the 10034 serving slice (tel_stream_kafka_rows / _triage_events). Proves
+# Kafka detection -> AI triage -> Databricks lake (where mapped) -> Postgres serving row. Fail-closed:
+# missing layers return an explicit status + null_reason; no fabricated offsets/triage/Delta pointers.
+
+@router.get("/stream/kafka/rows")
+def stream_kafka_rows(env_id: str = Query(...), business_id: UUID = Query(...),
+                      kind: str | None = Query(default=None),
+                      limit: int = Query(default=50, ge=1, le=200)):
+    """Recent rows from tel_stream_kafka_rows (newest first). Optional record_kind filter; bounded limit."""
+    from app.services import telemetry_stream_lineage as lineage
+    try:
+        return lineage.list_kafka_rows(env_id=env_id, business_id=business_id, kind=kind, limit=limit)
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/stream/kafka/provenance/{row_id}")
+def stream_kafka_provenance(row_id: UUID, env_id: str = Query(...), business_id: UUID = Query(...)):
+    """A single kafka row plus its provenance layers. Fail-closed if the row is absent."""
+    from app.services import telemetry_stream_lineage as lineage
+    try:
+        return lineage.get_provenance(env_id=env_id, business_id=business_id, row_id=row_id)
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/stream/kafka/triage/latest")
+def stream_kafka_triage_latest(env_id: str = Query(...), business_id: UUID = Query(...),
+                               limit: int = Query(default=50, ge=1, le=200)):
+    """Latest triage records from tel_stream_triage_events (newest first)."""
+    from app.services import telemetry_stream_lineage as lineage
+    try:
+        return lineage.latest_triage(env_id=env_id, business_id=business_id, limit=limit)
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/stream/kafka/triage/{anomaly_id}")
+def stream_kafka_triage_by_anomaly(anomaly_id: str, env_id: str = Query(...),
+                                   business_id: UUID = Query(...)):
+    """Triage for one anomaly. Returns status=not_available + null_reason=triage_not_emitted when none."""
+    from app.services import telemetry_stream_lineage as lineage
+    try:
+        return lineage.triage_for_anomaly(env_id=env_id, business_id=business_id, anomaly_id=anomaly_id)
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/stream/lineage/anomaly/{anomaly_id}")
+def stream_lineage_anomaly(anomaly_id: str, env_id: str = Query(...), business_id: UUID = Query(...)):
+    """Combined lineage for one anomaly: kafka_detection -> agent_triage -> databricks_lake ->
+    postgres_serving. Each layer fails closed with an explicit status + null_reason."""
+    from app.services import telemetry_stream_lineage as lineage
+    try:
+        return lineage.anomaly_lineage(env_id=env_id, business_id=business_id, anomaly_id=anomaly_id)
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)

--- a/backend/app/services/telemetry_stream_lineage.py
+++ b/backend/app/services/telemetry_stream_lineage.py
@@ -1,0 +1,277 @@
+"""Telemetry stream lineage / provenance serving (Ticket 4).
+
+Read-only contract over the 10034 Lakebase/Postgres serving slice (tel_stream_kafka_rows,
+tel_stream_triage_events, tel_stream_consumer_offsets). Lets the frontend prove how a displayed
+anomaly/triage flows: Kafka detection -> AI triage -> Databricks lake (where mapped) -> Postgres
+serving row.
+
+Honesty boundary (do not violate):
+  - Postgres is the SERVING/PROVENANCE slice, not the raw lake. Databricks/Delta is the raw lake.
+  - Every missing layer fails closed with an explicit status + null_reason. We never fabricate a
+    Kafka offset, a triage record, or a Databricks pointer.
+
+All reads go through get_telemetry_cursor (Lakebase pool; Supabase fallback locally) and are tenant
+scoped by (env_id, business_id), validated via resolve_tenant_id (fail closed if the business is
+unknown). Limits are bounded to avoid unbounded scans.
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.db import get_telemetry_cursor as get_cursor
+from app.services.reporting_common import resolve_tenant_id
+
+# Canonical topics (kept equal to backend/app/services/stargate_bridge.py::StargateTopics).
+ANOMALY_TOPIC = "stargate.printer.anomalies.v1"
+TRIAGE_TOPIC = "stargate.printer.anomaly.triage.v1"
+
+# Null reasons (explicit, fail-closed lineage).
+TRIAGE_NOT_EMITTED = "triage_not_emitted"
+KAFKA_PROVENANCE_UNAVAILABLE = "kafka_provenance_unavailable"
+DATABRICKS_TABLE_MAPPING_NOT_CONFIGURED = "databricks_table_mapping_not_configured"
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 200
+
+VALID_KINDS = {
+    "telemetry_sample", "telemetry", "agg5s", "anomaly", "triage", "dlq", "execution", "signal",
+}
+
+# Columns surfaced by the rows endpoint (the full provenance contract).
+_ROW_COLS = """
+    id, record_kind, kafka_topic, kafka_partition, kafka_offset, kafka_timestamp,
+    schema_id, schema_subject, schema_version,
+    printer_id, print_job_id, run_id, anomaly_id, triage_id,
+    decoded_payload, normalized_payload,
+    databricks_lineage_status, databricks_null_reason, ingested_at
+"""
+
+_TRIAGE_COLS = """
+    triage_id, anomaly_id, printer_id, print_job_id, run_id,
+    severity, status, incident_summary, likely_cause, leading_indicators,
+    recommended_action, confidence, requires_human_review, null_reason,
+    kafka_row_id, kafka_topic, kafka_partition, kafka_offset,
+    databricks_lineage_status, databricks_null_reason, created_at
+"""
+
+
+def _bound_limit(limit: int | None) -> int:
+    if not limit or limit < 1:
+        return DEFAULT_LIMIT
+    return min(limit, MAX_LIMIT)
+
+
+def list_kafka_rows(*, env_id: str, business_id: UUID, kind: str | None = None,
+                    limit: int | None = None) -> dict:
+    """Recent rows from tel_stream_kafka_rows for the tenant, newest first. Optional record_kind
+    filter; bounded limit. Returns {status, rows, count}."""
+    n = _bound_limit(limit)
+    if kind is not None and kind not in VALID_KINDS:
+        raise ValueError(f"invalid kind: {kind}")
+    with get_cursor() as cur:
+        resolve_tenant_id(cur, business_id)
+        params: list = [env_id, str(business_id)]
+        kind_clause = ""
+        if kind is not None:
+            kind_clause = " AND record_kind = %s"
+            params.append(kind)
+        params.append(n)
+        cur.execute(
+            f"""SELECT {_ROW_COLS}
+                FROM tel_stream_kafka_rows
+                WHERE env_id = %s AND business_id = %s{kind_clause}
+                ORDER BY ingested_at DESC
+                LIMIT %s""",
+            tuple(params),
+        )
+        rows = cur.fetchall()
+    return {"status": "ok", "rows": rows, "count": len(rows)}
+
+
+def get_provenance(*, env_id: str, business_id: UUID, row_id: UUID) -> dict:
+    """A single kafka row + its provenance layers. Fail closed if the row is absent."""
+    with get_cursor() as cur:
+        resolve_tenant_id(cur, business_id)
+        cur.execute(
+            f"""SELECT {_ROW_COLS}, consumer_group
+                FROM tel_stream_kafka_rows
+                WHERE env_id = %s AND business_id = %s AND id = %s""",
+            (env_id, str(business_id), str(row_id)),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return {"status": "not_available", "row": None,
+                    "null_reason": KAFKA_PROVENANCE_UNAVAILABLE}
+        return {"status": "ok", "row": row, "layers": _layers_from_row(row)}
+
+
+def latest_triage(*, env_id: str, business_id: UUID, limit: int | None = None) -> dict:
+    """Latest triage records from tel_stream_triage_events, newest first."""
+    n = _bound_limit(limit)
+    with get_cursor() as cur:
+        resolve_tenant_id(cur, business_id)
+        cur.execute(
+            f"""SELECT {_TRIAGE_COLS}
+                FROM tel_stream_triage_events
+                WHERE env_id = %s AND business_id = %s
+                ORDER BY created_at DESC
+                LIMIT %s""",
+            (env_id, str(business_id), n),
+        )
+        rows = cur.fetchall()
+    return {"status": "ok", "triage": rows, "count": len(rows)}
+
+
+def triage_for_anomaly(*, env_id: str, business_id: UUID, anomaly_id: str) -> dict:
+    """Triage for one anomaly. Fail closed (triage_not_emitted) when none exists."""
+    with get_cursor() as cur:
+        resolve_tenant_id(cur, business_id)
+        cur.execute(
+            f"""SELECT {_TRIAGE_COLS}
+                FROM tel_stream_triage_events
+                WHERE env_id = %s AND business_id = %s AND anomaly_id = %s
+                ORDER BY created_at DESC
+                LIMIT 1""",
+            (env_id, str(business_id), anomaly_id),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return {"status": "not_available", "triage": None, "null_reason": TRIAGE_NOT_EMITTED}
+    return {"status": "ok", "triage": row}
+
+
+def anomaly_lineage(*, env_id: str, business_id: UUID, anomaly_id: str) -> dict:
+    """Combined lineage for one anomaly: kafka_detection -> agent_triage -> databricks_lake ->
+    postgres_serving. Each layer fails closed with an explicit status + null_reason.
+
+    Top-level status is 'ok' when the kafka detection row exists, else 'not_available' (the anomaly is
+    unknown to the serving slice)."""
+    with get_cursor() as cur:
+        resolve_tenant_id(cur, business_id)
+
+        # Kafka detection row (the anomaly event on the anomalies topic).
+        cur.execute(
+            f"""SELECT {_ROW_COLS}
+                FROM tel_stream_kafka_rows
+                WHERE env_id = %s AND business_id = %s AND anomaly_id = %s
+                  AND record_kind = 'anomaly'
+                ORDER BY ingested_at DESC
+                LIMIT 1""",
+            (env_id, str(business_id), anomaly_id),
+        )
+        detection = cur.fetchone()
+
+        # AI triage projection for the anomaly.
+        cur.execute(
+            f"""SELECT {_TRIAGE_COLS}
+                FROM tel_stream_triage_events
+                WHERE env_id = %s AND business_id = %s AND anomaly_id = %s
+                ORDER BY created_at DESC
+                LIMIT 1""",
+            (env_id, str(business_id), anomaly_id),
+        )
+        triage = cur.fetchone()
+
+    if detection is None and triage is None:
+        return {
+            "status": "not_available", "anomaly_id": anomaly_id,
+            "null_reason": KAFKA_PROVENANCE_UNAVAILABLE,
+            "layers": {
+                "kafka_detection": {"status": "not_available",
+                                    "null_reason": KAFKA_PROVENANCE_UNAVAILABLE},
+                "agent_triage": {"status": "not_available", "null_reason": TRIAGE_NOT_EMITTED},
+                "databricks_lake": _databricks_layer(None),
+                "postgres_serving": {"status": "not_available",
+                                     "null_reason": KAFKA_PROVENANCE_UNAVAILABLE},
+            },
+        }
+
+    return {
+        "status": "ok",
+        "anomaly_id": anomaly_id,
+        "layers": {
+            "kafka_detection": _kafka_detection_layer(detection),
+            "agent_triage": _agent_triage_layer(triage),
+            "databricks_lake": _databricks_layer(detection or triage),
+            "postgres_serving": _postgres_serving_layer(detection, triage),
+        },
+    }
+
+
+# ── layer builders ────────────────────────────────────────────────────────────────────────────────────
+
+def _kafka_detection_layer(row: dict | None) -> dict:
+    if row is None:
+        return {"status": "not_available", "null_reason": KAFKA_PROVENANCE_UNAVAILABLE}
+    return {
+        "status": "available",
+        "topic": row["kafka_topic"],
+        "partition": row["kafka_partition"],
+        "offset": row["kafka_offset"],
+        "schema_id": row["schema_id"],
+        "schema_subject": row["schema_subject"],
+        "schema_version": row["schema_version"],
+        "row_id": str(row["id"]),
+    }
+
+
+def _agent_triage_layer(t: dict | None) -> dict:
+    if t is None:
+        return {"status": "not_available", "topic": TRIAGE_TOPIC, "null_reason": TRIAGE_NOT_EMITTED}
+    return {
+        "status": "available",
+        "topic": t.get("kafka_topic") or TRIAGE_TOPIC,
+        "partition": t.get("kafka_partition"),
+        "offset": t.get("kafka_offset"),
+        "triage_id": t["triage_id"],
+        "severity": t.get("severity"),
+        "summary": t.get("incident_summary"),
+        "recommended_action": t.get("recommended_action"),
+        "requires_human_review": t.get("requires_human_review"),
+        "null_reason": t.get("null_reason"),
+    }
+
+
+def _databricks_layer(row: dict | None) -> dict:
+    """Databricks/Delta pointer layer. Fails closed to not_available until a Stargate->Delta mapping
+    exists. Never fabricates catalog/schema/table/version."""
+    status = (row or {}).get("databricks_lineage_status") or "not_available"
+    if status != "available":
+        return {
+            "status": "not_available",
+            "catalog": None, "schema": None, "table": None, "delta_version": None,
+            "null_reason": (row or {}).get("databricks_null_reason")
+            or DATABRICKS_TABLE_MAPPING_NOT_CONFIGURED,
+        }
+    return {
+        "status": "available",
+        "catalog": row.get("databricks_catalog"),
+        "schema": row.get("databricks_schema"),
+        "table": row.get("databricks_table"),
+        "delta_version": row.get("delta_version"),
+        "null_reason": None,
+    }
+
+
+def _postgres_serving_layer(detection: dict | None, triage: dict | None) -> dict:
+    if detection is None and triage is None:
+        return {"status": "not_available", "null_reason": KAFKA_PROVENANCE_UNAVAILABLE}
+    out: dict = {"status": "available", "table": "tel_stream_kafka_rows"}
+    if detection is not None:
+        out["row_id"] = str(detection["id"])
+        out["ingested_at"] = detection["ingested_at"]
+    if triage is not None:
+        out["triage_id"] = triage["triage_id"]
+    return out
+
+
+def _layers_from_row(row: dict) -> dict:
+    """Provenance layers for a single kafka row (used by the provenance-by-id endpoint)."""
+    return {
+        "kafka": _kafka_detection_layer(row),
+        "databricks_lake": _databricks_layer(row),
+        "postgres_serving": {
+            "status": "available", "table": "tel_stream_kafka_rows",
+            "row_id": str(row["id"]), "ingested_at": row["ingested_at"],
+        },
+    }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -89,6 +89,7 @@ _GET_CURSOR_TARGETS = [
     "app.services.reports.get_cursor",
     "app.services.crm.get_cursor",
     "app.services.telemetry_serving.get_cursor",
+    "app.services.telemetry_stream_lineage.get_cursor",
     "app.services.telemetry_registry.get_cursor",
     "app.services.telemetry_factory.get_cursor",
     "app.services.copilot_logger.get_cursor",

--- a/backend/tests/test_telemetry_stream_lineage_routes.py
+++ b/backend/tests/test_telemetry_stream_lineage_routes.py
@@ -1,0 +1,204 @@
+"""Tests for the telemetry stream lineage / provenance routes (Ticket 4).
+
+Uses the client + fake_cursor fixtures (no real DB). Each request first issues resolve_tenant_id
+(consumes the first pushed result = the tenant row), then the service's own queries in order.
+Covers success, filters, bounded limits, and fail-closed null_reasons.
+"""
+from uuid import uuid4
+
+ENV = "telemetry-demo"
+BIZ = str(uuid4())
+TENANT = str(uuid4())
+ROW_ID = str(uuid4())
+
+
+def _tenant(fake_cursor):
+    fake_cursor.push_result([{"tenant_id": TENANT}])
+
+
+def _kafka_row(**over):
+    base = {
+        "id": ROW_ID, "record_kind": "anomaly",
+        "kafka_topic": "stargate.printer.anomalies.v1", "kafka_partition": 0, "kafka_offset": 123,
+        "kafka_timestamp": None, "schema_id": 100005,
+        "schema_subject": "stargate.printer.anomalies.v1-value", "schema_version": 1,
+        "printer_id": "P1", "print_job_id": "J9", "run_id": None,
+        "anomaly_id": "anom_1", "triage_id": None,
+        "decoded_payload": {"printer_id": "P1"}, "normalized_payload": None,
+        "databricks_lineage_status": "not_available",
+        "databricks_null_reason": "databricks_table_mapping_not_configured",
+        "ingested_at": "2026-06-25T00:00:00+00:00",
+    }
+    base.update(over)
+    return base
+
+
+def _triage(**over):
+    base = {
+        "triage_id": "tri_1", "anomaly_id": "anom_1", "printer_id": "P1", "print_job_id": "J9",
+        "run_id": None, "severity": "high", "status": "ok", "incident_summary": "cold melt pool",
+        "likely_cause": "feed interruption", "leading_indicators": ["temp_drop"],
+        "recommended_action": "pause job", "confidence": "high", "requires_human_review": True,
+        "null_reason": None, "kafka_row_id": ROW_ID,
+        "kafka_topic": "stargate.printer.anomaly.triage.v1", "kafka_partition": 0, "kafka_offset": 77,
+        "databricks_lineage_status": "not_available",
+        "databricks_null_reason": "databricks_table_mapping_not_configured",
+        "created_at": "2026-06-25T00:00:01+00:00",
+    }
+    base.update(over)
+    return base
+
+
+def _q(**extra):
+    return {"env_id": ENV, "business_id": BIZ, **extra}
+
+
+# ── /stream/kafka/rows ────────────────────────────────────────────────────────────────────────────────
+
+def test_rows_success(client, fake_cursor):
+    _tenant(fake_cursor)
+    fake_cursor.push_result([_kafka_row(), _kafka_row(kafka_offset=124)])
+    resp = client.get("/api/telemetry/stream/kafka/rows", params=_q())
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["status"] == "ok" and d["count"] == 2
+    assert d["rows"][0]["kafka_topic"] == "stargate.printer.anomalies.v1"
+    assert d["rows"][0]["databricks_lineage_status"] == "not_available"
+
+
+def test_rows_kind_filter_applied(client, fake_cursor):
+    _tenant(fake_cursor)
+    fake_cursor.push_result([_kafka_row(record_kind="triage")])
+    resp = client.get("/api/telemetry/stream/kafka/rows", params=_q(kind="triage"))
+    assert resp.status_code == 200
+    # the kind filter must be in the SQL the service issued
+    assert any("record_kind = %s" in q[0] for q in fake_cursor.queries)
+
+
+def test_rows_invalid_kind_400(client, fake_cursor):
+    _tenant(fake_cursor)
+    resp = client.get("/api/telemetry/stream/kafka/rows", params=_q(kind="bogus"))
+    assert resp.status_code == 400
+
+
+def test_rows_limit_bounded(client, fake_cursor):
+    _tenant(fake_cursor)
+    fake_cursor.push_result([])
+    # over the cap -> FastAPI le=200 rejects with 422 (bound enforced at the edge)
+    resp = client.get("/api/telemetry/stream/kafka/rows", params=_q(limit=9999))
+    assert resp.status_code == 422
+
+
+# ── /stream/kafka/provenance/{row_id} ─────────────────────────────────────────────────────────────────
+
+def test_provenance_success(client, fake_cursor):
+    _tenant(fake_cursor)
+    fake_cursor.push_result([dict(_kafka_row(), consumer_group="stargate-bridge-sink")])
+    resp = client.get(f"/api/telemetry/stream/kafka/provenance/{ROW_ID}", params=_q())
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["status"] == "ok"
+    assert d["layers"]["kafka"]["offset"] == 123
+    assert d["layers"]["databricks_lake"]["status"] == "not_available"
+    assert d["layers"]["databricks_lake"]["null_reason"] == "databricks_table_mapping_not_configured"
+
+
+def test_provenance_missing_fails_closed(client, fake_cursor):
+    _tenant(fake_cursor)
+    fake_cursor.push_result([])     # no row
+    resp = client.get(f"/api/telemetry/stream/kafka/provenance/{ROW_ID}", params=_q())
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["status"] == "not_available"
+    assert d["null_reason"] == "kafka_provenance_unavailable"
+    assert d["row"] is None
+
+
+# ── /stream/kafka/triage/latest ───────────────────────────────────────────────────────────────────────
+
+def test_triage_latest_success(client, fake_cursor):
+    _tenant(fake_cursor)
+    fake_cursor.push_result([_triage()])
+    resp = client.get("/api/telemetry/stream/kafka/triage/latest", params=_q())
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["status"] == "ok" and d["count"] == 1
+    assert d["triage"][0]["severity"] == "high"
+
+
+# ── /stream/kafka/triage/{anomaly_id} ─────────────────────────────────────────────────────────────────
+
+def test_triage_by_anomaly_success(client, fake_cursor):
+    _tenant(fake_cursor)
+    fake_cursor.push_result([_triage()])
+    resp = client.get("/api/telemetry/stream/kafka/triage/anom_1", params=_q())
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["status"] == "ok" and d["triage"]["triage_id"] == "tri_1"
+
+
+def test_triage_by_anomaly_not_emitted(client, fake_cursor):
+    _tenant(fake_cursor)
+    fake_cursor.push_result([])     # no triage
+    resp = client.get("/api/telemetry/stream/kafka/triage/anom_404", params=_q())
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["status"] == "not_available"
+    assert d["triage"] is None
+    assert d["null_reason"] == "triage_not_emitted"
+
+
+# ── /stream/lineage/anomaly/{anomaly_id} ──────────────────────────────────────────────────────────────
+
+def test_lineage_all_layers_available(client, fake_cursor):
+    _tenant(fake_cursor)
+    fake_cursor.push_result([_kafka_row()])   # detection
+    fake_cursor.push_result([_triage()])      # triage
+    resp = client.get("/api/telemetry/stream/lineage/anomaly/anom_1", params=_q())
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["status"] == "ok"
+    L = d["layers"]
+    assert L["kafka_detection"]["status"] == "available"
+    assert L["kafka_detection"]["offset"] == 123 and L["kafka_detection"]["schema_id"] == 100005
+    assert L["agent_triage"]["status"] == "available"
+    assert L["agent_triage"]["severity"] == "high"
+    # Databricks never faked
+    assert L["databricks_lake"]["status"] == "not_available"
+    assert L["databricks_lake"]["table"] is None
+    assert L["databricks_lake"]["null_reason"] == "databricks_table_mapping_not_configured"
+    assert L["postgres_serving"]["status"] == "available"
+    assert L["postgres_serving"]["row_id"] == ROW_ID
+
+
+def test_lineage_missing_triage(client, fake_cursor):
+    _tenant(fake_cursor)
+    fake_cursor.push_result([_kafka_row()])   # detection present
+    fake_cursor.push_result([])               # no triage
+    resp = client.get("/api/telemetry/stream/lineage/anomaly/anom_1", params=_q())
+    assert resp.status_code == 200
+    L = resp.json()["layers"]
+    assert L["kafka_detection"]["status"] == "available"
+    assert L["agent_triage"]["status"] == "not_available"
+    assert L["agent_triage"]["null_reason"] == "triage_not_emitted"
+    assert L["postgres_serving"]["status"] == "available"
+
+
+def test_lineage_unknown_anomaly_fails_closed(client, fake_cursor):
+    _tenant(fake_cursor)
+    fake_cursor.push_result([])   # no detection
+    fake_cursor.push_result([])   # no triage
+    resp = client.get("/api/telemetry/stream/lineage/anomaly/nope", params=_q())
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["status"] == "not_available"
+    assert d["null_reason"] == "kafka_provenance_unavailable"
+    assert d["layers"]["kafka_detection"]["status"] == "not_available"
+    assert d["layers"]["databricks_lake"]["status"] == "not_available"
+
+
+def test_lineage_missing_business_404(client, fake_cursor):
+    # resolve_tenant_id finds no business -> LookupError -> 404
+    fake_cursor.push_result([])   # business lookup empty
+    resp = client.get("/api/telemetry/stream/lineage/anomaly/anom_1", params=_q())
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Ticket 4 of the lineage walkthrough. Exposes the `10034` Lakebase/Postgres serving slice through FastAPI so the frontend (Ticket 5) can fetch Kafka rows, triage records, and a combined anomaly lineage object. Read-only, tenant-scoped, fail-closed.

## Endpoints (on the existing `/api/telemetry` router)
| Route | Returns |
|---|---|
| `GET /stream/kafka/rows?env_id&business_id&kind?&limit?` | Recent `tel_stream_kafka_rows` (newest first; optional `record_kind` filter; `limit` bounded `le=200`) |
| `GET /stream/kafka/provenance/{row_id}` | One row + provenance layers (kafka / databricks_lake / postgres_serving) |
| `GET /stream/kafka/triage/latest` | Latest `tel_stream_triage_events` |
| `GET /stream/kafka/triage/{anomaly_id}` | Triage for an anomaly; `not_available` + `triage_not_emitted` when none |
| `GET /stream/lineage/anomaly/{anomaly_id}` | Combined `kafka_detection → agent_triage → databricks_lake → postgres_serving` |

## Behavior / guardrails
- All reads via `get_telemetry_cursor`; tenant-scoped by `(env_id, business_id)` + `resolve_tenant_id` (missing business → 404, fail closed).
- Every missing layer returns an explicit `status` + `null_reason`: `kafka_provenance_unavailable`, `triage_not_emitted`, `databricks_table_mapping_not_configured`.
- **No fake Databricks linkage** — `databricks_lake` stays `not_available` with the real null_reason; `catalog/schema/table/version` are `null`, never fabricated.
- **No hardcoded sample fallback.** Limits bounded to avoid unbounded scans. No frontend/Confluent/consumer changes (one conftest line added to register the new service's cursor for test mocking).

## Tests
`pytest tests/test_telemetry_stream_lineage_routes.py` → **13 passed**: rows success / kind filter / invalid kind 400 / limit bound 422 / provenance success + fail-closed / triage latest / triage by anomaly + `triage_not_emitted` / full lineage all-layers / missing triage / unknown anomaly fail-closed / missing-business 404.
Regression: `test_health.py` + `test_telemetry_serving.py` + `test_telemetry_stream_consumer.py` → 30 passed. `ruff` clean.

## Scope
Backend routes + service + tests. No frontend, Confluent runtime, or consumer changes. No secrets. Scoring-lane untouched.

## Next
Ticket 5 — frontend lineage drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)