### PR TITLE
Telemetry lineage runbook + verification script (Ticket 7)

### DIFF
--- a/docs/runbooks/telemetry-confluent-databricks-lineage.md
+++ b/docs/runbooks/telemetry-confluent-databricks-lineage.md
@@ -1,0 +1,143 @@
+# Telemetry lineage runbook — Confluent → Databricks → Postgres
+
+How to start, check, and safely shut down the Stargate telemetry lineage demo. The lineage proves how a
+displayed anomaly/triage flows through real infrastructure:
+
+```
+Confluent Kafka (Stargate topics)
+  -> Streaming Agent triage (stargate.printer.anomaly.triage.v1)
+  -> durable consumer (default-off)
+  -> Lakebase/Postgres serving slice (tel_stream_kafka_rows / tel_stream_triage_events)
+  -> FastAPI lineage routes (/api/telemetry/stream/*)
+  -> frontend lineage drawer (Stargate console)
+```
+
+**Honesty boundary.** Confluent is real transport (topic/partition/offset + schema proof). Databricks/Delta
+is the raw lake (no Stargate→Delta mapping configured yet — lineage fails closed
+`databricks_table_mapping_not_configured`). Lakebase/Postgres is the **serving/provenance slice**, not the
+raw lake. Stargate is **deterministic synthetic printer replay through real Confluent infrastructure** —
+not live physical telemetry. The deterministic Flink rule detects; the Streaming Agent **explains**.
+
+## Architecture map
+
+| Layer | What | Where |
+|---|---|---|
+| Producer / replay | deterministic printer waveforms | `scripts/streaming/stargate/producer.py` (+ `capture_fixture.py`) |
+| Transport | Confluent Kafka `stargate.printer.*` topics | `infra/confluent/stargate/topics/` |
+| Detect | managed Flink 5s agg + anomaly route | `infra/confluent/stargate/flink/01,02_*.sql` |
+| Explain | Streaming Agent → triage topic | `infra/confluent/stargate/agents/` |
+| Sink | durable serving-slice consumer (default off) | `backend/app/services/telemetry_stream_consumer.py` |
+| Serve | `tel_stream_kafka_rows` / `tel_stream_triage_events` / `tel_stream_consumer_offsets` | `repo-b/db/schema/10033`, `10034` (Lakebase) |
+| API | lineage/provenance routes | `backend/app/services/telemetry_stream_lineage.py`, `backend/app/routes/telemetry.py` |
+| UI | lineage drawer | `repo-b/src/components/telemetry/stargate/StreamLineageDrawer.tsx` |
+
+## Prerequisites
+
+- `confluent login --save` (interactive, one-time — see `infra/confluent/stargate/README.md`).
+- The Stargate cluster + topics + Flink statements provisioned (`infra/confluent/stargate/provision.ps1`).
+- The Streaming Agent re-created from `infra/confluent/stargate/agents/` (model + connection + statements).
+- Backend deployed from `main` (Railway is **not** GitHub-connected — deploy with
+  `scripts/deploy_backend.sh`, verify `/api/version`). The `10034` schema is already applied to Lakebase.
+
+## Environment variables
+
+| Var | Purpose | Default |
+|---|---|---|
+| `CONFLUENT_BOOTSTRAP_SERVERS`, `CONFLUENT_API_KEY/SECRET` | broker access (producer + consumer) | local Redpanda |
+| `CONFLUENT_SR_URL`, `CONFLUENT_SR_API_KEY/SECRET` | Schema Registry | localhost:8081 |
+| `TELEMETRY_KAFKA_CONSUMER_ENABLED` | gate the durable consumer | `0` (off) |
+| `TELEMETRY_KAFKA_CONSUMER_GROUP` | consumer group | `stargate-bridge-sink` |
+| `TELEMETRY_KAFKA_RAW_SAMPLE_RATE` | persist raw telemetry iff `offset % N == 0` | `50` |
+| `TELEMETRY_DATABASE_URL` | Lakebase serving slice (Railway `authentic-sparkle`) | — |
+
+Secrets are shown once and never written to disk; keep them in `scripts/streaming/stargate/.env`
+(gitignored) or the shell. **Never commit credentials.**
+
+## Confirm the Confluent side exists
+
+```bash
+confluent kafka topic list                                  # expect stargate.printer.* incl. anomaly.triage.v1
+confluent schema-registry schema list --subject-prefix stargate
+confluent flink statement list --cloud gcp --region us-east1 # agg, anomaly route, triage agent
+```
+
+## Enable the backend consumer (intentional)
+
+The consumer is default-off. Enable it deliberately for a rehearsal, then turn it back off:
+
+```bash
+# Railway backend service (authentic-sparkle)
+railway variables set TELEMETRY_KAFKA_CONSUMER_ENABLED=1 --service authentic-sparkle
+# redeploy so the lifespan picks it up
+cd backend && bash ../scripts/deploy_backend.sh
+```
+
+## Run the producer (demo mode)
+
+```bash
+cd scripts/streaming/stargate
+python producer.py --mode cloud --rate 50 --printers 4 --duration 300   # ~60k msgs over 5 min
+```
+
+A pre-failure print job crosses both anomaly thresholds (`melt_pool_temp_c < 1400 AND arm_vibration_g >
+0.08`), so the Flink route emits anomalies, the agent emits triage, and the consumer persists rows.
+
+## Check rows landed in Lakebase/Postgres
+
+```sql
+-- via supabase db query --linked, or get_telemetry_cursor / psql against TELEMETRY_DATABASE_URL
+SELECT record_kind, count(*) FROM tel_stream_kafka_rows
+  WHERE env_id='telemetry-demo' GROUP BY 1 ORDER BY 2 DESC;
+SELECT count(*) FROM tel_stream_triage_events WHERE env_id='telemetry-demo';
+SELECT topic, partition, last_processed_offset, status FROM tel_stream_consumer_offsets
+  WHERE env_id='telemetry-demo';
+```
+
+## Call the FastAPI lineage routes
+
+```bash
+B=https://novendor.ai   # or the Railway backend / localhost:8000
+Q="env_id=telemetry-demo&business_id=7e1eb000-0000-4000-a000-000000000001"
+curl -s "$B/api/telemetry/stream/kafka/rows?$Q&limit=5"
+curl -s "$B/api/telemetry/stream/kafka/triage/latest?$Q"
+curl -s "$B/api/telemetry/stream/lineage/anomaly/<anomaly_id>?$Q"
+```
+
+Or run the verifier (PASS/WARN/FAIL, no secrets):
+
+```bash
+python scripts/streaming/stargate/verify_lineage.py --base https://novendor.ai
+```
+
+## Open the frontend drawer
+
+`https://novendor.ai/lab/env/telemetry-demo/telemetry/stargate` → click a routed anomaly in the **Anomaly
+ticker** → the lineage drawer shows Kafka detection → AI triage → Databricks lake (not_available) →
+Postgres serving row. With the consumer off / nothing emitted, the drawer fails closed honestly.
+
+## Shut down (cost hygiene — do this every time)
+
+```bash
+# 1. stop the producer (^C or let --duration elapse)
+# 2. turn the consumer back off
+railway variables set TELEMETRY_KAFKA_CONSUMER_ENABLED=0 --service authentic-sparkle && \
+  cd backend && bash ../scripts/deploy_backend.sh
+# 3. park the Stargate lane (lossless) + Flink at 0 CFU
+pwsh skills/confluent-stargate-lifecycle/scripts/lifecycle.ps1 -Action stop-serving
+# 4. confirm parked
+pwsh skills/confluent-stargate-lifecycle/scripts/lifecycle.ps1 -Action status
+confluent flink compute-pool list      # pool should be parked / deletable
+```
+
+**Confluent cost caveat:** the Kafka cluster bills by throughput/storage **while it exists** (the Stargate
+topics are tiny); the **Flink compute pool is the line item that grows while idle** — park it at 0 CFU or
+delete it. Delete any sample connector (`sample_data_*`) if it is not in use. `stop-serving` does not
+destroy topics/schemas; deleting the cluster does.
+
+## Known honest gaps
+
+- **No Stargate→Delta mapping** yet, so the Databricks lake layer always reports `not_available` /
+  `databricks_table_mapping_not_configured`. A follow-up ticket connects a real Delta table when it exists.
+- The Streaming Agent bills per OpenAI call — do not leave its statement running against a high-rate feed.
+- The consumer is default-off; the lineage routes/drawer fail closed (honest) until it is intentionally
+  enabled and rows land.

--- a/scripts/streaming/stargate/README.md
+++ b/scripts/streaming/stargate/README.md
@@ -45,6 +45,7 @@ Bridge endpoints: `/stargate/stream` (SSE), `/snapshot`, `/dlq`, `/health` on :8
 | `bridge.py` | Thin laptop wrapper — `uvicorn bridge:app` calls the backend's `create_app()`. Core (ring buffers, SSE, modes) lives in `backend/app/services/stargate_bridge.py` + `backend/app/routes/stargate_bridge.py`. |
 | `capture_fixture.py` | Regenerates `backend/app/data/stargate/replay_capture.jsonl` deterministically (includes the planted DLQ lines). |
 | `proto_gen/` | Generated bindings for `infra/confluent/proto/stargate_telemetry.proto`. |
+| `verify_lineage.py` | Read-only PASS/WARN/FAIL probe of the FastAPI lineage routes (`/api/telemetry/stream/*`). No secrets. `python verify_lineage.py --base https://novendor.ai`. See `docs/runbooks/telemetry-confluent-databricks-lineage.md`. |
 
 Tests live in `backend/tests/test_stargate_*.py`; capture-mode tests run with
 no broker and no Kafka client installed.

--- a/scripts/streaming/stargate/verify_lineage.py
+++ b/scripts/streaming/stargate/verify_lineage.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Telemetry lineage verification — PASS / WARN / FAIL over the FastAPI lineage routes.
+
+Read-only HTTP probe of the Ticket-4 routes. No secrets required: it calls the same-origin
+/api/telemetry/stream/* endpoints through whatever base URL you point it at (local dev, the Vercel
+proxy, or the Railway backend directly). It NEVER prints credentials and never writes anything.
+
+Usage:
+    python verify_lineage.py                         # defaults to http://localhost:8000
+    python verify_lineage.py --base https://novendor.ai
+    python verify_lineage.py --base https://novendor.ai --anomaly-id anom_v4-04-3_1700000000000000
+
+Exit code: 0 if no FAIL (WARN is allowed), 1 if any FAIL.
+
+What it checks (each line is PASS / WARN / FAIL):
+    - backend telemetry health route reachable
+    - latest Kafka rows route returns the {status, rows, count} contract
+    - latest triage route returns the {status, triage, count} contract
+    - triage-by-anomaly fails closed (triage_not_emitted) for an unknown id
+    - combined anomaly lineage returns the 4 layers, and the Databricks layer stays not_available
+      (databricks_table_mapping_not_configured) — i.e. no fabricated Delta pointer
+    - the expected fail-closed null_reasons are present where a layer is unavailable
+
+Empty serving slices are a WARN (the durable consumer may be off / nothing emitted yet), not a FAIL —
+the routes still answering with honest fail-closed shapes is the success criterion.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+DEMO_ENV_ID = "telemetry-demo"
+DEMO_BUSINESS_ID = "7e1eb000-0000-4000-a000-000000000001"
+
+GREEN, YELLOW, RED, RESET = "\033[32m", "\033[33m", "\033[31m", "\033[0m"
+_counts = {"PASS": 0, "WARN": 0, "FAIL": 0}
+
+
+def _emit(level: str, label: str, detail: str = "") -> None:
+    _counts[level] += 1
+    color = {"PASS": GREEN, "WARN": YELLOW, "FAIL": RED}[level]
+    line = f"  {color}{level:<4}{RESET}  {label}"
+    if detail:
+        line += f"  - {detail}"
+    print(line)
+
+
+def _get(base: str, path: str, params: dict, timeout: float) -> tuple[int, dict | None]:
+    """GET base+path?params. Returns (status_code, json|None). Never raises."""
+    qs = urllib.parse.urlencode(params)
+    url = f"{base.rstrip('/')}{path}?{qs}"
+    req = urllib.request.Request(url, headers={"x-telemetry-route-env-id": DEMO_ENV_ID})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8")
+            try:
+                return resp.status, json.loads(body)
+            except json.JSONDecodeError:
+                return resp.status, None
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read().decode("utf-8"))
+        except Exception:
+            return e.code, None
+    except Exception:
+        return 0, None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Verify the telemetry lineage routes (PASS/WARN/FAIL).")
+    ap.add_argument("--base", default="http://localhost:8000", help="backend base URL")
+    ap.add_argument("--env-id", default=DEMO_ENV_ID)
+    ap.add_argument("--business-id", default=DEMO_BUSINESS_ID)
+    ap.add_argument("--anomaly-id", default=None,
+                    help="a known anomaly id for the lineage check; omitted = use an unknown id (fail-closed path)")
+    ap.add_argument("--timeout", type=float, default=15.0)
+    args = ap.parse_args()
+
+    tenant = {"env_id": args.env_id, "business_id": args.business_id}
+    print(f"Telemetry lineage verification -> {args.base}  (env={args.env_id})\n")
+
+    # 1. health
+    code, body = _get(args.base, "/api/telemetry/health", {}, args.timeout)
+    if code == 200:
+        _emit("PASS", "telemetry health route reachable")
+    else:
+        _emit("FAIL", "telemetry health route", f"HTTP {code} (is the backend deployed/running?)")
+
+    # 2. kafka rows contract
+    code, body = _get(args.base, "/api/telemetry/stream/kafka/rows", {**tenant, "limit": 5}, args.timeout)
+    if code == 200 and isinstance(body, dict) and body.get("status") == "ok" and "rows" in body:
+        n = body.get("count", 0)
+        if n > 0:
+            _emit("PASS", "kafka rows route", f"{n} row(s)")
+        else:
+            _emit("WARN", "kafka rows route", "0 rows — durable consumer off / nothing landed yet")
+    else:
+        _emit("FAIL", "kafka rows route", f"HTTP {code} / unexpected shape")
+
+    # 3. triage latest contract
+    code, body = _get(args.base, "/api/telemetry/stream/kafka/triage/latest", {**tenant, "limit": 5}, args.timeout)
+    if code == 200 and isinstance(body, dict) and body.get("status") == "ok" and "triage" in body:
+        n = body.get("count", 0)
+        _emit("PASS" if n else "WARN", "triage latest route",
+              f"{n} record(s)" if n else "0 records — agent not emitted / consumer off")
+    else:
+        _emit("FAIL", "triage latest route", f"HTTP {code} / unexpected shape")
+
+    # 4. triage-by-anomaly fails closed for an unknown id
+    code, body = _get(args.base, "/api/telemetry/stream/kafka/triage/__verify_unknown__", tenant, args.timeout)
+    if code == 200 and isinstance(body, dict) and body.get("status") == "not_available" \
+            and body.get("null_reason") == "triage_not_emitted":
+        _emit("PASS", "triage-by-anomaly fails closed", "null_reason=triage_not_emitted")
+    else:
+        _emit("FAIL", "triage-by-anomaly fail-closed", f"HTTP {code} / got {body}")
+
+    # 5. combined anomaly lineage — layer shape + Databricks honesty
+    anomaly_id = args.anomaly_id or "__verify_unknown__"
+    code, body = _get(args.base, f"/api/telemetry/stream/lineage/anomaly/{urllib.parse.quote(anomaly_id)}",
+                      tenant, args.timeout)
+    if code == 200 and isinstance(body, dict) and "layers" in body:
+        layers = body["layers"]
+        if all(k in layers for k in ("kafka_detection", "agent_triage", "databricks_lake", "postgres_serving")):
+            _emit("PASS", "anomaly lineage returns all 4 layers")
+        else:
+            _emit("FAIL", "anomaly lineage layers", f"missing layer(s): {list(layers)}")
+
+        # Databricks must never fabricate a mapping
+        dl = layers.get("databricks_lake", {})
+        if dl.get("status") == "not_available" and not dl.get("table"):
+            _emit("PASS", "databricks lake fails closed (no fabricated mapping)",
+                  f"null_reason={dl.get('null_reason')}")
+        elif dl.get("status") == "available" and dl.get("table"):
+            _emit("PASS", "databricks lake mapped", f"table={dl.get('table')}")
+        else:
+            _emit("FAIL", "databricks lake layer", f"inconsistent: {dl}")
+
+        if args.anomaly_id and body.get("status") == "ok":
+            _emit("PASS", "known anomaly lineage resolved", f"anomaly_id={anomaly_id}")
+        elif not args.anomaly_id:
+            if body.get("status") == "not_available":
+                _emit("PASS", "unknown anomaly fails closed",
+                      f"null_reason={body.get('null_reason')}")
+            else:
+                _emit("WARN", "unknown anomaly id resolved unexpectedly", str(body.get("status")))
+    else:
+        _emit("FAIL", "anomaly lineage route", f"HTTP {code} / unexpected shape")
+
+    # summary
+    print(f"\n  {_counts['PASS']} PASS / {_counts['WARN']} WARN / {_counts['FAIL']} FAIL")
+    if _counts["FAIL"]:
+        print(f"  {RED}FAIL{RESET}: lineage verification did not pass.")
+        return 1
+    if _counts["WARN"]:
+        print(f"  {YELLOW}OK with warnings{RESET}: routes answer fail-closed; serving slice may be empty.")
+    else:
+        print(f"  {GREEN}OK{RESET}: lineage verified end to end.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Ticket 7. Operational runbook + a lightweight, secret-free verification script so the lineage demo can be started, checked, and shut down safely.

## Files
- **New** `docs/runbooks/telemetry-confluent-databricks-lineage.md` — architecture map, prereqs, env vars, confirm-Confluent steps, enable the default-off consumer, run the producer (demo mode), check Lakebase rows (SQL), call the FastAPI routes, open the frontend drawer, and **shut down with cost hygiene** (park Flink at 0 CFU, turn the consumer back off, delete unused sample connectors). Honest gaps called out.
- **New** `scripts/streaming/stargate/verify_lineage.py` — read-only PASS/WARN/FAIL probe of the lineage routes. **No secrets, never writes.**
- **Edit** `scripts/streaming/stargate/README.md` — pointer to the verifier.

## Verifier checks
health · kafka rows contract · triage latest contract · triage-by-anomaly fails closed (`triage_not_emitted`) · combined anomaly lineage returns all 4 layers · Databricks layer fails closed with no fabricated mapping. Empty serving slice → **WARN** (consumer off / nothing emitted), not FAIL. Exit 1 on any FAIL. ASCII-only output (runs on the Windows console).

## Validation
Smoke-tested against a dead backend: graceful 5× FAIL, real exit code 1, zero encoding garbage. No secrets in the diff (env var **names** referenced, never values).

## Cost / runtime controls documented
Kafka cluster bills while it exists; the **Flink compute pool is the line item that grows while idle** — park at 0 CFU or delete. `stop-serving` is lossless; deleting the cluster destroys topics. Agent bills per OpenAI call.

## Scope
Docs + script only. No code/route/frontend/Confluent runtime change.

## Next
Ticket 8 — live replay / end-to-end rehearsal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)