### PR TITLE
feat(telemetry): one real read-only DE receipt action (Phase 2D)

### DIFF
--- a/backend/app/routes/telemetry.py
+++ b/backend/app/routes/telemetry.py
@@ -201,6 +201,163 @@ def metadata_graph(
         raise _to_http(exc)
 
 
+# ---------------------------------------------------------------------------
+# Data Engineering — one real read-only action that leaves an audit receipt
+# (Phase 2D). "Profile metadata graph" reads the committed catalog + enrichment
+# (no writes to telemetry data) and records ONE audit event. Run Autopsy reads
+# these back via /data-engineering/receipts. This lives in the telemetry router,
+# NOT in ADE core: it never touches automated_data_engineering.py or the ADE
+# package. The only persistence is the audit event itself — nothing fabricated.
+# ---------------------------------------------------------------------------
+
+# Audit action namespace for telemetry Data Engineering receipts. The ADE /runs
+# endpoint filters action == "mcp.tool_call", so these never collide with it.
+_DE_ACTION_PREFIX = "ade.de."
+_DE_PROFILE_ACTION = "ade.de.profile_metadata"
+_DE_PROFILE_TOOL = "ade.profile_metadata_graph"
+
+
+def _resolve_actor(request: Request) -> str:
+    """Honest actor from the authenticated request; clear fallback if absent."""
+    auth = getattr(request.state, "auth", None)
+    actor = getattr(auth, "actor", None) if auth else None
+    return actor or "telemetry-demo"
+
+
+class ProfileMetadataResponse(BaseModel):
+    receipt_id: str
+    actor: str
+    action: str
+    tool_name: str
+    permission_mode: str
+    status: str
+    input_summary: dict
+    result_summary: dict
+    created_at: str
+    null_reason: str | None = None
+
+
+@router.post("/data-engineering/profile-metadata", response_model=ProfileMetadataResponse)
+def de_profile_metadata(
+    request: Request,
+    env_id: str = Query(..., min_length=1),
+    business_id: UUID = Query(...),
+):
+    """Read-only: profile the telemetry metadata graph and write ONE real audit receipt.
+
+    Counts nodes/edges, how many declare a grain, and the status breakdown. Writes no telemetry
+    data — the sole side effect is the audit event, which Run Autopsy then surfaces.
+    """
+    from app.services import audit as audit_svc
+    from app.services import telemetry_metadata as metadata_svc
+
+    started = datetime.now(timezone.utc)
+    actor = _resolve_actor(request)
+    success = True
+    error_message: str | None = None
+    result_summary: dict = {}
+    try:
+        graph = metadata_svc.get_metadata_graph(env_id=env_id, business_id=business_id)
+        nodes = graph.get("nodes", []) or []
+        edges = graph.get("edges", []) or []
+        with_grain = 0
+        status_counts: dict[str, int] = {}
+        for node in nodes:
+            meta = node.get("metadata") if isinstance(node, dict) else None
+            grain = meta.get("grain") if isinstance(meta, dict) else None
+            if isinstance(grain, str) and grain.strip():
+                with_grain += 1
+            status = (node.get("status") if isinstance(node, dict) else None) or "unknown"
+            status_counts[status] = status_counts.get(status, 0) + 1
+        result_summary = {
+            "nodes": len(nodes),
+            "edges": len(edges),
+            "with_grain": with_grain,
+            "status_counts": status_counts,
+            "graph_status": graph.get("status"),
+        }
+    except Exception as exc:  # noqa: BLE001 — record the failed attempt honestly, don't fabricate
+        success = False
+        error_message = str(exc)[:500]
+
+    latency_ms = int((datetime.now(timezone.utc) - started).total_seconds() * 1000)
+    receipt_id = audit_svc.record_event(
+        actor=actor,
+        action=_DE_PROFILE_ACTION,
+        tool_name=_DE_PROFILE_TOOL,
+        success=success,
+        latency_ms=latency_ms,
+        business_id=business_id,
+        input_data={"env_id": env_id},
+        output_data=result_summary,
+        error_message=error_message,
+    )
+    return ProfileMetadataResponse(
+        receipt_id=str(receipt_id),
+        actor=actor,
+        action=_DE_PROFILE_ACTION,
+        tool_name=_DE_PROFILE_TOOL,
+        permission_mode="read",
+        status="success" if success else "failed",
+        input_summary={"env_id": env_id},
+        result_summary=result_summary,
+        created_at=started.isoformat(),
+        null_reason=error_message,
+    )
+
+
+class DeReceiptRow(BaseModel):
+    tool_name: str
+    action: str
+    status: str
+    permission_mode: str
+    actor: str | None = None
+    latency_ms: int | None = None
+    created_at: str | None = None
+    input_summary: dict
+    result_summary: dict
+    null_reason: str | None = None
+
+
+class DeReceiptsResponse(BaseModel):
+    runs: list[DeReceiptRow]
+    null_reason: str | None = None
+
+
+@router.get("/data-engineering/receipts", response_model=DeReceiptsResponse)
+def de_receipts(env_id: str = Query(..., min_length=1), business_id: UUID = Query(...)):
+    """Read the real audit receipts produced by telemetry Data Engineering actions (ade.de.*)."""
+    from app.services import audit as audit_svc
+
+    try:
+        events = audit_svc.list_events(business_id=business_id, limit=100)
+    except Exception:  # noqa: BLE001 — fail closed, never fabricate
+        return DeReceiptsResponse(runs=[], null_reason="audit_read_unavailable")
+
+    runs: list[DeReceiptRow] = []
+    for e in events:
+        action = e.get("action") or ""
+        if not action.startswith(_DE_ACTION_PREFIX):
+            continue
+        created = e.get("created_at")
+        created_iso = created.isoformat() if hasattr(created, "isoformat") else (created or None)
+        runs.append(
+            DeReceiptRow(
+                tool_name=e.get("tool_name") or "—",
+                action=action,
+                status="success" if e.get("success") else "failed",
+                permission_mode="read",
+                actor=e.get("actor"),
+                latency_ms=e.get("latency_ms"),
+                created_at=created_iso,
+                input_summary=e.get("input_redacted") or {},
+                result_summary=e.get("output_redacted") or {},
+                null_reason=e.get("error_message"),
+            )
+        )
+    return DeReceiptsResponse(runs=runs, null_reason=None)
+
+
 @router.get("/fused-vector-info")
 def fused_vector_info(env_id: str = Query(...), business_id: UUID = Query(...)):
     """256-d fused state-vector summary (dim, channels, features, alignment caveat). No raw vectors."""

--- a/backend/tests/test_telemetry_de_receipts.py
+++ b/backend/tests/test_telemetry_de_receipts.py
@@ -1,0 +1,120 @@
+"""Tests for the telemetry Data Engineering receipt action (Phase 2D).
+
+POST /api/telemetry/data-engineering/profile-metadata performs a READ-ONLY profile of the metadata
+graph and writes ONE real audit event; GET /api/telemetry/data-engineering/receipts reads them back.
+These tests assert the route's own behavior — it writes a real receipt (no fabrication), fails closed
+when the graph read errors (still recording the failed attempt), and only surfaces ade.de.* events —
+without needing a live database (audit + metadata services are monkeypatched).
+"""
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from app.routes import telemetry as route
+
+ENV = "telemetry-demo"
+BIZ = str(uuid4())
+
+GRAPH = {
+    "status": "ok",
+    "generated_at": "2026-06-25T00:00:00Z",
+    "nodes": [
+        {"id": "a", "status": "fresh", "metadata": {"grain": "printer telemetry event"}},
+        {"id": "b", "status": "unknown", "metadata": {}},
+    ],
+    "edges": [{"id": "e1", "source": "a", "target": "b"}],
+}
+
+
+def test_profile_metadata_writes_a_real_receipt(client, monkeypatch):
+    captured = {}
+
+    def fake_record_event(**kwargs):
+        captured.update(kwargs)
+        return uuid4()
+
+    monkeypatch.setattr(route, "_resolve_actor", lambda request: "reviewer@example.com")
+    # Patch the lazily-imported services on their modules.
+    from app.services import audit as audit_svc
+    from app.services import telemetry_metadata as metadata_svc
+    monkeypatch.setattr(metadata_svc, "get_metadata_graph", lambda *, env_id, business_id: GRAPH)
+    monkeypatch.setattr(audit_svc, "record_event", fake_record_event)
+
+    resp = client.post("/api/telemetry/data-engineering/profile-metadata", params={"env_id": ENV, "business_id": BIZ})
+    assert resp.status_code == 200
+    body = resp.json()
+    # Real receipt: a genuine read-only action, recorded — not faked.
+    assert body["status"] == "success"
+    assert body["action"] == "ade.de.profile_metadata"
+    assert body["permission_mode"] == "read"
+    assert body["actor"] == "reviewer@example.com"
+    assert body["result_summary"]["nodes"] == 2
+    assert body["result_summary"]["edges"] == 1
+    assert body["result_summary"]["with_grain"] == 1
+    # The audit event was actually written with the right action.
+    assert captured["action"] == "ade.de.profile_metadata"
+    assert captured["success"] is True
+    assert captured["input_data"] == {"env_id": ENV}
+
+
+def test_profile_metadata_fails_closed_but_still_records_the_attempt(client, monkeypatch):
+    captured = {}
+
+    def fake_record_event(**kwargs):
+        captured.update(kwargs)
+        return uuid4()
+
+    def boom(*, env_id, business_id):
+        raise RuntimeError("metadata_graph_unreachable")
+
+    from app.services import audit as audit_svc
+    from app.services import telemetry_metadata as metadata_svc
+    monkeypatch.setattr(metadata_svc, "get_metadata_graph", boom)
+    monkeypatch.setattr(audit_svc, "record_event", fake_record_event)
+
+    resp = client.post("/api/telemetry/data-engineering/profile-metadata", params={"env_id": ENV, "business_id": BIZ})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "failed"
+    assert body["null_reason"] == "metadata_graph_unreachable"
+    assert body["result_summary"] == {}
+    # The failed attempt is still recorded honestly (success=False), not hidden.
+    assert captured["success"] is False
+    assert captured["error_message"] == "metadata_graph_unreachable"
+
+
+def test_receipts_only_surface_de_actions_and_shape_rows(client, monkeypatch):
+    rows = [
+        {"action": "ade.de.profile_metadata", "tool_name": "ade.profile_metadata_graph", "actor": "rev",
+         "success": True, "latency_ms": 12, "created_at": datetime(2026, 6, 25, tzinfo=timezone.utc),
+         "input_redacted": {"env_id": ENV}, "output_redacted": {"nodes": 2}, "error_message": None},
+        {"action": "mcp.tool_call", "tool_name": "bm.health_check", "actor": "x", "success": True,
+         "latency_ms": 1, "created_at": datetime(2026, 6, 25, tzinfo=timezone.utc),
+         "input_redacted": {}, "output_redacted": {}, "error_message": None},
+    ]
+    from app.services import audit as audit_svc
+    monkeypatch.setattr(audit_svc, "list_events", lambda **kwargs: rows)
+
+    resp = client.get("/api/telemetry/data-engineering/receipts", params={"env_id": ENV, "business_id": BIZ})
+    assert resp.status_code == 200
+    body = resp.json()
+    # Only the ade.de.* event is surfaced — the mcp.tool_call belongs to ADE /runs, not here.
+    assert len(body["runs"]) == 1
+    r = body["runs"][0]
+    assert r["action"] == "ade.de.profile_metadata"
+    assert r["permission_mode"] == "read"
+    assert r["status"] == "success"
+    assert r["result_summary"] == {"nodes": 2}
+
+
+def test_receipts_fail_closed_when_audit_read_errors(client, monkeypatch):
+    def boom(**kwargs):
+        raise RuntimeError("db down")
+
+    from app.services import audit as audit_svc
+    monkeypatch.setattr(audit_svc, "list_events", boom)
+
+    resp = client.get("/api/telemetry/data-engineering/receipts", params={"env_id": ENV, "business_id": BIZ})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["runs"] == []
+    assert body["null_reason"] == "audit_read_unavailable"

--- a/repo-b/src/components/telemetry/data-engineering/RunAutopsy.test.tsx
+++ b/repo-b/src/components/telemetry/data-engineering/RunAutopsy.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/telemetry/api", () => ({
+  TELEMETRY_DEMO_ENV_ID: "telemetry-demo",
+  TELEMETRY_DEMO_BUSINESS_ID: "biz-1",
+}));
+
+const getReceipts = vi.fn(() => Promise.resolve({ runs: [], null_reason: null }));
+const getGovernanceStats = vi.fn(() => Promise.resolve({
+  total_decisions: 0, successful: 0, failed: 0, success_rate: null, avg_latency_ms: null,
+  avg_grounding_score: null, high_grounding: 0, mixed_grounding: 0, low_grounding: 0,
+  top_tools: [], warehouse_export_configured: false, null_reason: null,
+}));
+vi.mock("@/lib/automated-data-engineering/api", () => ({
+  getReceipts: () => getReceipts(),
+  getGovernanceStats: () => getGovernanceStats(),
+}));
+
+const profileMetadataGraph = vi.fn();
+const getDeReceipts = vi.fn();
+vi.mock("@/lib/telemetry/dataEngineeringReceipts", () => ({
+  profileMetadataGraph: (...a: unknown[]) => profileMetadataGraph(...a),
+  getDeReceipts: (...a: unknown[]) => getDeReceipts(...a),
+}));
+
+import RunAutopsy from "./RunAutopsy";
+
+describe("RunAutopsy (Phase 2D — real receipt)", () => {
+  beforeEach(() => {
+    profileMetadataGraph.mockReset();
+    getDeReceipts.mockReset();
+  });
+
+  it("shows the honest empty state before any action is run (no seeded receipts)", async () => {
+    getDeReceipts.mockResolvedValue({ runs: [], null_reason: null });
+    render(<RunAutopsy envId="env-1" />);
+    expect(await screen.findByText("No receipts yet")).toBeInTheDocument();
+    expect(screen.getByText(/Run the read-only profiling action above/)).toBeInTheDocument();
+  });
+
+  it("runs the read-only action and surfaces the real recorded receipt", async () => {
+    // Empty first, then one real receipt after the action.
+    getDeReceipts
+      .mockResolvedValueOnce({ runs: [], null_reason: null })
+      .mockResolvedValueOnce({
+        runs: [{
+          tool_name: "ade.profile_metadata_graph", action: "ade.de.profile_metadata", status: "success",
+          permission_mode: "read", actor: "reviewer@example.com", latency_ms: 12,
+          created_at: "2026-06-25T00:00:00Z", input_summary: { env_id: "telemetry-demo" },
+          result_summary: { nodes: 2, edges: 1 }, null_reason: null,
+        }],
+        null_reason: null,
+      });
+    profileMetadataGraph.mockResolvedValue({
+      receipt_id: "abcd1234ef", actor: "reviewer@example.com", action: "ade.de.profile_metadata",
+      tool_name: "ade.profile_metadata_graph", permission_mode: "read", status: "success",
+      input_summary: { env_id: "telemetry-demo" }, result_summary: { nodes: 2, edges: 1 },
+      created_at: "2026-06-25T00:00:00Z", null_reason: null,
+    });
+
+    render(<RunAutopsy envId="env-1" />);
+    await screen.findByText("No receipts yet");
+    await userEvent.click(screen.getByRole("button", { name: /Run profiling action/ }));
+
+    expect(profileMetadataGraph).toHaveBeenCalled();
+    // The recorded receipt now appears with actor + action.
+    expect(await screen.findByText("ade.profile_metadata_graph")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("reviewer@example.com")).toBeInTheDocument());
+    expect(screen.getByText(/Recorded receipt abcd1234/)).toBeInTheDocument();
+  });
+
+  it("fails closed when the receipts read is unavailable", async () => {
+    getDeReceipts.mockResolvedValue({ runs: [], null_reason: "audit_read_unavailable" });
+    render(<RunAutopsy envId="env-1" />);
+    expect(await screen.findByText("Audit read unavailable")).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/data-engineering/RunAutopsy.tsx
+++ b/repo-b/src/components/telemetry/data-engineering/RunAutopsy.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import {
   TELEMETRY_DEMO_BUSINESS_ID,
@@ -13,6 +13,11 @@ import {
   type ReceiptsResponse,
 } from "@/lib/automated-data-engineering/api";
 import {
+  getDeReceipts,
+  profileMetadataGraph,
+  type DeReceiptsResponse,
+} from "@/lib/telemetry/dataEngineeringReceipts";
+import {
   C,
   EmptyState,
   InlineCode,
@@ -22,15 +27,18 @@ import {
   Panel,
   ScrollTable,
   StatGrid,
+  StatusDot,
   Tag,
+  TelemetryActionButton,
   TelemetrySection,
   TelemetryStatusBanner,
 } from "../primitives";
 
-// Run Autopsy — the "inspect" mode. After-the-fact view of what the fabric actually did: governed
-// AI-decision aggregates (/api/ade/governance-stats) and execution receipts (/api/ade/runs), both real
-// and tenant-scoped. NO-GO: never seed or backfill receipts. If empty, show the honest empty state and
-// name the action that would create the first one. null_reason is rendered verbatim.
+// Run Autopsy — the "inspect" mode. Now closes the loop with ONE real read-only action: "Profile
+// metadata graph" hits the telemetry endpoint, which writes a genuine audit receipt; the Data
+// Engineering receipts table below reads those real rows back. Plus the governed AI-decision aggregate
+// and ADE execution receipts (/api/ade/runs). NO-GO: nothing seeded or fabricated — an empty trail is
+// shown empty, and the only way a receipt appears is to run the action.
 
 function fmtTime(value?: string | null): string {
   if (!value) return "—";
@@ -45,11 +53,31 @@ function statusColor(status: string): string {
   return C.amber;
 }
 
+function summarize(obj: Record<string, unknown>): string {
+  const entries = Object.entries(obj || {});
+  if (entries.length === 0) return "—";
+  return entries
+    .slice(0, 4)
+    .map(([k, v]) => `${k}: ${typeof v === "object" ? JSON.stringify(v) : String(v)}`)
+    .join(" · ");
+}
+
 export default function RunAutopsy({ envId }: { envId: string }) {
   void envId;
   const [receipts, setReceipts] = useState<ReceiptsResponse | null>(null);
   const [gov, setGov] = useState<GovernanceStatsResponse | null>(null);
+  const [de, setDe] = useState<DeReceiptsResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+  const [actionMsg, setActionMsg] = useState<string | null>(null);
+
+  const loadDe = useCallback(async () => {
+    try {
+      setDe(await getDeReceipts(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID));
+    } catch {
+      setDe({ runs: [], null_reason: "audit_read_unavailable" });
+    }
+  }, []);
 
   useEffect(() => {
     let live = true;
@@ -59,27 +87,110 @@ export default function RunAutopsy({ envId }: { envId: string }) {
     getGovernanceStats(TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID)
       .then((g) => { if (live) setGov(g); })
       .catch(() => {});
+    void loadDe();
     return () => { live = false; };
-  }, []);
+  }, [loadDe]);
+
+  const runProfile = useCallback(async () => {
+    setRunning(true);
+    setActionMsg(null);
+    try {
+      const r = await profileMetadataGraph(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID);
+      setActionMsg(
+        r.status === "success"
+          ? `Recorded receipt ${r.receipt_id.slice(0, 8)} — ${summarize(r.result_summary)}`
+          : `Recorded a failed attempt — null_reason: ${r.null_reason ?? "unknown"}`,
+      );
+      await loadDe();
+    } catch (e) {
+      setActionMsg(`Action could not run: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setRunning(false);
+    }
+  }, [loadDe]);
 
   const heading = (
     <PageHeading
       eyebrow="Mode · Run Autopsy"
       title="Run Autopsy"
-      blurb="What ran, what it cost, what it refused, and the receipt that proves it. Failures and refusals are surfaced here, not hidden — an empty trail is shown as empty, never padded with examples."
+      blurb="What ran, what it cost, what it refused, and the receipt that proves it. Run the one read-only action below to leave a genuine audit receipt; everything else is shown exactly as recorded — an empty trail stays empty, never padded."
     />
   );
-
-  if (error && !receipts) {
-    return <>{heading}<TelemetryStatusBanner tone="error">Audit read path unavailable — {error}.</TelemetryStatusBanner></>;
-  }
-  if (!receipts) return <>{heading}<Loading label="Reading audit trail…" /></>;
 
   return (
     <>
       {heading}
 
-      {/* Governance aggregate — honest nulls when nothing is logged. */}
+      {/* The one real read-only action that leaves audit evidence. */}
+      <TelemetrySection label="Read-only action">
+        <Panel>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+            <div style={{ minWidth: 0 }}>
+              <div style={{ fontFamily: C.mono, fontSize: 13, color: C.text }}>Profile metadata graph</div>
+              <div style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, marginTop: 5, lineHeight: 1.5 }}>
+                Read-only: counts nodes, edges, declared grain, and status. Writes no telemetry data — the
+                only side effect is a real audit receipt, which appears below.
+              </div>
+            </div>
+            <TelemetryActionButton onClick={runProfile} disabled={running}>
+              {running ? "Running…" : "Run profiling action"}
+            </TelemetryActionButton>
+          </div>
+          {actionMsg && (
+            <div role="status" aria-live="polite" style={{ marginTop: 12, fontFamily: C.mono, fontSize: 11.5, color: C.cyan, lineHeight: 1.5 }}>
+              {actionMsg}
+            </div>
+          )}
+        </Panel>
+      </TelemetrySection>
+
+      {/* Real receipts produced by the DE action. */}
+      <TelemetrySection
+        label="Data Engineering receipts"
+        right={<Tag color={C.faint}>{de ? (de.null_reason ? "unavailable" : `${de.runs.length} recorded`) : "…"}</Tag>}
+      >
+        {!de ? (
+          <Loading label="Reading receipts…" />
+        ) : de.null_reason ? (
+          <EmptyState label="Audit read unavailable" hint={`null_reason: ${de.null_reason}`} />
+        ) : de.runs.length === 0 ? (
+          <EmptyState
+            label="No receipts yet"
+            hint="No Data Engineering actions have been recorded for this scope. Run the read-only profiling action above to record the first one — none are seeded or fabricated."
+          />
+        ) : (
+          <Panel pad={0}>
+            <ScrollTable minWidth={820}>
+              <table style={{ width: "100%", borderCollapse: "collapse" }}>
+                <thead>
+                  <tr>
+                    {["Action", "Status", "Permission", "Actor", "Latency", "When", "Result / reason"].map((h) => (
+                      <th key={h} style={{ textAlign: "left", padding: "10px 14px", fontFamily: C.mono, fontSize: 9, letterSpacing: "0.1em", textTransform: "uppercase", color: C.faint, borderBottom: `1px solid ${C.border}` }}>{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {de.runs.map((r, i) => (
+                    <tr key={`${r.action}-${i}`} style={{ borderBottom: `1px solid ${C.border}` }}>
+                      <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: C.text }}>{r.tool_name}</td>
+                      <td style={{ padding: "10px 14px" }}><Tag color={statusColor(r.status)}>{r.status}</Tag></td>
+                      <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: C.dim }}>{r.permission_mode}</td>
+                      <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: C.dim }}>{r.actor ?? "—"}</td>
+                      <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: C.dim }}>{r.latency_ms != null ? `${r.latency_ms} ms` : "—"}</td>
+                      <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: C.dim }}>{fmtTime(r.created_at)}</td>
+                      <td style={{ padding: "10px 14px", fontFamily: C.mono, fontSize: 11, color: r.status === "failed" ? C.amber : C.dim }}>
+                        {r.status === "failed" ? `null_reason: ${r.null_reason ?? "unknown"}` : summarize(r.result_summary)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </ScrollTable>
+          </Panel>
+        )}
+      </TelemetrySection>
+
+      {/* Governed AI-decision aggregate — honest nulls when nothing is logged. */}
       <TelemetrySection label="Governance (30-day window)">
         {gov == null ? (
           <Loading label="Loading governance stats…" />
@@ -104,18 +215,19 @@ export default function RunAutopsy({ envId }: { envId: string }) {
         )}
       </TelemetrySection>
 
-      {/* Execution receipts — fail-closed, no seeding. */}
+      {/* ADE execution receipts (mcp.tool_call) — separate audit stream, fail-closed. */}
       <TelemetrySection
-        label="Execution receipts"
-        right={<Tag color={C.faint}>{receipts.null_reason ? "unavailable" : `${receipts.runs.length} recorded`}</Tag>}
+        label="MCP tool-call receipts"
+        right={<Tag color={C.faint}>{receipts ? (receipts.null_reason ? "unavailable" : `${receipts.runs.length} recorded`) : "…"}</Tag>}
       >
-        {receipts.null_reason ? (
+        {error && !receipts ? (
+          <TelemetryStatusBanner tone="error">Audit read path unavailable — {error}.</TelemetryStatusBanner>
+        ) : !receipts ? (
+          <Loading label="Reading audit trail…" />
+        ) : receipts.null_reason ? (
           <EmptyState label="Audit read unavailable" hint={`null_reason: ${receipts.null_reason}`} />
         ) : receipts.runs.length === 0 ? (
-          <EmptyState
-            label="No receipts yet"
-            hint="The audit read path responded but no governed executions are recorded for this scope. Run a governed MCP tool from the Agent Workbench to record the first receipt — none are seeded or fabricated here."
-          />
+          <EmptyState label="No MCP tool-call receipts yet" hint="The audit read path responded but no MCP tool executions are recorded for this scope." />
         ) : (
           <Panel pad={0}>
             <ScrollTable minWidth={720}>
@@ -147,7 +259,8 @@ export default function RunAutopsy({ envId }: { envId: string }) {
 
       <div style={{ marginTop: 14 }}>
         <InlineCode color={C.faint}>
-          Source: app.audit_events (receipts) + ai_decision_audit_log (governance), tenant-scoped. Read-only.
+          Sources: app.audit_events (DE receipts + MCP tool-calls) · ai_decision_audit_log (governance),
+          tenant-scoped. The DE action is read-only; the only write is its own audit receipt.
         </InlineCode>
       </div>
     </>

--- a/repo-b/src/lib/telemetry/dataEngineeringReceipts.ts
+++ b/repo-b/src/lib/telemetry/dataEngineeringReceipts.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { apiFetch } from "@/lib/api";
+
+// Telemetry-side client for the Data Engineering receipt action (Phase 2D). These call the telemetry
+// router (NOT ADE core): a read-only "profile metadata graph" action that writes one real audit event,
+// and a reader for those real receipts. Run Autopsy uses both.
+
+export interface DeReceiptRow {
+  tool_name: string;
+  action: string;
+  status: string;
+  permission_mode: string;
+  actor: string | null;
+  latency_ms: number | null;
+  created_at: string | null;
+  input_summary: Record<string, unknown>;
+  result_summary: Record<string, unknown>;
+  null_reason: string | null;
+}
+
+export interface DeReceiptsResponse {
+  runs: DeReceiptRow[];
+  null_reason: string | null;
+}
+
+export interface ProfileMetadataResponse extends DeReceiptRow {
+  receipt_id: string;
+}
+
+export const profileMetadataGraph = (env: string, biz: string) =>
+  apiFetch<ProfileMetadataResponse>("/api/telemetry/data-engineering/profile-metadata", {
+    method: "POST",
+    params: { env_id: env, business_id: biz },
+  });
+
+export const getDeReceipts = (env: string, biz: string) =>
+  apiFetch<DeReceiptsResponse>("/api/telemetry/data-engineering/receipts", {
+    params: { env_id: env, business_id: biz },
+  });


### PR DESCRIPTION
## What (Phase 2D)
Close the loop with **one genuine read-only action that leaves audit evidence**, surfaced in Run Autopsy. Built on the **telemetry router — ADE core untouched.**

**Backend** (`backend/app/routes/telemetry.py`):
- `POST /api/telemetry/data-engineering/profile-metadata` — read-only: profiles the metadata graph (node/edge/grain/status counts) and writes **one real `app.audit_events` row** via the existing audit service (`action=ade.de.profile_metadata`, `tool_name=ade.profile_metadata_graph`, permission `read`, actor from auth). A failed read is recorded honestly (`success=false` + error), not hidden. No telemetry data is written — the only side effect is the receipt.
- `GET /api/telemetry/data-engineering/receipts` — reads those real `ade.de.*` receipts back (actor, action, status, permission, input/result summary, timestamp, null_reason). Fails closed to `audit_read_unavailable`. Never surfaces `mcp.tool_call` rows (those belong to ADE `/runs`).

**Why not ADE `/runs`:** it hard-filters `action == "mcp.tool_call"` — surfacing a new receipt there would require editing ADE core (forbidden). This telemetry-side stream is the honest alternative the spec anticipated.

**Frontend:** `lib/telemetry/dataEngineeringReceipts.ts` + Run Autopsy gains a "Run profiling action" button and a real DE-receipts table; governance + MCP tool-call sections stay. **No seeded receipts** — empty stays empty until the action runs.

## Receipt fields (spec)
actor · tool/action name · permission mode · input summary · result summary · timestamp · evidence (result_summary) or null_reason. ✓

## Tests (7, green)
4 backend (real write asserted, fail-closed-but-recorded, `ade.de.*`-only filter, audit-read fail-closed) + 3 frontend (empty→recorded, action surfaces the real receipt with actor, receipts-unavailable).

## Rules honored
No ADE core change (guard clean; route file diff confirmed none). Inside `TelemetryShell`. No fabrication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)