### PR TITLE
feat(telemetry): aerospace Agent Workbench skill view (Phase 2B)

### DIFF
--- a/repo-b/src/components/telemetry/data-engineering/AgentWorkbench.test.tsx
+++ b/repo-b/src/components/telemetry/data-engineering/AgentWorkbench.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const getSkillRegistry = vi.fn();
+vi.mock("@/lib/automated-data-engineering/api", () => ({
+  getSkillRegistry: () => getSkillRegistry(),
+}));
+
+import AgentWorkbench from "./AgentWorkbench";
+
+function tool(name: string, over: Record<string, unknown> = {}) {
+  return {
+    name, module: name.split(".")[0], description: `${name} description`, permission: "read",
+    side_effect_class: "read", permission_required: "read", confirmation_required: false,
+    lane_tags: [], skill_tags: [], input_fields: [], ...over,
+  };
+}
+
+const registry = {
+  tools: [tool("sql.validate_query"), tool("bm.health_check"), tool("business.create", { side_effect_class: "write", confirmation_required: true })],
+  modules: [{ module: "sql", tool_count: 1 }, { module: "bm", tool_count: 1 }, { module: "business", tool_count: 1 }],
+  null_reason: null,
+};
+
+describe("AgentWorkbench (Phase 2B)", () => {
+  beforeEach(() => getSkillRegistry.mockReset());
+
+  it("renders the four-group capability map with mode headers", async () => {
+    getSkillRegistry.mockResolvedValue(registry);
+    render(<AgentWorkbench envId="env-1" />);
+    expect(await screen.findByText(/Observe —/)).toBeInTheDocument();
+    expect(screen.getByText(/Propose —/)).toBeInTheDocument();
+    expect(screen.getByText(/Execute with guardrails —/)).toBeInTheDocument();
+    expect(screen.getByText("Advanced registry")).toBeInTheDocument();
+    // The nine curated capabilities appear.
+    expect(screen.getByText("Profile source")).toBeInTheDocument();
+    expect(screen.getByText("Dry-run SQL")).toBeInTheDocument();
+  });
+
+  it("backs dry-run SQL with the real skill but shows declared-only (cannot run) for unbacked capabilities", async () => {
+    getSkillRegistry.mockResolvedValue(registry);
+    render(<AgentWorkbench envId="env-1" />);
+    expect(await screen.findByText("sql.validate_query")).toBeInTheDocument(); // real backing
+    // Unbacked capabilities fail closed with the null_reason, never implied runnable.
+    expect(screen.getAllByText(/no_registered_skill_for_capability/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Declared capability — cannot run/).length).toBeGreaterThan(0);
+  });
+
+  it("keeps the full registry behind the Advanced toggle (opt-in)", async () => {
+    getSkillRegistry.mockResolvedValue(registry);
+    render(<AgentWorkbench envId="env-1" />);
+    await screen.findByText("Advanced registry");
+    // Full-registry rows are hidden until toggled.
+    expect(screen.queryByText("bm.health_check")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /Show full registry/ }));
+    expect(await screen.findByText("bm.health_check")).toBeInTheDocument();
+  });
+
+  it("fails closed when the registry is unavailable", async () => {
+    getSkillRegistry.mockResolvedValue({ tools: [], modules: [], null_reason: "skill_registry_unavailable" });
+    render(<AgentWorkbench envId="env-1" />);
+    expect(await screen.findByText("Skill registry unavailable")).toBeInTheDocument();
+    expect(screen.getByText(/skill_registry_unavailable/)).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/data-engineering/AgentWorkbench.tsx
+++ b/repo-b/src/components/telemetry/data-engineering/AgentWorkbench.tsx
@@ -8,76 +8,108 @@ import {
   type SkillSummary,
 } from "@/lib/automated-data-engineering/api";
 import {
+  capabilitiesByMode,
+  DE_MODES,
+  DE_MODE_BLURB,
+  DE_MODE_LABEL,
+  matchSkill,
+  type DeCapability,
+} from "@/lib/telemetry/deCapabilities";
+import {
   C,
   EmptyState,
   InlineCode,
   Loading,
-  MetricCard,
   PageHeading,
   Panel,
+  SectionTabButton,
   SelectField,
   StatGrid,
+  MetricCard,
   StatusDot,
   Tag,
   TelemetrySection,
   TelemetryStatusBanner,
 } from "../primitives";
 
-// Agent Workbench — the "propose" mode. It frames the live, governed MCP skill registry as the three
-// things AI is allowed to do over the data fabric: Observe (read-only), Propose (produce an artifact),
-// and Execute-with-guardrails (a write that requires confirmation). Skills come from /api/ade/skill-
-// registry (the real registry). Phase 1 shows the full registry; an aerospace-data-engineering default
-// view is declared next-phase, not faked.
+// Agent Workbench (Phase 2B) — the aerospace data-engineering action map. Four groups: Observe,
+// Propose, Execute-with-guardrails, and the full Advanced registry. Each curated capability is matched
+// to the LIVE governed skill registry: backed → shows the real skill's permission/side-effect/confirm;
+// unbacked → shown as a declared capability that CANNOT run (null_reason), never implied runnable.
 
-type Capability = "observe" | "propose" | "execute";
+function CapabilityCard({ cap, backing }: { cap: DeCapability; backing: SkillSummary | null }) {
+  return (
+    <div style={{ background: C.panel, border: `1px solid ${backing ? C.border : C.borderHi}`, borderRadius: 9, padding: 14 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <StatusDot color={backing ? C.green : C.faint} size={7} glow={Boolean(backing)} />
+        <span style={{ fontFamily: C.mono, fontSize: 13, color: C.text, fontWeight: 600 }}>{cap.label}</span>
+      </div>
+      <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.dim, lineHeight: 1.5, marginTop: 7 }}>{cap.blurb}</div>
 
-const CAP_META: Record<Capability, { label: string; blurb: string; color: string }> = {
-  observe: { label: "Observe", blurb: "Read-only: profile sources, read grain/freshness, inspect lineage. No side effects.", color: C.cyan },
-  propose: { label: "Propose", blurb: "Produce an artifact or change for review — a mapping, feature, contract, or PR.", color: C.green },
-  execute: { label: "Execute · guardrails", blurb: "A write that fails closed until explicitly confirmed.", color: C.amber },
-};
-
-function classify(skill: SkillSummary): Capability {
-  if (skill.confirmation_required) return "execute";
-  if (skill.side_effect_class === "read" || skill.permission === "read") return "observe";
-  return "propose";
+      {backing ? (
+        <div style={{ marginTop: 11, paddingTop: 10, borderTop: `1px solid ${C.border}` }}>
+          <div style={{ fontFamily: C.mono, fontSize: 10, color: C.green, letterSpacing: "0.06em", textTransform: "uppercase" }}>
+            Governed skill available
+          </div>
+          <div style={{ marginTop: 6 }}><InlineCode color={C.text}>{backing.name}</InlineCode></div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 8 }}>
+            <Tag color={C.cyan}>permission: {backing.permission}</Tag>
+            <Tag color={backing.side_effect_class === "read" ? C.green : C.amber}>side-effect: {backing.side_effect_class}</Tag>
+            {backing.confirmation_required && <Tag color={C.amber}>confirm required</Tag>}
+          </div>
+        </div>
+      ) : (
+        <div style={{ marginTop: 11, paddingTop: 10, borderTop: `1px solid ${C.border}` }}>
+          <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, letterSpacing: "0.06em", textTransform: "uppercase" }}>
+            Declared capability — cannot run
+          </div>
+          <div style={{ fontFamily: C.mono, fontSize: 11, color: C.amber, marginTop: 6 }}>
+            null_reason: no_registered_skill_for_capability
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default function AgentWorkbench({ envId }: { envId: string }) {
-  // envId is accepted for route symmetry; the skill registry is environment-agnostic (platform core).
+  // Skill registry is environment-agnostic (platform core); envId kept for route symmetry.
   void envId;
   const [registry, setRegistry] = useState<SkillRegistryResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [moduleFilter, setModuleFilter] = useState("");
   const [query, setQuery] = useState("");
 
   useEffect(() => {
     let live = true;
     getSkillRegistry()
-      .then((r) => { if (live) setRegistry(r); })
+      .then((r) => { if (!live) return; if (r) setRegistry(r); else setError("skill_registry_unreachable"); })
       .catch((e) => { if (live) setError(e instanceof Error ? e.message : String(e)); });
     return () => { live = false; };
   }, []);
 
-  const buckets = useMemo(() => {
-    const out: Record<Capability, number> = { observe: 0, propose: 0, execute: 0 };
-    for (const t of registry?.tools ?? []) out[classify(t)] += 1;
-    return out;
-  }, [registry]);
+  const tools = registry?.tools ?? [];
+  const byMode = useMemo(() => capabilitiesByMode(), []);
+  const backedCount = useMemo(
+    () => Object.values(byMode).flat().filter((c) => matchSkill(c, tools)).length,
+    [byMode, tools],
+  );
+  const totalCaps = useMemo(() => Object.values(byMode).flat().length, [byMode]);
 
-  const filtered = useMemo(() => {
+  const advancedList = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return (registry?.tools ?? [])
+    return tools
       .filter((t) => (!moduleFilter || t.module === moduleFilter))
       .filter((t) => (!q || `${t.name} ${t.description} ${t.skill_tags.join(" ")}`.toLowerCase().includes(q)))
       .sort((a, b) => a.name.localeCompare(b.name));
-  }, [registry, moduleFilter, query]);
+  }, [tools, moduleFilter, query]);
 
   const heading = (
     <PageHeading
       eyebrow="Mode · Agent Workbench"
       title="Agent Workbench"
-      blurb="What AI is allowed to do over the data fabric, governed. Every skill declares its permission, side-effect class, and whether it needs confirmation before it can run — so the boundary between observing, proposing, and executing is explicit, not implied."
+      blurb="The aerospace data-engineering actions, grouped by what they do to the data. Each is matched against the live governed skill registry — where a real skill backs it, you see its permission and side-effect class; where one doesn't exist yet, it's shown as a declared capability that cannot run. Nothing is implied runnable that isn't."
     />
   );
 
@@ -93,63 +125,81 @@ export default function AgentWorkbench({ envId }: { envId: string }) {
     <>
       {heading}
 
-      <TelemetryStatusBanner tone="info">
-        Showing the full governed skill registry ({registry.tools.length} skills · {registry.modules.length}{" "}
-        modules). An aerospace-data-engineering scoped default view (profile, infer-grain, validate-join,
-        generate-contract, propose-feature) is declared next-phase work.
-      </TelemetryStatusBanner>
-
-      <StatGrid cols={3} style={{ marginTop: 16 }}>
-        {(Object.keys(CAP_META) as Capability[]).map((cap) => (
-          <MetricCard key={cap} label={CAP_META[cap].label} value={buckets[cap]} sub={CAP_META[cap].blurb} accent={CAP_META[cap].color} />
-        ))}
+      <StatGrid cols={3} style={{ marginBottom: 4 }}>
+        <MetricCard label="DE capabilities" value={totalCaps} sub="aerospace data-engineering actions" />
+        <MetricCard label="Backed by a governed skill" value={backedCount} sub={`of ${totalCaps} runnable today`} accent={backedCount ? C.green : undefined} />
+        <MetricCard label="Full registry" value={registry.tools.length} sub={`${registry.modules.length} modules · advanced`} />
       </StatGrid>
 
-      <TelemetrySection
-        label="Governed skills"
-        right={
-          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-            <input
-              type="search"
-              aria-label="Search skills"
-              placeholder="Search skills…"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              style={{ minHeight: 34, borderRadius: 7, border: `1px solid ${C.borderHi}`, background: C.panelHi, color: C.text, padding: "0 11px", fontFamily: C.mono, fontSize: 11 }}
-            />
-            <SelectField value={moduleFilter} onChange={setModuleFilter} ariaLabel="Filter by module">
-              <option value="">All modules</option>
-              {registry.modules.map((m) => (
-                <option key={m.module} value={m.module}>{m.module} ({m.tool_count})</option>
-              ))}
-            </SelectField>
+      <TelemetryStatusBanner tone="info">
+        {backedCount} of {totalCaps} curated capabilities are backed by a registered governed skill today;
+        the rest are declared and fail closed (they cannot run). The complete registry is under Advanced.
+      </TelemetryStatusBanner>
+
+      {DE_MODES.map((mode) => (
+        <TelemetrySection key={mode} label={`${DE_MODE_LABEL[mode]} — ${DE_MODE_BLURB[mode]}`}>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {byMode[mode].map((cap) => (
+              <CapabilityCard key={cap.key} cap={cap} backing={matchSkill(cap, tools)} />
+            ))}
           </div>
+        </TelemetrySection>
+      ))}
+
+      {/* Advanced registry — the full governed skill list, opt-in. */}
+      <TelemetrySection
+        label="Advanced registry"
+        right={
+          <SectionTabButton active={advancedOpen} onClick={() => setAdvancedOpen((v) => !v)}>
+            {advancedOpen ? "Hide full registry" : `Show full registry (${registry.tools.length})`}
+          </SectionTabButton>
         }
       >
-        {filtered.length === 0 ? (
-          <EmptyState label="No skills match" hint="Clear the search or module filter." />
+        {!advancedOpen ? (
+          <span style={{ fontFamily: C.mono, fontSize: 11.5, color: C.faint }}>
+            The complete governed skill registry across all modules — declared permissions and side-effect
+            classes, the same data the curated cards above are matched against.
+          </span>
         ) : (
-          <Panel pad={0}>
-            <div style={{ maxHeight: 560, overflowY: "auto" }}>
-              {filtered.map((t) => {
-                const cap = classify(t);
-                return (
-                  <div key={t.name} style={{ display: "flex", alignItems: "flex-start", gap: 12, padding: "11px 16px", borderBottom: `1px solid ${C.border}` }}>
-                    <StatusDot color={CAP_META[cap].color} size={7} />
-                    <div style={{ minWidth: 0, flex: 1 }}>
-                      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-                        <InlineCode color={C.text}>{t.name}</InlineCode>
-                        <Tag color={CAP_META[cap].color}>{CAP_META[cap].label}</Tag>
-                        {t.confirmation_required && <Tag color={C.amber}>confirm required</Tag>}
-                      </div>
-                      <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.dim, lineHeight: 1.5, marginTop: 5 }}>{t.description}</div>
-                    </div>
-                    <span style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, whiteSpace: "nowrap" }}>{t.module}</span>
-                  </div>
-                );
-              })}
+          <>
+            <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", marginBottom: 12 }}>
+              <input
+                type="search"
+                aria-label="Search skills"
+                placeholder="Search skills…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                style={{ minHeight: 34, borderRadius: 7, border: `1px solid ${C.borderHi}`, background: C.panelHi, color: C.text, padding: "0 11px", fontFamily: C.mono, fontSize: 11 }}
+              />
+              <SelectField value={moduleFilter} onChange={setModuleFilter} ariaLabel="Filter by module">
+                <option value="">All modules</option>
+                {registry.modules.map((m) => (
+                  <option key={m.module} value={m.module}>{m.module} ({m.tool_count})</option>
+                ))}
+              </SelectField>
             </div>
-          </Panel>
+            {advancedList.length === 0 ? (
+              <EmptyState label="No skills match" hint="Clear the search or module filter." />
+            ) : (
+              <Panel pad={0}>
+                <div style={{ maxHeight: 520, overflowY: "auto" }}>
+                  {advancedList.map((t) => (
+                    <div key={t.name} style={{ display: "flex", alignItems: "flex-start", gap: 12, padding: "10px 16px", borderBottom: `1px solid ${C.border}` }}>
+                      <div style={{ minWidth: 0, flex: 1 }}>
+                        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                          <InlineCode color={C.text}>{t.name}</InlineCode>
+                          <Tag color={t.side_effect_class === "read" ? C.green : C.amber}>{t.side_effect_class}</Tag>
+                          {t.confirmation_required && <Tag color={C.amber}>confirm</Tag>}
+                        </div>
+                        <div style={{ fontFamily: C.sans, fontSize: 12, color: C.dim, lineHeight: 1.5, marginTop: 5 }}>{t.description}</div>
+                      </div>
+                      <span style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, whiteSpace: "nowrap" }}>{t.module}</span>
+                    </div>
+                  ))}
+                </div>
+              </Panel>
+            )}
+          </>
         )}
       </TelemetrySection>
     </>

--- a/repo-b/src/lib/telemetry/deCapabilities.test.ts
+++ b/repo-b/src/lib/telemetry/deCapabilities.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  capabilitiesByMode,
+  DE_CAPABILITIES,
+  matchSkill,
+  type DeCapability,
+} from "./deCapabilities";
+import type { SkillSummary } from "@/lib/automated-data-engineering/api";
+
+function skill(name: string, over: Partial<SkillSummary> = {}): SkillSummary {
+  return {
+    name, module: name.split(".")[0], description: name, permission: "read",
+    side_effect_class: "read", permission_required: "read", confirmation_required: false,
+    lane_tags: [], skill_tags: [], input_fields: [], ...over,
+  };
+}
+const cap = (key: string): DeCapability => DE_CAPABILITIES.find((c) => c.key === key)!;
+
+describe("deCapabilities", () => {
+  it("exposes the nine aerospace DE capabilities", () => {
+    expect(DE_CAPABILITIES.map((c) => c.key)).toEqual([
+      "profile_source", "infer_grain", "validate_relationship", "run_quality_check",
+      "generate_source_contract", "propose_feature_table", "dry_run_sql", "open_pr", "write_receipt",
+    ]);
+  });
+
+  it("groups capabilities into observe / propose / execute", () => {
+    const g = capabilitiesByMode();
+    expect(g.observe.map((c) => c.key)).toEqual(["profile_source", "infer_grain", "validate_relationship", "run_quality_check"]);
+    expect(g.propose.map((c) => c.key)).toEqual(["generate_source_contract", "propose_feature_table"]);
+    expect(g.execute.map((c) => c.key)).toEqual(["dry_run_sql", "open_pr", "write_receipt"]);
+  });
+
+  it("matches dry-run SQL to a real validate_query skill", () => {
+    const tools = [skill("sql.validate_query"), skill("sql.describe_schema")];
+    const m = matchSkill(cap("dry_run_sql"), tools);
+    expect(m?.name).toBe("sql.validate_query");
+  });
+
+  it("does NOT match write_receipt to wrong-domain accounting receipt tools (no false backing)", () => {
+    const tools = [skill("novendor.accounting.receipt.ingest"), skill("novendor.accounting.receipt.classify")];
+    expect(matchSkill(cap("write_receipt"), tools)).toBeNull();
+  });
+
+  it("does NOT match open_pr to approvals / provenance tools that merely contain 'pr'", () => {
+    const tools = [skill("repe.approve_change"), skill("repe.get_metric_provenance"), skill("platform.list_approvals")];
+    expect(matchSkill(cap("open_pr"), tools)).toBeNull();
+  });
+
+  it("does NOT match generate_source_contract to a sql-with-contract runner", () => {
+    const tools = [skill("repe.run_readonly_sql_with_contract")];
+    expect(matchSkill(cap("generate_source_contract"), tools)).toBeNull();
+  });
+
+  it("returns null for capabilities with no registered skill (fail-closed default)", () => {
+    const tools = [skill("bm.health_check"), skill("business.create")];
+    for (const key of ["profile_source", "infer_grain", "validate_relationship", "run_quality_check", "propose_feature_table"]) {
+      expect(matchSkill(cap(key), tools)).toBeNull();
+    }
+  });
+});

--- a/repo-b/src/lib/telemetry/deCapabilities.ts
+++ b/repo-b/src/lib/telemetry/deCapabilities.ts
@@ -1,0 +1,71 @@
+// Aerospace data-engineering capability map for the Agent Workbench (Phase 2B). Pure + testable.
+//
+// These are the data-engineering ACTIONS the workbench is meant to offer, grouped by what they do to
+// the data (Observe / Propose / Execute-with-guardrails). Each capability is matched against the LIVE
+// governed skill registry: if a real skill backs it, the card shows that skill's real permission /
+// side-effect / confirmation; if not, it is shown as a *declared capability that cannot run* — never
+// implied runnable. Matchers are deliberately specific name tokens so we never falsely claim a
+// wrong-domain skill (e.g. an accounting "receipt" tool is NOT an audit-receipt capability).
+
+import type { SkillSummary } from "@/lib/automated-data-engineering/api";
+
+export type DeMode = "observe" | "propose" | "execute";
+
+export const DE_MODE_LABEL: Record<DeMode, string> = {
+  observe: "Observe",
+  propose: "Propose",
+  execute: "Execute with guardrails",
+};
+
+export const DE_MODE_BLURB: Record<DeMode, string> = {
+  observe: "Read-only: inspect the data without side effects.",
+  propose: "Draft an artifact or change for review — nothing runs.",
+  execute: "A run that is read-only or fails closed until confirmed.",
+};
+
+export type DeCapability = {
+  key: string;
+  label: string;
+  mode: DeMode;
+  blurb: string;
+  /** Specific lowercase name tokens that indicate a TRUE backing skill (avoid loose matches). */
+  matchers: string[];
+};
+
+export const DE_CAPABILITIES: DeCapability[] = [
+  { key: "profile_source", label: "Profile source", mode: "observe",
+    blurb: "Row counts, null rates, distincts, and freshness for a source.", matchers: ["profile_source", "profile_table"] },
+  { key: "infer_grain", label: "Infer grain", mode: "observe",
+    blurb: "Determine the row grain (keys × period) of a table.", matchers: ["infer_grain", "detect_grain"] },
+  { key: "validate_relationship", label: "Validate relationship", mode: "observe",
+    blurb: "Check whether a join between two tables is safe.", matchers: ["validate_join", "validate_relationship", "join_path"] },
+  { key: "run_quality_check", label: "Run quality check", mode: "observe",
+    blurb: "Evaluate declared data-quality assertions for a table.", matchers: ["run_quality", "quality_check", "dq_assertion"] },
+  { key: "generate_source_contract", label: "Generate source contract", mode: "propose",
+    blurb: "Draft a source contract: schema, grain, keys, freshness SLA.", matchers: ["generate_contract", "source_contract"] },
+  { key: "propose_feature_table", label: "Propose feature table", mode: "propose",
+    blurb: "Draft a point-in-time-safe feature table definition.", matchers: ["propose_feature", "feature_table"] },
+  { key: "dry_run_sql", label: "Dry-run SQL", mode: "execute",
+    blurb: "Validate / plan SQL without writing — read-only execution.", matchers: ["validate_query", "dry_run_sql"] },
+  { key: "open_pr", label: "Open PR", mode: "execute",
+    blurb: "Open a pull request with the proposed change for review.", matchers: ["create_pr", "open_pr", "pull_request"] },
+  { key: "write_receipt", label: "Write receipt", mode: "execute",
+    blurb: "Record an audit receipt for a governed action.", matchers: ["write_audit_receipt", "record_audit_receipt"] },
+];
+
+/** First registry skill whose name contains one of the capability's specific matchers, else null. */
+export function matchSkill(cap: DeCapability, tools: SkillSummary[]): SkillSummary | null {
+  for (const t of tools) {
+    const name = t.name.toLowerCase();
+    if (cap.matchers.some((m) => name.includes(m))) return t;
+  }
+  return null;
+}
+
+export function capabilitiesByMode(): Record<DeMode, DeCapability[]> {
+  const out: Record<DeMode, DeCapability[]> = { observe: [], propose: [], execute: [] };
+  for (const c of DE_CAPABILITIES) out[c.mode].push(c);
+  return out;
+}
+
+export const DE_MODES: DeMode[] = ["observe", "propose", "execute"];


### PR DESCRIPTION
## What (Phase 2B)
Reframe the Agent Workbench into the aerospace data-engineering action map: **Observe / Propose / Execute-with-guardrails** groups + the full **Advanced registry**.

- New pure lib `lib/telemetry/deCapabilities.ts` — the nine curated capabilities (profile source, infer grain, validate relationship, run quality check, generate source contract, propose feature table, dry-run SQL, open PR, write receipt), each matched against the **live** registry with specific name tokens.
- **Honest backing:** only **dry-run SQL** is backed today (`sql.validate_query`, read-only). The other eight render as "declared capability — cannot run" with `null_reason: no_registered_skill_for_capability`. Wrong-domain false-matches are explicitly prevented (accounting receipt ≠ audit receipt; approvals/provenance ≠ open PR; sql-with-contract runner ≠ generate contract).
- Each backed card shows the real skill's permission, side-effect class, confirmation requirement. Full ADE registry behind an Advanced toggle.

## Rules honored
- No ADE core change (portability guard clean). Nothing implied runnable that isn't. Section stays inside `TelemetryShell` (no second rail).

## Tests (11, green)
`deCapabilities` grouping + matcher incl. false-backing guards; `AgentWorkbench` render (four groups, real backing, declared-only fail-closed, advanced opt-in, registry-unavailable fail-closed).

## Verification
`npm run typecheck` clean for these files · ESLint 0 errors · portability guard clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)