### PR TITLE
Stargate stream lineage drawer (Ticket 5)

### DIFF
--- a/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
+++ b/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
@@ -11,8 +11,18 @@ import { C, EmptyState, MetricCard, Panel, RowCard, SplitGrid, Tag } from "../pr
 import { TelemetryPageHeader } from "../TelemetryPageHeader";
 import DlqPanel from "./DlqPanel";
 import TempVibrationChart from "./TempVibrationChart";
+import StreamLineageDrawer from "./StreamLineageDrawer";
 import { useStargateStream } from "@/lib/lab/stargateStream";
+import { TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID } from "@/lib/telemetry/api";
 import { useIsMobile } from "@/hooks/useIsMobile";
+
+// The agent stamps a deterministic anomaly id from the detection event (see
+// infra/confluent/stargate/agents/anomaly_triage_agent.sql): anom_{printer_id}_{ts_us}. The same id
+// links a live SSE anomaly to its PERSISTED lineage in the 10034 serving slice. When the durable
+// consumer is off / nothing has landed yet, the drawer fails closed honestly.
+function anomalyLineageId(printerId: string, tsUs: number): string {
+  return `anom_${printerId}_${tsUs}`;
+}
 
 const PrinterHead3D = dynamic(() => import("./PrinterHead3D"), {
   ssr: false,
@@ -31,6 +41,7 @@ function aggBadge(source?: string): { label: string; color: string } {
 export default function StargateConsole() {
   const stream = useStargateStream();
   const [selected, setSelected] = useState<string | null>(null);
+  const [lineageAnomalyId, setLineageAnomalyId] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
   const [startMsg, setStartMsg] = useState<string | null>(null);
   // The three.js canvas only mounts on desktop, and only after hydration —
@@ -204,20 +215,33 @@ export default function StargateConsole() {
           ) : (
             <div style={{ maxHeight: 220, overflowY: "auto" }}>
               {[...printerAnomalies].reverse().slice(0, 50).map((a, i) => (
-                <div key={`${a.ts_us}-${i}`} style={{ display: "flex", gap: 12, padding: "8px 14px",
-                  borderBottom: `1px solid ${C.border}`, fontFamily: C.mono, fontSize: 11 }}>
+                <button key={`${a.ts_us}-${i}`} type="button"
+                  onClick={() => setLineageAnomalyId(anomalyLineageId(a.printer_id, a.ts_us))}
+                  title="Show lineage — Kafka → triage → Databricks → serving"
+                  style={{ display: "flex", gap: 12, padding: "8px 14px", width: "100%", textAlign: "left",
+                    background: "transparent", border: "none", cursor: "pointer",
+                    borderBottom: `1px solid ${C.border}`, fontFamily: C.mono, fontSize: 11 }}>
                   <span style={{ color: C.faint }}>{new Date(a.ts_us / 1000).toLocaleTimeString([], { hour12: false })}</span>
                   <span style={{ color: C.red }}>{a.melt_pool_temp_c.toFixed(0)}°C</span>
                   <span style={{ color: C.amber }}>{a.arm_vibration_g.toFixed(3)}g</span>
                   <span style={{ color: C.dim }}>layer {a.layer}</span>
                   <span style={{ color: C.faint, overflow: "hidden", textOverflow: "ellipsis" }}>{a.print_job_id}</span>
-                </div>
+                  <span style={{ color: C.cyan, marginLeft: "auto" }}>lineage →</span>
+                </button>
               ))}
             </div>
           )}
         </Panel>
         <DlqPanel rows={dlq} count={stream.dlqCount} />
       </SplitGrid>
+
+      <StreamLineageDrawer
+        anomalyId={lineageAnomalyId}
+        servingEnvId={TELEMETRY_DEMO_ENV_ID}
+        businessId={TELEMETRY_DEMO_BUSINESS_ID}
+        routeEnvId={TELEMETRY_DEMO_ENV_ID}
+        onClose={() => setLineageAnomalyId(null)}
+      />
     </div>
   );
 }

--- a/repo-b/src/components/telemetry/stargate/StreamLineageDrawer.test.tsx
+++ b/repo-b/src/components/telemetry/stargate/StreamLineageDrawer.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import StreamLineageDrawer from "./StreamLineageDrawer";
+import type { AnomalyLineage } from "@/lib/telemetry/streamLineage";
+
+// Mock the fetch helper so the drawer's load states are driven deterministically (no real network).
+vi.mock("@/lib/telemetry/streamLineage", () => ({ getAnomalyLineage: vi.fn() }));
+import { getAnomalyLineage as _getAnomalyLineage } from "@/lib/telemetry/streamLineage";
+const getAnomalyLineage = vi.mocked(_getAnomalyLineage);
+
+const PROPS = {
+  servingEnvId: "telemetry-demo",
+  businessId: "7e1eb000-0000-4000-a000-000000000001",
+  routeEnvId: "telemetry-demo",
+  onClose: () => {},
+};
+
+function fullLineage(): AnomalyLineage {
+  return {
+    status: "ok",
+    anomaly_id: "anom_1",
+    layers: {
+      kafka_detection: {
+        status: "available", topic: "stargate.printer.anomalies.v1", partition: 0, offset: 123,
+        schema_id: 100005, schema_subject: "stargate.printer.anomalies.v1-value", schema_version: 1,
+        row_id: "row-1",
+      },
+      agent_triage: {
+        status: "available", topic: "stargate.printer.anomaly.triage.v1", partition: 0, offset: 77,
+        triage_id: "tri_1", severity: "high", summary: "cold melt pool",
+        recommended_action: "pause job", requires_human_review: true,
+      },
+      databricks_lake: {
+        status: "not_available", catalog: null, schema: null, table: null, delta_version: null,
+        null_reason: "databricks_table_mapping_not_configured",
+      },
+      postgres_serving: {
+        status: "available", table: "tel_stream_kafka_rows", row_id: "row-1",
+        ingested_at: "2026-06-25T00:00:00Z",
+      },
+    },
+  };
+}
+
+describe("StreamLineageDrawer", () => {
+  beforeEach(() => getAnomalyLineage.mockReset());
+
+  it("renders Kafka detection provenance when available", async () => {
+    getAnomalyLineage.mockResolvedValue(fullLineage());
+    render(<StreamLineageDrawer anomalyId="anom_1" {...PROPS} />);
+    await waitFor(() => expect(screen.getByText("stargate.printer.anomalies.v1")).toBeInTheDocument());
+    expect(screen.getByText("123")).toBeInTheDocument();           // offset
+    expect(screen.getByText("100005")).toBeInTheDocument();        // schema id
+  });
+
+  it("renders AI triage when available", async () => {
+    getAnomalyLineage.mockResolvedValue(fullLineage());
+    render(<StreamLineageDrawer anomalyId="anom_1" {...PROPS} />);
+    await waitFor(() => expect(screen.getByText("cold melt pool")).toBeInTheDocument());
+    expect(screen.getByText("pause job")).toBeInTheDocument();
+  });
+
+  it("renders Databricks not_available without fabricating table/version", async () => {
+    getAnomalyLineage.mockResolvedValue(fullLineage());
+    render(<StreamLineageDrawer anomalyId="anom_1" {...PROPS} />);
+    await waitFor(() =>
+      expect(screen.getByText(/databricks_table_mapping_not_configured/)).toBeInTheDocument());
+    // the Databricks section must not show a real table/version
+    expect(screen.queryByText(/novendor_1/)).not.toBeInTheDocument();
+  });
+
+  it("renders triage_not_emitted when triage layer is unavailable", async () => {
+    const data = fullLineage();
+    data.layers.agent_triage = { status: "not_available", null_reason: "triage_not_emitted" };
+    getAnomalyLineage.mockResolvedValue(data);
+    render(<StreamLineageDrawer anomalyId="anom_1" {...PROPS} />);
+    await waitFor(() => expect(screen.getByText(/triage_not_emitted/)).toBeInTheDocument());
+  });
+
+  it("renders a top-level fail-closed note when the anomaly is unknown to the serving slice", async () => {
+    getAnomalyLineage.mockResolvedValue({
+      status: "not_available", anomaly_id: "nope", null_reason: "kafka_provenance_unavailable",
+      layers: {
+        kafka_detection: { status: "not_available", null_reason: "kafka_provenance_unavailable" },
+        agent_triage: { status: "not_available", null_reason: "triage_not_emitted" },
+        databricks_lake: { status: "not_available", null_reason: "databricks_table_mapping_not_configured" },
+        postgres_serving: { status: "not_available", null_reason: "kafka_provenance_unavailable" },
+      },
+    } as AnomalyLineage);
+    render(<StreamLineageDrawer anomalyId="nope" {...PROPS} />);
+    await waitFor(() =>
+      expect(screen.getByText(/No lineage recorded for this anomaly yet/)).toBeInTheDocument());
+    expect(screen.getByText(/kafka_provenance_unavailable/)).toBeInTheDocument();
+  });
+
+  it("handles API error", async () => {
+    getAnomalyLineage.mockRejectedValueOnce(new Error("boom"));
+    render(<StreamLineageDrawer anomalyId="anom_1" {...PROPS} />);
+    await waitFor(() => expect(screen.getByText(/Could not load lineage/)).toBeInTheDocument());
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  it("does not fetch or render when closed (anomalyId null)", () => {
+    render(<StreamLineageDrawer anomalyId={null} {...PROPS} />);
+    expect(getAnomalyLineage).not.toHaveBeenCalled();
+  });
+});

--- a/repo-b/src/components/telemetry/stargate/StreamLineageDrawer.tsx
+++ b/repo-b/src/components/telemetry/stargate/StreamLineageDrawer.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+// Stream lineage drawer — the durable, persisted lineage chain for one anomaly, read from the
+// Ticket-4 routes (/api/telemetry/stream/lineage/anomaly/{id}) over the 10034 serving slice.
+//
+// Distinct from AnomalyInspectionDrawer (which inspects a single in-memory SSE anomaly via the
+// stargate bridge): this drawer proves the PERSISTED chain
+//   Kafka detection -> AI triage -> Databricks lake (where mapped) -> Postgres serving row.
+//
+// Honest copy only: "deterministic anomaly event", "AI triage explanation", "Databricks mapping not
+// configured", "serving slice row", "Kafka offset proof". Every layer is fail-closed — a missing
+// layer renders its explicit status + null_reason, never a blank or a fabricated table/version.
+
+import { useEffect, useState } from "react";
+import { C, Tag } from "../primitives";
+import { DrawerWrapper, DrawerHeader, FieldRow } from "../drawerPrimitives";
+import {
+  getAnomalyLineage,
+  type AnomalyLineage,
+  type AgentTriageLayer,
+  type DatabricksLakeLayer,
+  type KafkaDetectionLayer,
+  type PostgresServingLayer,
+} from "@/lib/telemetry/streamLineage";
+
+type LoadState =
+  | { phase: "loading" }
+  | { phase: "error"; message: string }
+  | { phase: "ready"; data: AnomalyLineage };
+
+function statusColor(status?: string | null) {
+  return status === "available" ? C.green : C.amber;
+}
+
+/** A titled layer block with a status tag; renders rows or an explicit unavailable note. */
+function LayerSection({
+  title, status, nullReason, children,
+}: {
+  title: string;
+  status?: string | null;
+  nullReason?: string | null;
+  children?: React.ReactNode;
+}) {
+  const available = status === "available";
+  return (
+    <section style={{ marginTop: 16 }} aria-label={title}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+        <div style={{ fontFamily: C.mono, color: C.faint, fontSize: 9, letterSpacing: "0.12em", textTransform: "uppercase" }}>
+          {title}
+        </div>
+        <Tag color={statusColor(status)}>{status ?? "unknown"}</Tag>
+      </div>
+      {available ? (
+        children
+      ) : (
+        <div style={{ border: `1px solid ${C.border}`, borderRadius: 7, background: C.panelHi,
+          padding: "9px 11px", color: C.amber, fontFamily: C.mono, fontSize: 11, lineHeight: 1.5 }}>
+          Not available
+          <div style={{ color: C.faint, fontSize: 10, marginTop: 4 }}>
+            null_reason: {nullReason ?? "unknown"}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function KafkaSection({ layer }: { layer: KafkaDetectionLayer }) {
+  return (
+    <LayerSection title="Kafka detection" status={layer.status} nullReason={layer.null_reason}>
+      <FieldRow label="Topic" value={layer.topic} />
+      <FieldRow label="Partition" value={layer.partition} />
+      <FieldRow label="Offset" value={layer.offset} />
+      <FieldRow label="Schema id" value={layer.schema_id} />
+      <FieldRow label="Schema subject" value={layer.schema_subject} />
+      <FieldRow label="Schema version" value={layer.schema_version} />
+      <FieldRow label="Serving row id" value={layer.row_id} />
+    </LayerSection>
+  );
+}
+
+function TriageSection({ layer }: { layer: AgentTriageLayer }) {
+  return (
+    <LayerSection title="AI triage" status={layer.status} nullReason={layer.null_reason}>
+      <FieldRow label="Severity" value={layer.severity} />
+      <FieldRow label="Summary" value={layer.summary} />
+      <FieldRow label="Recommended action" value={layer.recommended_action} />
+      <FieldRow label="Requires human review" value={layer.requires_human_review} />
+      <FieldRow label="Triage topic" value={layer.topic} />
+      <FieldRow label="Partition" value={layer.partition} />
+      <FieldRow label="Offset" value={layer.offset} />
+      <FieldRow label="Triage id" value={layer.triage_id} />
+    </LayerSection>
+  );
+}
+
+function DatabricksSection({ layer }: { layer: DatabricksLakeLayer }) {
+  // Never show fabricated table/version: when not available we render the explicit null_reason only.
+  return (
+    <LayerSection title="Databricks lake" status={layer.status} nullReason={layer.null_reason}>
+      <FieldRow label="Catalog" value={layer.catalog} />
+      <FieldRow label="Schema" value={layer.schema} />
+      <FieldRow label="Table" value={layer.table} />
+      <FieldRow label="Delta version" value={layer.delta_version} />
+    </LayerSection>
+  );
+}
+
+function ServingSection({ layer }: { layer: PostgresServingLayer }) {
+  return (
+    <LayerSection title="Postgres serving slice" status={layer.status} nullReason={layer.null_reason}>
+      <FieldRow label="Table" value={layer.table} />
+      <FieldRow label="Serving row id" value={layer.row_id} />
+      <FieldRow label="Triage id" value={layer.triage_id} />
+      <FieldRow label="Ingested at" value={layer.ingested_at} />
+    </LayerSection>
+  );
+}
+
+export default function StreamLineageDrawer({
+  anomalyId, servingEnvId, businessId, routeEnvId, onClose,
+}: {
+  /** When set, the drawer is open and fetches lineage for this anomaly. null = closed. */
+  anomalyId: string | null;
+  servingEnvId: string;
+  businessId: string;
+  routeEnvId: string;
+  onClose: () => void;
+}) {
+  const [state, setState] = useState<LoadState>({ phase: "loading" });
+
+  useEffect(() => {
+    if (!anomalyId) return;
+    setState({ phase: "loading" });
+    getAnomalyLineage(anomalyId, servingEnvId, businessId, routeEnvId)
+      .then((data) => setState({ phase: "ready", data }))
+      .catch((err) => setState({ phase: "error", message: String(err?.message ?? err) }));
+  }, [anomalyId, servingEnvId, businessId, routeEnvId]);
+
+  return (
+    <DrawerWrapper open={Boolean(anomalyId)} onClose={onClose}>
+      {anomalyId && (
+        <>
+          <DrawerHeader
+            title={`Lineage · ${anomalyId}`}
+            description="Where this anomaly comes from — deterministic Kafka event → AI triage explanation → Databricks lake (where mapped) → Postgres serving slice."
+            closeLabel="Close lineage"
+          />
+
+          {state.phase === "loading" && (
+            <div style={{ marginTop: 18, color: C.dim, fontFamily: C.mono, fontSize: 11 }} aria-label="Loading lineage">
+              Loading lineage…
+            </div>
+          )}
+
+          {state.phase === "error" && (
+            <div style={{ marginTop: 18, border: `1px solid ${C.border}`, borderRadius: 7, background: C.panelHi,
+              padding: "10px 12px", color: C.red, fontFamily: C.mono, fontSize: 11, lineHeight: 1.5 }}
+              aria-label="Lineage error">
+              Could not load lineage.
+              <div style={{ color: C.faint, fontSize: 10, marginTop: 4 }}>{state.message}</div>
+            </div>
+          )}
+
+          {state.phase === "ready" && state.data.status !== "ok" && (
+            // Top-level fail-closed: the anomaly is unknown to the serving slice (e.g. consumer off /
+            // not emitted yet). Explain what hasn't happened rather than showing a blank drawer.
+            <div style={{ marginTop: 18, border: `1px solid ${C.border}`, borderRadius: 7, background: C.panelHi,
+              padding: "10px 12px", color: C.amber, fontFamily: C.mono, fontSize: 11, lineHeight: 1.5 }}
+              aria-label="Lineage not available">
+              No lineage recorded for this anomaly yet.
+              <div style={{ color: C.faint, fontSize: 10, marginTop: 4 }}>
+                null_reason: {state.data.null_reason ?? "kafka_provenance_unavailable"} — nothing has landed in
+                the serving slice for this id (the durable consumer may be off, or it has not been emitted).
+              </div>
+            </div>
+          )}
+
+          {state.phase === "ready" && state.data.status === "ok" && (
+            <>
+              <KafkaSection layer={state.data.layers.kafka_detection} />
+              <TriageSection layer={state.data.layers.agent_triage} />
+              <DatabricksSection layer={state.data.layers.databricks_lake} />
+              <ServingSection layer={state.data.layers.postgres_serving} />
+            </>
+          )}
+
+          <div style={{ marginTop: 16, color: C.faint, fontFamily: C.mono, fontSize: 9, lineHeight: 1.6 }}>
+            Source: durable serving slice (/api/telemetry/stream/lineage/anomaly). Deterministic synthetic
+            replay through real Confluent infrastructure — not live physical telemetry. The Streaming Agent
+            explains anomalies; it does not detect them.
+          </div>
+        </>
+      )}
+    </DrawerWrapper>
+  );
+}

--- a/repo-b/src/lib/telemetry/streamLineage.ts
+++ b/repo-b/src/lib/telemetry/streamLineage.ts
@@ -1,0 +1,83 @@
+"use client";
+
+// Client contract for the Ticket-4 stream lineage routes (backend
+// backend/app/services/telemetry_stream_lineage.py). Proves a displayed anomaly's chain:
+// Kafka detection -> AI triage -> Databricks lake (where mapped) -> Postgres serving row.
+// Every layer is fail-closed: a missing layer carries an explicit status + null_reason; the UI
+// renders that honestly instead of a blank or a fabricated value.
+
+import { apiFetch } from "@/lib/api";
+
+export type LayerStatus = "available" | "not_available";
+
+export interface KafkaDetectionLayer {
+  status: LayerStatus;
+  topic?: string;
+  partition?: number | null;
+  offset?: number | null;
+  schema_id?: number | null;
+  schema_subject?: string | null;
+  schema_version?: number | null;
+  row_id?: string;
+  null_reason?: string | null;
+}
+
+export interface AgentTriageLayer {
+  status: LayerStatus;
+  topic?: string;
+  partition?: number | null;
+  offset?: number | null;
+  triage_id?: string;
+  severity?: string | null;
+  summary?: string | null;
+  recommended_action?: string | null;
+  requires_human_review?: boolean | null;
+  null_reason?: string | null;
+}
+
+export interface DatabricksLakeLayer {
+  status: LayerStatus;
+  catalog?: string | null;
+  schema?: string | null;
+  table?: string | null;
+  delta_version?: number | null;
+  null_reason?: string | null;
+}
+
+export interface PostgresServingLayer {
+  status: LayerStatus;
+  table?: string;
+  row_id?: string;
+  triage_id?: string;
+  ingested_at?: string;
+  null_reason?: string | null;
+}
+
+export interface AnomalyLineage {
+  /** Top-level: "ok" when the kafka detection row exists, else "not_available". */
+  status: "ok" | "not_available";
+  anomaly_id: string;
+  null_reason?: string | null;
+  layers: {
+    kafka_detection: KafkaDetectionLayer;
+    agent_triage: AgentTriageLayer;
+    databricks_lake: DatabricksLakeLayer;
+    postgres_serving: PostgresServingLayer;
+  };
+}
+
+/** Combined lineage for one anomaly. */
+export function getAnomalyLineage(
+  anomalyId: string,
+  servingEnvId: string,
+  businessId: string,
+  routeEnvId: string,
+) {
+  return apiFetch<AnomalyLineage>(
+    `/api/telemetry/stream/lineage/anomaly/${encodeURIComponent(anomalyId)}`,
+    {
+      params: { env_id: servingEnvId, business_id: businessId },
+      headers: { "x-telemetry-route-env-id": routeEnvId },
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Ticket 5. Exposes the Ticket-4 lineage chain visually in the Stargate console. Clicking a routed anomaly opens `StreamLineageDrawer`, which fetches `/api/telemetry/stream/lineage/anomaly/{id}` and renders the durable provenance chain: **Kafka detection → AI triage → Databricks lake → Postgres serving row**.

## Files
- **New** `repo-b/src/lib/telemetry/streamLineage.ts` — types + `getAnomalyLineage` (matches the metadata-graph fetch convention: `env_id`/`business_id` params + `x-telemetry-route-env-id` header; proxied through the existing `/api/telemetry/[...path]` route).
- **New** `repo-b/src/components/telemetry/stargate/StreamLineageDrawer.tsx` — reuses the shared `drawerPrimitives` (Radix shell, `DrawerHeader`, fail-closed `FieldRow`) + the `C` token atoms.
- **New** `StreamLineageDrawer.test.tsx` — 7 tests.
- **Edit** `StargateConsole.tsx` — anomaly ticker rows are now clickable; opens the drawer for the deterministic `anom_{printer_id}_{ts_us}` id (same id the agent SQL stamps), bridging a live SSE anomaly to its persisted serving-slice lineage.

## States rendered (no blank drawer, no fabrication)
`loading` · `error` · per-layer `available` · per-layer `not_available` (with explicit `null_reason`) · top-level "No lineage recorded for this anomaly yet" (when the consumer is off / nothing emitted). The Databricks layer shows `databricks_table_mapping_not_configured` and **never** a fabricated table/version.

## Honest copy
"Deterministic synthetic replay through real Confluent infrastructure", "the Streaming Agent explains anomalies; it does not detect them", "Databricks mapping not configured", "serving slice row". No "live rocket telemetry", no "AI detected the failure", no "full raw telemetry in Postgres".

## Tests / checks
- `vitest run src/components/telemetry/stargate/` → **16 passed** (incl. my 7: kafka provenance / AI triage / databricks not_available without fabrication / `triage_not_emitted` / top-level fail-closed / API error / closed-no-fetch).
- `next lint` on the new files → clean. `tsc` clean for the new files (2 pre-existing unrelated tsc errors on main left as-is).

## Scope
Frontend only. No backend, Confluent runtime, or consumer changes. No secrets.

## Production verification
Backend isn't auto-deployed (Railway, not GitHub-connected), so the lineage routes aren't live in prod yet — the drawer fails closed gracefully until then. Backend deploy + live page verification happen in Ticket 8's rehearsal.

## Next
Ticket 6 — contract/catalog hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)