### PR TITLE
fix(#720): broker probe via Confluent REST API

### DIFF
--- a/.github/workflows/confluent-broker-refresh.yml
+++ b/.github/workflows/confluent-broker-refresh.yml
@@ -33,6 +33,11 @@ jobs:
       CONFLUENT_CLUSTER_ID: ${{ vars.CONFLUENT_CLUSTER_ID || 'lkc-gqpvvyv' }}
       CONFLUENT_FLINK_CLOUD: gcp
       CONFLUENT_FLINK_REGION: us-east1
+      # Flink statement check is best-effort: needs a Flink-scoped key + org id. If unset,
+      # the probe records "flink not checked" and still classifies on cluster + connectors.
+      CONFLUENT_FLINK_API_KEY: ${{ secrets.CONFLUENT_FLINK_API_KEY }}
+      CONFLUENT_FLINK_API_SECRET: ${{ secrets.CONFLUENT_FLINK_API_SECRET }}
+      CONFLUENT_ORG_ID: ${{ vars.CONFLUENT_ORG_ID || '1a391082-151c-449f-b168-c25f59934d58' }}
       TELEMETRY_DATABASE_URL: ${{ secrets.TELEMETRY_DATABASE_URL }}
     steps:
       - name: Checkout
@@ -46,30 +51,10 @@ jobs:
       - name: Install deps
         run: pip install psycopg2-binary
 
-      - name: Install confluent CLI
-        # Install to a user-writable dir — the runner's /usr/local/bin is not chmod-able
-        # without sudo ("Operation not permitted").
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          curl -sL --http1.1 https://cnfl.io/cli | sh -s -- -b "$HOME/.local/bin"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/confluent" version
-
-      - name: Confluent context (env-var auth, no interactive login)
-        # The Confluent CLI authenticates to Cloud via CONFLUENT_CLOUD_API_KEY/_SECRET env
-        # (already exported at job level) — `confluent login` is NOT a valid API-key auth mode
-        # and produced "no credentials found". We only need to pin the active environment.
-        # Non-fatal: if it fails, the refresh script still runs and fails CLOSED to 'stale'.
-        continue-on-error: true
-        run: |
-          if [ -z "$CONFLUENT_CLOUD_API_KEY" ] || [ -z "$CONFLUENT_CLOUD_API_SECRET" ]; then
-            echo "Confluent API key secrets not set — refresh will fail closed to 'stale'."
-            exit 0
-          fi
-          confluent environment use "$CONFLUENT_ENV_ID" || true
-
+      # No confluent CLI needed — the probe uses the Confluent Cloud REST API directly
+      # with HTTP-basic API-key auth (the CLI's control-plane commands require a full
+      # username/password login, which a service-account key cannot do).
       - name: Refresh broker row
-        # The script itself fails closed: a failed Confluent probe → 'stale' + reason.
-        # It exits non-zero only if it cannot reach the DB at all (no TELEMETRY_DATABASE_URL),
-        # which surfaces here as a clear, expected failure.
+        # The script fails closed: an unobservable state (auth/network) → 'stale' + reason,
+        # never a false 'fresh'/'gone'. It exits non-zero only if the DB is unreachable.
         run: python skills/confluent-stargate-lifecycle/scripts/refresh_broker_row.py

--- a/skills/confluent-stargate-lifecycle/scripts/refresh_broker_row.py
+++ b/skills/confluent-stargate-lifecycle/scripts/refresh_broker_row.py
@@ -2,10 +2,15 @@
 """Scheduled refresh of the Confluent broker cost-state row on the Telemetry
 Mission Control PIPELINE panel.
 
-Runs in CI (GitHub Actions, ~every 15 min) where the interactive `confluent` CLI
-login is unavailable — auth is via a Confluent service-account API key passed as
-env. Probes the REAL Confluent state, maps it to an honest cost state from
-OBSERVED FACTS ONLY, and writes the broker row to tel_pipeline_status.
+Runs in CI (GitHub Actions, ~every 15 min). Probes the REAL Confluent state via the
+Confluent Cloud REST API with HTTP-basic API-key auth (the `confluent` CLI's
+control-plane commands require a full username/password login that a service-account
+key cannot do — so we call REST directly). Maps the state to an honest cost state
+from OBSERVED FACTS ONLY and writes the broker row to tel_pipeline_status.
+
+Reads: cluster existence (cmk/v2) + connectors (connect/v1) with the Cloud key.
+Flink running statements are BEST EFFORT (need a Flink-scoped key + org id); if those
+are absent the reason notes "flink not checked" rather than failing.
 
 Honest states (never inferred, never claimed without observation):
   hot   — cluster up AND (>=1 connector OR >=1 running Flink statement)
@@ -25,10 +30,12 @@ Auth env (service account):
 """
 from __future__ import annotations
 
+import base64
 import json
 import os
-import subprocess
 import sys
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 
 # Reuse the single row-writer so there is exactly one place that touches the DB.
@@ -41,18 +48,19 @@ FLINK_CLOUD = os.environ.get("CONFLUENT_FLINK_CLOUD", "gcp")
 FLINK_REGION = os.environ.get("CONFLUENT_FLINK_REGION", "us-east1")
 FLINK_POOLS = ["lfcp-22wznzq", "lfcp-v7pqqvj"]
 RUNNING_STATES = {"RUNNING", "PENDING", "DEGRADED"}
-REJECT_MARKERS = ("Bad Request", "Violations", "is not one of", "Error:", "Unauthorized", "Forbidden")
-# A genuine "this resource does not exist" — the ONLY signal that justifies 'gone'.
-# Anything else (auth, network, "no credentials found") is ambiguous → 'stale', never 'gone'.
-NOT_FOUND_MARKERS = ("not found", "does not exist", "resource was not found", "404")
+
+CLOUD_API = "https://api.confluent.cloud"
+# Flink statements need a region data-plane host + a Flink-scoped key — kept best-effort.
+FLINK_API = f"https://flink.{FLINK_REGION}.{FLINK_CLOUD}.confluent.cloud"
 
 
 class CheckError(Exception):
-    """A probe failed in a way that means we cannot trust the observed state."""
+    """A probe failed in a way that means we cannot trust the observed state.
+    Caller turns this into a 'stale' row — NEVER a fresh-looking status."""
 
 
 class NotFoundError(CheckError):
-    """The resource genuinely does not exist (404) — distinct from an auth/network failure.
+    """The resource genuinely returned 404 — distinct from auth/network failure.
     Only this justifies declaring the lane 'gone'."""
 
 
@@ -60,71 +68,81 @@ def _utc_hhmm() -> str:
     return datetime.now(timezone.utc).strftime("%H:%MZ")
 
 
-def _run(args: list[str]) -> str:
-    """Run a confluent CLI command, returning stdout. Treats exit!=0 OR a rejection
-    marker in output as a failure (the CLI can exit 0 while rejecting an argument)."""
-    proc = subprocess.run(
-        ["confluent", *args], capture_output=True, text=True, timeout=60
-    )
-    out = (proc.stdout or "") + (proc.stderr or "")
-    if proc.returncode != 0 or any(m in out for m in REJECT_MARKERS):
-        msg = f"`confluent {' '.join(args)}` failed: {out.strip()[:300]}"
-        if any(m in out.lower() for m in NOT_FOUND_MARKERS):
-            raise NotFoundError(msg)
-        raise CheckError(msg)
-    return proc.stdout
-
-
-def _json(args: list[str]):
-    """Run a CLI command expecting JSON; strip any leading notice line before the
-    first '[' or '{' (e.g. flink statement list prints an endpoint notice)."""
-    raw = _run(args)
-    i = min(
-        (raw.find(c) for c in "[{" if raw.find(c) != -1),
-        default=-1,
-    )
-    if i < 0:
-        raise CheckError(f"no JSON in output of `confluent {' '.join(args)}`")
-    return json.loads(raw[i:])
+def _get(url: str, key: str, secret: str):
+    """GET a Confluent REST endpoint with HTTP-basic API-key auth. Returns parsed JSON.
+    Raises NotFoundError on 404, CheckError on any other non-2xx / transport error —
+    so auth (401/403) and network failures are ambiguous, never read as 'gone'."""
+    token = base64.b64encode(f"{key}:{secret}".encode()).decode()
+    req = urllib.request.Request(url, headers={"Authorization": f"Basic {token}",
+                                               "Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode() or "{}")
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            raise NotFoundError(f"GET {url} -> 404 not found")
+        body = ""
+        try:
+            body = e.read().decode()[:200]
+        except Exception:
+            pass
+        raise CheckError(f"GET {url} -> HTTP {e.code} {body}")
+    except Exception as e:
+        raise CheckError(f"GET {url} failed: {str(e)[:200]}")
 
 
 def probe_state() -> tuple[str, str]:
-    """Return (status, reason) from observed Confluent facts. Raises CheckError if
-    the state cannot be observed (caller turns that into a 'stale' row)."""
-    # Cluster existence. CRITICAL: only a genuine 404 (NotFoundError) means "gone".
-    # An auth/network failure (CheckError, e.g. "no credentials found") is ambiguous and
-    # must propagate → caller writes 'stale', NEVER a false 'gone'.
+    """Return (status, reason) from observed Confluent facts via the Cloud REST API.
+    Raises CheckError if state cannot be observed (caller writes 'stale')."""
+    key = os.environ.get("CONFLUENT_CLOUD_API_KEY", "")
+    secret = os.environ.get("CONFLUENT_CLOUD_API_SECRET", "")
+    if not key or not secret:
+        raise CheckError("CONFLUENT_CLOUD_API_KEY/_SECRET not set — cannot observe state")
+
+    # 1. Cluster existence (cmk v2). Only a genuine 404 (NotFoundError) means "gone";
+    #    auth/network errors propagate as CheckError → 'stale'.
     cluster_missing = False
     try:
-        _json(["kafka", "cluster", "describe", CLUSTER_ID, "--environment", ENV_ID, "-o", "json"])
+        _get(f"{CLOUD_API}/cmk/v2/clusters/{CLUSTER_ID}?environment={ENV_ID}", key, secret)
     except NotFoundError:
         cluster_missing = True
-    # (other CheckError propagates out of probe_state → 'stale')
 
     if cluster_missing:
-        # Confirm pools are also genuinely gone (404) before declaring the lane torn down.
-        for p in FLINK_POOLS:
-            try:
-                _json(["flink", "compute-pool", "describe", p, "--environment", ENV_ID, "-o", "json"])
-                # A pool still answers → ambiguous, don't claim a state.
-                raise CheckError("cluster 404 but a Flink pool still responds — ambiguous, not claiming a state")
-            except NotFoundError:
-                continue  # this pool is also gone — consistent with teardown
-        return "gone", f"cluster + flink pools deleted · recreate from export · checked {_utc_hhmm()}"
+        return "gone", f"cluster {CLUSTER_ID} not found · recreate from export · checked {_utc_hhmm()}"
 
-    # Connectors
-    connectors = _json(["connect", "cluster", "list", "--cluster", CLUSTER_ID,
-                        "--environment", ENV_ID, "-o", "json"]) or []
-    n_conn = len(connectors)
+    # 2. Connectors (connect v1) — the primary active-cost signal.
+    conns = _get(
+        f"{CLOUD_API}/connect/v1/environments/{ENV_ID}/clusters/{CLUSTER_ID}/connectors",
+        key, secret,
+    )
+    n_conn = len(conns) if isinstance(conns, list) else len(conns or {})
 
-    # Running Flink statements
-    statements = _json(["flink", "statement", "list", "--environment", ENV_ID,
-                       "--cloud", FLINK_CLOUD, "--region", FLINK_REGION, "-o", "json"]) or []
-    n_running = sum(1 for s in statements if s.get("status") in RUNNING_STATES)
+    # 3. Running Flink statements — BEST EFFORT. Needs a Flink-scoped key; if it isn't
+    #    available we record that it wasn't checked rather than failing the whole probe.
+    flink_note = ""
+    n_running = None
+    fkey = os.environ.get("CONFLUENT_FLINK_API_KEY", "")
+    fsecret = os.environ.get("CONFLUENT_FLINK_API_SECRET", "")
+    if fkey and fsecret:
+        org = os.environ.get("CONFLUENT_ORG_ID", "")
+        try:
+            data = _get(
+                f"{FLINK_API}/sql/v1/organizations/{org}/environments/{ENV_ID}/statements?page_size=100",
+                fkey, fsecret,
+            )
+            stmts = data.get("data", []) if isinstance(data, dict) else []
+            n_running = sum(1 for s in stmts
+                            if (s.get("status") or {}).get("phase") in RUNNING_STATES)
+        except CheckError as e:
+            flink_note = f" · flink check skipped ({str(e)[:60]})"
+    else:
+        flink_note = " · flink not checked (no flink key)"
 
-    if n_conn > 0 or n_running > 0:
-        return "fresh", f"serving · {n_conn} connector(s) + {n_running} flink stmt(s) running · checked {_utc_hhmm()}"
-    return "warm", f"idle · 0 connectors · 0 running flink stmts · topics retained · checked {_utc_hhmm()}"
+    running_flink = n_running or 0
+    if n_conn > 0 or running_flink > 0:
+        fl = f"{running_flink} flink stmt(s) running" if n_running is not None else "flink unchecked"
+        return "fresh", f"serving · {n_conn} connector(s) + {fl} · checked {_utc_hhmm()}{flink_note}"
+    return "warm", f"idle · 0 connectors · topics retained · checked {_utc_hhmm()}{flink_note}"
 
 
 def main() -> int:

--- a/skills/confluent-stargate-lifecycle/scripts/test_refresh_broker_row.py
+++ b/skills/confluent-stargate-lifecycle/scripts/test_refresh_broker_row.py
@@ -87,48 +87,67 @@ check("observed teardown -> 'gone'", status == "gone")
 # 6. 'stale' is an accepted status for the DB writer (won't be rejected).
 check("graph_bind accepts 'stale' as a valid status", "stale" in graph_bind.VALID)
 
-# 7. REAL probe_state classification (the false-'gone' regression):
-#    an AUTH failure ("no credentials found") must NOT be read as 'gone' — it's ambiguous → stale.
-#    Only a genuine 404 on cluster AND pools yields 'gone'.
-import subprocess as _sp
+# 7. REAL probe_state classification over the REST probe (the false-'gone' regression):
+#    auth/network failure (403/401/timeout) must NOT be read as 'gone' — it's ambiguous → stale.
+#    Only a genuine 404 on the CLUSTER yields 'gone'.
+os.environ["CONFLUENT_CLOUD_API_KEY"] = "k"
+os.environ["CONFLUENT_CLOUD_API_SECRET"] = "s"
+os.environ.pop("CONFLUENT_FLINK_API_KEY", None)  # force "flink not checked" path
 
-class _FakeProc:
-    def __init__(self, rc, out):
-        self.returncode = rc
-        self.stdout = out
-        self.stderr = ""
+_orig_get = r._get
 
-_orig_run = _sp.run
+def _set_get(fn):
+    r._get = fn  # probe_state calls module-level _get
 
-def _set_cli(rc, out):
-    # refresh_broker_row._run calls subprocess.run via the `subprocess` module object.
-    _sp.run = lambda *a, **k: _FakeProc(rc, out)
+def _reset_get():
+    r._get = _orig_get
 
-def _reset_cli():
-    _sp.run = _orig_run
-
-# 7a. "no credentials found" on every call → ambiguous → CheckError → caller writes 'stale', NOT 'gone'.
-_set_cli(1, "Error: no credentials found")
+# 7a. cluster describe returns 403 (auth) → CheckError → caller writes 'stale', NOT 'gone'.
+def _get_403(url, key, secret):
+    raise r.CheckError(f"GET {url} -> HTTP 403 forbidden")
+_set_get(_get_403)
 try:
     st, _ = _real_probe_state()
     outcome = ("returned", st)
 except r.CheckError:
     outcome = ("raised", "CheckError")
 finally:
-    _reset_cli()
-check("auth failure is NOT classified 'gone'", outcome != ("returned", "gone"))
-check("auth failure raises CheckError (caller -> stale)", outcome == ("raised", "CheckError"))
+    _reset_get()
+check("auth (403) failure is NOT classified 'gone'", outcome != ("returned", "gone"))
+check("auth (403) failure raises CheckError (caller -> stale)", outcome == ("raised", "CheckError"))
 
-# 7b. genuine 404 on cluster AND both pools → 'gone'.
-_set_cli(1, "Error: resource was not found (404)")
+# 7b. cluster describe 404 → 'gone'.
+def _get_cluster_404(url, key, secret):
+    if "/cmk/v2/clusters/" in url:
+        raise r.NotFoundError(f"GET {url} -> 404 not found")
+    return []
+_set_get(_get_cluster_404)
 try:
     st, _ = _real_probe_state()
     outcome2 = st
 except r.CheckError:
     outcome2 = "raised-checkerror"
 finally:
-    _reset_cli()
-check("genuine 404 on cluster + pools -> 'gone'", outcome2 == "gone")
+    _reset_get()
+check("genuine cluster 404 -> 'gone'", outcome2 == "gone")
+
+# 7c. cluster OK + 0 connectors + no flink key → 'warm' with a 'flink not checked' note.
+def _get_idle(url, key, secret):
+    if "/cmk/v2/clusters/" in url:
+        return {"id": "lkc-x", "status": {"phase": "PROVISIONED"}}
+    if "/connectors" in url:
+        return []
+    raise r.CheckError("unexpected url")
+_set_get(_get_idle)
+try:
+    st, rs = _real_probe_state()
+    outcome3 = (st, "flink not checked" in rs)
+except r.CheckError:
+    outcome3 = ("raised", False)
+finally:
+    _reset_get()
+check("cluster up + 0 connectors + no flink key -> 'warm'", outcome3[0] == "warm")
+check("warm reason notes flink was not checked", outcome3[1] is True)
 
 print("")
 if fails:


### PR DESCRIPTION
The CLI control-plane commands need a full username/password login a service-account key can't do. Rewrote the probe to call the Confluent Cloud REST API with HTTP-basic API-key auth: cluster (cmk/v2, 404→gone, 401/403/net→stale), connectors (connect/v1), flink (best-effort, needs flink key→else 'not checked'). Granted the SA Operator read role. Dropped CLI install/login from the workflow. Tests patch the REST layer; live-verified warm/idle against prod. Follow-up to #353.