### PR TITLE
feat(telemetry): real replay model diagnostics + honest firing divergence (ADO #734)

### DIFF
--- a/backend/app/services/telemetry_serving.py
+++ b/backend/app/services/telemetry_serving.py
@@ -24,6 +24,10 @@ from app.services.reporting_common import resolve_tenant_id
 # Champion hyperparameters (frozen from the Phase 2 promoted model).
 MAD_K = 4.0
 GLOBAL_TRAIN_SCALE = 0.033866801182436346   # median abs residual across all SMAP/MSL train channels
+# Frozen champion detector threshold in residual units (MAD rule: resid > k*scale; D-4 uses the global
+# scale fallback). This is the SAME threshold /score applies — exposed for the replay forensics surface
+# so the per-tick honest score/margin can be shown instead of the degenerate fixture score.
+DETECTOR_THRESHOLD = MAD_K * GLOBAL_TRAIN_SCALE   # 0.13546720472974538
 
 # Deterministic replay fixture: precomputed REAL champion outputs exported from
 # novendor_1.telemetry.gold_replay_feed_scored (Phase 2). Loaded once, cached in-process.
@@ -291,15 +295,72 @@ def monitoring(*, env_id: str, business_id: UUID) -> dict:
     }
 
 
+def _scoring_diagnostics(feed: list | None) -> dict:
+    """Honest, DB-free scoring provenance for the replay forensics surface. Exposes the frozen serving
+    threshold (the global-scale fallback /score applies) AND, computed from the committed fixture, whether
+    that threshold actually reproduces the champion's firing. For D-4 it does NOT: every fired tick sits
+    below the global threshold, so the champion must fire on a tighter per-channel scale the serving
+    constants do not carry. We surface that divergence honestly rather than invent a per-tick verdict that
+    would contradict model_pred. feed[].score stays degenerate (~1e12) and display-only."""
+    feed = feed or []
+    fired_resid = [abs(p["value"] - p["rmean"]) for p in feed if p.get("model_pred") == 1]
+    fired_above = sum(1 for r in fired_resid if r > DETECTOR_THRESHOLD)
+    diverges = len(fired_resid) > 0 and fired_above == 0
+    max_fired = max(fired_resid) if fired_resid else None
+    return {
+        "mad_k": MAD_K,
+        "global_train_scale": GLOBAL_TRAIN_SCALE,
+        "threshold_residual_units": DETECTOR_THRESHOLD,
+        "threshold_source": "serving global-scale fallback (the frozen MAD threshold /score applies)",
+        "residual_definition": "residual = abs(value - rmean) — the quantity the MAD rule thresholds",
+        "fired_ticks": len(fired_resid),
+        "fired_ticks_above_threshold": fired_above,
+        "max_fired_residual": max_fired,
+        "threshold_reproduces_firing": fired_above > 0,
+        "per_channel_caveat": (
+            "The serving global-scale fallback threshold does NOT reproduce the champion's D-4 firing — "
+            f"0 of {len(fired_resid)} fired ticks exceed it (max fired residual {max_fired:.4f}). The "
+            "champion fired on a tighter per-channel D-4 scale the serving constants do not carry; "
+            "model_pred is authoritative, and a per-tick GO/REVIEW/NO_GO cannot be derived from this "
+            "threshold for D-4."
+        ) if diverges else None,
+        "fixture_score_degenerate": True,
+        "note": "feed[].score is degenerate (~1e12), display-only. Residual = abs(value - rmean).",
+    }
+
+
+def _replay_lineage(prov: dict) -> dict:
+    """Reproducibility chain for the replay verdict (DB-free; ids from the committed fixture provenance
+    + the known Unity Catalog coordinates). The run id here is the fixture's RECORDED champion run; the
+    live model registry may hold a different run id (the frontend surfaces both, never reconciles)."""
+    return {
+        "databricks_catalog": "novendor_1.telemetry",
+        "source_table": prov.get("source_table"),
+        "champion_model": prov.get("champion_model"),
+        "champion_mlflow_run_id_fixture": prov.get("champion_mlflow_run_id"),
+        "scoring_notebook": "telemetry-platform/databricks/11_score_replay_feed.py -> gold_replay_feed_scored",
+        "backend_route": "GET /api/telemetry/replay",
+    }
+
+
 def replay_feed() -> dict:
     """Return the deterministic replay fixture (precomputed real champion outputs). No DB, no
-    Databricks — fast and identical every call. Fails closed if the fixture is missing."""
+    Databricks — fast and identical every call. Fails closed if the fixture is missing.
+
+    ADDITIVE diagnostics (backward-compatible): `scoringDiagnostics` (the frozen detector threshold +
+    the honest score/margin definitions; pure constants, no DB) and `lineage` (the reproducibility chain
+    from the fixture provenance). Existing top-level keys and feed[] rows are unchanged; the degenerate
+    feed[].score is kept verbatim and never reinterpreted."""
     global _replay_cache
     if _replay_cache is None:
         if not _REPLAY_FIXTURE_PATH.exists():
             return {"feed": [], "null_reason": "data_not_ingested",
-                    "note": "replay fixture not present"}
-        _replay_cache = json.loads(_REPLAY_FIXTURE_PATH.read_text(encoding="utf-8"))
+                    "note": "replay fixture not present",
+                    "scoringDiagnostics": _scoring_diagnostics(None)}
+        fixture = json.loads(_REPLAY_FIXTURE_PATH.read_text(encoding="utf-8"))
+        fixture["scoringDiagnostics"] = _scoring_diagnostics(fixture.get("feed") or [])
+        fixture["lineage"] = _replay_lineage(fixture.get("provenance") or {})
+        _replay_cache = fixture
     return _replay_cache
 
 

--- a/backend/tests/test_telemetry_serving.py
+++ b/backend/tests/test_telemetry_serving.py
@@ -160,3 +160,47 @@ def test_monitoring_no_predictions(client, fake_cursor):
     d = resp.json()
     assert d["prediction_count"] == 0
     assert d["null_reason"] == "no_prediction_rows"
+
+
+def test_replay_returns_scoring_diagnostics_and_lineage(client):
+    """Additive replay diagnostics: the frozen MAD threshold + reproducibility lineage, DB-free and
+    backward-compatible (existing top-level keys + feed[] rows unchanged)."""
+    import app.services.telemetry_serving as svc
+    svc._replay_cache = None  # force a fresh fixture load through the enrichment path
+    resp = client.get("/api/telemetry/replay")
+    assert resp.status_code == 200
+    d = resp.json()
+    # back-compat: existing shape preserved; feed rows keep exactly their original 6 keys
+    assert isinstance(d["feed"], list) and len(d["feed"]) > 0
+    assert d["provenance"]["champion_model"].endswith("tel_anomaly_detector@champion")
+    assert set(d["feed"][0]) == {"t", "value", "rmean", "score", "model_pred", "is_anomaly"}
+    # scoringDiagnostics: the REAL frozen detector threshold (not the degenerate fixture score)
+    sd = d["scoringDiagnostics"]
+    assert sd["mad_k"] == svc.MAD_K
+    assert sd["global_train_scale"] == svc.GLOBAL_TRAIN_SCALE
+    assert sd["threshold_residual_units"] == svc.DETECTOR_THRESHOLD == svc.MAD_K * svc.GLOBAL_TRAIN_SCALE
+    assert sd["fixture_score_degenerate"] is True
+    # honest divergence (computed from the committed fixture): the serving global-fallback threshold does
+    # NOT reproduce the champion's D-4 firing — no fired tick exceeds it, so model_pred is authoritative.
+    assert sd["fired_ticks"] == 412
+    assert sd["fired_ticks_above_threshold"] == 0
+    assert sd["threshold_reproduces_firing"] is False
+    assert sd["max_fired_residual"] < sd["threshold_residual_units"]
+    assert "per-channel" in sd["per_channel_caveat"]
+    # lineage: reproducibility chain echoed from the fixture provenance (no fabrication)
+    ln = d["lineage"]
+    assert ln["source_table"] == d["provenance"]["source_table"]
+    assert ln["champion_model"] == d["provenance"]["champion_model"]
+    assert ln["champion_mlflow_run_id_fixture"] == d["provenance"]["champion_mlflow_run_id"]
+    assert ln["databricks_catalog"] == "novendor_1.telemetry"
+    assert "11_score_replay_feed.py" in ln["scoring_notebook"]
+
+
+def test_replay_threshold_matches_live_score_threshold():
+    """The exposed replay threshold must equal the live /score threshold (MAD_K*GLOBAL_TRAIN_SCALE) so
+    the forensics surface can never invent a second threshold."""
+    import app.services.telemetry_serving as svc
+    svc._replay_cache = None
+    sd = svc.replay_feed()["scoringDiagnostics"]
+    assert sd["threshold_residual_units"] == 0.13546720472974538
+    assert sd["threshold_residual_units"] == svc.MAD_K * svc.GLOBAL_TRAIN_SCALE

--- a/repo-b/src/components/telemetry/ReplayForensicsDrawer.test.tsx
+++ b/repo-b/src/components/telemetry/ReplayForensicsDrawer.test.tsx
@@ -52,6 +52,22 @@ const feed: ReplayFeed = {
 
 const fireTick = feed.feed[2];
 
+// Same feed enriched with the backend scoringDiagnostics — the real D-4 case where the serving
+// global-fallback threshold does NOT reproduce the champion's firing (every fired tick is below it).
+const scoredFeed: ReplayFeed = {
+  ...feed,
+  scoringDiagnostics: {
+    mad_k: 4, global_train_scale: 0.0339, threshold_residual_units: 0.135467,
+    threshold_source: "serving global-scale fallback",
+    residual_definition: "residual = abs(value - rmean)",
+    fired_ticks: 2, fired_ticks_above_threshold: 0, max_fired_residual: 0.07,
+    threshold_reproduces_firing: false,
+    per_channel_caveat:
+      "The serving global-scale fallback threshold does NOT reproduce the champion's D-4 firing — 0 of 2 fired ticks exceed it. model_pred is authoritative.",
+    fixture_score_degenerate: true, note: "test",
+  },
+};
+
 describe("ReplayForensicsDrawer", () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -78,9 +94,12 @@ describe("ReplayForensicsDrawer", () => {
     expect(screen.getAllByText(/NASA-labeled window/i).length).toBeGreaterThan(0);
   });
 
-  it("Lineage tab fails closed on the workspace link and the unavailable fields", () => {
+  it("Lineage tab renders live Databricks/MLflow links and keeps genuinely-absent fields fail-closed", () => {
     render(<ReplayForensicsDrawer open onClose={() => {}} feed={feed} cursorTick={fireTick} fired initialTab="lineage" />);
-    expect(screen.getByText(/Link unavailable/i)).toBeInTheDocument();
+    // Workspace links are live by DEFAULT (committed workspace) — a real MLflow run hyperlink, not a dead link.
+    const runLink = screen.getByRole("link", { name: /Open MLflow Run/i });
+    expect(runLink.getAttribute("href")).toContain("4a48cb6af8714609b9581d66e904544c");
+    // Genuinely-absent-from-the-public-benchmark fields stay fail-closed.
     expect(screen.getByText(/no test-stage, phase, segment, or regime boundary/i)).toBeInTheDocument();
     expect(screen.getByText(/single channel \(D-4\)/i)).toBeInTheDocument();
   });
@@ -105,5 +124,24 @@ describe("ReplayForensicsDrawer", () => {
     render(<ReplayForensicsDrawer open onClose={() => {}} feed={empty} cursorTick={null} fired={false} />);
     expect(screen.getByText(/data_not_ingested/)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Evidence" })).not.toBeInTheDocument();
+  });
+
+  it("Model tab shows the REAL serving threshold + firing divergence when scoringDiagnostics is present, NaRow when absent", () => {
+    const { unmount } = render(<ReplayForensicsDrawer open onClose={() => {}} feed={scoredFeed} cursorTick={fireTick} fired initialTab="model" />);
+    expect(screen.getByText(/serving threshold \(residual units\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/fired ticks above threshold/i)).toBeInTheDocument();
+    // the honest divergence caveat renders (the threshold does NOT reproduce D-4 firing)
+    expect(screen.getByText(/does NOT reproduce the champion's D-4 firing/i)).toBeInTheDocument();
+    // the fail-closed NaRow reason must NOT appear when the real threshold is available
+    expect(screen.queryByText(/the firing flag comes from the champion model's MAD rule/i)).not.toBeInTheDocument();
+    unmount();
+    render(<ReplayForensicsDrawer open onClose={() => {}} feed={feed} cursorTick={fireTick} fired initialTab="model" />);
+    expect(screen.getByText(/the firing flag comes from the champion model's MAD rule/i)).toBeInTheDocument();
+  });
+
+  it("Evidence tab surfaces the serving-threshold-vs-firing divergence when scoringDiagnostics is present", () => {
+    render(<ReplayForensicsDrawer open onClose={() => {}} feed={scoredFeed} cursorTick={fireTick} fired initialTab="evidence" />);
+    expect(screen.getByText(/Serving threshold vs champion firing/i)).toBeInTheDocument();
+    expect(screen.getByText(/does NOT reproduce the champion's D-4 firing/i)).toBeInTheDocument();
   });
 });

--- a/repo-b/src/components/telemetry/ReplayForensicsDrawer.tsx
+++ b/repo-b/src/components/telemetry/ReplayForensicsDrawer.tsx
@@ -29,6 +29,7 @@ import {
   NA_REASONS,
   type ReplayDiagnostics,
 } from "@/lib/telemetry/replayDiagnostics";
+import { mlflowRunLink, mlflowExperimentLink, deltaTableLink, type ExternalEvidenceLink } from "@/lib/lab/factoryEvidenceLinks";
 import { DrawerWrapper, DrawerHeader, FieldRow } from "./drawerPrimitives";
 import { C, Tag, StatusDot, MetricRow, ErrorState, Loading, SectionTabButton } from "./primitives";
 import { CopilotExplanationPanel } from "./Copilot";
@@ -60,6 +61,29 @@ function fmt(v: number | null | undefined, digits = 4): string {
   if (v == null || Number.isNaN(v)) return "—";
   if (Number.isInteger(v)) return String(v);
   return Number(v.toFixed(digits)).toString();
+}
+
+// External evidence link (Databricks/MLflow). Renders a real hyperlink when the workspace + identifier
+// resolve (live by default), else the builder's fail-closed reason via NaRow — never a dead link.
+function LinkRow({ label, link }: { label: string; link: ExternalEvidenceLink }) {
+  if (!link.href) {
+    return (
+      <NaRow
+        label={label}
+        reason={`Link unavailable — ${link.unavailableReason ?? "missing identifier"}${link.copyText ? ` (copy: ${link.copyText})` : ""}`}
+      />
+    );
+  }
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "minmax(96px,0.8fr) minmax(0,1.5fr)", gap: 12,
+      padding: "8px 0", borderBottom: `1px solid ${C.border}` }}>
+      <div style={{ color: C.faint, fontFamily: C.mono, fontSize: 9, letterSpacing: "0.09em", textTransform: "uppercase" }}>{label}</div>
+      <a href={link.href} target="_blank" rel="noopener noreferrer"
+        style={{ fontFamily: C.mono, fontSize: 11, color: C.cyan, textDecoration: "underline", overflowWrap: "anywhere" }}>
+        {link.label} ↗
+      </a>
+    </div>
+  );
 }
 
 // Section sub-heading inside a tab.
@@ -261,6 +285,9 @@ function ModelPanel({ diag }: { diag: ReplayDiagnostics }) {
           <FieldRow label="version" value={st.champ.model_version} />
           <FieldRow label="promotion state" value={st.champ.promotion_state} />
           <FieldRow label="experiment id" value={st.champ.experiment_id ?? undefined} />
+          {st.champ.mlflow_run_id && st.champ.mlflow_run_id !== diag.championMlflowRunId && (
+            <NaRow label="run id mismatch" reason={`Heads-up — the fixture's recorded champion run (${diag.championMlflowRunId.slice(0, 10)}…) differs from the live registry run (${st.champ.mlflow_run_id.slice(0, 10)}…). Both are real; the fixture was scored by its recorded run. Surfaced, never silently reconciled.`} />
+          )}
           {metrics.length > 0 ? (
             <>
               <Sub>Registered metrics (model registry · tel_model_runs — not this replay)</Sub>
@@ -296,9 +323,28 @@ function ModelPanel({ diag }: { diag: ReplayDiagnostics }) {
         )
       )}
 
-      <Sub>Not available from this payload</Sub>
-      <NaRow label="threshold (score units)" reason={NA_REASONS.detectorThreshold} />
-      <NaRow label="margin to threshold" reason={NA_REASONS.marginToThreshold} />
+      <Sub>Detector threshold &amp; firing divergence (serving MAD rule · /api/telemetry/replay)</Sub>
+      {diag.scoringAvailable ? (
+        <>
+          <FieldRow label="serving threshold (residual units)" value={`${fmt(diag.threshold, 6)}  ·  k=${fmt(diag.madK, 1)} MAD on |value−rmean| (global-scale fallback)`} />
+          <FieldRow label="fired ticks above threshold" value={diag.firedTicksScored != null ? `${diag.firedAboveThreshold} of ${diag.firedTicksScored}` : undefined} />
+          <FieldRow label="max fired residual" value={diag.maxFiredResidual != null ? `${fmt(diag.maxFiredResidual, 6)} (${diag.thresholdReproducesFiring ? "above" : "below"} the serving threshold)` : undefined} />
+          {diag.perChannelCaveat ? (
+            <p style={{ fontFamily: C.mono, fontSize: 10, color: C.amber, marginTop: 6, lineHeight: 1.5 }}>
+              {diag.perChannelCaveat}
+            </p>
+          ) : (
+            <p style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 6, lineHeight: 1.5 }}>
+              Serving global-scale fallback threshold (the value /score applies); on this channel it reproduces the champion&apos;s firing.
+            </p>
+          )}
+        </>
+      ) : (
+        <>
+          <NaRow label="threshold (score units)" reason={NA_REASONS.detectorThreshold} />
+          <NaRow label="margin to threshold" reason={NA_REASONS.marginToThreshold} />
+        </>
+      )}
     </div>
   );
 }
@@ -353,6 +399,24 @@ function EvidencePanel({ feed, diag }: { feed: ReplayFeed; diag: ReplayDiagnosti
       <FieldRow label="labeled ticks" value={diag.labelAnomalyTicks} />
       <FieldRow label="residual at fire" value={fmt(diag.residualAtFire, 6)} />
       <FieldRow label="sampling fraction" value={diag.samplingFraction != null ? `${(diag.samplingFraction * 100).toFixed(2)}%` : undefined} />
+
+      {diag.scoringAvailable && (
+        <>
+          <Sub>Serving threshold vs champion firing (real — from /api/telemetry/replay)</Sub>
+          <FieldRow label="serving threshold (residual units)" value={fmt(diag.threshold, 6)} />
+          <FieldRow label="fired ticks above threshold" value={diag.firedTicksScored != null ? `${diag.firedAboveThreshold} of ${diag.firedTicksScored}` : undefined} />
+          <FieldRow label="max fired residual" value={fmt(diag.maxFiredResidual, 6)} />
+          {diag.perChannelCaveat ? (
+            <p style={{ fontFamily: C.mono, fontSize: 10, color: C.amber, marginTop: 6, lineHeight: 1.5 }}>
+              {diag.perChannelCaveat}
+            </p>
+          ) : (
+            <p style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 6, lineHeight: 1.5 }}>
+              The serving global-scale fallback threshold reproduces the champion&apos;s firing on this channel.
+            </p>
+          )}
+        </>
+      )}
 
       <Sub>Not available from this payload</Sub>
       <NaRow label="held-out P / R / F1" reason={NA_REASONS.heldOutMetrics} />
@@ -422,13 +486,22 @@ function OperatorPanel({ diag, fired }: { diag: ReplayDiagnostics; fired: boolea
         </p>
       )}
 
-      <Sub>Not available from this payload</Sub>
-      <NaRow label="per-tick GO/REVIEW/NO_GO" reason={NA_REASONS.perTickVerdict} />
+      <Sub>Per-tick severity bands</Sub>
+      {diag.scoringAvailable && diag.perChannelCaveat ? (
+        <div style={{ border: `1px solid ${C.amber}33`, background: `${C.amber}0d`, borderRadius: 7, padding: "8px 10px", display: "flex", gap: 8 }}>
+          <span style={{ marginTop: 3 }}><StatusDot color={C.amber} size={6} /></span>
+          <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.amber, lineHeight: 1.5 }}>
+            No per-tick GO/REVIEW/NO_GO ladder is derivable — {diag.perChannelCaveat} The operational verdict flips on the model&apos;s binary model_pred.
+          </span>
+        </div>
+      ) : (
+        <NaRow label="per-tick GO/REVIEW/NO_GO" reason={NA_REASONS.perTickVerdict} />
+      )}
     </div>
   );
 }
 
-function LineagePanel({ diag }: { diag: ReplayDiagnostics }) {
+function LineagePanel({ diag, feed }: { diag: ReplayDiagnostics; feed: ReplayFeed }) {
   const chain = [
     { label: "Source table", value: diag.sourceTable, copy: true },
     { label: "Champion model", value: diag.championModel, copy: true },
@@ -447,8 +520,12 @@ function LineagePanel({ diag }: { diag: ReplayDiagnostics }) {
           ? <CopyRow key={c.label} label={c.label} value={c.value} />
           : <FieldRow key={c.label} label={c.label} value={c.value} />
       ))}
-      <Sub>Workspace links</Sub>
-      <NaRow label="Databricks / MLflow link" reason="Link unavailable — no client-side workspace URL is configured (ML_DEMO_DATABRICKS_WORKSPACE_URL is backend-only). Copy the run id and table above to open them in the workspace manually." />
+      <Sub>Workspace links (live by default)</Sub>
+      <LinkRow label="MLflow run" link={mlflowRunLink(diag.championMlflowRunId)} />
+      <LinkRow label="MLflow experiment" link={mlflowExperimentLink()} />
+      <LinkRow label="Delta scoring table" link={deltaTableLink(diag.sourceTable)} />
+      {feed.lineage?.databricks_catalog && <FieldRow label="catalog" value={feed.lineage.databricks_catalog} />}
+      {feed.lineage?.scoring_notebook && <FieldRow label="scoring notebook" value={feed.lineage.scoring_notebook} />}
       <Sub>Not available from this payload</Sub>
       <NaRow label="stage / phase boundaries" reason={NA_REASONS.stageBoundaries} />
       <NaRow label="top contributing channels" reason={NA_REASONS.topContributingChannels} />
@@ -487,7 +564,7 @@ export default function ReplayForensicsDrawer({ open, onClose, feed, cursorTick,
             {tab === "model" && <ModelPanel diag={diag} />}
             {tab === "evidence" && <EvidencePanel feed={feed} diag={diag} />}
             {tab === "operator" && <OperatorPanel diag={diag} fired={fired} />}
-            {tab === "lineage" && <LineagePanel diag={diag} />}
+            {tab === "lineage" && <LineagePanel diag={diag} feed={feed} />}
           </div>
         </>
       )}

--- a/repo-b/src/lib/telemetry/api.ts
+++ b/repo-b/src/lib/telemetry/api.ts
@@ -33,6 +33,40 @@ export interface ReplayFeed {
   };
   feed: ReplayTick[];
   null_reason?: string | null;
+  // Additive replay diagnostics from the backend (Ticket 2 — Replay Model Diagnostics API). Optional
+  // and nullable for backward-compatibility with older payloads / consumers.
+  scoringDiagnostics?: ReplayScoringDiagnostics | null;
+  lineage?: ReplayLineage | null;
+}
+
+// The frozen serving threshold (MAD_K * GLOBAL_TRAIN_SCALE — the SAME threshold /score applies) PLUS the
+// honest divergence facts the backend computes from the committed fixture: whether that threshold actually
+// reproduces the champion's firing. For D-4 it does NOT — every fired tick sits below the global-fallback
+// threshold, so the champion fires on a tighter per-channel scale the serving constants do not carry. We
+// surface that divergence (per_channel_caveat) rather than invent a per-tick verdict that contradicts model_pred.
+export interface ReplayScoringDiagnostics {
+  mad_k: number;
+  global_train_scale: number;
+  threshold_residual_units: number;
+  threshold_source: string;
+  residual_definition: string;
+  fired_ticks: number;
+  fired_ticks_above_threshold: number;
+  max_fired_residual: number | null;
+  threshold_reproduces_firing: boolean;
+  per_channel_caveat: string | null;
+  fixture_score_degenerate: boolean;
+  note: string;
+}
+
+// Reproducibility chain echoed from the replay fixture provenance (no DB).
+export interface ReplayLineage {
+  databricks_catalog: string | null;
+  source_table: string | null;
+  champion_model: string | null;
+  champion_mlflow_run_id_fixture: string | null;
+  scoring_notebook: string | null;
+  backend_route: string | null;
 }
 
 export interface ModelRun {

--- a/repo-b/src/lib/telemetry/replayDiagnostics.test.ts
+++ b/repo-b/src/lib/telemetry/replayDiagnostics.test.ts
@@ -180,3 +180,59 @@ describe("NA_REASONS", () => {
     }
   });
 });
+
+describe("computeReplayDiagnostics — scoring diagnostics (Ticket 2)", () => {
+  it("is fail-closed (scoringAvailable false, all scoring fields null) when the payload has no scoringDiagnostics", () => {
+    const d = computeReplayDiagnostics(feed); // `feed` carries no scoringDiagnostics
+    expect(d.scoringAvailable).toBe(false);
+    expect(d.threshold).toBeNull();
+    expect(d.firedAboveThreshold).toBeNull();
+    expect(d.maxFiredResidual).toBeNull();
+    expect(d.thresholdReproducesFiring).toBeNull();
+    expect(d.perChannelCaveat).toBeNull();
+  });
+
+  // The real D-4 shape: the serving global-fallback threshold does NOT reproduce the champion's firing
+  // (every fired tick sits below it), so the backend reports the divergence and we surface it verbatim.
+  const scored: ReplayFeed = {
+    ...feed,
+    scoringDiagnostics: {
+      mad_k: 4, global_train_scale: 0.0339, threshold_residual_units: 0.135467,
+      threshold_source: "serving global-scale fallback",
+      residual_definition: "residual = abs(value - rmean)",
+      fired_ticks: 412, fired_ticks_above_threshold: 0, max_fired_residual: 0.0699,
+      threshold_reproduces_firing: false,
+      per_channel_caveat: "The serving global-scale fallback threshold does NOT reproduce the champion's D-4 firing.",
+      fixture_score_degenerate: true, note: "test",
+    },
+  };
+  const d = computeReplayDiagnostics(scored);
+
+  it("surfaces the backend divergence facts verbatim and never invents a per-tick verdict", () => {
+    expect(d.scoringAvailable).toBe(true);
+    expect(d.threshold).toBe(0.135467);
+    expect(d.madK).toBe(4);
+    expect(d.firedTicksScored).toBe(412);
+    expect(d.firedAboveThreshold).toBe(0);
+    expect(d.maxFiredResidual).toBeCloseTo(0.0699, 6);
+    expect(d.thresholdReproducesFiring).toBe(false);
+    expect(d.perChannelCaveat).toMatch(/does NOT reproduce/i);
+    // internally consistent: the largest fired residual sits BELOW the serving threshold
+    expect(d.maxFiredResidual!).toBeLessThan(d.threshold!);
+  });
+
+  it("still reports the real residual at the first fire (the trustworthy quantity), degenerate score flagged", () => {
+    // fire tick t=10: residual |1.0-(-0.9)| = 1.9; the fixture score there is the degenerate 1.48e12
+    expect(d.residualAtFire).toBeCloseTo(1.9, 6);
+    expect(d.scoreIsDegenerate).toBe(true);
+    expect(d.residualAtFire).not.toBe(d.scoreAtFire);
+  });
+
+  it("inspectTick no longer fabricates a per-tick verdict — it returns the real residual only", () => {
+    const insp = inspectTick(scored, 10);
+    expect(insp!.residual).toBeCloseTo(1.9, 6);
+    // the removed per-tick verdict fields must not reappear on the shape
+    expect((insp as Record<string, unknown>).verdict).toBeUndefined();
+    expect((insp as Record<string, unknown>).realScore).toBeUndefined();
+  });
+});

--- a/repo-b/src/lib/telemetry/replayDiagnostics.ts
+++ b/repo-b/src/lib/telemetry/replayDiagnostics.ts
@@ -110,6 +110,21 @@ export interface ReplayDiagnostics {
   scoreAtFire: number | null;
   scoreIsDegenerate: boolean;
 
+  // Scoring provenance from the backend scoringDiagnostics block (DB-free). The threshold is the frozen
+  // serving global-fallback (MAD_K * GLOBAL_TRAIN_SCALE — the SAME value /score applies). The divergence
+  // fields are the HONEST headline: for D-4 the threshold does NOT reproduce the champion's firing (every
+  // fired tick is below it), so model_pred is authoritative and no per-tick verdict is derivable. All
+  // null / false when the payload carries no scoringDiagnostics — the drawer keeps its fail-closed rows.
+  scoringAvailable: boolean;
+  threshold: number | null; // residual units (MAD_K * GLOBAL_TRAIN_SCALE) — serving global-scale fallback
+  madK: number | null;
+  thresholdSource: string | null;
+  firedTicksScored: number | null; // model_pred==1 ticks the backend scored against the threshold
+  firedAboveThreshold: number | null; // how many of those exceed the threshold (0 for D-4 => divergence)
+  maxFiredResidual: number | null; // largest residual among fired ticks (below the threshold for D-4)
+  thresholdReproducesFiring: boolean | null; // false => the model fired below the serving threshold
+  perChannelCaveat: string | null; // the divergence explanation; null when the threshold does reproduce firing
+
   // Cross-checks: do the recomputed values match the payload's top-level summary scalars?
   crosscheck: { firstFire: boolean; fired: boolean; labeled: boolean };
 }
@@ -127,6 +142,13 @@ function directionOf(tick: ReplayTick): "above" | "below" | "at" {
   if (d > 0) return "above";
   if (d < 0) return "below";
   return "at";
+}
+
+// The frozen detector threshold from the backend scoringDiagnostics block (residual units), or null
+// when the payload predates Ticket 2. Never hard-coded in the frontend — the backend owns the constant.
+function thresholdOf(feed: ReplayFeed): number | null {
+  const t = feed.scoringDiagnostics?.threshold_residual_units;
+  return typeof t === "number" && t > 0 ? t : null;
 }
 
 // Inspect a single tick by its t-index. Returns null when t is not present in the (downsampled) feed.
@@ -195,6 +217,15 @@ export function computeReplayDiagnostics(feed: ReplayFeed): ReplayDiagnostics {
       residualAtFire: null,
       scoreAtFire: null,
       scoreIsDegenerate: true,
+      scoringAvailable: false,
+      threshold: null,
+      madK: null,
+      thresholdSource: null,
+      firedTicksScored: null,
+      firedAboveThreshold: null,
+      maxFiredResidual: null,
+      thresholdReproducesFiring: null,
+      perChannelCaveat: null,
       crosscheck: { firstFire: false, fired: false, labeled: false },
     };
   }
@@ -248,6 +279,14 @@ export function computeReplayDiagnostics(feed: ReplayFeed): ReplayDiagnostics {
   const samplingFraction =
     base.totalTicksSource > 0 ? base.fixtureTicks / base.totalTicksSource : null;
 
+  // Scoring provenance: the frozen serving threshold (from the backend, DB-free) AND the honest divergence
+  // the backend computed from the fixture. For D-4 the threshold does NOT reproduce the champion's firing
+  // (every fired tick is below it), so we surface the divergence instead of deriving a per-tick verdict
+  // that would contradict model_pred. All null/false when the payload carries no scoringDiagnostics.
+  const sd = feed.scoringDiagnostics ?? null;
+  const threshold = thresholdOf(feed);
+  const residAtFire = fireTick ? residualOf(fireTick) : null;
+
   return {
     available: true,
     nullReason: null,
@@ -262,11 +301,20 @@ export function computeReplayDiagnostics(feed: ReplayFeed): ReplayDiagnostics {
     preLabelFalseAlarms,
     latencyFraming,
     confusion: { tp, fp, fn, tn, precision, recall, f1, caveat: AGREEMENT_CAVEAT },
-    residualAtFire: fireTick ? residualOf(fireTick) : null,
+    residualAtFire: residAtFire,
     scoreAtFire: fireTick ? fireTick.score : null,
     // The fixture score is |value-rmean|/median(resid); on this near-constant channel it is degenerate
     // (~1e12 at fire ticks). Always flagged so the UI never treats it as a calibrated/comparable axis.
     scoreIsDegenerate: true,
+    scoringAvailable: threshold != null,
+    threshold,
+    madK: sd?.mad_k ?? null,
+    thresholdSource: sd?.threshold_source ?? null,
+    firedTicksScored: sd?.fired_ticks ?? null,
+    firedAboveThreshold: sd?.fired_ticks_above_threshold ?? null,
+    maxFiredResidual: sd?.max_fired_residual ?? null,
+    thresholdReproducesFiring: sd?.threshold_reproduces_firing ?? null,
+    perChannelCaveat: sd?.per_channel_caveat ?? null,
     crosscheck: {
       firstFire: feed.first_model_fire_t == null || feed.first_model_fire_t === firstFireRecomputed,
       fired: feed.model_fired_ticks == null || feed.model_fired_ticks === firedTicks.length,


### PR DESCRIPTION
## What

Additive, DB-free diagnostics on `GET /api/telemetry/replay` so the Replay Forensics drawer shows real model/scoring provenance instead of only fail-closed placeholders.

- **scoringDiagnostics** — the frozen serving threshold (`MAD_K * GLOBAL_TRAIN_SCALE` = 0.135467, the same value `/score` applies) PLUS the divergence computed from the committed fixture.
- **lineage** — reproducibility chain echoed from the fixture provenance (catalog, source table, champion, MLflow run, scoring notebook, backend route).

## The honest finding (why there's no per-tick verdict)

The intake assumed `score_t = residual / threshold` would reproduce `model_pred`. It does **not** for D-4: **0 of 412 fired ticks** exceed the global-fallback threshold (max fired residual 0.070 << 0.135). The champion fired on a tighter **per-channel** scale the serving constants do not carry. Rather than render a per-tick "GO" that contradicts the model firing, the surface states the divergence plainly — `model_pred` stays authoritative.

## Frontend
- **Model / Evidence** tabs: real serving threshold + `fired ticks above threshold` + max fired residual + amber per-channel caveat.
- **Operator**: honest "no per-tick ladder is derivable" note.
- **Lineage**: live Databricks/MLflow links via `factoryEvidenceLinks`.
- All fields fail closed with specific reasons when diagnostics are absent.

## Compatibility
Existing replay keys + `feed[]` rows unchanged. Held-out metrics still served by `/api/telemetry/model-performance`.

## Tests / gates
- Backend 12/12 (threshold == live `/score` threshold; divergence facts; back-compat).
- Frontend adapter + drawer 25/25; full telemetry suite 208/208; typecheck + lint clean.
- Visual gate at 1280×800 dark (local render of this commit via mock backend) — Model/Evidence/Operator/Lineage all verified.

ADO #734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)