### PR TITLE
feat: governed Agent Builder and staged eval gate

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -83,6 +83,7 @@ from app.routes import consulting
 from app.routes import telemetry
 from app.routes import telemetry_copilot
 from app.routes import telemetry_control_tower
+from app.routes import agent_builder
 from app.routes import ade_ops
 from app.routes import automated_data_engineering
 from app.routes import intelligence_cards
@@ -592,6 +593,7 @@ app.include_router(consulting.router)
 app.include_router(telemetry.router)
 app.include_router(telemetry_copilot.router)
 app.include_router(telemetry_control_tower.router)
+app.include_router(agent_builder.router)
 app.include_router(automated_data_engineering.router)
 app.include_router(ade_ops.router)
 app.include_router(intelligence_cards.router)

--- a/backend/app/mcp/schemas/telemetry_tools.py
+++ b/backend/app/mcp/schemas/telemetry_tools.py
@@ -37,3 +37,28 @@ class GetAnomalyEventsInWindowInput(BaseModel):
     run_key: str = Field(description="Test run key")
     t_start: int = Field(description="Window start tick (inclusive)")
     t_end: int = Field(description="Window end tick (inclusive)")
+
+
+class PreviewScoreWindowInput(BaseModel):
+    """Score a supplied telemetry window without inserting a prediction receipt."""
+    model_config = {"extra": "forbid"}
+    env_id: str = Field(description="Environment id (tenant scope)")
+    business_id: UUID = Field(description="Business id (tenant scope)")
+    run_key: str = Field(description="Existing test run key")
+    channel_name: str = Field(description="Telemetry channel name")
+    window: list[dict] = Field(min_length=1, description="Ordered readings with t and value")
+
+
+class PreviewScoreWindowOutput(BaseModel):
+    """Fail-closed score preview contract used by Agent Builder dry-runs."""
+    verdict: str
+    anomaly_score: float | None = None
+    threshold: float | None = None
+    model_name: str | None = None
+    model_version: str | None = None
+    model_alias: str | None = None
+    mlflow_run_id: str | None = None
+    attribution: list[dict] = Field(default_factory=list)
+    confidence: float = 0.0
+    missing_data: list[str] = Field(default_factory=list)
+    null_reason: str | None = None

--- a/backend/app/mcp/tools/telemetry_tools.py
+++ b/backend/app/mcp/tools/telemetry_tools.py
@@ -17,6 +17,8 @@ from app.mcp.schemas.telemetry_tools import (
     GetAnomalyEventsInWindowInput,
     GetModelRunDetailInput,
     GetTriggeringPredictionInput,
+    PreviewScoreWindowInput,
+    PreviewScoreWindowOutput,
 )
 from app.services import audit as audit_svc
 from app.services import telemetry_serving as svc
@@ -26,6 +28,7 @@ TELEMETRY_TOOL_NAMES = frozenset({
     "telemetry.get_triggering_prediction",
     "telemetry.get_model_run_detail",
     "telemetry.get_anomaly_events_in_window",
+    "telemetry.preview_score_window",
 })
 
 SCOPE_DENIED_REASON = "tool_not_in_telemetry_scope"
@@ -48,6 +51,16 @@ def _get_anomaly_events_in_window(ctx: McpContext, inp: GetAnomalyEventsInWindow
     return svc.get_anomaly_events_in_window(
         env_id=inp.env_id, business_id=inp.business_id,
         run_key=inp.run_key, t_start=inp.t_start, t_end=inp.t_end)
+
+
+def _preview_score_window(ctx: McpContext, inp: PreviewScoreWindowInput) -> dict:
+    return svc.preview_score_window(
+        env_id=inp.env_id,
+        business_id=inp.business_id,
+        run_key=inp.run_key,
+        channel_name=inp.channel_name,
+        window=inp.window,
+    )
 
 
 def register_telemetry_tools() -> None:
@@ -78,6 +91,16 @@ def register_telemetry_tools() -> None:
         input_model=GetAnomalyEventsInWindowInput,
         handler=_get_anomaly_events_in_window,
         tags=frozenset({"telemetry", "read-only", "anomaly"}),
+    ))
+    registry.register(ToolDef(
+        name="telemetry.preview_score_window",
+        description="Score a telemetry window with the promoted champion without writing tel_predictions.",
+        module="telemetry",
+        permission="read",
+        input_model=PreviewScoreWindowInput,
+        output_model=PreviewScoreWindowOutput,
+        handler=_preview_score_window,
+        tags=frozenset({"telemetry", "read-only", "scoring", "agent-builder"}),
     ))
 
 

--- a/backend/app/routes/agent_builder.py
+++ b/backend/app/routes/agent_builder.py
@@ -1,0 +1,235 @@
+"""FastAPI surface for the governed Agent Builder read-only MVP."""
+
+from __future__ import annotations
+
+import psycopg
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from app.auth.platform import require_tenant_context
+from app.schemas.agent_builder import (
+    DryRunRequest,
+    PublishRequest,
+    WorkflowCreateRequest,
+    WorkflowDraftRequest,
+)
+from app.services import agent_builder as service
+from app.services import agent_builder_evals as eval_service
+
+
+router = APIRouter(prefix="/api/agent-builder", tags=["agent-builder"])
+
+
+def _scope(request: Request, *, mutate: bool = False) -> tuple[str, str, str]:
+    auth = require_tenant_context(request)
+    if not auth.env_id:
+        raise HTTPException(status_code=403, detail="Environment context required")
+    if mutate and "write" not in auth.permissions and "admin" not in auth.roles:
+        raise HTTPException(status_code=403, detail="Operator or admin role required")
+    return auth.env_id, str(auth.business_id), auth.actor
+
+
+def _to_http(exc: Exception) -> HTTPException:
+    if isinstance(exc, service.VersionConflictError):
+        return HTTPException(status_code=409, detail=str(exc))
+    if isinstance(exc, (service.WorkflowNotFoundError, LookupError)):
+        return HTTPException(status_code=404, detail=str(exc))
+    if isinstance(exc, (ValueError, TypeError)):
+        return HTTPException(status_code=400, detail=str(exc))
+    if isinstance(exc, (psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn)):
+        return HTTPException(
+            status_code=503,
+            detail=(
+                "Agent Builder schema not migrated "
+                "(apply 10035_agent_builder_mvp.sql and 10036_agent_builder_evals.sql)"
+            ),
+        )
+    return HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/palette")
+def palette(request: Request):
+    _scope(request)
+    return {"schema_version": "agent-graph/v1", "nodes": service.NODE_CATALOG}
+
+
+@router.get("/mcp-tools")
+def mcp_tools(request: Request):
+    _scope(request)
+    return {"tools": service.describe_tools()}
+
+
+@router.get("/workflows")
+def workflows(request: Request):
+    env_id, business_id, _ = _scope(request)
+    try:
+        return {"workflows": service.list_workflows(env_id=env_id, business_id=business_id)}
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.post("/workflows")
+def create_workflow(payload: WorkflowCreateRequest, request: Request):
+    env_id, business_id, actor = _scope(request, mutate=True)
+    try:
+        return service.create_workflow(
+            env_id=env_id,
+            business_id=business_id,
+            actor=actor,
+            name=payload.name,
+            description=payload.description,
+            graph=payload.graph,
+            tags=payload.tags,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/workflows/{workflow_id}")
+def get_workflow(workflow_id: str, request: Request):
+    env_id, business_id, _ = _scope(request)
+    try:
+        return service.get_workflow(
+            env_id=env_id, business_id=business_id, workflow_id=workflow_id
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.patch("/workflows/{workflow_id}/draft")
+def save_draft(workflow_id: str, payload: WorkflowDraftRequest, request: Request):
+    env_id, business_id, actor = _scope(request, mutate=True)
+    try:
+        return service.save_draft(
+            env_id=env_id,
+            business_id=business_id,
+            actor=actor,
+            workflow_id=workflow_id,
+            base_version_number=payload.base_version_number,
+            graph=payload.graph,
+            name=payload.name,
+            description=payload.description,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.post("/workflows/{workflow_id}/validate")
+def validate_workflow(workflow_id: str, request: Request):
+    env_id, business_id, _ = _scope(request, mutate=True)
+    try:
+        return service.validate_saved_workflow(
+            env_id=env_id, business_id=business_id, workflow_id=workflow_id
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.post("/workflows/{workflow_id}/dry-run")
+def dry_run(workflow_id: str, payload: DryRunRequest, request: Request):
+    env_id, business_id, actor = _scope(request, mutate=True)
+    try:
+        return service.dry_run(
+            env_id=env_id,
+            business_id=business_id,
+            actor=actor,
+            workflow_id=workflow_id,
+            run_input=payload.input,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.post("/workflows/{workflow_id}/evals/run")
+def run_evals(workflow_id: str, request: Request):
+    env_id, business_id, actor = _scope(request, mutate=True)
+    try:
+        return eval_service.run_evals(
+            env_id=env_id,
+            business_id=business_id,
+            actor=actor,
+            workflow_id=workflow_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/workflows/{workflow_id}/evals")
+def workflow_evals(workflow_id: str, request: Request):
+    env_id, business_id, _ = _scope(request)
+    try:
+        return eval_service.get_workflow_evals(
+            env_id=env_id,
+            business_id=business_id,
+            workflow_id=workflow_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.post("/workflows/{workflow_id}/publish")
+def publish_workflow(workflow_id: str, payload: PublishRequest, request: Request):
+    env_id, business_id, actor = _scope(request, mutate=True)
+    try:
+        return eval_service.publish_workflow(
+            env_id=env_id,
+            business_id=business_id,
+            actor=actor,
+            workflow_id=workflow_id,
+            desired_status=payload.status,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/runs")
+def runs(request: Request, limit: int = Query(default=50, ge=1, le=200)):
+    env_id, business_id, _ = _scope(request)
+    try:
+        return {"runs": service.list_runs(env_id=env_id, business_id=business_id, limit=limit)}
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/runs/{run_id}")
+def get_run(run_id: str, request: Request):
+    env_id, business_id, _ = _scope(request)
+    try:
+        return service.get_run(env_id=env_id, business_id=business_id, run_id=run_id)
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/runs/{run_id}/events")
+def get_events(run_id: str, request: Request):
+    env_id, business_id, _ = _scope(request)
+    try:
+        return {"events": service.get_run_events(env_id=env_id, business_id=business_id, run_id=run_id)}
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/eval-runs/{eval_run_id}")
+def get_eval_run(eval_run_id: str, request: Request):
+    env_id, business_id, _ = _scope(request)
+    try:
+        return eval_service.get_eval_run(
+            env_id=env_id,
+            business_id=business_id,
+            eval_run_id=eval_run_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.post("/runs/{run_id}/promote-failure")
+def promote_failure(run_id: str, request: Request):
+    env_id, business_id, actor = _scope(request, mutate=True)
+    try:
+        return eval_service.promote_failure(
+            env_id=env_id,
+            business_id=business_id,
+            actor=actor,
+            run_id=run_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)

--- a/backend/app/schemas/agent_builder.py
+++ b/backend/app/schemas/agent_builder.py
@@ -1,0 +1,86 @@
+"""Typed contracts for the governed Agent Builder read-only MVP."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+
+NodeType = Literal[
+    "manual_trigger",
+    "context_loader",
+    "mcp_tool",
+    "prompt_llm",
+    "policy_gate",
+    "cost_guardrail",
+    "human_approval",
+    "receipt_writer",
+    "output",
+    "eval_assertion",
+]
+
+
+class GraphPosition(BaseModel):
+    x: float
+    y: float
+
+
+class AgentNode(BaseModel):
+    id: str = Field(min_length=1, max_length=120)
+    type: NodeType
+    label: str | None = Field(default=None, max_length=160)
+    position: GraphPosition
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentEdge(BaseModel):
+    id: str | None = None
+    source: str
+    target: str
+    source_handle: str | None = None
+    target_handle: str | None = None
+    data_type: str = "control"
+
+
+class AgentLimits(BaseModel):
+    max_runtime_seconds: int = Field(default=120, ge=1, le=600)
+    max_tool_calls: int = Field(default=10, ge=0, le=100)
+    max_cost_usd: float = Field(default=1.0, ge=0, le=100)
+
+
+class AgentGraph(BaseModel):
+    schema_version: Literal["agent-graph/v1"] = "agent-graph/v1"
+    nodes: list[AgentNode]
+    edges: list[AgentEdge]
+    limits: AgentLimits = Field(default_factory=AgentLimits)
+    model_route_policy: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def unique_ids(self) -> "AgentGraph":
+        ids = [node.id for node in self.nodes]
+        if len(ids) != len(set(ids)):
+            raise ValueError("node ids must be unique")
+        return self
+
+
+class WorkflowCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=160)
+    description: str | None = Field(default=None, max_length=2000)
+    graph: AgentGraph
+    tags: list[str] = Field(default_factory=list)
+
+
+class WorkflowDraftRequest(BaseModel):
+    base_version_number: int = Field(ge=1)
+    graph: AgentGraph
+    name: str | None = Field(default=None, min_length=1, max_length=160)
+    description: str | None = Field(default=None, max_length=2000)
+
+
+class DryRunRequest(BaseModel):
+    input: dict[str, Any] = Field(default_factory=dict)
+
+
+class PublishRequest(BaseModel):
+    status: Literal["staged", "published"] = "staged"

--- a/backend/app/services/agent_builder.py
+++ b/backend/app/services/agent_builder.py
@@ -1,0 +1,1085 @@
+"""Governed Agent Builder graph validation, persistence, and read-only dry-run runtime."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from jsonschema import ValidationError as JsonSchemaValidationError
+from jsonschema import validate as validate_json_schema
+import psycopg
+from psycopg.types.json import Json
+
+from app.db import get_cursor
+from app.mcp.audit import execute_tool
+from app.mcp.auth import McpContext
+from app.mcp.registry import ToolDef, registry
+from app.schemas.agent_builder import AgentEdge, AgentGraph, AgentNode
+from app.services.ai_dispatch.models import (
+    AIRequest,
+    DispatchStatus,
+    Privacy,
+    ProviderName,
+    RiskLevel,
+    TaskMode,
+)
+from app.services.ai_dispatch.supervisor import run_dispatch
+from app.services.control_tower.routing import control_tower_registry
+
+
+NODE_CATALOG: list[dict[str, Any]] = [
+    {"type": "manual_trigger", "label": "Manual Trigger", "category": "Input", "description": "Starts a manual dry-run."},
+    {"type": "context_loader", "label": "Context Loader", "category": "Input", "description": "Loads tenant and operator context."},
+    {"type": "mcp_tool", "label": "MCP Tool", "category": "Action", "description": "Calls a pinned read-only MCP tool."},
+    {"type": "prompt_llm", "label": "Prompt / LLM", "category": "Reasoning", "description": "Runs a bounded governed model call."},
+    {"type": "policy_gate", "label": "Policy Gate", "category": "Governance", "description": "Selects a policy-controlled branch."},
+    {"type": "cost_guardrail", "label": "Cost Guardrail", "category": "Governance", "description": "Blocks or branches when a budget is exceeded."},
+    {"type": "human_approval", "label": "Human Approval", "category": "Governance", "description": "Ends MVP dry-runs with a simulated pending approval."},
+    {"type": "receipt_writer", "label": "Receipt Writer", "category": "Evidence", "description": "Materializes an audit checkpoint."},
+    {"type": "output", "label": "Output", "category": "Output", "description": "Single terminal workflow output."},
+    {"type": "eval_assertion", "label": "Eval Assertion", "category": "Evaluation", "description": "Checks a deterministic assertion."},
+]
+
+TERMINAL_STATUSES = {"succeeded", "blocked", "failed", "not_available", "cancelled"}
+SECRET_KEY_RE = re.compile(
+    r"(^|_)(api_?key|secret|password|passwd|authorization|access_?token|refresh_?token|private_?key)($|_)",
+    re.IGNORECASE,
+)
+SECRET_VALUE_RE = re.compile(
+    r"(-----BEGIN [A-Z ]*PRIVATE KEY-----|\bBearer\s+[A-Za-z0-9._~+/-]{12,}|"
+    r"\b(?:sk|rk|pk)-[A-Za-z0-9_-]{12,})",
+    re.IGNORECASE,
+)
+MOUSTACHE_RE = re.compile(r"^\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}$")
+
+
+class VersionConflictError(ValueError):
+    pass
+
+
+class WorkflowNotFoundError(LookupError):
+    pass
+
+
+@dataclass
+class NodeExecution:
+    status: str
+    output: dict[str, Any]
+    branch_handle: str | None = None
+    tool_name: str | None = None
+    model_name: str | None = None
+    cost_usd: float = 0.0
+    reason: str | None = None
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, (UUID, datetime, date, Decimal)):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    return value
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(_jsonable(value), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_json(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def redact_payload(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, child in value.items():
+            if SECRET_KEY_RE.search(str(key)):
+                redacted[str(key)] = "[REDACTED]"
+            else:
+                redacted[str(key)] = redact_payload(child)
+        return redacted
+    if isinstance(value, list):
+        return [redact_payload(item) for item in value]
+    if isinstance(value, str) and SECRET_VALUE_RE.search(value):
+        return "[REDACTED]"
+    return _jsonable(value)
+
+
+def find_secret_paths(value: Any, path: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}"
+            if SECRET_KEY_RE.search(str(key)):
+                found.append(child_path)
+            found.extend(find_secret_paths(child, child_path))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            found.extend(find_secret_paths(child, f"{path}[{index}]"))
+    elif isinstance(value, str) and SECRET_VALUE_RE.search(value):
+        found.append(path)
+    return found
+
+
+def tool_schema_digest(tool: ToolDef) -> str:
+    manifest = tool.manifest()
+    payload = {
+        "name": tool.name,
+        "permission": manifest["permission_required"],
+        "side_effect_class": manifest["side_effect_class"],
+        "input_schema": tool.input_schema,
+        "output_schema": tool.output_schema,
+    }
+    return sha256_json(payload)
+
+
+def describe_tools() -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = []
+    for tool in sorted(registry.list_all(), key=lambda item: item.name):
+        manifest = tool.manifest()
+        is_read = (
+            tool.permission == "read"
+            and manifest["permission_required"] == "read"
+            and manifest["side_effect_class"] == "read"
+        )
+        tools.append(
+            {
+                "name": tool.name,
+                "description": tool.description,
+                "module": tool.module,
+                "permission": tool.permission,
+                "effective_permission": manifest["permission_required"],
+                "side_effect_class": manifest["side_effect_class"],
+                "confirmation_required": manifest["confirmation_required"],
+                "input_schema": tool.input_schema,
+                "output_schema": tool.output_schema,
+                "schema_digest": tool_schema_digest(tool),
+                "enabled": is_read,
+                "disabled_reason": None if is_read else "MVP permits read-only MCP tools only",
+            }
+        )
+    return tools
+
+
+def _issue(code: str, message: str, *, node_id: str | None = None, severity: str = "error") -> dict[str, Any]:
+    return {"code": code, "message": message, "node_id": node_id, "severity": severity}
+
+
+def _graph_maps(graph: AgentGraph) -> tuple[dict[str, AgentNode], dict[str, list[AgentEdge]], dict[str, list[AgentEdge]]]:
+    nodes = {node.id: node for node in graph.nodes}
+    outgoing: dict[str, list[AgentEdge]] = defaultdict(list)
+    incoming: dict[str, list[AgentEdge]] = defaultdict(list)
+    for edge in graph.edges:
+        outgoing[edge.source].append(edge)
+        incoming[edge.target].append(edge)
+    return nodes, outgoing, incoming
+
+
+def topological_order(graph: AgentGraph) -> list[str]:
+    nodes, outgoing, incoming = _graph_maps(graph)
+    indegree = {node_id: len(incoming[node_id]) for node_id in nodes}
+    queue = deque(sorted(node_id for node_id, degree in indegree.items() if degree == 0))
+    order: list[str] = []
+    while queue:
+        node_id = queue.popleft()
+        order.append(node_id)
+        for edge in sorted(outgoing[node_id], key=lambda item: (item.target, item.source_handle or "")):
+            indegree[edge.target] -= 1
+            if indegree[edge.target] == 0:
+                queue.append(edge.target)
+    return order
+
+
+def validate_graph(graph: AgentGraph) -> dict[str, Any]:
+    issues: list[dict[str, Any]] = []
+    nodes, outgoing, incoming = _graph_maps(graph)
+    triggers = [node for node in graph.nodes if node.type == "manual_trigger"]
+    outputs = [node for node in graph.nodes if node.type == "output"]
+
+    if len(triggers) != 1:
+        issues.append(_issue("TRIGGER_COUNT", "Graph must contain exactly one Manual Trigger node."))
+    if len(outputs) != 1:
+        issues.append(_issue("OUTPUT_COUNT", "Graph must contain exactly one Output node."))
+
+    for edge in graph.edges:
+        if edge.source not in nodes or edge.target not in nodes:
+            issues.append(_issue("EDGE_NODE_MISSING", f"Edge {edge.source} -> {edge.target} references a missing node."))
+        if edge.source == edge.target:
+            issues.append(_issue("SELF_LOOP", f"Node {edge.source} cannot connect to itself.", node_id=edge.source))
+        if edge.data_type not in {"control", "json", "context", "evidence"}:
+            issues.append(_issue("EDGE_TYPE", f"Unsupported edge data_type '{edge.data_type}'."))
+
+    order = topological_order(graph)
+    if len(order) != len(nodes):
+        issues.append(_issue("CYCLE", "Graph must be a directed acyclic graph."))
+
+    if triggers:
+        trigger = triggers[0]
+        if incoming[trigger.id]:
+            issues.append(_issue("TRIGGER_INCOMING", "Manual Trigger cannot have incoming edges.", node_id=trigger.id))
+        reachable: set[str] = set()
+        queue = deque([trigger.id])
+        while queue:
+            current = queue.popleft()
+            if current in reachable:
+                continue
+            reachable.add(current)
+            queue.extend(edge.target for edge in outgoing[current])
+        for node_id in sorted(set(nodes) - reachable):
+            issues.append(_issue("UNREACHABLE_NODE", f"Node '{node_id}' is unreachable.", node_id=node_id))
+
+    for output in outputs:
+        if outgoing[output.id]:
+            issues.append(_issue("OUTPUT_NOT_TERMINAL", "Output node cannot have outgoing edges.", node_id=output.id))
+
+    for node in graph.nodes:
+        if node.type != "output" and not outgoing[node.id] and node.type != "human_approval":
+            issues.append(_issue("MISSING_TERMINAL_PATH", "Non-terminal node has no outgoing edge.", node_id=node.id))
+        if node.type == "mcp_tool":
+            tool_name = str(node.config.get("tool_name") or "")
+            tool = registry.get(tool_name) if tool_name else None
+            if not tool:
+                issues.append(_issue("TOOL_NOT_AVAILABLE", f"Tool '{tool_name or '(unset)'}' is not registered.", node_id=node.id))
+            else:
+                manifest = tool.manifest()
+                if (
+                    tool.permission != "read"
+                    or manifest["permission_required"] != "read"
+                    or manifest["side_effect_class"] != "read"
+                ):
+                    issues.append(_issue("WRITE_TOOL_FORBIDDEN", f"Tool '{tool.name}' is not read-only.", node_id=node.id))
+                expected = tool_schema_digest(tool)
+                if node.config.get("tool_schema_digest") != expected:
+                    issues.append(_issue("SCHEMA_DIGEST_DRIFT", f"Tool schema pin for '{tool.name}' is missing or stale.", node_id=node.id))
+        elif node.type == "prompt_llm":
+            if not node.config.get("prompt_template"):
+                issues.append(_issue("PROMPT_REQUIRED", "Prompt node requires prompt_template.", node_id=node.id))
+            if not node.config.get("prompt_version"):
+                issues.append(_issue("PROMPT_VERSION_REQUIRED", "Prompt node requires prompt_version.", node_id=node.id))
+            if not isinstance(node.config.get("output_schema"), dict):
+                issues.append(_issue("OUTPUT_SCHEMA_REQUIRED", "Prompt node requires a JSON output_schema.", node_id=node.id))
+        elif node.type == "policy_gate":
+            handles = {edge.source_handle for edge in outgoing[node.id]}
+            if not {"pass", "fail"}.issubset(handles):
+                issues.append(_issue("GATE_HANDLES", "Policy Gate requires pass and fail outgoing handles.", node_id=node.id))
+        elif node.type == "cost_guardrail":
+            handles = {edge.source_handle for edge in outgoing[node.id]}
+            if not {"under_budget", "over_budget"}.issubset(handles):
+                issues.append(_issue("COST_HANDLES", "Cost Guardrail requires under_budget and over_budget handles.", node_id=node.id))
+
+    for path in find_secret_paths(graph.model_dump(mode="json")):
+        issues.append(_issue("SECRET_DETECTED", f"Secret-shaped workflow data is forbidden at {path}."))
+
+    status = "pass" if not any(item["severity"] == "error" for item in issues) else "fail"
+    return {
+        "status": status,
+        "checks": {
+            "dag": not any(item["code"] == "CYCLE" for item in issues),
+            "single_trigger": len(triggers) == 1,
+            "single_output": len(outputs) == 1,
+            "read_only_tools": not any(item["code"] == "WRITE_TOOL_FORBIDDEN" for item in issues),
+            "secrets_absent": not any(item["code"] == "SECRET_DETECTED" for item in issues),
+        },
+        "issues": issues,
+        "topological_order": order,
+    }
+
+
+def compile_pins(graph: AgentGraph) -> dict[str, Any]:
+    prompt_versions: dict[str, str] = {}
+    tool_digests: dict[str, str] = {}
+    for node in graph.nodes:
+        if node.type == "prompt_llm":
+            prompt_versions[node.id] = str(node.config.get("prompt_version") or "")
+        if node.type == "mcp_tool":
+            tool_digests[node.id] = str(node.config.get("tool_schema_digest") or "")
+    return {
+        "prompt_versions": prompt_versions,
+        "tool_schema_digests": tool_digests,
+        "model_route_policy": graph.model_route_policy,
+        "required_permissions": ["read"],
+    }
+
+
+def _row(row: Any) -> dict[str, Any]:
+    return _jsonable(dict(row)) if row else {}
+
+
+def _serialize_workflow(row: Any) -> dict[str, Any]:
+    result = _row(row)
+    if "graph_json" in result:
+        result["graph"] = result.pop("graph_json")
+    return result
+
+
+def _insert_version(cur, *, workflow_id: str, env_id: str, business_id: str, version_number: int,
+                    graph: AgentGraph, actor: str) -> tuple[str, dict[str, Any]]:
+    validation = validate_graph(graph)
+    pins = compile_pins(graph)
+    cur.execute(
+        """INSERT INTO ai_agent_workflow_versions
+             (env_id, business_id, workflow_id, version_number, graph_json,
+              prompt_versions, tool_schema_digests, model_route_policy,
+              required_permissions, validation_status, validation_results, created_by)
+           VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+           RETURNING id""",
+        (
+            env_id, business_id, workflow_id, version_number,
+            Json(graph.model_dump(mode="json")),
+            Json(pins["prompt_versions"]), Json(pins["tool_schema_digests"]),
+            Json(pins["model_route_policy"]), pins["required_permissions"],
+            validation["status"], Json(validation), actor,
+        ),
+    )
+    return str(cur.fetchone()["id"]), validation
+
+
+def create_workflow(*, env_id: str, business_id: str, actor: str, name: str,
+                    description: str | None, graph: AgentGraph, tags: list[str] | None = None,
+                    is_template: bool = False, template_key: str | None = None) -> dict[str, Any]:
+    if find_secret_paths(graph.model_dump(mode="json")):
+        raise ValueError("Workflow graph contains secret-shaped keys or values")
+    with get_cursor() as cur:
+        cur.execute(
+            """INSERT INTO ai_agent_workflows
+                 (env_id, business_id, name, description, owner_user_id, tags, is_template, template_key)
+               VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
+               RETURNING id""",
+            (env_id, business_id, name, description, actor, tags or [], is_template, template_key),
+        )
+        workflow_id = str(cur.fetchone()["id"])
+        version_id, validation = _insert_version(
+            cur, workflow_id=workflow_id, env_id=env_id, business_id=business_id,
+            version_number=1, graph=graph, actor=actor,
+        )
+        cur.execute(
+            "UPDATE ai_agent_workflows SET current_version_id=%s, updated_at=now() WHERE id=%s",
+            (version_id, workflow_id),
+        )
+    return get_workflow(env_id=env_id, business_id=business_id, workflow_id=workflow_id) | {
+        "validation": validation
+    }
+
+
+def save_draft(*, env_id: str, business_id: str, actor: str, workflow_id: str,
+               base_version_number: int, graph: AgentGraph, name: str | None = None,
+               description: str | None = None) -> dict[str, Any]:
+    if find_secret_paths(graph.model_dump(mode="json")):
+        raise ValueError("Workflow graph contains secret-shaped keys or values")
+    with get_cursor() as cur:
+        cur.execute(
+            """SELECT v.version_number
+               FROM ai_agent_workflows w
+               JOIN ai_agent_workflow_versions v ON v.id = w.current_version_id
+               WHERE w.id=%s AND w.env_id=%s AND w.business_id=%s
+               FOR UPDATE""",
+            (workflow_id, env_id, business_id),
+        )
+        current = cur.fetchone()
+        if not current:
+            raise WorkflowNotFoundError("workflow not found")
+        current_version = int(current["version_number"])
+        if current_version != base_version_number:
+            raise VersionConflictError(
+                f"Version conflict: current version is {current_version}, base was {base_version_number}"
+            )
+        next_version = current_version + 1
+        version_id, validation = _insert_version(
+            cur, workflow_id=workflow_id, env_id=env_id, business_id=business_id,
+            version_number=next_version, graph=graph, actor=actor,
+        )
+        cur.execute(
+            """UPDATE ai_agent_workflows
+               SET current_version_id=%s,
+                   name=COALESCE(%s, name),
+                   description=COALESCE(%s, description),
+                   status='draft',
+                   updated_at=now()
+               WHERE id=%s AND env_id=%s AND business_id=%s""",
+            (version_id, name, description, workflow_id, env_id, business_id),
+        )
+    return get_workflow(env_id=env_id, business_id=business_id, workflow_id=workflow_id) | {
+        "validation": validation
+    }
+
+
+def list_workflows(*, env_id: str, business_id: str) -> list[dict[str, Any]]:
+    seed_templates(env_id=env_id, business_id=business_id, actor="agent_builder_seed")
+    with get_cursor() as cur:
+        cur.execute(
+            """SELECT w.id, w.name, w.description, w.owner_user_id, w.status, w.tags,
+                      w.is_template, w.template_key, w.created_at, w.updated_at,
+                      v.id AS version_id, v.version_number, v.validation_status,
+                      v.validation_results, v.publish_status,
+                      (SELECT r.status FROM ai_agent_runs r
+                       WHERE r.workflow_id=w.id AND r.env_id=w.env_id AND r.business_id=w.business_id
+                       ORDER BY r.started_at DESC LIMIT 1) AS last_run_status,
+                      (SELECT er.overall_status FROM ai_agent_eval_runs er
+                       WHERE er.workflow_id=w.id AND er.workflow_version_id=v.id
+                         AND er.env_id=w.env_id AND er.business_id=w.business_id
+                       ORDER BY er.started_at DESC LIMIT 1) AS eval_overall_status,
+                      (SELECT er.summary_json FROM ai_agent_eval_runs er
+                       WHERE er.workflow_id=w.id AND er.workflow_version_id=v.id
+                         AND er.env_id=w.env_id AND er.business_id=w.business_id
+                       ORDER BY er.started_at DESC LIMIT 1) AS eval_summary
+               FROM ai_agent_workflows w
+               JOIN ai_agent_workflow_versions v ON v.id=w.current_version_id
+               WHERE w.env_id=%s AND w.business_id=%s
+               ORDER BY w.is_template DESC, w.updated_at DESC""",
+            (env_id, business_id),
+        )
+        return [_row(item) for item in cur.fetchall()]
+
+
+def get_workflow(*, env_id: str, business_id: str, workflow_id: str) -> dict[str, Any]:
+    with get_cursor() as cur:
+        cur.execute(
+            """SELECT w.id, w.name, w.description, w.owner_user_id, w.status, w.tags,
+                      w.is_template, w.template_key, w.created_at, w.updated_at,
+                      v.id AS version_id, v.version_number, v.graph_json,
+                      v.prompt_versions, v.tool_schema_digests, v.model_route_policy,
+                      v.required_permissions, v.validation_status, v.validation_results,
+                      v.publish_status, v.published_by, v.published_at, v.publish_blockers
+               FROM ai_agent_workflows w
+               JOIN ai_agent_workflow_versions v ON v.id=w.current_version_id
+               WHERE w.id=%s AND w.env_id=%s AND w.business_id=%s""",
+            (workflow_id, env_id, business_id),
+        )
+        item = cur.fetchone()
+        if not item:
+            raise WorkflowNotFoundError("workflow not found")
+        cur.execute(
+            """SELECT id, version_number, validation_status, publish_status, publish_blockers,
+                      published_by, published_at, created_by, created_at
+               FROM ai_agent_workflow_versions
+               WHERE workflow_id=%s AND env_id=%s AND business_id=%s
+               ORDER BY version_number DESC""",
+            (workflow_id, env_id, business_id),
+        )
+        result = _serialize_workflow(item)
+        result["versions"] = [_row(version) for version in cur.fetchall()]
+        return result
+
+
+def validate_saved_workflow(*, env_id: str, business_id: str, workflow_id: str) -> dict[str, Any]:
+    workflow = get_workflow(env_id=env_id, business_id=business_id, workflow_id=workflow_id)
+    graph = AgentGraph.model_validate(workflow["graph"])
+    validation = validate_graph(graph)
+    with get_cursor() as cur:
+        cur.execute(
+            """UPDATE ai_agent_workflow_versions
+               SET validation_status=%s, validation_results=%s
+               WHERE id=%s AND env_id=%s AND business_id=%s""",
+            (validation["status"], Json(validation), workflow["version_id"], env_id, business_id),
+        )
+    return validation
+
+
+def list_runs(*, env_id: str, business_id: str, limit: int = 50) -> list[dict[str, Any]]:
+    with get_cursor() as cur:
+        cur.execute(
+            """SELECT r.id, r.workflow_id, w.name AS workflow_name, r.workflow_version_id,
+                      v.version_number, r.actor_user_id, r.runtime_mode, r.status,
+                      r.terminal_reason, r.started_at, r.finished_at, r.cost_estimate,
+                      r.actual_cost
+               FROM ai_agent_runs r
+               JOIN ai_agent_workflows w ON w.id=r.workflow_id
+               JOIN ai_agent_workflow_versions v ON v.id=r.workflow_version_id
+               WHERE r.env_id=%s AND r.business_id=%s
+               ORDER BY r.started_at DESC LIMIT %s""",
+            (env_id, business_id, min(max(limit, 1), 200)),
+        )
+        return [_row(item) for item in cur.fetchall()]
+
+
+def get_run(*, env_id: str, business_id: str, run_id: str) -> dict[str, Any]:
+    with get_cursor() as cur:
+        cur.execute(
+            """SELECT r.*, w.name AS workflow_name, v.version_number
+               FROM ai_agent_runs r
+               JOIN ai_agent_workflows w ON w.id=r.workflow_id
+               JOIN ai_agent_workflow_versions v ON v.id=r.workflow_version_id
+               WHERE r.id=%s AND r.env_id=%s AND r.business_id=%s""",
+            (run_id, env_id, business_id),
+        )
+        run = cur.fetchone()
+        if not run:
+            raise LookupError("run not found")
+        cur.execute(
+            """SELECT * FROM ai_agent_run_steps
+               WHERE run_id=%s AND env_id=%s AND business_id=%s ORDER BY started_at, node_id""",
+            (run_id, env_id, business_id),
+        )
+        steps = [_row(item) for item in cur.fetchall()]
+        cur.execute(
+            """SELECT * FROM ai_agent_receipts
+               WHERE run_id=%s AND env_id=%s AND business_id=%s ORDER BY created_at""",
+            (run_id, env_id, business_id),
+        )
+        receipts = [_row(item) for item in cur.fetchall()]
+        result = _row(run)
+        result["steps"] = steps
+        result["receipts"] = receipts
+        return result
+
+
+def get_run_events(*, env_id: str, business_id: str, run_id: str) -> list[dict[str, Any]]:
+    with get_cursor() as cur:
+        cur.execute(
+            """SELECT * FROM ai_agent_run_events
+               WHERE run_id=%s AND env_id=%s AND business_id=%s ORDER BY sequence_number""",
+            (run_id, env_id, business_id),
+        )
+        return [_row(item) for item in cur.fetchall()]
+
+
+def _resolve_path(path: str, *, run_input: dict[str, Any], outputs: dict[str, dict[str, Any]]) -> Any:
+    parts = path.split(".")
+    if parts[0] == "input":
+        current: Any = run_input
+        parts = parts[1:]
+    else:
+        current = outputs.get(parts[0])
+        parts = parts[1:]
+    for part in parts:
+        if not isinstance(current, dict) or part not in current:
+            raise KeyError(path)
+        current = current[part]
+    return current
+
+
+def resolve_bindings(value: Any, *, run_input: dict[str, Any], outputs: dict[str, dict[str, Any]]) -> Any:
+    if isinstance(value, dict):
+        return {key: resolve_bindings(child, run_input=run_input, outputs=outputs) for key, child in value.items()}
+    if isinstance(value, list):
+        return [resolve_bindings(child, run_input=run_input, outputs=outputs) for child in value]
+    if isinstance(value, str):
+        match = MOUSTACHE_RE.match(value)
+        if match:
+            return _resolve_path(match.group(1), run_input=run_input, outputs=outputs)
+        rendered = value
+        for token in re.findall(r"\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}", value):
+            rendered = re.sub(
+                r"\{\{\s*" + re.escape(token) + r"\s*\}\}",
+                str(_resolve_path(token, run_input=run_input, outputs=outputs)),
+                rendered,
+            )
+        return rendered
+    return value
+
+
+def _execute_node(*, node: AgentNode, graph: AgentGraph, run_input: dict[str, Any],
+                  outputs: dict[str, dict[str, Any]], env_id: str, business_id: str,
+                  actor: str, accumulated_cost: float, run_id: str) -> NodeExecution:
+    config = node.config
+    if node.type == "manual_trigger":
+        return NodeExecution("completed", dict(run_input))
+    if node.type == "context_loader":
+        return NodeExecution(
+            "completed",
+            {"env_id": env_id, "business_id": business_id, "actor": actor, **dict(config.get("context") or {})},
+        )
+    if node.type == "mcp_tool":
+        tool_name = str(config.get("tool_name") or "")
+        tool = registry.get(tool_name)
+        if not tool:
+            return NodeExecution("not_available", {}, tool_name=tool_name, reason="tool_not_registered")
+        manifest = tool.manifest()
+        if (
+            tool.permission != "read"
+            or manifest["permission_required"] != "read"
+            or manifest["side_effect_class"] != "read"
+        ):
+            return NodeExecution("failed", {}, tool_name=tool_name, reason="write_tool_forbidden")
+        if config.get("tool_schema_digest") != tool_schema_digest(tool):
+            return NodeExecution("not_available", {}, tool_name=tool_name, reason="tool_schema_digest_mismatch")
+        try:
+            raw_input = resolve_bindings(
+                config.get("bindings") or {}, run_input=run_input, outputs=outputs
+            )
+        except KeyError as exc:
+            return NodeExecution("not_available", {}, tool_name=tool_name, reason=f"missing_binding:{exc.args[0]}")
+        ctx = McpContext(
+            actor=actor,
+            token_valid=True,
+            resolved_scope={"env_id": env_id, "business_id": business_id},
+        )
+        try:
+            result = execute_tool(tool, ctx, raw_input)
+        except Exception as exc:  # noqa: BLE001
+            return NodeExecution("not_available", {}, tool_name=tool_name, reason=str(exc)[:500])
+        if tool.output_model is not None:
+            try:
+                result = tool.output_model.model_validate(result).model_dump(mode="json")
+            except Exception as exc:  # noqa: BLE001
+                return NodeExecution(
+                    "not_available",
+                    {},
+                    tool_name=tool_name,
+                    reason=f"tool_output_schema_mismatch:{exc}",
+                )
+        return NodeExecution("completed", _jsonable(result), tool_name=tool_name)
+    if node.type == "prompt_llm":
+        from app.config import AI_DISPATCH_ENABLED
+
+        if not AI_DISPATCH_ENABLED:
+            return NodeExecution("not_available", {}, reason="AI_DISPATCH_ENABLED is false")
+        configured_estimate = float(config.get("estimated_cost_usd") or 0)
+        if accumulated_cost + configured_estimate > graph.limits.max_cost_usd:
+            return NodeExecution("blocked", {}, reason="max_cost_exceeded_before_model_call")
+        try:
+            task = resolve_bindings(
+                str(config.get("prompt_template") or ""), run_input=run_input, outputs=outputs
+            )
+        except KeyError as exc:
+            return NodeExecution("not_available", {}, reason=f"missing_binding:{exc.args[0]}")
+        privacy = Privacy(str(config.get("privacy") or "internal"))
+        risk = RiskLevel(str(config.get("risk_level") or "medium"))
+        mode = TaskMode(str(config.get("mode") or "classification"))
+        sensitive = privacy == Privacy.SENSITIVE or bool(config.get("itar_tagged"))
+        forced_provider = ProviderName.GEMMA_GCP if sensitive else (
+            ProviderName(config["forced_provider"]) if config.get("forced_provider") else None
+        )
+        request = AIRequest(
+            task=task,
+            mode=mode,
+            risk_level=risk,
+            privacy=Privacy.SENSITIVE if sensitive else privacy,
+            env_id=env_id,
+            business_id=business_id,
+            allow_fallback=False if sensitive else bool(config.get("allow_fallback", False)),
+            forced_provider=forced_provider,
+            max_tokens=int(config.get("max_tokens") or 512),
+            metadata={"agent_builder_run_id": run_id, "node_id": node.id},
+        )
+        result = run_dispatch(
+            request,
+            registry=control_tower_registry() if sensitive else None,
+        ) if sensitive else run_dispatch(request)
+        if result.status != DispatchStatus.SUCCESS or not result.answer:
+            return NodeExecution(
+                "not_available", {},
+                model_name=result.model,
+                reason=(result.null_reason.value if result.null_reason else result.routing_reason),
+            )
+        try:
+            parsed = json.loads(result.answer)
+            validate_json_schema(instance=parsed, schema=config["output_schema"])
+        except (json.JSONDecodeError, JsonSchemaValidationError, KeyError) as exc:
+            return NodeExecution("failed", {}, model_name=result.model, reason=f"output_schema_validation_failed:{exc}")
+        prompt_tokens = result.usage.prompt_tokens or 0
+        completion_tokens = result.usage.completion_tokens or 0
+        estimated_cost = float(config.get("estimated_cost_usd") or ((prompt_tokens + completion_tokens) * 0.000001))
+        return NodeExecution("completed", _jsonable(parsed), model_name=result.model, cost_usd=estimated_cost)
+    if node.type == "policy_gate":
+        policy = str(config.get("policy") or "always_pass")
+        passed = policy in {"always_pass", "read_only_only", "no_write_without_operator_approval"}
+        if policy == "require_input":
+            required = str(config.get("required_input") or "")
+            try:
+                passed = bool(_resolve_path(required, run_input=run_input, outputs=outputs))
+            except KeyError:
+                passed = False
+        return NodeExecution(
+            "completed" if passed else "warning",
+            {"policy": policy, "passed": passed},
+            branch_handle="pass" if passed else "fail",
+            reason=None if passed else f"policy_denied:{policy}",
+        )
+    if node.type == "cost_guardrail":
+        estimate = accumulated_cost + float(config.get("estimated_next_cost_usd") or 0)
+        budget = float(config.get("max_cost_usd") or graph.limits.max_cost_usd)
+        under = estimate <= budget
+        return NodeExecution(
+            "completed" if under else "warning",
+            {"estimated_cost_usd": estimate, "budget_usd": budget, "under_budget": under},
+            branch_handle="under_budget" if under else "over_budget",
+            reason=None if under else "cost_budget_exceeded",
+        )
+    if node.type == "human_approval":
+        return NodeExecution(
+            "blocked",
+            {"approval_status": "simulated_pending", "reason": config.get("reason") or "human approval required"},
+            reason="human_approval_required",
+        )
+    if node.type == "receipt_writer":
+        return NodeExecution("completed", {"checkpoint": config.get("checkpoint") or node.id})
+    if node.type == "eval_assertion":
+        path = str(config.get("path") or "")
+        try:
+            actual = _resolve_path(path, run_input=run_input, outputs=outputs)
+        except KeyError:
+            return NodeExecution("failed", {}, reason=f"assertion_path_missing:{path}")
+        expected = config.get("equals")
+        if actual != expected:
+            return NodeExecution("failed", {"actual": actual, "expected": expected}, reason="eval_assertion_failed")
+        return NodeExecution("completed", {"passed": True, "actual": actual})
+    if node.type == "output":
+        try:
+            value = resolve_bindings(config.get("bindings") or {}, run_input=run_input, outputs=outputs)
+        except KeyError as exc:
+            return NodeExecution("not_available", {}, reason=f"missing_binding:{exc.args[0]}")
+        return NodeExecution("completed", _jsonable(value))
+    return NodeExecution("failed", {}, reason=f"unsupported_node_type:{node.type}")
+
+
+def _insert_event(cur, *, env_id: str, business_id: str, run_id: str,
+                  sequence: int, event_type: str, status: str | None,
+                  node_id: str | None = None, step_id: str | None = None,
+                  payload: dict[str, Any] | None = None) -> None:
+    cur.execute(
+        """INSERT INTO ai_agent_run_events
+             (env_id,business_id,run_id,step_id,node_id,sequence_number,event_type,status,payload_json)
+           VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+        (env_id, business_id, run_id, step_id, node_id, sequence, event_type, status, Json(redact_payload(payload or {}))),
+    )
+
+
+def dry_run(*, env_id: str, business_id: str, actor: str, workflow_id: str,
+            run_input: dict[str, Any]) -> dict[str, Any]:
+    workflow = get_workflow(env_id=env_id, business_id=business_id, workflow_id=workflow_id)
+    graph = AgentGraph.model_validate(workflow["graph"])
+    validation = validate_graph(graph)
+    fatal_codes = {item["code"] for item in validation["issues"] if item["severity"] == "error"}
+    validation_terminal = (
+        "not_available"
+        if fatal_codes & {"TOOL_NOT_AVAILABLE", "SCHEMA_DIGEST_DRIFT"}
+        else "failed"
+    )
+    with get_cursor() as cur:
+        cur.execute(
+            """INSERT INTO ai_agent_runs
+                 (env_id,business_id,workflow_id,workflow_version_id,actor_user_id,
+                  runtime_mode,status,input_json)
+               VALUES (%s,%s,%s,%s,%s,'dry_run','running',%s)
+               RETURNING id""",
+            (env_id, business_id, workflow_id, workflow["version_id"], actor, Json(redact_payload(run_input))),
+        )
+        run_id = str(cur.fetchone()["id"])
+        sequence = 1
+        _insert_event(
+            cur, env_id=env_id, business_id=business_id, run_id=run_id,
+            sequence=sequence, event_type="run.started", status="running",
+            payload={"workflow_version": workflow["version_number"]},
+        )
+
+    if validation["status"] != "pass":
+        with get_cursor() as cur:
+            sequence += 1
+            _insert_event(
+                cur, env_id=env_id, business_id=business_id, run_id=run_id,
+                sequence=sequence, event_type="run.completed", status=validation_terminal,
+                payload={"validation": validation},
+            )
+            cur.execute(
+                """UPDATE ai_agent_runs
+                   SET status=%s, terminal_reason='graph_validation_failed', finished_at=now(),
+                       error_json=%s
+                   WHERE id=%s""",
+                (validation_terminal, Json(validation), run_id),
+            )
+        return get_run(env_id=env_id, business_id=business_id, run_id=run_id)
+
+    nodes, outgoing, incoming = _graph_maps(graph)
+    order = validation["topological_order"]
+    outputs: dict[str, dict[str, Any]] = {}
+    selected_edges: set[tuple[str, str, str | None]] = set()
+    executed: set[str] = set()
+    terminal_status = "succeeded"
+    terminal_reason: str | None = None
+    actual_cost = 0.0
+    tool_calls = 0
+    final_output: dict[str, Any] = {}
+    run_started = time.monotonic()
+
+    for node_id in order:
+        node = nodes[node_id]
+        active = node.type == "manual_trigger" or any(
+            (edge.source, edge.target, edge.source_handle) in selected_edges
+            for edge in incoming[node_id]
+        )
+        status = "running" if active else "skipped"
+        input_view = {
+            "run_input": run_input if node.type == "manual_trigger" else {},
+            "upstream": {edge.source: outputs.get(edge.source) for edge in incoming[node_id] if edge.source in outputs},
+            "config": node.config,
+        }
+        input_hash = sha256_json(input_view)
+        with get_cursor() as cur:
+            cur.execute(
+                """INSERT INTO ai_agent_run_steps
+                     (env_id,business_id,run_id,node_id,node_type,status,input_hash,input_json)
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
+                   RETURNING id""",
+                (env_id, business_id, run_id, node.id, node.type, status, input_hash, Json(redact_payload(input_view))),
+            )
+            step_id = str(cur.fetchone()["id"])
+            sequence += 1
+            _insert_event(
+                cur, env_id=env_id, business_id=business_id, run_id=run_id,
+                step_id=step_id, node_id=node.id, sequence=sequence,
+                event_type="step.started", status=status,
+            )
+
+        if not active or terminal_status != "succeeded":
+            execution = NodeExecution("skipped", {})
+        elif time.monotonic() - run_started > graph.limits.max_runtime_seconds:
+            execution = NodeExecution("failed", {}, reason="max_runtime_exceeded")
+        elif node.type == "mcp_tool" and tool_calls >= graph.limits.max_tool_calls:
+            execution = NodeExecution("blocked", {}, reason="max_tool_calls_exceeded")
+        else:
+            started = time.monotonic()
+            execution = _execute_node(
+                node=node, graph=graph, run_input=run_input, outputs=outputs,
+                env_id=env_id, business_id=business_id, actor=actor,
+                accumulated_cost=actual_cost, run_id=run_id,
+            )
+            if time.monotonic() - started > graph.limits.max_runtime_seconds:
+                execution = NodeExecution("failed", {}, reason="max_runtime_exceeded")
+            if node.type == "mcp_tool" and execution.status != "skipped":
+                tool_calls += 1
+
+        output_hash = sha256_json(execution.output)
+        actual_cost += execution.cost_usd
+        if execution.status in {"completed", "warning"}:
+            outputs[node.id] = execution.output
+            executed.add(node.id)
+            if node.type == "output":
+                final_output = execution.output
+            for edge in outgoing[node.id]:
+                if execution.branch_handle is None or edge.source_handle == execution.branch_handle:
+                    selected_edges.add((edge.source, edge.target, edge.source_handle))
+        elif execution.status in {"blocked", "failed", "not_available"} and terminal_status == "succeeded":
+            terminal_status = execution.status
+            terminal_reason = execution.reason
+
+        receipt_payload = {
+            "workflow_id": workflow_id,
+            "workflow_version": workflow["version_number"],
+            "run_id": run_id,
+            "node_id": node.id,
+            "actor": actor,
+            "input_hash": input_hash,
+            "output_hash": output_hash,
+            "tools_called": [execution.tool_name] if execution.tool_name else [],
+            "model_used": execution.model_name,
+            "cost_estimate": execution.cost_usd,
+            "terminal_status": execution.status,
+            "failure_reason": execution.reason,
+        }
+        with get_cursor() as cur:
+            if execution.status == "blocked" and node.type == "human_approval":
+                cur.execute(
+                    """INSERT INTO ai_agent_approvals
+                         (env_id,business_id,run_id,node_id,requested_by,approval_status,approval_reason)
+                       VALUES (%s,%s,%s,%s,%s,'simulated_pending',%s)""",
+                    (env_id, business_id, run_id, node.id, actor, execution.reason),
+                )
+            cur.execute(
+                """INSERT INTO ai_agent_receipts
+                     (env_id,business_id,workflow_id,workflow_version_id,run_id,step_id,node_id,
+                      receipt_type,actor,input_hash,output_hash,tools_called,model_used,cost_estimate,
+                      terminal_status,failure_reason,receipt_json)
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                   RETURNING id""",
+                (
+                    env_id, business_id, workflow_id, workflow["version_id"], run_id, step_id, node.id,
+                    "tool" if execution.tool_name else "model" if execution.model_name else "step",
+                    actor, input_hash, output_hash, Json(receipt_payload["tools_called"]),
+                    execution.model_name, execution.cost_usd, execution.status, execution.reason,
+                    Json(receipt_payload),
+                ),
+            )
+            receipt_id = str(cur.fetchone()["id"])
+            cur.execute(
+                """UPDATE ai_agent_run_steps
+                   SET status=%s, finished_at=now(), output_hash=%s, output_json=%s,
+                       tool_name=%s, model_name=%s, error_json=%s, receipt_id=%s
+                   WHERE id=%s""",
+                (
+                    execution.status, output_hash, Json(redact_payload(execution.output)),
+                    execution.tool_name, execution.model_name,
+                    Json({"reason": execution.reason}) if execution.reason else None,
+                    receipt_id, step_id,
+                ),
+            )
+            sequence += 1
+            _insert_event(
+                cur, env_id=env_id, business_id=business_id, run_id=run_id,
+                step_id=step_id, node_id=node.id, sequence=sequence,
+                event_type="step.completed", status=execution.status,
+                payload={"receipt_id": receipt_id, "reason": execution.reason},
+            )
+
+    if terminal_status == "succeeded" and not any(nodes[node_id].type == "output" for node_id in executed):
+        terminal_status = "not_available"
+        terminal_reason = "output_not_reached"
+
+    with get_cursor() as cur:
+        sequence += 1
+        _insert_event(
+            cur, env_id=env_id, business_id=business_id, run_id=run_id,
+            sequence=sequence, event_type="run.completed", status=terminal_status,
+            payload={"terminal_reason": terminal_reason},
+        )
+        cur.execute(
+            """UPDATE ai_agent_runs
+               SET status=%s, terminal_reason=%s, finished_at=now(), output_json=%s,
+                   actual_cost=%s
+               WHERE id=%s""",
+            (terminal_status, terminal_reason, Json(redact_payload(final_output)), actual_cost, run_id),
+        )
+    return get_run(env_id=env_id, business_id=business_id, run_id=run_id)
+
+
+def _node(node_id: str, node_type: str, x: int, label: str, config: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {"id": node_id, "type": node_type, "label": label, "position": {"x": x, "y": 120}, "config": config or {}}
+
+
+def _edge(source: str, target: str, source_handle: str | None = None) -> dict[str, Any]:
+    return {
+        "id": f"{source}-{source_handle or 'next'}-{target}",
+        "source": source,
+        "target": target,
+        "source_handle": source_handle,
+        "data_type": "control",
+    }
+
+
+def template_graphs() -> list[dict[str, Any]]:
+    preview = registry.get("telemetry.preview_score_window")
+    preview_digest = tool_schema_digest(preview) if preview else "not_available"
+    telemetry_graph = {
+        "schema_version": "agent-graph/v1",
+        "limits": {"max_runtime_seconds": 120, "max_tool_calls": 3, "max_cost_usd": 0.25},
+        "model_route_policy": {"sensitive_fallback": "fail_closed"},
+        "nodes": [
+            _node("trigger", "manual_trigger", 40, "Manual Trigger"),
+            _node("context", "context_loader", 250, "Load Run Context"),
+            _node("score", "mcp_tool", 470, "Preview Score Window", {
+                "tool_name": "telemetry.preview_score_window",
+                "tool_schema_digest": preview_digest,
+                "bindings": {
+                    "env_id": "{{context.env_id}}",
+                    "business_id": "{{context.business_id}}",
+                    "run_key": "{{trigger.run_key}}",
+                    "channel_name": "{{trigger.channel}}",
+                    "window": "{{trigger.window}}",
+                },
+            }),
+            _node("receipt", "receipt_writer", 700, "Receipt Writer"),
+            _node("output", "output", 910, "Operator Verdict", {
+                "bindings": {
+                    "verdict": "{{score.verdict}}",
+                    "model_version": "{{score.model_version}}",
+                    "confidence": "{{score.confidence}}",
+                    "missing_data": "{{score.missing_data}}",
+                }
+            }),
+        ],
+        "edges": [
+            _edge("trigger", "context"), _edge("context", "score"),
+            _edge("score", "receipt"), _edge("receipt", "output"),
+        ],
+    }
+
+    definitions = [
+        ("telemetry-triage", "Telemetry Go/No-Go Triage Agent", "Runnable read-only telemetry score preview.", telemetry_graph),
+        ("metric-lineage-qa", "Metric Lineage QA Agent", "Draft shell for governed metric and lineage QA.", None),
+        ("grounded-flight-readiness", "Grounded Flight Readiness Analyst", "Draft shell for cited RAG answers.", None),
+        ("cost-guardrail-query", "Cost Guardrail Query Agent", "Draft shell that demonstrates deterministic budget branching.", None),
+        ("sensitive-private-tier", "Sensitive Routing / Private Tier Agent", "Draft shell that fails closed without private model capacity.", None),
+        ("ticket-to-pr-evidence", "Ticket-to-PR Evidence Agent", "Dry-run planning shell ending at simulated human approval.", None),
+    ]
+    templates: list[dict[str, Any]] = []
+    for index, (key, name, description, graph) in enumerate(definitions):
+        if graph is None:
+            nodes = [
+                _node("trigger", "manual_trigger", 40, "Manual Trigger"),
+                _node("context", "context_loader", 260, "Load Context"),
+            ]
+            edges = [_edge("trigger", "context")]
+            if key == "cost-guardrail-query":
+                nodes.extend([
+                    _node("guard", "cost_guardrail", 480, "Cost Guardrail", {"max_cost_usd": 0.1, "estimated_next_cost_usd": 1.0}),
+                    _node("safe", "receipt_writer", 700, "Suggest Safer Query"),
+                    _node("blocked", "receipt_writer", 700, "Blocked Attempt Receipt"),
+                    _node("output", "output", 920, "Operator Output", {"bindings": {"status": "BLOCKED_OR_SCOPED"}}),
+                ])
+                edges.extend([
+                    _edge("context", "guard"), _edge("guard", "safe", "under_budget"),
+                    _edge("guard", "blocked", "over_budget"), _edge("safe", "output"), _edge("blocked", "output"),
+                ])
+            elif key == "ticket-to-pr-evidence":
+                nodes.extend([
+                    _node("approval", "human_approval", 500, "Human Approval", {"reason": "Write action deferred in read-only MVP"}),
+                    _node("output", "output", 760, "Evidence Report", {"bindings": {"status": "PENDING_APPROVAL"}}),
+                ])
+                edges.extend([_edge("context", "approval"), _edge("approval", "output")])
+            elif key == "sensitive-private-tier":
+                nodes.extend([
+                    _node("prompt", "prompt_llm", 480, "Private Tier Model Call", {
+                        "prompt_template": "Classify the supplied request: {{trigger.request}}",
+                        "prompt_version": "sensitive-route/v1",
+                        "privacy": "sensitive",
+                        "itar_tagged": True,
+                        "mode": "classification",
+                        "output_schema": {
+                            "type": "object",
+                            "properties": {"classification": {"type": "string"}},
+                            "required": ["classification"],
+                            "additionalProperties": False,
+                        },
+                    }),
+                    _node("output", "output", 740, "Routing Report", {"bindings": {"classification": "{{prompt.classification}}"}}),
+                ])
+                edges.extend([_edge("context", "prompt"), _edge("prompt", "output")])
+            else:
+                nodes.extend([
+                    _node("approval", "human_approval", 500, "Capability Gate", {"reason": "Capability deferred from read-only MVP"}),
+                    _node("output", "output", 760, "Result", {"bindings": {"status": "NOT_AVAILABLE"}}),
+                ])
+                edges.extend([_edge("context", "approval"), _edge("approval", "output")])
+            graph = {
+                "schema_version": "agent-graph/v1",
+                "limits": {"max_runtime_seconds": 120, "max_tool_calls": 5, "max_cost_usd": 0.5},
+                "model_route_policy": {"sensitive_fallback": "fail_closed"},
+                "nodes": nodes,
+                "edges": edges,
+            }
+        templates.append({"key": key, "name": name, "description": description, "graph": graph, "sort": index})
+    return templates
+
+
+def seed_templates(*, env_id: str, business_id: str, actor: str) -> None:
+    with get_cursor() as cur:
+        cur.execute(
+            """SELECT template_key FROM ai_agent_workflows
+               WHERE env_id=%s AND business_id=%s AND is_template=true""",
+            (env_id, business_id),
+        )
+        existing = {item["template_key"] for item in cur.fetchall()}
+    for template in template_graphs():
+        if template["key"] in existing:
+            continue
+        try:
+            create_workflow(
+                env_id=env_id, business_id=business_id, actor=actor,
+                name=template["name"], description=template["description"],
+                graph=AgentGraph.model_validate(template["graph"]),
+                tags=["template", "read-only-mvp"], is_template=True,
+                template_key=template["key"],
+            )
+        except psycopg.errors.UniqueViolation:
+            # Concurrent first access may seed the same unique template. The next
+            # registry read will show the committed row; never duplicate it.
+            continue

--- a/backend/app/services/agent_builder_evals.py
+++ b/backend/app/services/agent_builder_evals.py
@@ -1,0 +1,694 @@
+"""Deterministic Agent Builder eval lifecycle and staged publish gate."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+from uuid import uuid4
+
+from psycopg.types.json import Json
+
+from app.db import get_cursor
+from app.mcp.registry import registry
+from app.schemas.agent_builder import AgentGraph
+from app.services import agent_builder
+
+
+REQUIRED_STAGED_CLASSES = (
+    "graph_lint",
+    "tool_contract",
+    "permission",
+    "fail_closed",
+    "cost",
+    "regression",
+    "replay_determinism",
+)
+OPTIONAL_CLASSES = ("rag_grounding", "visual_smoke", "production_smoke")
+ALL_CLASSES = REQUIRED_STAGED_CLASSES + OPTIONAL_CLASSES
+
+CLASS_LABELS = {
+    "graph_lint": "Graph validation",
+    "tool_contract": "Tool contracts",
+    "permission": "Permission checks",
+    "fail_closed": "Fail-closed behavior",
+    "cost": "Cost guardrail",
+    "regression": "Regression cases",
+    "replay_determinism": "Replay determinism",
+    "rag_grounding": "RAG grounding",
+    "visual_smoke": "Visual smoke",
+    "production_smoke": "Production smoke",
+}
+
+
+def _row(value: Any) -> dict[str, Any]:
+    return agent_builder._row(value)
+
+
+def _default_case(eval_class: str) -> dict[str, Any]:
+    expectations = {
+        "graph_lint": {"validation_status": "pass"},
+        "tool_contract": {"registered": True, "schema_pins_current": True},
+        "permission": {"read_only": True},
+        "fail_closed": {"unsafe_fallbacks": 0},
+        "cost": {"budgets_bounded": True},
+        "regression": {"promoted_failures_recurred": 0},
+        "replay_determinism": {"stable_plan": True},
+        "rag_grounding": {"status": "not_applicable_without_rag_nodes"},
+        "visual_smoke": {"status": "manual_evidence_required"},
+        "production_smoke": {"status": "deferred_until_production_execution"},
+    }
+    return {
+        "case_key": f"{eval_class}-default",
+        "eval_class": eval_class,
+        "title": CLASS_LABELS[eval_class],
+        "input_json": {},
+        "expected_json": expectations[eval_class],
+        "source": "generated",
+    }
+
+
+def _result(
+    case: dict[str, Any],
+    status: str,
+    actual: dict[str, Any],
+    assertion: str | None = None,
+    trace_run_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "eval_case_id": case["id"],
+        "case_key": case["case_key"],
+        "eval_class": case["eval_class"],
+        "title": case["title"],
+        "status": status,
+        "input_json": case.get("input_json") or {},
+        "expected_json": case.get("expected_json") or {},
+        "actual_json": actual,
+        "failed_assertion": assertion,
+        "trace_run_id": trace_run_id,
+    }
+
+
+def evaluate_cases(
+    graph: AgentGraph,
+    cases: list[dict[str, Any]],
+    *,
+    regression_evidence: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Evaluate version-pinned cases without model or tool execution."""
+    evidence = regression_evidence or {}
+    validation = agent_builder.validate_graph(graph)
+    results: list[dict[str, Any]] = []
+
+    for case in cases:
+        eval_class = case["eval_class"]
+        if eval_class == "graph_lint":
+            passed = validation["status"] == "pass"
+            results.append(
+                _result(
+                    case,
+                    "pass" if passed else "fail",
+                    {"validation": validation},
+                    None if passed else "Graph validation must pass.",
+                )
+            )
+            continue
+
+        if eval_class == "tool_contract":
+            failures: list[dict[str, str]] = []
+            for node in graph.nodes:
+                if node.type != "mcp_tool":
+                    continue
+                tool_name = str(node.config.get("tool_name") or "")
+                tool = registry.get(tool_name)
+                if not tool:
+                    failures.append({"node_id": node.id, "reason": "tool_not_registered"})
+                elif node.config.get("tool_schema_digest") != agent_builder.tool_schema_digest(tool):
+                    failures.append({"node_id": node.id, "reason": "schema_digest_drift"})
+            results.append(
+                _result(
+                    case,
+                    "pass" if not failures else "fail",
+                    {"failures": failures, "tool_nodes": sum(node.type == "mcp_tool" for node in graph.nodes)},
+                    None if not failures else "Every MCP node must resolve to its pinned registry schema.",
+                )
+            )
+            continue
+
+        if eval_class == "permission":
+            violations: list[dict[str, str]] = []
+            for node in graph.nodes:
+                if node.type != "mcp_tool":
+                    continue
+                tool = registry.get(str(node.config.get("tool_name") or ""))
+                manifest = tool.manifest() if tool else {}
+                if (
+                    not tool
+                    or tool.permission != "read"
+                    or manifest.get("permission_required") != "read"
+                    or manifest.get("side_effect_class") != "read"
+                ):
+                    violations.append({"node_id": node.id, "reason": "non_read_tool"})
+            results.append(
+                _result(
+                    case,
+                    "pass" if not violations else "fail",
+                    {"violations": violations},
+                    None if not violations else "Staged workflows may only use effective read tools.",
+                )
+            )
+            continue
+
+        if eval_class == "fail_closed":
+            violations: list[dict[str, str]] = []
+            for node in graph.nodes:
+                if node.type == "prompt_llm":
+                    if not isinstance(node.config.get("output_schema"), dict):
+                        violations.append({"node_id": node.id, "reason": "missing_output_schema"})
+                    sensitive = node.config.get("privacy") == "sensitive" or bool(node.config.get("itar_tagged"))
+                    if sensitive and bool(node.config.get("allow_fallback", False)):
+                        violations.append({"node_id": node.id, "reason": "sensitive_external_fallback"})
+            forbidden_codes = {
+                "TOOL_NOT_AVAILABLE",
+                "WRITE_TOOL_FORBIDDEN",
+                "SCHEMA_DIGEST_DRIFT",
+                "SECRET_DETECTED",
+                "OUTPUT_SCHEMA_REQUIRED",
+            }
+            violations.extend(
+                {"node_id": issue.get("node_id") or "", "reason": issue["code"]}
+                for issue in validation["issues"]
+                if issue["code"] in forbidden_codes
+            )
+            results.append(
+                _result(
+                    case,
+                    "pass" if not violations else "fail",
+                    {"violations": violations},
+                    None if not violations else "Missing, unsafe, or unbounded capabilities must fail closed.",
+                )
+            )
+            continue
+
+        if eval_class == "cost":
+            violations: list[dict[str, Any]] = []
+            if graph.limits.max_runtime_seconds <= 0:
+                violations.append({"scope": "graph", "reason": "runtime_unbounded"})
+            if graph.limits.max_tool_calls < 0:
+                violations.append({"scope": "graph", "reason": "tool_calls_unbounded"})
+            if graph.limits.max_cost_usd < 0:
+                violations.append({"scope": "graph", "reason": "cost_unbounded"})
+            for node in graph.nodes:
+                estimate = float(node.config.get("estimated_cost_usd") or 0)
+                if node.type == "prompt_llm" and estimate > graph.limits.max_cost_usd:
+                    violations.append(
+                        {"node_id": node.id, "reason": "estimate_exceeds_run_budget", "estimate": estimate}
+                    )
+            results.append(
+                _result(
+                    case,
+                    "pass" if not violations else "fail",
+                    {"limits": graph.limits.model_dump(), "violations": violations},
+                    None if not violations else "Every run and model call must remain inside configured limits.",
+                )
+            )
+            continue
+
+        if eval_class == "regression":
+            if case.get("source") != "promoted_failure":
+                results.append(_result(case, "pass", {"promoted_failures_recurred": 0}))
+                continue
+            trace_run_id = evidence.get(str(case["id"]))
+            results.append(
+                _result(
+                    case,
+                    "pass" if trace_run_id else "fail",
+                    {"successful_replay_run_id": trace_run_id},
+                    None if trace_run_id else "Promoted failure requires a matching successful dry-run on this version.",
+                    trace_run_id=trace_run_id,
+                )
+            )
+            continue
+
+        if eval_class == "replay_determinism":
+            first = {
+                "order": agent_builder.topological_order(graph),
+                "graph_hash": agent_builder.sha256_json(graph.model_dump(mode="json")),
+                "pins": agent_builder.compile_pins(graph),
+            }
+            second = {
+                "order": agent_builder.topological_order(graph),
+                "graph_hash": agent_builder.sha256_json(graph.model_dump(mode="json")),
+                "pins": agent_builder.compile_pins(graph),
+            }
+            passed = first == second
+            results.append(
+                _result(
+                    case,
+                    "pass" if passed else "fail",
+                    {"first": first, "second": second},
+                    None if passed else "Compilation must be deterministic for the immutable version.",
+                )
+            )
+            continue
+
+        if eval_class == "rag_grounding":
+            results.append(
+                _result(
+                    case,
+                    "not_applicable",
+                    {"reason": "RAG node types are not available in agent-graph/v1."},
+                )
+            )
+            continue
+
+        if eval_class == "visual_smoke":
+            results.append(
+                _result(
+                    case,
+                    "not_applicable",
+                    {"reason": "Authenticated browser evidence has not been attached to this eval run."},
+                )
+            )
+            continue
+
+        if eval_class == "production_smoke":
+            results.append(
+                _result(
+                    case,
+                    "not_applicable",
+                    {"reason": "Production execution is disabled for the read-only MVP."},
+                )
+            )
+            continue
+
+        results.append(_result(case, "fail", {"reason": "unknown_eval_class"}, "Unknown eval class."))
+    return results
+
+
+def summarize_results(results: list[dict[str, Any]]) -> dict[str, Any]:
+    by_class: dict[str, str] = {}
+    for eval_class in ALL_CLASSES:
+        statuses = [item["status"] for item in results if item["eval_class"] == eval_class]
+        if not statuses:
+            by_class[eval_class] = "not_applicable"
+        elif "fail" in statuses:
+            by_class[eval_class] = "fail"
+        elif all(status == "not_applicable" for status in statuses):
+            by_class[eval_class] = "not_applicable"
+        else:
+            by_class[eval_class] = "pass"
+    blockers = [
+        {"eval_class": eval_class, "reason": "required_eval_not_passing"}
+        for eval_class in REQUIRED_STAGED_CLASSES
+        if by_class.get(eval_class) != "pass"
+    ]
+    counts = Counter(item["status"] for item in results)
+    return {
+        "overall_status": "staged_ready" if not blockers else "blocked",
+        "by_class": by_class,
+        "blockers": blockers,
+        "counts": {
+            "pass": counts["pass"],
+            "fail": counts["fail"],
+            "not_applicable": counts["not_applicable"],
+            "total": len(results),
+        },
+    }
+
+
+def _ensure_suite(
+    cur,
+    *,
+    env_id: str,
+    business_id: str,
+    actor: str,
+    workflow: dict[str, Any],
+) -> str:
+    cur.execute(
+        """INSERT INTO ai_agent_eval_suites
+             (env_id,business_id,workflow_id,workflow_version_id,name,required_classes,created_by)
+           VALUES (%s,%s,%s,%s,'Publish readiness',%s,%s)
+           ON CONFLICT (workflow_version_id,name)
+           DO UPDATE SET status='active'
+           RETURNING id""",
+        (
+            env_id,
+            business_id,
+            workflow["id"],
+            workflow["version_id"],
+            list(REQUIRED_STAGED_CLASSES),
+            actor,
+        ),
+    )
+    suite_id = str(cur.fetchone()["id"])
+    for eval_class in ALL_CLASSES:
+        case = _default_case(eval_class)
+        cur.execute(
+            """INSERT INTO ai_agent_eval_cases
+                 (env_id,business_id,suite_id,case_key,eval_class,title,input_json,expected_json,source)
+               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)
+               ON CONFLICT (suite_id,case_key) DO NOTHING""",
+            (
+                env_id,
+                business_id,
+                suite_id,
+                case["case_key"],
+                case["eval_class"],
+                case["title"],
+                Json(case["input_json"]),
+                Json(case["expected_json"]),
+                case["source"],
+            ),
+        )
+    cur.execute(
+        """SELECT id, input_json, expected_behavior, source_run_id
+           FROM ai_agent_failure_memory
+           WHERE workflow_id=%s AND env_id=%s AND business_id=%s
+           ORDER BY created_at""",
+        (workflow["id"], env_id, business_id),
+    )
+    for memory in cur.fetchall():
+        cur.execute(
+            """INSERT INTO ai_agent_eval_cases
+                 (env_id,business_id,suite_id,case_key,eval_class,title,input_json,expected_json,source)
+               VALUES (%s,%s,%s,%s,'regression',%s,%s,%s,'promoted_failure')
+               ON CONFLICT (suite_id,case_key) DO NOTHING""",
+            (
+                env_id,
+                business_id,
+                suite_id,
+                f"regression-{memory['id']}",
+                f"Promoted failure {memory['source_run_id']}",
+                Json(memory["input_json"] or {}),
+                Json(memory["expected_behavior"] or {}),
+            ),
+        )
+    return suite_id
+
+
+def run_evals(
+    *,
+    env_id: str,
+    business_id: str,
+    actor: str,
+    workflow_id: str,
+) -> dict[str, Any]:
+    workflow = agent_builder.get_workflow(
+        env_id=env_id, business_id=business_id, workflow_id=workflow_id
+    )
+    graph = AgentGraph.model_validate(workflow["graph"])
+    with get_cursor() as cur:
+        suite_id = _ensure_suite(
+            cur,
+            env_id=env_id,
+            business_id=business_id,
+            actor=actor,
+            workflow=workflow,
+        )
+        cur.execute(
+            """SELECT * FROM ai_agent_eval_cases
+               WHERE suite_id=%s AND env_id=%s AND business_id=%s AND active=true
+               ORDER BY eval_class, created_at, case_key""",
+            (suite_id, env_id, business_id),
+        )
+        cases = [_row(item) for item in cur.fetchall()]
+        regression_evidence: dict[str, str] = {}
+        for case in cases:
+            if case["eval_class"] != "regression" or case["source"] != "promoted_failure":
+                continue
+            cur.execute(
+                """SELECT id FROM ai_agent_runs
+                   WHERE workflow_id=%s AND workflow_version_id=%s
+                     AND env_id=%s AND business_id=%s
+                     AND status='succeeded' AND input_json=%s
+                     AND started_at > COALESCE(
+                       (SELECT started_at FROM ai_agent_runs WHERE id=%s),
+                       '-infinity'::timestamptz
+                     )
+                   ORDER BY started_at DESC LIMIT 1""",
+                (
+                    workflow_id,
+                    workflow["version_id"],
+                    env_id,
+                    business_id,
+                    Json(case["input_json"] or {}),
+                    (case.get("expected_json") or {}).get("source_run_id"),
+                ),
+            )
+            replay = cur.fetchone()
+            if replay:
+                regression_evidence[str(case["id"])] = str(replay["id"])
+
+        results = evaluate_cases(graph, cases, regression_evidence=regression_evidence)
+        summary = summarize_results(results)
+        cur.execute(
+            """INSERT INTO ai_agent_eval_runs
+                 (env_id,business_id,suite_id,workflow_id,workflow_version_id,
+                  actor_user_id,status,overall_status,summary_json,finished_at)
+               VALUES (%s,%s,%s,%s,%s,%s,'completed',%s,%s,now())
+               RETURNING id""",
+            (
+                env_id,
+                business_id,
+                suite_id,
+                workflow_id,
+                workflow["version_id"],
+                actor,
+                summary["overall_status"],
+                Json(summary),
+            ),
+        )
+        eval_run_id = str(cur.fetchone()["id"])
+        for result in results:
+            cur.execute(
+                """INSERT INTO ai_agent_eval_results
+                     (env_id,business_id,eval_run_id,eval_case_id,eval_class,status,
+                      input_json,expected_json,actual_json,failed_assertion,trace_run_id)
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+                (
+                    env_id,
+                    business_id,
+                    eval_run_id,
+                    result["eval_case_id"],
+                    result["eval_class"],
+                    result["status"],
+                    Json(agent_builder.redact_payload(result["input_json"])),
+                    Json(result["expected_json"]),
+                    Json(agent_builder.redact_payload(result["actual_json"])),
+                    result["failed_assertion"],
+                    result["trace_run_id"],
+                ),
+            )
+    return get_eval_run(
+        env_id=env_id, business_id=business_id, eval_run_id=eval_run_id
+    )
+
+
+def get_eval_run(*, env_id: str, business_id: str, eval_run_id: str) -> dict[str, Any]:
+    with get_cursor() as cur:
+        cur.execute(
+            """SELECT er.*, w.name AS workflow_name, v.version_number
+               FROM ai_agent_eval_runs er
+               JOIN ai_agent_workflows w ON w.id=er.workflow_id
+               JOIN ai_agent_workflow_versions v ON v.id=er.workflow_version_id
+               WHERE er.id=%s AND er.env_id=%s AND er.business_id=%s""",
+            (eval_run_id, env_id, business_id),
+        )
+        run = cur.fetchone()
+        if not run:
+            raise LookupError("eval run not found")
+        cur.execute(
+            """SELECT r.*, c.case_key, c.title, c.source
+               FROM ai_agent_eval_results r
+               JOIN ai_agent_eval_cases c ON c.id=r.eval_case_id
+               WHERE r.eval_run_id=%s AND r.env_id=%s AND r.business_id=%s
+               ORDER BY r.eval_class, c.created_at, c.case_key""",
+            (eval_run_id, env_id, business_id),
+        )
+        result = _row(run)
+        result["results"] = [_row(item) for item in cur.fetchall()]
+        return result
+
+
+def get_workflow_evals(
+    *, env_id: str, business_id: str, workflow_id: str
+) -> dict[str, Any]:
+    workflow = agent_builder.get_workflow(
+        env_id=env_id, business_id=business_id, workflow_id=workflow_id
+    )
+    with get_cursor() as cur:
+        cur.execute(
+            """SELECT id FROM ai_agent_eval_runs
+               WHERE workflow_id=%s AND workflow_version_id=%s
+                 AND env_id=%s AND business_id=%s
+               ORDER BY started_at DESC LIMIT 1""",
+            (workflow_id, workflow["version_id"], env_id, business_id),
+        )
+        latest = cur.fetchone()
+    if latest:
+        return get_eval_run(
+            env_id=env_id, business_id=business_id, eval_run_id=str(latest["id"])
+        )
+    pending = {
+        eval_class: "not_run" if eval_class in REQUIRED_STAGED_CLASSES else "not_applicable"
+        for eval_class in ALL_CLASSES
+    }
+    return {
+        "workflow_id": workflow_id,
+        "workflow_version_id": workflow["version_id"],
+        "version_number": workflow["version_number"],
+        "status": "not_run",
+        "overall_status": "blocked",
+        "summary_json": {
+            "overall_status": "blocked",
+            "by_class": pending,
+            "blockers": [
+                {"eval_class": eval_class, "reason": "required_eval_not_run"}
+                for eval_class in REQUIRED_STAGED_CLASSES
+            ],
+            "counts": {"pass": 0, "fail": 0, "not_applicable": 3, "total": 10},
+        },
+        "results": [],
+    }
+
+
+def publish_workflow(
+    *,
+    env_id: str,
+    business_id: str,
+    actor: str,
+    workflow_id: str,
+    desired_status: str,
+) -> dict[str, Any]:
+    if desired_status != "staged":
+        raise ValueError("Production publication is deferred; only staged publication is supported")
+    workflow = agent_builder.get_workflow(
+        env_id=env_id, business_id=business_id, workflow_id=workflow_id
+    )
+    readiness = get_workflow_evals(
+        env_id=env_id, business_id=business_id, workflow_id=workflow_id
+    )
+    blockers = readiness["summary_json"].get("blockers") or []
+    if readiness.get("overall_status") != "staged_ready" or blockers:
+        raise ValueError("Workflow is blocked from staging by publish-readiness evals")
+    with get_cursor() as cur:
+        cur.execute(
+            """UPDATE ai_agent_workflow_versions
+               SET publish_status='staged', published_by=%s, published_at=now(),
+                   publish_blockers='[]'::jsonb
+               WHERE id=%s AND env_id=%s AND business_id=%s""",
+            (actor, workflow["version_id"], env_id, business_id),
+        )
+        cur.execute(
+            """UPDATE ai_agent_workflows
+               SET status='staged', updated_at=now()
+               WHERE id=%s AND current_version_id=%s AND env_id=%s AND business_id=%s""",
+            (workflow_id, workflow["version_id"], env_id, business_id),
+        )
+    return agent_builder.get_workflow(
+        env_id=env_id, business_id=business_id, workflow_id=workflow_id
+    ) | {"publish_readiness": readiness}
+
+
+def promote_failure(
+    *,
+    env_id: str,
+    business_id: str,
+    actor: str,
+    run_id: str,
+) -> dict[str, Any]:
+    run = agent_builder.get_run(env_id=env_id, business_id=business_id, run_id=run_id)
+    if run["status"] not in {"failed", "blocked", "not_available"}:
+        raise ValueError("Only failed, blocked, or not_available runs can become regression cases")
+    protected_payload = {
+        "input": run.get("input_json") or {},
+        "output": run.get("output_json") or {},
+        "error": run.get("error_json") or {},
+    }
+    secret_paths = agent_builder.find_secret_paths(protected_payload)
+    if secret_paths:
+        raise ValueError("Run contains secret-shaped data and cannot be promoted")
+    workflow = agent_builder.get_workflow(
+        env_id=env_id,
+        business_id=business_id,
+        workflow_id=str(run["workflow_id"]),
+    )
+    with get_cursor() as cur:
+        cur.execute(
+            """SELECT * FROM ai_agent_failure_memory
+               WHERE source_run_id=%s AND env_id=%s AND business_id=%s""",
+            (run_id, env_id, business_id),
+        )
+        existing = cur.fetchone()
+        if existing:
+            return _row(existing) | {"already_promoted": True}
+
+        suite_id = _ensure_suite(
+            cur,
+            env_id=env_id,
+            business_id=business_id,
+            actor=actor,
+            workflow=workflow,
+        )
+        memory_id = str(uuid4())
+        input_json = agent_builder.redact_payload(run.get("input_json") or {})
+        expected = {
+            "terminal_status": "succeeded",
+            "source_run_id": run_id,
+            "source_version_number": run["version_number"],
+        }
+        actual = {
+            "terminal_status": run["status"],
+            "terminal_reason": run.get("terminal_reason"),
+            "output": agent_builder.redact_payload(run.get("output_json") or {}),
+            "error": agent_builder.redact_payload(run.get("error_json") or {}),
+        }
+        cur.execute(
+            """INSERT INTO ai_agent_eval_cases
+                 (env_id,business_id,suite_id,case_key,eval_class,title,input_json,expected_json,source)
+               VALUES (%s,%s,%s,%s,'regression',%s,%s,%s,'promoted_failure')
+               RETURNING id""",
+            (
+                env_id,
+                business_id,
+                suite_id,
+                f"regression-{memory_id}",
+                f"Promoted failure {run_id}",
+                Json(input_json),
+                Json(expected),
+            ),
+        )
+        eval_case_id = str(cur.fetchone()["id"])
+        signature = agent_builder.sha256_json(
+            {
+                "workflow_id": run["workflow_id"],
+                "status": run["status"],
+                "terminal_reason": run.get("terminal_reason"),
+                "input": input_json,
+            }
+        )
+        cur.execute(
+            """INSERT INTO ai_agent_failure_memory
+                 (id,env_id,business_id,workflow_id,workflow_version_id,source_run_id,
+                  eval_case_id,failure_signature,input_hash,input_json,expected_behavior,
+                  actual_behavior,failure_reason,created_by)
+               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+               RETURNING *""",
+            (
+                memory_id,
+                env_id,
+                business_id,
+                run["workflow_id"],
+                run["workflow_version_id"],
+                run_id,
+                eval_case_id,
+                signature,
+                agent_builder.sha256_json(input_json),
+                Json(input_json),
+                Json(expected),
+                Json(actual),
+                run.get("terminal_reason"),
+                actor,
+            ),
+        )
+        return _row(cur.fetchone()) | {"already_promoted": False}

--- a/backend/app/services/telemetry_serving.py
+++ b/backend/app/services/telemetry_serving.py
@@ -58,16 +58,27 @@ def _champion(cur, env_id: str, business_id: UUID, model_kind: str) -> dict | No
     return cur.fetchone()
 
 
-def score_window(*, env_id: str, business_id: UUID, run_key: str, channel_name: str,
-                 window: list[dict]) -> dict:
-    """Score a window of readings with the promoted anomaly champion, persist a receipt, return the
-    verdict. Fails closed (verdict NOT_AVAILABLE + null_reason) when prerequisites are missing."""
+def _score_window(*, env_id: str, business_id: UUID, run_key: str, channel_name: str,
+                  window: list[dict], persist: bool) -> dict:
+    """Shared champion score path. ``persist=False`` is the read-only Agent Builder preview."""
+    if not window:
+        return {
+            "verdict": "NOT_AVAILABLE",
+            "null_reason": "empty_window",
+            "confidence": 0.0,
+            "missing_data": ["window"],
+        }
     with get_cursor() as cur:
         resolve_tenant_id(cur, business_id)   # validates the business exists (fail closed otherwise)
 
         champ = _champion(cur, env_id, business_id, "anomaly")
         if champ is None:
-            return {"verdict": "NOT_AVAILABLE", "null_reason": "model_not_promoted"}
+            return {
+                "verdict": "NOT_AVAILABLE",
+                "null_reason": "model_not_promoted",
+                "confidence": 0.0,
+                "missing_data": ["promoted anomaly model"],
+            }
 
         cur.execute(
             "SELECT id FROM tel_test_runs WHERE env_id = %s AND business_id = %s AND run_key = %s",
@@ -75,8 +86,14 @@ def score_window(*, env_id: str, business_id: UUID, run_key: str, channel_name: 
         )
         run_row = cur.fetchone()
         if run_row is None:
-            return {"verdict": "NOT_AVAILABLE", "null_reason": "missing_run",
-                    "model_name": champ["model_name"], "model_version": champ["model_version"]}
+            return {
+                "verdict": "NOT_AVAILABLE",
+                "null_reason": "missing_run",
+                "model_name": champ["model_name"],
+                "model_version": champ["model_version"],
+                "confidence": 0.0,
+                "missing_data": ["test run"],
+            }
         run_id = run_row["id"]
 
         # Champion rule. Use caller-supplied rolling mean if present, else compute over the window.
@@ -98,21 +115,7 @@ def score_window(*, env_id: str, business_id: UUID, run_key: str, channel_name: 
 
         attribution = [{"channel_name": channel_name, "contribution": round(peak_resid, 6)}]
 
-        cur.execute(
-            """INSERT INTO tel_predictions
-                 (env_id, business_id, run_id, channel_name, window_start_t, window_end_t,
-                  anomaly_score, threshold, verdict, model_name, model_version, mlflow_run_id,
-                  attribution, is_backfilled)
-               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb,false)
-               RETURNING id""",
-            (env_id, str(business_id), run_id, channel_name,
-             window[0]["t"], window[-1]["t"], anomaly_score, threshold, verdict,
-             champ["model_name"], champ["model_version"], champ["mlflow_run_id"],
-             _json(attribution)),
-        )
-        receipt_id = cur.fetchone()["id"]
-
-        return {
+        result = {
             "verdict": verdict,
             "anomaly_score": anomaly_score,
             "threshold": threshold,
@@ -121,8 +124,54 @@ def score_window(*, env_id: str, business_id: UUID, run_key: str, channel_name: 
             "model_alias": champ["model_alias"],
             "mlflow_run_id": champ["mlflow_run_id"],
             "attribution": attribution,
-            "receipt_id": receipt_id,
+            "confidence": round(
+                min(0.99, max(0.5, abs((anomaly_score or 0) - 1.0) / 3.0 + 0.5)),
+                3,
+            ),
+            "missing_data": [],
+            "null_reason": None,
         }
+        if persist:
+            cur.execute(
+                """INSERT INTO tel_predictions
+                     (env_id, business_id, run_id, channel_name, window_start_t, window_end_t,
+                      anomaly_score, threshold, verdict, model_name, model_version, mlflow_run_id,
+                      attribution, is_backfilled)
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb,false)
+                   RETURNING id""",
+                (env_id, str(business_id), run_id, channel_name,
+                 window[0]["t"], window[-1]["t"], anomaly_score, threshold, verdict,
+                 champ["model_name"], champ["model_version"], champ["mlflow_run_id"],
+                 _json(attribution)),
+            )
+            result["receipt_id"] = cur.fetchone()["id"]
+        return result
+
+
+def score_window(*, env_id: str, business_id: UUID, run_key: str, channel_name: str,
+                 window: list[dict]) -> dict:
+    """Score a window and persist the existing tel_predictions receipt."""
+    return _score_window(
+        env_id=env_id,
+        business_id=business_id,
+        run_key=run_key,
+        channel_name=channel_name,
+        window=window,
+        persist=True,
+    )
+
+
+def preview_score_window(*, env_id: str, business_id: UUID, run_key: str,
+                         channel_name: str, window: list[dict]) -> dict:
+    """Read-only score preview. Never inserts into tel_predictions."""
+    return _score_window(
+        env_id=env_id,
+        business_id=business_id,
+        run_key=run_key,
+        channel_name=channel_name,
+        window=window,
+        persist=False,
+    )
 
 
 def list_runs(*, env_id: str, business_id: UUID) -> list[dict]:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -217,6 +217,7 @@ _GET_CURSOR_TARGETS = [
     "app.services.control_tower.approval.get_cursor",
     "app.services.control_tower.signing.get_cursor",
     "app.services.control_tower.gemma_tier.get_cursor",
+    "app.services.agent_builder.get_cursor",
     # telemetry_stream_etl / telemetry_stream_ingest import get_cursor lazily inside functions,
     # so the app.db.get_cursor patch above covers them (module-level targets would fail to patch).
 ]

--- a/backend/tests/test_agent_builder.py
+++ b/backend/tests/test_agent_builder.py
@@ -1,0 +1,950 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+from uuid import uuid4
+
+from app.mcp.registry import registry
+from app.routes import agent_builder as agent_builder_route
+from app.schemas.agent_builder import AgentGraph, AgentNode
+from app.services import agent_builder
+from app.services import agent_builder_evals
+from app.services.ai_dispatch.models import (
+    DispatchResult,
+    DispatchStatus,
+    ProviderName,
+    Usage,
+)
+
+
+ENV = "agent-builder-test"
+BIZ = str(uuid4())
+
+
+def graph(nodes: list[dict], edges: list[dict], **limits) -> AgentGraph:
+    return AgentGraph.model_validate(
+        {
+            "schema_version": "agent-graph/v1",
+            "nodes": nodes,
+            "edges": edges,
+            "limits": {
+                "max_runtime_seconds": limits.get("max_runtime_seconds", 120),
+                "max_tool_calls": limits.get("max_tool_calls", 10),
+                "max_cost_usd": limits.get("max_cost_usd", 1),
+            },
+            "model_route_policy": {"sensitive_fallback": "fail_closed"},
+        }
+    )
+
+
+def node(node_id: str, node_type: str, x: int, config=None) -> dict:
+    return {
+        "id": node_id,
+        "type": node_type,
+        "position": {"x": x, "y": 0},
+        "config": config or {},
+    }
+
+
+def edge(source: str, target: str, handle: str | None = None) -> dict:
+    return {"source": source, "target": target, "source_handle": handle}
+
+
+def valid_minimal_graph() -> AgentGraph:
+    return graph(
+        [node("trigger", "manual_trigger", 0), node("output", "output", 200)],
+        [edge("trigger", "output")],
+    )
+
+
+def test_graph_lint_detects_cycle_unreachable_and_missing_terminal():
+    candidate = graph(
+        [
+            node("trigger", "manual_trigger", 0),
+            node("context", "context_loader", 100),
+            node("orphan", "receipt_writer", 100),
+            node("output", "output", 200),
+        ],
+        [
+            edge("trigger", "context"),
+            edge("context", "trigger"),
+            edge("context", "output"),
+        ],
+    )
+    result = agent_builder.validate_graph(candidate)
+    codes = {issue["code"] for issue in result["issues"]}
+    assert result["status"] == "fail"
+    assert {"CYCLE", "TRIGGER_INCOMING", "UNREACHABLE_NODE", "MISSING_TERMINAL_PATH"} <= codes
+
+
+def test_secret_shaped_workflow_data_is_rejected():
+    candidate = graph(
+        [
+            node("trigger", "manual_trigger", 0, {"api_key": "sk-secret-value-123456"}),
+            node("output", "output", 200),
+        ],
+        [edge("trigger", "output")],
+    )
+    result = agent_builder.validate_graph(candidate)
+    assert any(issue["code"] == "SECRET_DETECTED" for issue in result["issues"])
+    assert agent_builder.redact_payload({"authorization": "Bearer abcdefghijklmnop"}) == {
+        "authorization": "[REDACTED]"
+    }
+
+
+def test_write_capable_tool_is_disabled_and_rejected():
+    write_tool = registry.get("business.create")
+    assert write_tool is not None and write_tool.permission == "write"
+    candidate = graph(
+        [
+            node("trigger", "manual_trigger", 0),
+            node(
+                "tool",
+                "mcp_tool",
+                100,
+                {
+                    "tool_name": write_tool.name,
+                    "tool_schema_digest": agent_builder.tool_schema_digest(write_tool),
+                    "bindings": {},
+                },
+            ),
+            node("output", "output", 200),
+        ],
+        [edge("trigger", "tool"), edge("tool", "output")],
+    )
+    result = agent_builder.validate_graph(candidate)
+    assert any(issue["code"] == "WRITE_TOOL_FORBIDDEN" for issue in result["issues"])
+    described = next(tool for tool in agent_builder.describe_tools() if tool["name"] == write_tool.name)
+    assert described["enabled"] is False
+
+
+def test_tool_schema_digest_drift_fails_closed():
+    read_tool = registry.get("telemetry.preview_score_window")
+    assert read_tool is not None
+    candidate = graph(
+        [
+            node("trigger", "manual_trigger", 0),
+            node(
+                "tool",
+                "mcp_tool",
+                100,
+                {
+                    "tool_name": read_tool.name,
+                    "tool_schema_digest": "stale",
+                    "bindings": {},
+                },
+            ),
+            node("output", "output", 200),
+        ],
+        [edge("trigger", "tool"), edge("tool", "output")],
+    )
+    result = agent_builder.validate_graph(candidate)
+    assert any(issue["code"] == "SCHEMA_DIGEST_DRIFT" for issue in result["issues"])
+
+
+def test_policy_and_cost_nodes_require_typed_branch_handles():
+    candidate = graph(
+        [
+            node("trigger", "manual_trigger", 0),
+            node("policy", "policy_gate", 100, {"policy": "read_only_only"}),
+            node("cost", "cost_guardrail", 200),
+            node("output", "output", 300),
+        ],
+        [
+            edge("trigger", "policy"),
+            edge("policy", "cost"),
+            edge("cost", "output"),
+        ],
+    )
+    result = agent_builder.validate_graph(candidate)
+    codes = {issue["code"] for issue in result["issues"]}
+    assert {"GATE_HANDLES", "COST_HANDLES"} <= codes
+
+
+def test_policy_cost_and_approval_nodes_emit_deterministic_runtime_states():
+    candidate = valid_minimal_graph()
+    policy = agent_builder._execute_node(
+        node=AgentNode.model_validate(
+            node("policy", "policy_gate", 100, {"policy": "require_input", "required_input": "input.allowed"})
+        ),
+        graph=candidate,
+        run_input={"allowed": False},
+        outputs={},
+        env_id=ENV,
+        business_id=BIZ,
+        actor="operator",
+        accumulated_cost=0,
+        run_id="run-policy",
+    )
+    assert policy.status == "warning"
+    assert policy.branch_handle == "fail"
+
+    cost = agent_builder._execute_node(
+        node=AgentNode.model_validate(
+            node("cost", "cost_guardrail", 100, {"max_cost_usd": 1, "estimated_next_cost_usd": 2})
+        ),
+        graph=candidate,
+        run_input={},
+        outputs={},
+        env_id=ENV,
+        business_id=BIZ,
+        actor="operator",
+        accumulated_cost=0,
+        run_id="run-cost",
+    )
+    assert cost.status == "warning"
+    assert cost.branch_handle == "over_budget"
+
+    approval = agent_builder._execute_node(
+        node=AgentNode.model_validate(node("approval", "human_approval", 100)),
+        graph=candidate,
+        run_input={},
+        outputs={},
+        env_id=ENV,
+        business_id=BIZ,
+        actor="operator",
+        accumulated_cost=0,
+        run_id="run-approval",
+    )
+    assert approval.status == "blocked"
+    assert approval.output["approval_status"] == "simulated_pending"
+
+
+def test_prompt_node_uses_live_dispatch_contract_and_strict_json(monkeypatch):
+    monkeypatch.setattr("app.config.AI_DISPATCH_ENABLED", True)
+    captured = {}
+
+    def fake_dispatch(request, **kwargs):
+        captured["request"] = request
+        captured["registry"] = kwargs.get("registry")
+        return DispatchResult(
+            request_id="dispatch-1",
+            status=DispatchStatus.SUCCESS,
+            provider=ProviderName.OPENAI,
+            model="mock-model",
+            answer='{"verdict":"GO"}',
+            usage=Usage(prompt_tokens=10, completion_tokens=5),
+        )
+
+    monkeypatch.setattr(agent_builder, "run_dispatch", fake_dispatch)
+    candidate = valid_minimal_graph()
+    prompt = AgentNode.model_validate(
+        node(
+            "prompt",
+            "prompt_llm",
+            100,
+            {
+                "prompt_template": "Assess {{input.question}}",
+                "prompt_version": "triage/v1",
+                "mode": "classification",
+                "privacy": "internal",
+                "output_schema": {
+                    "type": "object",
+                    "properties": {"verdict": {"enum": ["GO", "NO_GO"]}},
+                    "required": ["verdict"],
+                    "additionalProperties": False,
+                },
+            },
+        )
+    )
+    result = agent_builder._execute_node(
+        node=prompt,
+        graph=candidate,
+        run_input={"question": "window"},
+        outputs={},
+        env_id=ENV,
+        business_id=BIZ,
+        actor="operator",
+        accumulated_cost=0,
+        run_id="run-1",
+    )
+    assert result.status == "completed"
+    assert result.output == {"verdict": "GO"}
+    assert captured["request"].business_id == BIZ
+
+
+def test_prompt_schema_mismatch_fails_without_claiming_success(monkeypatch):
+    monkeypatch.setattr("app.config.AI_DISPATCH_ENABLED", True)
+    monkeypatch.setattr(
+        agent_builder,
+        "run_dispatch",
+        lambda request, **kwargs: DispatchResult(
+            request_id="dispatch-bad",
+            status=DispatchStatus.SUCCESS,
+            provider=ProviderName.OPENAI,
+            model="mock-model",
+            answer='{"unsupported":"claim"}',
+        ),
+    )
+    prompt = AgentNode.model_validate(
+        node(
+            "prompt",
+            "prompt_llm",
+            100,
+            {
+                "prompt_template": "Return a verdict",
+                "prompt_version": "triage/v1",
+                "mode": "classification",
+                "privacy": "internal",
+                "output_schema": {
+                    "type": "object",
+                    "properties": {"verdict": {"type": "string"}},
+                    "required": ["verdict"],
+                    "additionalProperties": False,
+                },
+            },
+        )
+    )
+    result = agent_builder._execute_node(
+        node=prompt,
+        graph=valid_minimal_graph(),
+        run_input={},
+        outputs={},
+        env_id=ENV,
+        business_id=BIZ,
+        actor="operator",
+        accumulated_cost=0,
+        run_id="run-bad-schema",
+    )
+    assert result.status == "failed"
+    assert result.reason.startswith("output_schema_validation_failed")
+
+
+def test_sensitive_prompt_forces_private_tier_without_fallback(monkeypatch):
+    monkeypatch.setattr("app.config.AI_DISPATCH_ENABLED", True)
+    captured = {}
+
+    def fake_dispatch(request, **kwargs):
+        captured["request"] = request
+        captured["registry"] = kwargs.get("registry")
+        return DispatchResult(
+            request_id="dispatch-2",
+            status=DispatchStatus.UNAVAILABLE,
+            routing_reason="private tier unavailable",
+            rejected={"openai": "privacy_forbidden"},
+        )
+
+    monkeypatch.setattr(agent_builder, "run_dispatch", fake_dispatch)
+    prompt = AgentNode.model_validate(
+        node(
+            "prompt",
+            "prompt_llm",
+            100,
+            {
+                "prompt_template": "Classify sensitive input",
+                "prompt_version": "private/v1",
+                "mode": "classification",
+                "privacy": "sensitive",
+                "output_schema": {"type": "object"},
+            },
+        )
+    )
+    result = agent_builder._execute_node(
+        node=prompt,
+        graph=valid_minimal_graph(),
+        run_input={},
+        outputs={},
+        env_id=ENV,
+        business_id=BIZ,
+        actor="operator",
+        accumulated_cost=0,
+        run_id="run-2",
+    )
+    assert result.status == "not_available"
+    assert captured["request"].forced_provider == ProviderName.GEMMA_GCP
+    assert captured["request"].allow_fallback is False
+    assert captured["registry"] is not None
+
+
+def test_prompt_budget_blocks_before_provider_call(monkeypatch):
+    monkeypatch.setattr("app.config.AI_DISPATCH_ENABLED", True)
+    dispatch = patch.object(agent_builder, "run_dispatch")
+    mocked = dispatch.start()
+    try:
+        prompt = AgentNode.model_validate(
+            node(
+                "prompt",
+                "prompt_llm",
+                100,
+                {
+                    "prompt_template": "bounded",
+                    "prompt_version": "v1",
+                    "mode": "classification",
+                    "privacy": "internal",
+                    "estimated_cost_usd": 2,
+                    "output_schema": {"type": "object"},
+                },
+            )
+        )
+        result = agent_builder._execute_node(
+            node=prompt,
+            graph=graph(
+                [node("trigger", "manual_trigger", 0), node("output", "output", 200)],
+                [edge("trigger", "output")],
+                max_cost_usd=1,
+            ),
+            run_input={},
+            outputs={},
+            env_id=ENV,
+            business_id=BIZ,
+            actor="operator",
+            accumulated_cost=0,
+            run_id="run-3",
+        )
+        assert result.status == "blocked"
+        mocked.assert_not_called()
+    finally:
+        dispatch.stop()
+
+
+def test_templates_are_six_drafts_and_validate_with_registered_tools():
+    templates = agent_builder.template_graphs()
+    assert len(templates) == 6
+    assert templates[0]["key"] == "telemetry-triage"
+    results = [
+        agent_builder.validate_graph(AgentGraph.model_validate(template["graph"]))["status"]
+        for template in templates
+    ]
+    assert results == ["pass"] * 6
+
+
+def test_deterministic_eval_suite_is_staged_ready_for_valid_read_only_graph():
+    cases = [
+        {"id": f"case-{eval_class}", **agent_builder_evals._default_case(eval_class)}
+        for eval_class in agent_builder_evals.ALL_CLASSES
+    ]
+    results = agent_builder_evals.evaluate_cases(valid_minimal_graph(), cases)
+    summary = agent_builder_evals.summarize_results(results)
+    assert summary["overall_status"] == "staged_ready"
+    assert summary["by_class"]["graph_lint"] == "pass"
+    assert summary["by_class"]["visual_smoke"] == "not_applicable"
+    assert summary["by_class"]["production_smoke"] == "not_applicable"
+
+
+def test_promoted_regression_blocks_until_matching_successful_replay_exists():
+    case = {
+        "id": "regression-case",
+        "case_key": "regression-memory-1",
+        "eval_class": "regression",
+        "title": "Promoted failure",
+        "input_json": {"run_key": "failed-run"},
+        "expected_json": {"terminal_status": "succeeded"},
+        "source": "promoted_failure",
+    }
+    blocked = agent_builder_evals.evaluate_cases(valid_minimal_graph(), [case])
+    assert blocked[0]["status"] == "fail"
+    assert "matching successful dry-run" in blocked[0]["failed_assertion"]
+
+    passing = agent_builder_evals.evaluate_cases(
+        valid_minimal_graph(),
+        [case],
+        regression_evidence={"regression-case": "run-success"},
+    )
+    assert passing[0]["status"] == "pass"
+    assert passing[0]["trace_run_id"] == "run-success"
+
+
+def test_eval_migration_has_tenant_rls_and_append_only_guards():
+    migration = (
+        Path(__file__).resolve().parents[2]
+        / "repo-b"
+        / "db"
+        / "schema"
+        / "10036_agent_builder_evals.sql"
+    )
+    sql = migration.read_text(encoding="utf-8").lower()
+    for table in (
+        "ai_agent_eval_suites",
+        "ai_agent_eval_cases",
+        "ai_agent_eval_runs",
+        "ai_agent_eval_results",
+        "ai_agent_failure_memory",
+    ):
+        assert f"create table if not exists {table}" in sql
+        assert table in sql
+    assert sql.count("enable row level security") >= 5
+    assert "ai_agent_eval_results_append_only" in sql
+    assert "ai_agent_failure_memory_append_only" in sql
+    assert "published_by" in sql and "publish_blockers" in sql
+
+
+def test_permission_eval_rejects_write_tool_even_if_graph_was_tampered():
+    write_tool = registry.get("business.create")
+    assert write_tool is not None
+    candidate = graph(
+        [
+            node("trigger", "manual_trigger", 0),
+            node(
+                "tool",
+                "mcp_tool",
+                100,
+                {
+                    "tool_name": write_tool.name,
+                    "tool_schema_digest": agent_builder.tool_schema_digest(write_tool),
+                },
+            ),
+            node("output", "output", 200),
+        ],
+        [edge("trigger", "tool"), edge("tool", "output")],
+    )
+    case = {
+        "id": "permission-case",
+        **agent_builder_evals._default_case("permission"),
+    }
+    result = agent_builder_evals.evaluate_cases(candidate, [case])[0]
+    assert result["status"] == "fail"
+    assert result["actual_json"]["violations"][0]["reason"] == "non_read_tool"
+
+
+def test_agent_builder_api_requires_tenant_and_exposes_palette(client):
+    assert client.get("/api/agent-builder/palette").status_code == 403
+    response = client.get(
+        "/api/agent-builder/palette",
+        headers={
+            "x-bm-auth-provider": "platform-session",
+            "x-bm-user-id": "user-1",
+            "x-bm-actor": "user:test:user-1",
+            "x-bm-env-id": ENV,
+            "x-bm-business-id": BIZ,
+            "x-bm-membership-role": "member",
+        },
+    )
+    assert response.status_code == 200
+    assert len(response.json()["nodes"]) == 10
+
+
+def _platform_headers(role: str = "member") -> dict[str, str]:
+    return {
+        "x-bm-auth-provider": "platform-session",
+        "x-bm-user-id": "user-1",
+        "x-bm-actor": "user:test:user-1",
+        "x-bm-env-id": ENV,
+        "x-bm-business-id": BIZ,
+        "x-bm-membership-role": role,
+    }
+
+
+def test_agent_builder_api_enforces_viewer_vs_operator_mutations(client, monkeypatch):
+    payload = {"name": "Agent", "graph": valid_minimal_graph().model_dump(mode="json")}
+    monkeypatch.setattr(
+        agent_builder_route.service,
+        "create_workflow",
+        lambda **kwargs: {"id": "workflow-1", "version_number": 1},
+    )
+    assert client.post("/api/agent-builder/workflows", headers=_platform_headers("viewer"), json=payload).status_code == 403
+    response = client.post("/api/agent-builder/workflows", headers=_platform_headers("member"), json=payload)
+    assert response.status_code == 200
+    assert response.json()["version_number"] == 1
+
+
+def test_agent_builder_api_save_validate_and_dry_run_contracts(client, monkeypatch):
+    monkeypatch.setattr(
+        agent_builder_route.service,
+        "save_draft",
+        lambda **kwargs: {"id": kwargs["workflow_id"], "version_number": kwargs["base_version_number"] + 1},
+    )
+    monkeypatch.setattr(
+        agent_builder_route.service,
+        "validate_saved_workflow",
+        lambda **kwargs: {"status": "pass", "issues": [], "checks": {}, "topological_order": ["trigger", "output"]},
+    )
+    monkeypatch.setattr(
+        agent_builder_route.service,
+        "dry_run",
+        lambda **kwargs: {"id": "run-1", "status": "succeeded", "steps": [], "receipts": []},
+    )
+    headers = _platform_headers("member")
+    saved = client.patch(
+        "/api/agent-builder/workflows/workflow-1/draft",
+        headers=headers,
+        json={"base_version_number": 1, "graph": valid_minimal_graph().model_dump(mode="json")},
+    )
+    assert saved.status_code == 200
+    assert saved.json()["version_number"] == 2
+    assert client.post("/api/agent-builder/workflows/workflow-1/validate", headers=headers).json()["status"] == "pass"
+    run = client.post(
+        "/api/agent-builder/workflows/workflow-1/dry-run",
+        headers=headers,
+        json={"input": {"run_key": "run-1"}},
+    )
+    assert run.status_code == 200
+    assert run.json()["status"] == "succeeded"
+
+
+def test_agent_builder_api_eval_publish_and_failure_promotion_contracts(client, monkeypatch):
+    monkeypatch.setattr(
+        agent_builder_route.eval_service,
+        "run_evals",
+        lambda **kwargs: {"id": "eval-run-1", "overall_status": "staged_ready"},
+    )
+    monkeypatch.setattr(
+        agent_builder_route.eval_service,
+        "get_workflow_evals",
+        lambda **kwargs: {"id": "eval-run-1", "overall_status": "staged_ready"},
+    )
+    monkeypatch.setattr(
+        agent_builder_route.eval_service,
+        "get_eval_run",
+        lambda **kwargs: {"id": kwargs["eval_run_id"], "overall_status": "staged_ready"},
+    )
+    monkeypatch.setattr(
+        agent_builder_route.eval_service,
+        "publish_workflow",
+        lambda **kwargs: {"id": kwargs["workflow_id"], "status": kwargs["desired_status"]},
+    )
+    monkeypatch.setattr(
+        agent_builder_route.eval_service,
+        "promote_failure",
+        lambda **kwargs: {"source_run_id": kwargs["run_id"], "already_promoted": False},
+    )
+    headers = _platform_headers("member")
+    assert client.post(
+        "/api/agent-builder/workflows/workflow-1/evals/run", headers=headers
+    ).json()["overall_status"] == "staged_ready"
+    assert client.get(
+        "/api/agent-builder/workflows/workflow-1/evals", headers=headers
+    ).status_code == 200
+    assert client.get(
+        "/api/agent-builder/eval-runs/eval-run-1", headers=headers
+    ).status_code == 200
+    assert client.post(
+        "/api/agent-builder/workflows/workflow-1/publish",
+        headers=headers,
+        json={"status": "staged"},
+    ).json()["status"] == "staged"
+    assert client.post(
+        "/api/agent-builder/runs/run-1/promote-failure", headers=headers
+    ).json()["source_run_id"] == "run-1"
+
+
+def test_production_publish_request_fails_closed(client, monkeypatch):
+    monkeypatch.setattr(
+        agent_builder_route.eval_service,
+        "publish_workflow",
+        lambda **kwargs: (_ for _ in ()).throw(
+            ValueError("Production publication is deferred")
+        ),
+    )
+    response = client.post(
+        "/api/agent-builder/workflows/workflow-1/publish",
+        headers=_platform_headers("member"),
+        json={"status": "published"},
+    )
+    assert response.status_code == 400
+    assert "deferred" in response.json()["detail"]
+
+
+class EvalCursor:
+    def __init__(self):
+        self.current = ""
+        self.eval_result_count = 0
+        self.queries: list[str] = []
+        self.cases = [
+            {
+                "id": f"case-{eval_class}",
+                **agent_builder_evals._default_case(eval_class),
+                "created_at": None,
+            }
+            for eval_class in agent_builder_evals.ALL_CLASSES
+        ]
+
+    def execute(self, sql, params=None):
+        self.current = " ".join(sql.split())
+        self.queries.append(self.current)
+        if "INSERT INTO ai_agent_eval_results" in self.current:
+            self.eval_result_count += 1
+        return self
+
+    def fetchone(self):
+        if "INSERT INTO ai_agent_eval_suites" in self.current:
+            return {"id": "suite-1"}
+        if "INSERT INTO ai_agent_eval_runs" in self.current:
+            return {"id": "eval-run-1"}
+        if "FROM ai_agent_eval_runs er" in self.current:
+            return {
+                "id": "eval-run-1",
+                "workflow_id": "workflow-1",
+                "workflow_version_id": "version-1",
+                "workflow_name": "Agent",
+                "version_number": 1,
+                "status": "completed",
+                "overall_status": "staged_ready",
+                "summary_json": {
+                    "overall_status": "staged_ready",
+                    "by_class": {},
+                    "blockers": [],
+                },
+            }
+        return None
+
+    def fetchall(self):
+        if "FROM ai_agent_failure_memory" in self.current:
+            return []
+        if "FROM ai_agent_eval_cases" in self.current:
+            return self.cases
+        if "FROM ai_agent_eval_results" in self.current:
+            return []
+        return []
+
+
+def test_eval_run_persists_one_append_only_result_per_case(monkeypatch):
+    workflow = {
+        "id": "workflow-1",
+        "version_id": "version-1",
+        "version_number": 1,
+        "graph": valid_minimal_graph().model_dump(mode="json"),
+    }
+    cursor = EvalCursor()
+
+    @contextmanager
+    def fake_cursor():
+        yield cursor
+
+    monkeypatch.setattr(agent_builder_evals.agent_builder, "get_workflow", lambda **kwargs: workflow)
+    monkeypatch.setattr(agent_builder_evals, "get_cursor", fake_cursor)
+    result = agent_builder_evals.run_evals(
+        env_id=ENV,
+        business_id=BIZ,
+        actor="operator",
+        workflow_id="workflow-1",
+    )
+    assert result["overall_status"] == "staged_ready"
+    assert cursor.eval_result_count == len(agent_builder_evals.ALL_CLASSES)
+
+
+def test_staged_publish_updates_only_after_current_version_is_ready(monkeypatch):
+    workflow = {
+        "id": "workflow-1",
+        "version_id": "version-1",
+        "version_number": 1,
+        "graph": valid_minimal_graph().model_dump(mode="json"),
+    }
+    queries: list[str] = []
+
+    class PublishCursor:
+        def execute(self, sql, params=None):
+            queries.append(" ".join(sql.split()))
+            return self
+
+    @contextmanager
+    def fake_cursor():
+        yield PublishCursor()
+
+    monkeypatch.setattr(agent_builder_evals.agent_builder, "get_workflow", lambda **kwargs: workflow)
+    monkeypatch.setattr(
+        agent_builder_evals,
+        "get_workflow_evals",
+        lambda **kwargs: {
+            "overall_status": "staged_ready",
+            "summary_json": {"blockers": []},
+        },
+    )
+    monkeypatch.setattr(agent_builder_evals, "get_cursor", fake_cursor)
+    result = agent_builder_evals.publish_workflow(
+        env_id=ENV,
+        business_id=BIZ,
+        actor="operator",
+        workflow_id="workflow-1",
+        desired_status="staged",
+    )
+    assert result["publish_readiness"]["overall_status"] == "staged_ready"
+    assert any("publish_status='staged'" in sql for sql in queries)
+    assert any("SET status='staged'" in sql for sql in queries)
+
+
+def test_failure_promotion_rejects_secret_shaped_run_payload(monkeypatch):
+    monkeypatch.setattr(
+        agent_builder_evals.agent_builder,
+        "get_run",
+        lambda **kwargs: {
+            "id": "run-1",
+            "workflow_id": "workflow-1",
+            "workflow_version_id": "version-1",
+            "version_number": 1,
+            "status": "failed",
+            "input_json": {"api_key": "sk-secret-value-123456"},
+            "output_json": {},
+            "error_json": {},
+        },
+    )
+    try:
+        agent_builder_evals.promote_failure(
+            env_id=ENV,
+            business_id=BIZ,
+            actor="operator",
+            run_id="run-1",
+        )
+    except ValueError as exc:
+        assert "secret-shaped" in str(exc)
+    else:
+        raise AssertionError("expected secret-bearing failure promotion to be rejected")
+
+
+def test_save_draft_rejects_optimistic_version_conflict(monkeypatch):
+    class ConflictCursor:
+        def execute(self, sql, params=None):
+            return self
+
+        def fetchone(self):
+            return {"version_number": 3}
+
+    @contextmanager
+    def fake_cursor():
+        yield ConflictCursor()
+
+    monkeypatch.setattr(agent_builder, "get_cursor", fake_cursor)
+    try:
+        agent_builder.save_draft(
+            env_id=ENV,
+            business_id=BIZ,
+            actor="operator",
+            workflow_id="workflow-1",
+            base_version_number=2,
+            graph=valid_minimal_graph(),
+        )
+    except agent_builder.VersionConflictError as exc:
+        assert "current version is 3" in str(exc)
+    else:
+        raise AssertionError("expected VersionConflictError")
+
+
+def test_compile_pins_records_prompt_and_tool_versions():
+    tool = registry.get("telemetry.preview_score_window")
+    assert tool is not None
+    candidate = graph(
+        [
+            node("trigger", "manual_trigger", 0),
+            node("tool", "mcp_tool", 100, {
+                "tool_name": tool.name,
+                "tool_schema_digest": agent_builder.tool_schema_digest(tool),
+                "bindings": {},
+            }),
+            node("prompt", "prompt_llm", 200, {
+                "prompt_template": "Bounded",
+                "prompt_version": "bounded/v2",
+                "output_schema": {"type": "object"},
+            }),
+            node("output", "output", 300),
+        ],
+        [edge("trigger", "tool"), edge("tool", "prompt"), edge("prompt", "output")],
+    )
+    pins = agent_builder.compile_pins(candidate)
+    assert pins["prompt_versions"] == {"prompt": "bounded/v2"}
+    assert pins["tool_schema_digests"]["tool"] == agent_builder.tool_schema_digest(tool)
+    assert pins["required_permissions"] == ["read"]
+
+
+class RuntimeCursor:
+    """Small SQL-aware fake proving dry-run writes steps, events, and receipts."""
+
+    def __init__(self, workflow: dict):
+        self.workflow = workflow
+        self.queries: list[str] = []
+        self.current = ""
+        self.step_count = 0
+        self.receipt_count = 0
+        self.event_count = 0
+        self.steps: list[dict] = []
+        self.receipts: list[dict] = []
+
+    def execute(self, sql, params=None):
+        self.current = " ".join(sql.split())
+        self.queries.append(self.current)
+        if "INSERT INTO ai_agent_run_steps" in self.current:
+            self.step_count += 1
+            self.steps.append(
+                {
+                    "id": f"step-{self.step_count}",
+                    "node_id": params[3],
+                    "node_type": params[4],
+                    "status": params[5],
+                    "receipt_id": None,
+                }
+            )
+        elif "INSERT INTO ai_agent_receipts" in self.current:
+            self.receipt_count += 1
+            self.receipts.append(
+                {
+                    "id": f"receipt-{self.receipt_count}",
+                    "node_id": params[6],
+                    "receipt_type": params[7],
+                    "terminal_status": params[14],
+                }
+            )
+        elif "INSERT INTO ai_agent_run_events" in self.current:
+            self.event_count += 1
+        return self
+
+    def fetchone(self):
+        if "FROM ai_agent_workflows w JOIN ai_agent_workflow_versions" in self.current:
+            return self.workflow
+        if "INSERT INTO ai_agent_runs" in self.current:
+            return {"id": "run-1"}
+        if "INSERT INTO ai_agent_run_steps" in self.current:
+            return {"id": f"step-{self.step_count}"}
+        if "INSERT INTO ai_agent_receipts" in self.current:
+            return {"id": f"receipt-{self.receipt_count}"}
+        if "SELECT r.*, w.name AS workflow_name" in self.current:
+            return {
+                "id": "run-1",
+                "workflow_id": "workflow-1",
+                "workflow_version_id": "version-1",
+                "workflow_name": "Test Agent",
+                "version_number": 1,
+                "status": "succeeded",
+            }
+        return None
+
+    def fetchall(self):
+        if "FROM ai_agent_workflow_versions" in self.current:
+            return [{"id": "version-1", "version_number": 1}]
+        if "FROM ai_agent_run_steps" in self.current:
+            return self.steps
+        if "FROM ai_agent_receipts" in self.current:
+            return self.receipts
+        return []
+
+
+def test_dry_run_writes_step_events_and_receipts(monkeypatch):
+    candidate = valid_minimal_graph()
+    workflow = {
+        "id": "workflow-1",
+        "name": "Test Agent",
+        "description": None,
+        "owner_user_id": "operator",
+        "status": "draft",
+        "tags": [],
+        "is_template": False,
+        "template_key": None,
+        "created_at": None,
+        "updated_at": None,
+        "version_id": "version-1",
+        "version_number": 1,
+        "graph_json": candidate.model_dump(mode="json"),
+        "prompt_versions": {},
+        "tool_schema_digests": {},
+        "model_route_policy": {},
+        "required_permissions": ["read"],
+        "validation_status": "pass",
+        "validation_results": agent_builder.validate_graph(candidate),
+        "publish_status": "draft",
+    }
+    cursor = RuntimeCursor(workflow)
+
+    @contextmanager
+    def fake_cursor():
+        yield cursor
+
+    monkeypatch.setattr(agent_builder, "get_cursor", fake_cursor)
+    result = agent_builder.dry_run(
+        env_id=ENV,
+        business_id=BIZ,
+        actor="operator",
+        workflow_id="workflow-1",
+        run_input={"value": 1},
+    )
+    assert result["status"] == "succeeded"
+    assert cursor.step_count == 2
+    assert cursor.receipt_count == 2
+    assert cursor.event_count == 6  # run start/end + before/after each step

--- a/backend/tests/test_telemetry_mcp.py
+++ b/backend/tests/test_telemetry_mcp.py
@@ -52,6 +52,36 @@ def test_input_schema_accepts_valid_payload():
     assert inp.fire_tick == 728
 
 
+def test_preview_score_window_is_read_only(fake_cursor):
+    fake_cursor.push_result([{"tenant_id": str(uuid4())}])
+    fake_cursor.push_result([{
+        "model_name": "tel_anomaly_detector",
+        "model_version": "v1",
+        "model_alias": "champion",
+        "mlflow_run_id": "mlflow-1",
+        "metrics": {},
+        "gate": {},
+    }])
+    fake_cursor.push_result([{"id": str(uuid4())}])
+    tool = registry.get("telemetry.preview_score_window")
+    assert tool is not None
+    ctx = McpContext(actor="agent_builder", token_valid=True, resolved_scope={"business_id": BIZ})
+    with patch("app.services.audit.record_event"), patch("app.services.governance.record_decision"):
+        result = tool.handler(
+            ctx,
+            tool.input_model.model_validate({
+                "env_id": "telemetry-demo",
+                "business_id": BIZ,
+                "run_key": "run-1",
+                "channel_name": "D-4",
+                "window": [{"t": 0, "value": 1.0}, {"t": 1, "value": 1.001}],
+            }),
+        )
+    assert result["verdict"] == "GO"
+    assert "receipt_id" not in result
+    assert not any("INSERT INTO tel_predictions" in sql for sql, _ in fake_cursor.queries)
+
+
 # ── Allowed read call: runs through execute_tool and writes an audit receipt ────
 def test_allowed_read_call_executes_and_audits(fake_cursor):
     # get_triggering_prediction: resolve_tenant_id -> _run_id_for_key (empty -> missing_run, no DB shape needed)

--- a/docs/plans/03-implementation-plans/active/0009-agent-builder-read-only-mvp.md
+++ b/docs/plans/03-implementation-plans/active/0009-agent-builder-read-only-mvp.md
@@ -1,0 +1,82 @@
+# Agent Builder Read-Only MVP
+
+**ADO:** Story #478 under Feature #477 / Epic #476
+**Risk:** High
+**Status:** Implemented locally; superseded for active work by Story #735 eval/publish gate
+**Last updated:** 2026-06-25
+
+## Outcome
+
+The telemetry Agent Control Tower now preserves the existing Run Console and adds five governed modes:
+Agent Builder, Agent Registry, Run History, Tool Registry, and Evals.
+
+The MVP provides:
+
+- `agent-graph/v1` with ten typed node kinds and typed edges.
+- Immutable Save Draft versioning with optimistic concurrency.
+- Graph linting for DAG structure, reachability, terminal paths, gate handles, schema pins, read-only
+  permissions, budgets, and secret-shaped data.
+- Live governed prompt execution through AI dispatch with strict JSON Schema output validation.
+- Sensitive/private-tier routing that forces Gemma and does not fall back to an external model.
+- Read-only MCP execution with canonical schema digests and runtime permission re-checks.
+- A no-write `telemetry.preview_score_window` tool.
+- Synchronous dry-runs with persisted steps, ordered events, receipts, hashes, redacted payloads, and
+  simulated pending approvals.
+- Six tenant-scoped draft templates; only capabilities present in this slice may report success.
+- A persisted eval lifecycle and staged publish gate are now implemented under follow-on Story #735;
+  see `0010-agent-builder-eval-publish-gate.md`.
+
+## Persistence
+
+Migration: `repo-b/db/schema/10035_agent_builder_mvp.sql`.
+
+Tables:
+
+- `ai_agent_workflows`
+- `ai_agent_workflow_versions`
+- `ai_agent_runs`
+- `ai_agent_run_steps`
+- `ai_agent_run_events`
+- `ai_agent_receipts`
+- `ai_agent_approvals`
+
+All seven tables include `env_id`, `business_id`, RLS, comments, and tenant indexes. Run events and
+receipts have DB-level update/delete guards.
+
+## API
+
+Implemented under `/api/agent-builder`:
+
+- `GET /palette`, `/mcp-tools`, `/workflows`, `/workflows/{id}`, `/runs`
+- `POST /workflows`, `/workflows/{id}/validate`, `/workflows/{id}/dry-run`
+- `PATCH /workflows/{id}/draft`
+- `GET /runs/{runId}`, `/runs/{runId}/events`
+
+The Next.js same-origin proxy forwards authenticated platform-session scope headers.
+
+## Verification status
+
+- Backend Agent Builder/MCP/AI dispatch/Control Tower regressions: 87 passed.
+- Frontend telemetry, proxy, schema-order, and Control Tower regressions: 172 passed.
+- Frontend typecheck: passed.
+- Frontend lint: passed with existing repository warnings.
+- Migrations 10035 and 10036 targeted dry-run: 65 statements parsed; no statements executed.
+- Full frontend suite remains red from three pre-existing REPE fund-page tests stuck on
+  `Loading fund...`; the initial baseline had five failures in the same file. The operator approved
+  proceeding with that recorded exception.
+- Full backend suite exceeded ten minutes; the focused owning-surface suite is green.
+
+## Deferred
+
+- Production publish and production run.
+- Real approval resolution/resume.
+- Cancellation and replay execution.
+- Production-only visual/smoke evidence and production publication.
+- Vector retrieval and Databricks analytics export.
+- Write-capable MCP nodes.
+- Applying migration 10035 or deploying any service.
+
+## Next ticket
+
+Apply and verify migrations 10035/10036 in an authorized non-production database, then run
+authenticated desktop/mobile browser smoke and capture persisted workflow/eval/run/receipt evidence.

--- a/docs/plans/03-implementation-plans/active/0010-agent-builder-eval-publish-gate.md
+++ b/docs/plans/03-implementation-plans/active/0010-agent-builder-eval-publish-gate.md
@@ -1,0 +1,86 @@
+# Agent Builder Eval Lifecycle + Staged Publish Gate
+
+**ADO:** Story #735 under Feature #477 / Epic #476  
+**Risk:** High  
+**Status:** Implemented locally; database application and authenticated browser verification pending  
+**Last updated:** 2026-06-25
+
+## Outcome
+
+The read-only Agent Builder now has a persisted eval lifecycle instead of an informational shell.
+Every eval run is pinned to an immutable workflow version and produces append-only per-case evidence.
+
+Implemented:
+
+- Additive migration `10036_agent_builder_evals.sql`.
+- Eval suites, cases, runs, results, and promoted failure memory.
+- Deterministic graph, tool-contract, permission, fail-closed, cost, regression, and replay checks.
+- Explicit N/A results for RAG, visual smoke, and production smoke when those capabilities/evidence
+  are absent.
+- Failed run promotion into regression memory.
+- Regression blocking until the current version has a later matching successful dry-run.
+- Staged-only publish gate for the current immutable version.
+- Real Evals UI with expected/actual/assertion evidence and trace links.
+- Registry readiness status, builder staging control, and Run History regression promotion.
+
+Production publication, production execution, write-capable tools, and approval resume remain
+disabled and fail closed.
+
+## Persistence
+
+Migration `repo-b/db/schema/10036_agent_builder_evals.sql` adds:
+
+- `ai_agent_eval_suites`
+- `ai_agent_eval_cases`
+- `ai_agent_eval_runs`
+- `ai_agent_eval_results`
+- `ai_agent_failure_memory`
+
+It also adds `published_by`, `published_at`, and `publish_blockers` to immutable workflow versions.
+All five tables are tenant scoped with RLS, comments, and indexes. Eval results and failure memory
+have database-level update/delete guards.
+
+## Publish readiness
+
+Staged publication requires PASS for:
+
+- Graph lint
+- Tool contracts
+- Permissions
+- Fail-closed behavior
+- Cost controls
+- Regression cases
+- Replay determinism
+
+RAG grounding may be N/A while `agent-graph/v1` has no RAG node. Visual and production smoke remain
+N/A in this local increment. They do not authorize production publication; the API rejects any
+publish status other than `staged`.
+
+## API
+
+Added:
+
+- `POST /api/agent-builder/workflows/{id}/evals/run`
+- `GET /api/agent-builder/workflows/{id}/evals`
+- `GET /api/agent-builder/eval-runs/{evalRunId}`
+- `POST /api/agent-builder/runs/{runId}/promote-failure`
+- `POST /api/agent-builder/workflows/{id}/publish` (`staged` only)
+
+## Verification
+
+- Focused backend Agent Builder/MCP/AI dispatch/Control Tower suite: 79 passed.
+- Backend Agent Builder persistence/route suite: 26 passed.
+- Ruff: passed.
+- Frontend focused Agent Builder/Control Tower/proxy/schema-order suite: 15 passed.
+- Frontend Agent Builder component suite: 7 passed.
+- Frontend typecheck: passed.
+- Frontend lint: passed.
+- Targeted migration dry-run: migrations 10035 and 10036, 65 statements parsed, none executed.
+- Database application: blocked because no local `DATABASE_URL` or `SUPABASE_DB_URL` is configured.
+- Authenticated browser screenshots: pending database application and a usable local platform session.
+
+## Next production ticket
+
+Apply and verify migrations 10035/10036 in an authorized non-production Supabase environment, run
+authenticated desktop/mobile smoke, and attach eval/run/receipt database evidence. After that,
+implement durable approval resume and cancellation before considering production execution.

--- a/repo-b/db/schema/10035_agent_builder_mvp.sql
+++ b/repo-b/db/schema/10035_agent_builder_mvp.sql
@@ -1,0 +1,288 @@
+-- 10035_agent_builder_mvp.sql
+-- Governed Agent Builder read-only MVP.
+--
+-- Primary Postgres/Supabase is the operational source of truth for workflow drafts,
+-- immutable versions, synchronous dry-runs, append-only events, receipts, and
+-- simulated approvals. Heavy telemetry analytics remain outside these tables.
+-- Additive and idempotent. Owning module: AI / Agent Control Tower.
+
+CREATE TABLE IF NOT EXISTS ai_agent_workflows (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id              text NOT NULL,
+    business_id         uuid NOT NULL,
+    name                text NOT NULL,
+    description         text,
+    owner_user_id       text,
+    status              text NOT NULL DEFAULT 'draft',
+    current_version_id  uuid,
+    tags                text[] NOT NULL DEFAULT '{}'::text[],
+    is_template         boolean NOT NULL DEFAULT false,
+    template_key        text,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (env_id, business_id, template_key)
+);
+
+CREATE TABLE IF NOT EXISTS ai_agent_workflow_versions (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id                text NOT NULL,
+    business_id           uuid NOT NULL,
+    workflow_id           uuid NOT NULL REFERENCES ai_agent_workflows(id) ON DELETE CASCADE,
+    version_number        integer NOT NULL CHECK (version_number > 0),
+    graph_json            jsonb NOT NULL,
+    compiled_plan_json    jsonb,
+    prompt_versions       jsonb NOT NULL DEFAULT '{}'::jsonb,
+    tool_schema_digests   jsonb NOT NULL DEFAULT '{}'::jsonb,
+    model_route_policy    jsonb NOT NULL DEFAULT '{}'::jsonb,
+    required_permissions  text[] NOT NULL DEFAULT ARRAY['read']::text[],
+    validation_status     text NOT NULL DEFAULT 'pending',
+    validation_results    jsonb NOT NULL DEFAULT '[]'::jsonb,
+    publish_status        text NOT NULL DEFAULT 'draft',
+    created_by            text,
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (workflow_id, version_number)
+);
+
+DO $$
+BEGIN
+    ALTER TABLE ai_agent_workflows
+        ADD CONSTRAINT ai_agent_workflows_current_version_fk
+        FOREIGN KEY (current_version_id)
+        REFERENCES ai_agent_workflow_versions(id)
+        DEFERRABLE INITIALLY DEFERRED;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS ai_agent_runs (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id                text NOT NULL,
+    business_id           uuid NOT NULL,
+    workflow_id           uuid NOT NULL REFERENCES ai_agent_workflows(id),
+    workflow_version_id   uuid NOT NULL REFERENCES ai_agent_workflow_versions(id),
+    actor_user_id         text,
+    runtime_mode          text NOT NULL DEFAULT 'dry_run',
+    status                text NOT NULL,
+    terminal_reason       text,
+    started_at            timestamptz NOT NULL DEFAULT now(),
+    finished_at           timestamptz,
+    input_json            jsonb NOT NULL DEFAULT '{}'::jsonb,
+    output_json           jsonb,
+    error_json            jsonb,
+    cost_estimate         numeric(14, 6) NOT NULL DEFAULT 0,
+    actual_cost           numeric(14, 6) NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS ai_agent_run_steps (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id          text NOT NULL,
+    business_id     uuid NOT NULL,
+    run_id          uuid NOT NULL REFERENCES ai_agent_runs(id) ON DELETE CASCADE,
+    node_id         text NOT NULL,
+    node_type       text NOT NULL,
+    status          text NOT NULL,
+    started_at      timestamptz NOT NULL DEFAULT now(),
+    finished_at     timestamptz,
+    input_hash      text,
+    output_hash     text,
+    input_json      jsonb NOT NULL DEFAULT '{}'::jsonb,
+    output_json     jsonb,
+    tool_name       text,
+    model_name      text,
+    error_json      jsonb,
+    receipt_id      uuid,
+    UNIQUE (run_id, node_id)
+);
+
+CREATE TABLE IF NOT EXISTS ai_agent_run_events (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id          text NOT NULL,
+    business_id     uuid NOT NULL,
+    run_id          uuid NOT NULL REFERENCES ai_agent_runs(id) ON DELETE CASCADE,
+    step_id         uuid REFERENCES ai_agent_run_steps(id),
+    node_id         text,
+    sequence_number bigint NOT NULL,
+    event_type      text NOT NULL,
+    status          text,
+    payload_json    jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (run_id, sequence_number)
+);
+
+CREATE TABLE IF NOT EXISTS ai_agent_receipts (
+    id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id            text NOT NULL,
+    business_id       uuid NOT NULL,
+    workflow_id       uuid NOT NULL REFERENCES ai_agent_workflows(id),
+    workflow_version_id uuid NOT NULL REFERENCES ai_agent_workflow_versions(id),
+    run_id            uuid NOT NULL REFERENCES ai_agent_runs(id) ON DELETE CASCADE,
+    step_id           uuid REFERENCES ai_agent_run_steps(id),
+    node_id           text NOT NULL,
+    receipt_type      text NOT NULL,
+    actor             text,
+    input_hash        text,
+    output_hash       text,
+    tools_called      jsonb NOT NULL DEFAULT '[]'::jsonb,
+    model_used        text,
+    cost_estimate     numeric(14, 6) NOT NULL DEFAULT 0,
+    terminal_status   text NOT NULL,
+    failure_reason    text,
+    receipt_json      jsonb NOT NULL,
+    created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+DO $$
+BEGIN
+    ALTER TABLE ai_agent_run_steps
+        ADD CONSTRAINT ai_agent_run_steps_receipt_fk
+        FOREIGN KEY (receipt_id) REFERENCES ai_agent_receipts(id)
+        DEFERRABLE INITIALLY DEFERRED;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS ai_agent_approvals (
+    id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id            text NOT NULL,
+    business_id       uuid NOT NULL,
+    run_id            uuid NOT NULL REFERENCES ai_agent_runs(id) ON DELETE CASCADE,
+    node_id           text NOT NULL,
+    requested_by      text,
+    approved_by       text,
+    approval_status   text NOT NULL DEFAULT 'simulated_pending',
+    approval_reason   text,
+    requested_at      timestamptz NOT NULL DEFAULT now(),
+    resolved_at       timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_agent_workflows_tenant_updated
+    ON ai_agent_workflows (env_id, business_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ai_agent_versions_tenant_workflow
+    ON ai_agent_workflow_versions (env_id, business_id, workflow_id, version_number DESC);
+CREATE INDEX IF NOT EXISTS idx_ai_agent_runs_tenant_started
+    ON ai_agent_runs (env_id, business_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ai_agent_steps_run
+    ON ai_agent_run_steps (env_id, business_id, run_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_ai_agent_events_run_sequence
+    ON ai_agent_run_events (env_id, business_id, run_id, sequence_number);
+CREATE INDEX IF NOT EXISTS idx_ai_agent_receipts_run
+    ON ai_agent_receipts (env_id, business_id, run_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_ai_agent_approvals_run
+    ON ai_agent_approvals (env_id, business_id, run_id, requested_at);
+
+ALTER TABLE ai_agent_workflows ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_agent_workflow_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_agent_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_agent_run_steps ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_agent_run_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_agent_receipts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_agent_approvals ENABLE ROW LEVEL SECURITY;
+
+DO $$
+DECLARE
+    table_name text;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'ai_agent_workflows',
+        'ai_agent_workflow_versions',
+        'ai_agent_runs',
+        'ai_agent_run_steps',
+        'ai_agent_run_events',
+        'ai_agent_receipts',
+        'ai_agent_approvals'
+    ]
+    LOOP
+        BEGIN
+            EXECUTE format(
+                'CREATE POLICY %I ON %I
+                 USING (
+                    env_id = current_setting(''app.env_id'', true)
+                    AND (
+                        nullif(current_setting(''app.business_id'', true), '''') IS NULL
+                        OR business_id::text = current_setting(''app.business_id'', true)
+                    )
+                 )
+                 WITH CHECK (
+                    env_id = current_setting(''app.env_id'', true)
+                    AND (
+                        nullif(current_setting(''app.business_id'', true), '''') IS NULL
+                        OR business_id::text = current_setting(''app.business_id'', true)
+                    )
+                 )',
+                table_name || '_tenant',
+                table_name
+            );
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END;
+    END LOOP;
+END $$;
+
+CREATE OR REPLACE FUNCTION ai_agent_reject_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION '% is append-only; % is not permitted', TG_TABLE_NAME, TG_OP;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ai_agent_run_events_append_only ON ai_agent_run_events;
+CREATE TRIGGER ai_agent_run_events_append_only
+    BEFORE UPDATE OR DELETE ON ai_agent_run_events
+    FOR EACH ROW EXECUTE FUNCTION ai_agent_reject_mutation();
+
+DROP TRIGGER IF EXISTS ai_agent_receipts_append_only ON ai_agent_receipts;
+CREATE TRIGGER ai_agent_receipts_append_only
+    BEFORE UPDATE OR DELETE ON ai_agent_receipts
+    FOR EACH ROW EXECUTE FUNCTION ai_agent_reject_mutation();
+
+COMMENT ON TABLE ai_agent_workflows IS
+  'Agent Builder workflow identity and mutable pointer to the current immutable draft version. Tenant-scoped operational truth.';
+COMMENT ON TABLE ai_agent_workflow_versions IS
+  'Immutable Agent Builder graph versions with prompt/tool/model-route pins and validation evidence.';
+COMMENT ON TABLE ai_agent_runs IS
+  'Agent Builder synchronous execution records. MVP runtime_mode is dry_run only.';
+COMMENT ON TABLE ai_agent_run_steps IS
+  'Per-node Agent Builder execution trace with redacted payloads and canonical SHA-256 hashes.';
+COMMENT ON TABLE ai_agent_run_events IS
+  'Append-only ordered Agent Builder run events used for UI state, trace, and replay evidence.';
+COMMENT ON TABLE ai_agent_receipts IS
+  'Append-only Agent Builder audit receipts for tool, model, approval, and workflow steps.';
+COMMENT ON TABLE ai_agent_approvals IS
+  'Agent Builder approval requests. MVP writes simulated_pending rows and does not resume execution.';
+
+DO $$
+DECLARE
+    table_count int;
+    rls_count int;
+    trigger_count int;
+BEGIN
+    SELECT count(*) INTO table_count
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name IN (
+        'ai_agent_workflows', 'ai_agent_workflow_versions', 'ai_agent_runs',
+        'ai_agent_run_steps', 'ai_agent_run_events', 'ai_agent_receipts',
+        'ai_agent_approvals'
+      );
+
+    SELECT count(*) INTO rls_count
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND rowsecurity = true
+      AND tablename IN (
+        'ai_agent_workflows', 'ai_agent_workflow_versions', 'ai_agent_runs',
+        'ai_agent_run_steps', 'ai_agent_run_events', 'ai_agent_receipts',
+        'ai_agent_approvals'
+      );
+
+    SELECT count(*) INTO trigger_count
+    FROM pg_trigger
+    WHERE NOT tgisinternal
+      AND tgname IN ('ai_agent_run_events_append_only', 'ai_agent_receipts_append_only');
+
+    IF table_count <> 7 OR rls_count <> 7 OR trigger_count <> 2 THEN
+        RAISE EXCEPTION
+          'agent builder 10035 incomplete: tables %, RLS %, append-only triggers %',
+          table_count, rls_count, trigger_count;
+    END IF;
+    RAISE NOTICE 'agent builder 10035 ready: 7 tables, 7 RLS policies, 2 append-only guards';
+END $$;

--- a/repo-b/db/schema/10036_agent_builder_evals.sql
+++ b/repo-b/db/schema/10036_agent_builder_evals.sql
@@ -1,0 +1,218 @@
+-- 10036_agent_builder_evals.sql
+-- Deterministic Agent Builder eval lifecycle and staged publish gate.
+--
+-- Additive and idempotent. Production execution remains disabled: this migration
+-- only persists eval evidence, regression memory, and staged publication metadata.
+
+ALTER TABLE ai_agent_workflow_versions
+    ADD COLUMN IF NOT EXISTS published_by text,
+    ADD COLUMN IF NOT EXISTS published_at timestamptz,
+    ADD COLUMN IF NOT EXISTS publish_blockers jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+CREATE TABLE IF NOT EXISTS ai_agent_eval_suites (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id                text NOT NULL,
+    business_id           uuid NOT NULL,
+    workflow_id           uuid NOT NULL REFERENCES ai_agent_workflows(id) ON DELETE CASCADE,
+    workflow_version_id   uuid NOT NULL REFERENCES ai_agent_workflow_versions(id) ON DELETE CASCADE,
+    name                  text NOT NULL DEFAULT 'Publish readiness',
+    status                text NOT NULL DEFAULT 'active',
+    required_classes      text[] NOT NULL DEFAULT ARRAY[
+                            'graph_lint', 'tool_contract', 'permission',
+                            'fail_closed', 'cost', 'regression',
+                            'replay_determinism'
+                          ]::text[],
+    created_by            text,
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (workflow_version_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS ai_agent_eval_cases (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id                text NOT NULL,
+    business_id           uuid NOT NULL,
+    suite_id              uuid NOT NULL REFERENCES ai_agent_eval_suites(id) ON DELETE CASCADE,
+    case_key              text NOT NULL,
+    eval_class            text NOT NULL,
+    title                 text NOT NULL,
+    input_json            jsonb NOT NULL DEFAULT '{}'::jsonb,
+    expected_json         jsonb NOT NULL DEFAULT '{}'::jsonb,
+    source                text NOT NULL DEFAULT 'generated',
+    active                boolean NOT NULL DEFAULT true,
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (suite_id, case_key)
+);
+
+CREATE TABLE IF NOT EXISTS ai_agent_eval_runs (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id                text NOT NULL,
+    business_id           uuid NOT NULL,
+    suite_id              uuid NOT NULL REFERENCES ai_agent_eval_suites(id),
+    workflow_id           uuid NOT NULL REFERENCES ai_agent_workflows(id),
+    workflow_version_id   uuid NOT NULL REFERENCES ai_agent_workflow_versions(id),
+    actor_user_id         text,
+    status                text NOT NULL DEFAULT 'running',
+    overall_status        text NOT NULL DEFAULT 'blocked',
+    summary_json          jsonb NOT NULL DEFAULT '{}'::jsonb,
+    started_at            timestamptz NOT NULL DEFAULT now(),
+    finished_at           timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS ai_agent_eval_results (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id                text NOT NULL,
+    business_id           uuid NOT NULL,
+    eval_run_id           uuid NOT NULL REFERENCES ai_agent_eval_runs(id) ON DELETE CASCADE,
+    eval_case_id          uuid NOT NULL REFERENCES ai_agent_eval_cases(id),
+    eval_class            text NOT NULL,
+    status                text NOT NULL,
+    input_json            jsonb NOT NULL DEFAULT '{}'::jsonb,
+    expected_json         jsonb NOT NULL DEFAULT '{}'::jsonb,
+    actual_json           jsonb NOT NULL DEFAULT '{}'::jsonb,
+    failed_assertion      text,
+    trace_run_id          uuid REFERENCES ai_agent_runs(id),
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (eval_run_id, eval_case_id)
+);
+
+CREATE TABLE IF NOT EXISTS ai_agent_failure_memory (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    env_id                text NOT NULL,
+    business_id           uuid NOT NULL,
+    workflow_id           uuid NOT NULL REFERENCES ai_agent_workflows(id) ON DELETE CASCADE,
+    workflow_version_id   uuid NOT NULL REFERENCES ai_agent_workflow_versions(id),
+    source_run_id         uuid NOT NULL REFERENCES ai_agent_runs(id),
+    eval_case_id          uuid REFERENCES ai_agent_eval_cases(id),
+    failure_signature     text NOT NULL,
+    input_hash            text NOT NULL,
+    input_json            jsonb NOT NULL DEFAULT '{}'::jsonb,
+    expected_behavior     jsonb NOT NULL DEFAULT '{}'::jsonb,
+    actual_behavior       jsonb NOT NULL DEFAULT '{}'::jsonb,
+    failure_reason        text,
+    created_by            text,
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (source_run_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_agent_eval_suites_tenant_workflow
+    ON ai_agent_eval_suites (env_id, business_id, workflow_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ai_agent_eval_cases_tenant_suite
+    ON ai_agent_eval_cases (env_id, business_id, suite_id, eval_class, active);
+CREATE INDEX IF NOT EXISTS idx_ai_agent_eval_runs_tenant_workflow
+    ON ai_agent_eval_runs (env_id, business_id, workflow_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ai_agent_eval_results_tenant_run
+    ON ai_agent_eval_results (env_id, business_id, eval_run_id, eval_class);
+CREATE INDEX IF NOT EXISTS idx_ai_agent_failure_memory_tenant_workflow
+    ON ai_agent_failure_memory (env_id, business_id, workflow_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ai_agent_failure_memory_input
+    ON ai_agent_failure_memory (workflow_id, input_hash, created_at DESC);
+
+ALTER TABLE ai_agent_eval_suites ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_agent_eval_cases ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_agent_eval_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_agent_eval_results ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_agent_failure_memory ENABLE ROW LEVEL SECURITY;
+
+DO $$
+DECLARE
+    table_name text;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'ai_agent_eval_suites',
+        'ai_agent_eval_cases',
+        'ai_agent_eval_runs',
+        'ai_agent_eval_results',
+        'ai_agent_failure_memory'
+    ]
+    LOOP
+        BEGIN
+            EXECUTE format(
+                'CREATE POLICY %I ON %I
+                 USING (
+                    env_id = current_setting(''app.env_id'', true)
+                    AND (
+                        nullif(current_setting(''app.business_id'', true), '''') IS NULL
+                        OR business_id::text = current_setting(''app.business_id'', true)
+                    )
+                 )
+                 WITH CHECK (
+                    env_id = current_setting(''app.env_id'', true)
+                    AND (
+                        nullif(current_setting(''app.business_id'', true), '''') IS NULL
+                        OR business_id::text = current_setting(''app.business_id'', true)
+                    )
+                 )',
+                table_name || '_tenant',
+                table_name
+            );
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END;
+    END LOOP;
+END $$;
+
+DROP TRIGGER IF EXISTS ai_agent_eval_results_append_only ON ai_agent_eval_results;
+CREATE TRIGGER ai_agent_eval_results_append_only
+    BEFORE UPDATE OR DELETE ON ai_agent_eval_results
+    FOR EACH ROW EXECUTE FUNCTION ai_agent_reject_mutation();
+
+DROP TRIGGER IF EXISTS ai_agent_failure_memory_append_only ON ai_agent_failure_memory;
+CREATE TRIGGER ai_agent_failure_memory_append_only
+    BEFORE UPDATE OR DELETE ON ai_agent_failure_memory
+    FOR EACH ROW EXECUTE FUNCTION ai_agent_reject_mutation();
+
+COMMENT ON TABLE ai_agent_eval_suites IS
+  'Version-pinned Agent Builder publish-readiness suite and required deterministic eval classes.';
+COMMENT ON TABLE ai_agent_eval_cases IS
+  'First-class generated and regression Agent Builder eval cases.';
+COMMENT ON TABLE ai_agent_eval_runs IS
+  'Persisted evaluation executions for one immutable workflow version.';
+COMMENT ON TABLE ai_agent_eval_results IS
+  'Append-only per-case eval evidence with expected, actual, assertion, and trace linkage.';
+COMMENT ON TABLE ai_agent_failure_memory IS
+  'Append-only promoted failed runs used to prevent regressions on later workflow versions.';
+
+DO $$
+DECLARE
+    table_count int;
+    rls_count int;
+    trigger_count int;
+    version_column_count int;
+BEGIN
+    SELECT count(*) INTO table_count
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name IN (
+        'ai_agent_eval_suites', 'ai_agent_eval_cases', 'ai_agent_eval_runs',
+        'ai_agent_eval_results', 'ai_agent_failure_memory'
+      );
+
+    SELECT count(*) INTO rls_count
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND rowsecurity = true
+      AND tablename IN (
+        'ai_agent_eval_suites', 'ai_agent_eval_cases', 'ai_agent_eval_runs',
+        'ai_agent_eval_results', 'ai_agent_failure_memory'
+      );
+
+    SELECT count(*) INTO trigger_count
+    FROM pg_trigger
+    WHERE NOT tgisinternal
+      AND tgname IN (
+        'ai_agent_eval_results_append_only',
+        'ai_agent_failure_memory_append_only'
+      );
+
+    SELECT count(*) INTO version_column_count
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'ai_agent_workflow_versions'
+      AND column_name IN ('published_by', 'published_at', 'publish_blockers');
+
+    IF table_count <> 5 OR rls_count <> 5 OR trigger_count <> 2 OR version_column_count <> 3 THEN
+        RAISE EXCEPTION
+          'agent builder 10036 incomplete: tables %, RLS %, append-only triggers %, version columns %',
+          table_count, rls_count, trigger_count, version_column_count;
+    END IF;
+    RAISE NOTICE 'agent builder 10036 ready: 5 eval tables, 5 RLS policies, 2 append-only guards';
+END $$;

--- a/repo-b/src/app/api/agent-builder/[...path]/route.test.ts
+++ b/repo-b/src/app/api/agent-builder/[...path]/route.test.ts
@@ -1,0 +1,70 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/server/sessionAuth", () => ({
+  parseSessionFromRequest: vi.fn(async (request: Request) =>
+    request.headers.get("cookie") ? { platform_user_id: "user-1" } : null,
+  ),
+}));
+
+vi.mock("@/lib/server/platformForwardHeaders", () => ({
+  buildPlatformSessionHeaders: vi.fn(async () => ({
+    "x-bm-actor": "user:test:user-1",
+    "x-bm-auth-provider": "platform-session",
+    "x-bm-user-id": "user-1",
+    "x-bm-env-id": "env-1",
+    "x-bm-business-id": "00000000-0000-0000-0000-000000000001",
+  })),
+}));
+
+import { GET, PATCH, POST } from "./route";
+
+describe("agent builder proxy", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fails closed without a platform session", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/agent-builder/palette"),
+      { params: { path: ["palette"] } },
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it.each([
+    ["GET", GET, undefined],
+    ["POST", POST, JSON.stringify({ graph: {} })],
+    ["PATCH", PATCH, JSON.stringify({ base_version_number: 1 })],
+  ] as const)("forwards %s with platform scope headers", async (method, handler, body) => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const request = new NextRequest(
+      "http://localhost:3000/api/agent-builder/workflows/abc/draft?limit=1",
+      {
+        method,
+        headers: { cookie: "bm_session=test", "content-type": "application/json" },
+        body,
+      },
+    );
+    const response = await handler(request, {
+      params: { path: ["workflows", "abc", "draft"] },
+    });
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/api/agent-builder/workflows/abc/draft?limit=1"),
+      expect.objectContaining({
+        method,
+        headers: expect.objectContaining({
+          "x-bm-auth-provider": "platform-session",
+          "x-bm-business-id": "00000000-0000-0000-0000-000000000001",
+        }),
+      }),
+    );
+  });
+});

--- a/repo-b/src/app/api/agent-builder/[...path]/route.ts
+++ b/repo-b/src/app/api/agent-builder/[...path]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { buildPlatformSessionHeaders } from "@/lib/server/platformForwardHeaders";
+import { parseSessionFromRequest } from "@/lib/server/sessionAuth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const FASTAPI_BASE = (
+  process.env.BOS_API_ORIGIN ||
+  process.env.NEXT_PUBLIC_BOS_API_BASE_URL ||
+  "http://localhost:8000"
+).replace(/\/$/, "");
+
+async function forward(req: NextRequest, ctx: { params: { path: string[] } }) {
+  const session = await parseSessionFromRequest(req);
+  if (!session) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  const path = (ctx.params.path || []).map(encodeURIComponent).join("/");
+  const target = new URL(`/api/agent-builder/${path}`, FASTAPI_BASE);
+  target.search = req.nextUrl.search;
+  const body =
+    req.method === "GET" || req.method === "HEAD" ? undefined : await req.text();
+
+  try {
+    const upstream = await fetch(target.toString(), {
+      method: req.method,
+      cache: "no-store",
+      headers: {
+        "content-type": req.headers.get("content-type") || "application/json",
+        "x-bm-request-id": req.headers.get("x-bm-request-id") || "",
+        ...(await buildPlatformSessionHeaders(req)),
+      },
+      body,
+    });
+    return new NextResponse(await upstream.text(), {
+      status: upstream.status,
+      headers: {
+        "content-type": upstream.headers.get("content-type") || "application/json",
+        "cache-control": "no-store",
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to reach backend";
+    return NextResponse.json({ error: `Agent Builder proxy error: ${message}` }, { status: 502 });
+  }
+}
+
+export async function GET(req: NextRequest, ctx: { params: { path: string[] } }) {
+  return forward(req, ctx);
+}
+
+export async function POST(req: NextRequest, ctx: { params: { path: string[] } }) {
+  return forward(req, ctx);
+}
+
+export async function PATCH(req: NextRequest, ctx: { params: { path: string[] } }) {
+  return forward(req, ctx);
+}

--- a/repo-b/src/app/api/auth/oidc/__tests__/callback-route.test.ts
+++ b/repo-b/src/app/api/auth/oidc/__tests__/callback-route.test.ts
@@ -44,7 +44,7 @@ describe("oidcPkce helpers", () => {
   it("rejects tampered payloads", () => {
     const envelope = buildEnvelope();
     const token = signEnvelope(envelope);
-    const tampered = token.replace(/.$/, "x");
+    const tampered = `${token.slice(0, -1)}${token.endsWith("x") ? "y" : "x"}`;
     expect(verifyEnvelope(tampered)).toBeNull();
   });
 

--- a/repo-b/src/components/telemetry/AgentBuilder.test.tsx
+++ b/repo-b/src/components/telemetry/AgentBuilder.test.tsx
@@ -1,0 +1,354 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  AgentGraph,
+  AgentRun,
+  WorkflowDetail,
+  WorkflowSummary,
+} from "@/lib/telemetry/agentBuilder-api";
+
+vi.mock("@xyflow/react", () => ({
+  ReactFlow: ({
+    nodes,
+    onNodeClick,
+    children,
+  }: {
+    nodes: Array<{ id: string; data: { label: React.ReactNode } }>;
+    onNodeClick?: (event: unknown, node: { id: string }) => void;
+    children?: React.ReactNode;
+  }) => (
+    <div data-testid="agent-canvas">
+      {nodes.map((node) => (
+        <button key={node.id} type="button" onClick={() => onNodeClick?.({}, node)}>
+          {node.data.label}
+        </button>
+      ))}
+      {children}
+    </div>
+  ),
+  Background: () => null,
+  Controls: () => null,
+  MiniMap: () => null,
+  Handle: () => null,
+  Position: { Left: "left", Right: "right" },
+  addEdge: (connection: unknown, edges: unknown[]) => [...edges, connection],
+  useNodesState: (initial: unknown[]) => {
+    const [value, setValue] = React.useState(initial);
+    return [value, setValue, vi.fn()];
+  },
+  useEdgesState: (initial: unknown[]) => {
+    const [value, setValue] = React.useState(initial);
+    return [value, setValue, vi.fn()];
+  },
+}));
+
+const api = vi.hoisted(() => ({
+  getPalette: vi.fn(),
+  getMcpTools: vi.fn(),
+  getWorkflows: vi.fn(),
+  getRuns: vi.fn(),
+  getWorkflow: vi.fn(),
+  createWorkflow: vi.fn(),
+  saveWorkflowDraft: vi.fn(),
+  validateWorkflow: vi.fn(),
+  dryRunWorkflow: vi.fn(),
+  getRun: vi.fn(),
+  getWorkflowEvals: vi.fn(),
+  runWorkflowEvals: vi.fn(),
+  stageWorkflow: vi.fn(),
+  promoteRunFailure: vi.fn(),
+}));
+
+vi.mock("@/lib/telemetry/agentBuilder-api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/telemetry/agentBuilder-api")>(
+    "@/lib/telemetry/agentBuilder-api",
+  );
+  return { ...actual, ...api };
+});
+
+import AgentBuilder from "./AgentBuilder";
+
+const graph: AgentGraph = {
+  schema_version: "agent-graph/v1",
+  limits: { max_runtime_seconds: 120, max_tool_calls: 10, max_cost_usd: 1 },
+  model_route_policy: { sensitive_fallback: "fail_closed" },
+  nodes: [
+    { id: "trigger", type: "manual_trigger", label: "Manual Trigger", position: { x: 0, y: 0 }, config: {} },
+    { id: "output", type: "output", label: "Output", position: { x: 300, y: 0 }, config: {} },
+  ],
+  edges: [{ id: "e1", source: "trigger", target: "output", data_type: "control" }],
+};
+
+const summary: WorkflowSummary = {
+  id: "workflow-1",
+  name: "Telemetry Agent",
+  description: "Read-only telemetry triage",
+  owner_user_id: "operator",
+  status: "draft",
+  tags: ["template"],
+  is_template: true,
+  template_key: "telemetry-triage",
+  version_id: "version-1",
+  version_number: 1,
+  validation_status: "pass",
+  validation_results: {
+    status: "pass",
+    checks: { dag: true },
+    issues: [],
+    topological_order: ["trigger", "output"],
+  },
+  publish_status: "draft",
+  last_run_status: null,
+  eval_overall_status: null,
+  eval_summary: null,
+  updated_at: "2026-06-25T12:00:00Z",
+};
+
+const detail: WorkflowDetail = {
+  ...summary,
+  graph,
+  versions: [{
+    id: "version-1",
+    version_number: 1,
+    validation_status: "pass",
+    publish_status: "draft",
+    publish_blockers: [],
+    published_by: null,
+    published_at: null,
+    created_by: "operator",
+    created_at: "2026-06-25T12:00:00Z",
+  }],
+  published_by: null,
+  published_at: null,
+  publish_blockers: [],
+};
+
+const stagedReadyEval = {
+  id: "eval-run-1",
+  workflow_id: "workflow-1",
+  workflow_version_id: "version-1",
+  version_number: 1,
+  status: "completed",
+  overall_status: "staged_ready" as const,
+  summary_json: {
+    overall_status: "staged_ready" as const,
+    by_class: {
+      graph_lint: "pass" as const,
+      tool_contract: "pass" as const,
+      permission: "pass" as const,
+      fail_closed: "pass" as const,
+      cost: "pass" as const,
+      regression: "pass" as const,
+      replay_determinism: "pass" as const,
+      rag_grounding: "not_applicable" as const,
+      visual_smoke: "not_applicable" as const,
+      production_smoke: "not_applicable" as const,
+    },
+    blockers: [],
+    counts: { pass: 7, fail: 0, not_applicable: 3, total: 10 },
+  },
+  results: [],
+};
+
+const blockedEval = {
+  ...stagedReadyEval,
+  id: undefined,
+  status: "not_run",
+  overall_status: "blocked" as const,
+  summary_json: {
+    ...stagedReadyEval.summary_json,
+    overall_status: "blocked" as const,
+    by_class: {
+      ...stagedReadyEval.summary_json.by_class,
+      graph_lint: "not_run" as const,
+      tool_contract: "not_run" as const,
+      permission: "not_run" as const,
+      fail_closed: "not_run" as const,
+      cost: "not_run" as const,
+      regression: "not_run" as const,
+      replay_determinism: "not_run" as const,
+    },
+    blockers: [{ eval_class: "graph_lint", reason: "required_eval_not_run" }],
+    counts: { pass: 0, fail: 0, not_applicable: 3, total: 10 },
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getPalette.mockResolvedValue({
+    schema_version: "agent-graph/v1",
+    nodes: [
+      { type: "context_loader", label: "Context Loader", category: "Input", description: "Load context" },
+      { type: "mcp_tool", label: "MCP Tool", category: "Action", description: "Read tool" },
+    ],
+  });
+  api.getMcpTools.mockResolvedValue({
+    tools: [
+      {
+        name: "telemetry.preview_score_window",
+        description: "Preview",
+        module: "telemetry",
+        permission: "read",
+        effective_permission: "read",
+        side_effect_class: "read",
+        input_schema: {},
+        output_schema: {},
+        schema_digest: "digest-read",
+        enabled: true,
+        disabled_reason: null,
+      },
+      {
+        name: "business.create",
+        description: "Write",
+        module: "business",
+        permission: "write",
+        effective_permission: "write_confirmed",
+        side_effect_class: "write",
+        input_schema: {},
+        output_schema: null,
+        schema_digest: "digest-write",
+        enabled: false,
+        disabled_reason: "MVP permits read-only MCP tools only",
+      },
+    ],
+  });
+  api.getWorkflows.mockResolvedValue({ workflows: [summary] });
+  api.getRuns.mockResolvedValue({ runs: [] });
+  api.getWorkflow.mockResolvedValue(detail);
+  api.getWorkflowEvals.mockResolvedValue(blockedEval);
+  api.saveWorkflowDraft.mockResolvedValue({ ...detail, version_number: 2 });
+  api.validateWorkflow.mockResolvedValue(detail.validation_results);
+  api.dryRunWorkflow.mockResolvedValue({
+    id: "run-1",
+    workflow_id: "workflow-1",
+    workflow_name: "Telemetry Agent",
+    workflow_version_id: "version-1",
+    version_number: 1,
+    status: "succeeded",
+    terminal_reason: null,
+    started_at: "2026-06-25T12:00:00Z",
+    finished_at: "2026-06-25T12:00:01Z",
+    actual_cost: 0,
+    steps: [
+      { id: "step-1", node_id: "trigger", node_type: "manual_trigger", status: "completed", tool_name: null, model_name: null, output_json: {}, error_json: null, receipt_id: "receipt-1" },
+      { id: "step-2", node_id: "output", node_type: "output", status: "completed", tool_name: null, model_name: null, output_json: {}, error_json: null, receipt_id: "receipt-2" },
+    ],
+    receipts: [
+      { id: "receipt-1", node_id: "trigger", receipt_type: "step", tools_called: [], model_used: null, terminal_status: "completed", failure_reason: null, created_at: "2026-06-25T12:00:00Z" },
+    ],
+  } satisfies AgentRun);
+  api.runWorkflowEvals.mockResolvedValue(stagedReadyEval);
+  api.stageWorkflow.mockResolvedValue({
+    ...detail,
+    status: "staged",
+    publish_status: "staged",
+  });
+  api.promoteRunFailure.mockResolvedValue({
+    source_run_id: "run-1",
+    already_promoted: false,
+  });
+});
+
+describe("AgentBuilder", () => {
+  it("adds and configures a node, pins read tools, and saves an immutable draft", async () => {
+    const user = userEvent.setup();
+    render(<AgentBuilder tab="builder" onOpenBuilder={() => {}} />);
+    expect(await screen.findByText("Agent Builder")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Context Loader Input/i }));
+    const label = screen.getByLabelText("Label");
+    await user.clear(label);
+    await user.type(label, "Environment Context");
+    await user.click(screen.getByRole("button", { name: "Save Draft" }));
+
+    await waitFor(() => expect(api.saveWorkflowDraft).toHaveBeenCalled());
+    const payload = api.saveWorkflowDraft.mock.calls[0][1];
+    expect(payload.base_version_number).toBe(1);
+    expect(payload.graph.nodes.some((node: { label?: string }) => node.label === "Environment Context")).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: /MCP Tool Action/i }));
+    expect(screen.getByRole("option", { name: /business.create · blocked/i })).toBeDisabled();
+  });
+
+  it("shows validation, persisted run states, and receipts after dry-run", async () => {
+    const user = userEvent.setup();
+    render(<AgentBuilder tab="builder" onOpenBuilder={() => {}} />);
+    await screen.findByText("Agent Builder");
+    await user.click(screen.getByRole("button", { name: "Validate" }));
+    expect(await screen.findByText("pass")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Dry Run" }));
+    expect(await screen.findByText(/Run succeeded/i)).toBeInTheDocument();
+    expect(screen.getByText(/receipt-1/)).toBeInTheDocument();
+    expect(api.dryRunWorkflow).toHaveBeenCalledWith(
+      "workflow-1",
+      expect.objectContaining({ run_key: "FD001-test-001", channel: "D-4" }),
+    );
+  });
+
+  it("renders write tools as blocked in the Tool Registry", async () => {
+    render(<AgentBuilder tab="tools" onOpenBuilder={() => {}} />);
+    expect(await screen.findByText("Tool Registry")).toBeInTheDocument();
+    expect(screen.getByText("business.create")).toBeInTheDocument();
+    expect(screen.getByText("write · blocked")).toBeInTheDocument();
+  });
+
+  it("keeps publish readiness blocked while deferred eval classes are N/A", async () => {
+    render(<AgentBuilder tab="evals" onOpenBuilder={() => {}} />);
+    expect(await screen.findByText("Publish readiness")).toBeInTheDocument();
+    expect(screen.getAllByText("N/A").length).toBeGreaterThan(0);
+    expect(screen.getByText("BLOCKED")).toBeInTheDocument();
+  });
+
+  it("runs persisted publish-readiness evals", async () => {
+    const user = userEvent.setup();
+    render(<AgentBuilder tab="evals" onOpenBuilder={() => {}} />);
+    await user.click(await screen.findByRole("button", { name: "Run Evals" }));
+    await waitFor(() => expect(api.runWorkflowEvals).toHaveBeenCalledWith("workflow-1"));
+    expect(await screen.findByText("STAGED READY")).toBeInTheDocument();
+  });
+
+  it("stages only after deterministic checks pass", async () => {
+    const user = userEvent.setup();
+    api.getWorkflowEvals.mockResolvedValue(stagedReadyEval);
+    render(<AgentBuilder tab="builder" onOpenBuilder={() => {}} />);
+    await screen.findByText("Agent Builder");
+    const stage = screen.getByRole("button", { name: "Stage" });
+    expect(stage).toBeEnabled();
+    await user.click(stage);
+    await waitFor(() => expect(api.stageWorkflow).toHaveBeenCalledWith("workflow-1"));
+  });
+
+  it("promotes a failed run into regression memory", async () => {
+    const user = userEvent.setup();
+    const failedRun: AgentRun = {
+      id: "run-failed",
+      workflow_id: "workflow-1",
+      workflow_name: "Telemetry Agent",
+      workflow_version_id: "version-1",
+      version_number: 1,
+      status: "not_available",
+      terminal_reason: "missing_data",
+      started_at: "2026-06-25T12:00:00Z",
+      finished_at: "2026-06-25T12:00:01Z",
+      actual_cost: 0,
+      steps: [],
+      receipts: [],
+    };
+    api.getRuns.mockResolvedValue({ runs: [failedRun] });
+    api.getRun.mockResolvedValue(failedRun);
+    api.promoteRunFailure.mockResolvedValue({
+      source_run_id: "run-failed",
+      already_promoted: false,
+    });
+
+    render(<AgentBuilder tab="history" onOpenBuilder={() => {}} />);
+    await user.click(await screen.findByRole("button", { name: /Telemetry Agent/i }));
+    await user.click(await screen.findByRole("button", { name: "Promote failure to regression" }));
+    await waitFor(() => expect(api.promoteRunFailure).toHaveBeenCalledWith("run-failed"));
+    expect(await screen.findByRole("button", { name: "Promoted to regression" })).toBeDisabled();
+  });
+});

--- a/repo-b/src/components/telemetry/AgentBuilder.tsx
+++ b/repo-b/src/components/telemetry/AgentBuilder.tsx
@@ -1,0 +1,978 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Background,
+  Controls,
+  Handle,
+  MiniMap,
+  Position,
+  ReactFlow,
+  addEdge,
+  useEdgesState,
+  useNodesState,
+  type Connection,
+  type Edge,
+  type Node,
+  type NodeProps,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+
+import {
+  AgentGraph,
+  AgentGraphNode,
+  AgentEvalRun,
+  AgentNodeType,
+  AgentReceipt,
+  AgentRun,
+  AgentRunStep,
+  McpTool,
+  PaletteNode,
+  ValidationResult,
+  WorkflowDetail,
+  WorkflowSummary,
+  createWorkflow,
+  dryRunWorkflow,
+  getMcpTools,
+  getPalette,
+  getRun,
+  getRuns,
+  getWorkflow,
+  getWorkflowEvals,
+  getWorkflows,
+  promoteRunFailure,
+  runWorkflowEvals,
+  saveWorkflowDraft,
+  stageWorkflow,
+  validateWorkflow,
+} from "@/lib/telemetry/agentBuilder-api";
+import { C, EmptyState, ErrorState, Loading, MetricCard, Panel, PageHeading, StatGrid, Tag } from "./primitives";
+
+export type ControlTowerTab =
+  | "builder"
+  | "registry"
+  | "history"
+  | "tools"
+  | "evals";
+
+const STATUS_COLOR: Record<string, string> = {
+  running: C.cyan,
+  completed: C.green,
+  succeeded: C.green,
+  blocked: C.amber,
+  warning: C.amber,
+  failed: C.red,
+  not_available: C.amber,
+  skipped: C.faint,
+};
+
+const inputStyle = {
+  width: "100%",
+  background: C.bg,
+  color: C.text,
+  border: `1px solid ${C.border}`,
+  borderRadius: 6,
+  padding: "7px 9px",
+  fontFamily: C.mono,
+  fontSize: 11,
+};
+
+const buttonStyle = (color: string, disabled = false) => ({
+  background: `${color}18`,
+  border: `1px solid ${color}55`,
+  color,
+  borderRadius: 6,
+  padding: "7px 11px",
+  fontFamily: C.mono,
+  fontSize: 11,
+  cursor: disabled ? "not-allowed" : "pointer",
+  opacity: disabled ? 0.45 : 1,
+});
+
+type BuilderNodeData = {
+  label: string;
+  nodeType: AgentNodeType;
+  displayLabel: string;
+  config: Record<string, unknown>;
+  state: string;
+};
+
+function AgentGraphNodeView({ data }: NodeProps<Node<BuilderNodeData>>) {
+  const color = STATUS_COLOR[data.state] || "#6b7280";
+  const source = (id: string, top: string) => (
+    <Handle
+      type="source"
+      id={id}
+      position={Position.Right}
+      style={{ top, width: 9, height: 9, background: color, borderColor: C.bg }}
+    />
+  );
+  return (
+    <div style={{ minWidth: 150, position: "relative" }}>
+      {data.nodeType !== "manual_trigger" && (
+        <Handle
+          type="target"
+          position={Position.Left}
+          style={{ width: 9, height: 9, background: color, borderColor: C.bg }}
+        />
+      )}
+      <div style={{ fontFamily: C.mono, fontSize: 9, color, textTransform: "uppercase" }}>
+        {data.state}
+      </div>
+      <div style={{ fontFamily: C.mono, fontSize: 11, color: C.text, marginTop: 3 }}>
+        {data.displayLabel}
+      </div>
+      <div style={{ fontFamily: C.mono, fontSize: 9, color: C.faint, marginTop: 3 }}>
+        {data.nodeType}
+      </div>
+      {data.nodeType === "policy_gate" ? (
+        <>
+          {source("pass", "38%")}
+          {source("fail", "76%")}
+          <span style={{ position: "absolute", right: 8, top: "28%", color: C.green, fontFamily: C.mono, fontSize: 8 }}>pass</span>
+          <span style={{ position: "absolute", right: 8, top: "66%", color: C.red, fontFamily: C.mono, fontSize: 8 }}>fail</span>
+        </>
+      ) : data.nodeType === "cost_guardrail" ? (
+        <>
+          {source("under_budget", "38%")}
+          {source("over_budget", "76%")}
+          <span style={{ position: "absolute", right: 8, top: "28%", color: C.green, fontFamily: C.mono, fontSize: 8 }}>under</span>
+          <span style={{ position: "absolute", right: 8, top: "66%", color: C.amber, fontFamily: C.mono, fontSize: 8 }}>over</span>
+        </>
+      ) : data.nodeType !== "output" ? source("next", "50%") : null}
+    </div>
+  );
+}
+
+const NODE_TYPES = { agent: AgentGraphNodeView };
+
+function graphNodeToFlow(
+  node: AgentGraphNode,
+  steps: AgentRunStep[] = [],
+): Node<BuilderNodeData> {
+  const state = steps.find((step) => step.node_id === node.id)?.status || "idle";
+  const color = STATUS_COLOR[state] || "#6b7280";
+  return {
+    id: node.id,
+    type: "agent",
+    position: node.position,
+    data: {
+      label: node.label || node.type,
+      nodeType: node.type,
+      displayLabel: node.label || node.type,
+      config: node.config,
+      state,
+    },
+    style: {
+      color: C.text,
+      background: C.panel,
+      border: `1px solid ${color}`,
+      borderRadius: 8,
+      boxShadow: state === "running" ? `0 0 0 3px ${C.cyan}22` : "none",
+    },
+  };
+}
+
+function flowToGraph(
+  nodes: Node<BuilderNodeData>[],
+  edges: Edge[],
+  current?: AgentGraph,
+): AgentGraph {
+  return {
+    schema_version: "agent-graph/v1",
+    limits: current?.limits || { max_runtime_seconds: 120, max_tool_calls: 10, max_cost_usd: 1 },
+    model_route_policy: current?.model_route_policy || { sensitive_fallback: "fail_closed" },
+    nodes: nodes.map((node) => ({
+      id: node.id,
+      type: node.data.nodeType,
+      label: node.data.displayLabel,
+      position: node.position,
+      config: node.data.config,
+    })),
+    edges: edges.map((edge) => ({
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      source_handle: edge.sourceHandle,
+      target_handle: edge.targetHandle,
+      data_type: "control",
+    })),
+  };
+}
+
+function RegistryView({
+  workflows,
+  onOpen,
+}: {
+  workflows: WorkflowSummary[];
+  onOpen: (workflowId: string) => void;
+}) {
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: 12 }}>
+      {workflows.map((workflow) => (
+        <button
+          type="button"
+          key={workflow.id}
+          onClick={() => onOpen(workflow.id)}
+          style={{
+            textAlign: "left",
+            background: C.panel,
+            border: `1px solid ${C.border}`,
+            borderRadius: 10,
+            padding: 14,
+            color: C.text,
+            cursor: "pointer",
+          }}
+        >
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+            <strong style={{ fontFamily: C.mono, fontSize: 13 }}>{workflow.name}</strong>
+            <Tag color={workflow.validation_status === "pass" ? C.green : C.amber}>v{workflow.version_number}</Tag>
+          </div>
+          <p style={{ color: C.dim, fontFamily: C.sans, fontSize: 12, minHeight: 34 }}>
+            {workflow.description || "No description"}
+          </p>
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            <Tag color={C.cyan}>{workflow.status}</Tag>
+            <Tag color={workflow.validation_status === "pass" ? C.green : C.red}>
+              graph {workflow.validation_status}
+            </Tag>
+            <Tag color={STATUS_COLOR[workflow.last_run_status || "skipped"]}>
+              last {workflow.last_run_status || "not run"}
+            </Tag>
+            <Tag color={workflow.eval_overall_status === "staged_ready" ? C.green : C.amber}>
+              evals {workflow.eval_overall_status || "not run"}
+            </Tag>
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function RunHistoryView({ runs, onInspect }: { runs: AgentRun[]; onInspect: (id: string) => void }) {
+  if (!runs.length) return <EmptyState label="No Agent Builder runs" hint="Dry-run a saved workflow to create a trace." />;
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      {runs.map((run) => (
+        <button
+          type="button"
+          key={run.id}
+          onClick={() => onInspect(run.id)}
+          className="agent-run-row"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1.5fr .6fr .5fr 1fr",
+            gap: 10,
+            alignItems: "center",
+            textAlign: "left",
+            background: C.panel,
+            border: `1px solid ${C.border}`,
+            borderRadius: 8,
+            padding: 11,
+            color: C.text,
+            cursor: "pointer",
+            fontFamily: C.mono,
+            fontSize: 11,
+          }}
+        >
+          <span>{run.workflow_name}</span>
+          <Tag color={STATUS_COLOR[run.status] || C.dim}>{run.status}</Tag>
+          <span>v{run.version_number}</span>
+          <span style={{ color: C.faint }}>{new Date(run.started_at).toLocaleString()}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ToolRegistryView({ tools }: { tools: McpTool[] }) {
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      {tools.map((tool) => (
+        <div key={tool.name} style={{ background: C.panel, border: `1px solid ${C.border}`, borderRadius: 8, padding: 11 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 10 }}>
+            <code style={{ color: C.text }}>{tool.name}</code>
+            <Tag color={tool.enabled ? C.green : C.red}>{tool.enabled ? "read · enabled" : "write · blocked"}</Tag>
+          </div>
+          <div style={{ color: C.dim, fontSize: 12, marginTop: 6 }}>{tool.description}</div>
+          <div style={{ color: C.faint, fontFamily: C.mono, fontSize: 9, marginTop: 6 }}>
+            schema {tool.schema_digest.slice(0, 16)}… · {tool.module}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const EVAL_LABELS: Record<string, string> = {
+  graph_lint: "Graph validation",
+  tool_contract: "Tool contracts",
+  permission: "Permission checks",
+  fail_closed: "Fail-closed behavior",
+  cost: "Cost guardrail",
+  regression: "Regression cases",
+  replay_determinism: "Replay determinism",
+  rag_grounding: "RAG grounding",
+  visual_smoke: "Visual smoke",
+  production_smoke: "Production smoke",
+};
+
+function EvalsView({
+  workflow,
+  evalRun,
+  busy,
+  onRun,
+  onInspectTrace,
+}: {
+  workflow: WorkflowDetail | null;
+  evalRun: AgentEvalRun | null;
+  busy: boolean;
+  onRun: () => void;
+  onInspectTrace: (runId: string) => void;
+}) {
+  const summary = evalRun?.summary_json;
+  const failed = evalRun?.results.filter((result) => result.status === "fail") || [];
+  return (
+    <div style={{ display: "grid", gap: 10 }}>
+      <Panel
+        title="Publish readiness"
+        right={(
+          <div style={{ display: "flex", gap: 7, alignItems: "center" }}>
+            <Tag color={evalRun?.overall_status === "staged_ready" ? C.green : C.red}>
+              {evalRun?.overall_status === "staged_ready" ? "STAGED READY" : "BLOCKED"}
+            </Tag>
+            <button
+              type="button"
+              style={buttonStyle(C.cyan, busy || !workflow)}
+              disabled={busy || !workflow}
+              onClick={onRun}
+            >
+              {busy ? "Running…" : "Run Evals"}
+            </button>
+          </div>
+        )}
+      >
+        <div style={{ display: "grid", gap: 8 }}>
+          {Object.entries(EVAL_LABELS).map(([evalClass, label]) => {
+            const value = summary?.by_class[evalClass] || "not_run";
+            const display = value === "not_applicable" ? "N/A" : value.replace("_", " ").toUpperCase();
+            return (
+              <div key={evalClass} style={{ display: "flex", justifyContent: "space-between", fontFamily: C.mono, fontSize: 12 }}>
+                <span style={{ color: C.dim }}>{label}</span>
+                <span style={{ color: value === "pass" ? C.green : value === "fail" ? C.red : C.faint }}>{display}</span>
+              </div>
+            );
+          })}
+        </div>
+        <div style={{ marginTop: 14, color: C.faint, fontFamily: C.mono, fontSize: 10 }}>
+          Staging requires all deterministic classes to pass. Visual and production smoke remain N/A; production publication stays disabled.
+        </div>
+      </Panel>
+
+      {failed.length > 0 && (
+        <Panel title="Failed cases" right={<Tag color={C.red}>{failed.length} blocking</Tag>}>
+          <div style={{ display: "grid", gap: 9 }}>
+            {failed.map((result) => (
+              <div key={result.id || result.eval_case_id} style={{ border: `1px solid ${C.border}`, borderRadius: 8, padding: 10 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+                  <strong style={{ color: C.text, fontFamily: C.mono, fontSize: 11 }}>{result.title}</strong>
+                  <Tag color={C.red}>FAIL</Tag>
+                </div>
+                <div style={{ color: C.red, fontFamily: C.mono, fontSize: 10, marginTop: 7 }}>
+                  {result.failed_assertion || "Assertion failed"}
+                </div>
+                <details style={{ marginTop: 7 }}>
+                  <summary style={{ color: C.dim, cursor: "pointer", fontFamily: C.mono, fontSize: 10 }}>
+                    Input / expected / actual
+                  </summary>
+                  <pre style={{ color: C.faint, fontFamily: C.mono, fontSize: 9, whiteSpace: "pre-wrap" }}>
+                    {JSON.stringify({
+                      input: result.input_json,
+                      expected: result.expected_json,
+                      actual: result.actual_json,
+                    }, null, 2)}
+                  </pre>
+                </details>
+                {result.trace_run_id && (
+                  <button type="button" style={buttonStyle(C.cyan)} onClick={() => onInspectTrace(result.trace_run_id!)}>
+                    Open trace {result.trace_run_id}
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        </Panel>
+      )}
+    </div>
+  );
+}
+
+export default function AgentBuilder({ tab, onOpenBuilder }: { tab: ControlTowerTab; onOpenBuilder: () => void }) {
+  const [palette, setPalette] = useState<PaletteNode[]>([]);
+  const [tools, setTools] = useState<McpTool[]>([]);
+  const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
+  const [runs, setRuns] = useState<AgentRun[]>([]);
+  const [workflow, setWorkflow] = useState<WorkflowDetail | null>(null);
+  const [run, setRun] = useState<AgentRun | null>(null);
+  const [evalRun, setEvalRun] = useState<AgentEvalRun | null>(null);
+  const [promotedRunIds, setPromotedRunIds] = useState<string[]>([]);
+  const [validation, setValidation] = useState<ValidationResult | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node<BuilderNodeData>>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [runKey, setRunKey] = useState("FD001-test-001");
+  const [channel, setChannel] = useState("D-4");
+  const [sample, setSample] = useState<"nominal" | "anomaly">("anomaly");
+
+  const loadWorkflow = useCallback(async (workflowId: string) => {
+    setBusy("load");
+    try {
+      const detail = await getWorkflow(workflowId);
+      const evals = await getWorkflowEvals(workflowId);
+      setWorkflow(detail);
+      setEvalRun(evals);
+      setValidation(detail.validation_results || null);
+      setNodes(detail.graph.nodes.map((node) => graphNodeToFlow(node)));
+      setEdges(detail.graph.edges.map((edge, index) => ({
+        id: edge.id || `edge-${index}`,
+        source: edge.source,
+        target: edge.target,
+        sourceHandle: edge.source_handle || undefined,
+        targetHandle: edge.target_handle || undefined,
+        animated: false,
+        style: { stroke: C.faint },
+      })));
+      setSelectedId(null);
+      setRun(null);
+      return detail;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      return null;
+    } finally {
+      setBusy(null);
+    }
+  }, [setEdges, setNodes]);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const [paletteResult, toolResult, workflowResult, runResult] = await Promise.all([
+        getPalette(),
+        getMcpTools(),
+        getWorkflows(),
+        getRuns(),
+      ]);
+      setPalette(paletteResult.nodes);
+      setTools(toolResult.tools);
+      setWorkflows(workflowResult.workflows);
+      setRuns(runResult.runs);
+      if (!workflow && workflowResult.workflows[0]) {
+        await loadWorkflow(workflowResult.workflows[0].id);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [loadWorkflow, workflow]);
+
+  useEffect(() => {
+    void refresh();
+    // Initial load only. Subsequent refreshes are explicit after mutations.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onConnect = useCallback(
+    (connection: Connection) =>
+      setEdges((current) =>
+        addEdge({ ...connection, style: { stroke: C.faint } } as Edge, current),
+      ),
+    [setEdges],
+  );
+
+  const selectedNode = useMemo(() => nodes.find((node) => node.id === selectedId) || null, [nodes, selectedId]);
+
+  const addNode = (item: PaletteNode) => {
+    const id = `${item.type}_${Date.now().toString(36)}`;
+    const readTool = tools.find((tool) => tool.enabled);
+    const config: Record<string, unknown> =
+      item.type === "mcp_tool" && readTool
+        ? { tool_name: readTool.name, tool_schema_digest: readTool.schema_digest, bindings: {} }
+        : item.type === "prompt_llm"
+          ? {
+              prompt_template: "Return a bounded JSON summary for: {{input.question}}",
+              prompt_version: "custom/v1",
+              mode: "classification",
+              privacy: "internal",
+              output_schema: { type: "object", properties: { summary: { type: "string" } }, required: ["summary"] },
+            }
+          : item.type === "policy_gate"
+            ? { policy: "read_only_only" }
+            : item.type === "cost_guardrail"
+              ? { max_cost_usd: 1, estimated_next_cost_usd: 0 }
+              : {};
+    setNodes((current) => [
+      ...current,
+      graphNodeToFlow({
+        id,
+        type: item.type,
+        label: item.label,
+        position: { x: 180 + current.length * 28, y: 180 + current.length * 20 },
+        config,
+      }),
+    ]);
+    setSelectedId(id);
+  };
+
+  const updateSelected = (patch: { label?: string; config?: Record<string, unknown> }) => {
+    if (!selectedId) return;
+    setNodes((current) =>
+      current.map((node) =>
+        node.id === selectedId
+          ? {
+              ...node,
+              data: {
+                ...node.data,
+                displayLabel: patch.label ?? node.data.displayLabel ?? node.data.nodeType,
+                label: patch.label ?? node.data.displayLabel ?? node.data.nodeType,
+                config: patch.config ?? node.data.config,
+              },
+            }
+          : node,
+      ),
+    );
+  };
+
+  const save = async () => {
+    const graph = flowToGraph(nodes, edges, workflow?.graph);
+    setBusy("save");
+    setError(null);
+    try {
+      const saved = workflow
+        ? await saveWorkflowDraft(workflow.id, {
+            base_version_number: workflow.version_number,
+            graph,
+          })
+        : await createWorkflow({ name: "Untitled Agent", graph, tags: ["read-only-mvp"] });
+      setWorkflow(saved);
+      setValidation(saved.validation_results || null);
+      setEvalRun(null);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const validate = async () => {
+    if (!workflow) {
+      setError("Save the workflow before validation.");
+      return;
+    }
+    setBusy("validate");
+    try {
+      setValidation(await validateWorkflow(workflow.id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const dryRun = async () => {
+    if (!workflow) {
+      setError("Save the workflow before dry-run.");
+      return;
+    }
+    const window = Array.from({ length: 60 }, (_, t) => ({
+      t,
+      value: Number((sample === "anomaly" && t >= 55 ? 1 + (t - 54) * 0.6 : 1 + ((t % 5) - 2) * 0.002).toFixed(4)),
+    }));
+    setBusy("run");
+    try {
+      const result = await dryRunWorkflow(workflow.id, {
+        run_key: runKey,
+        channel,
+        sample_window: sample,
+        window,
+        question: "Assess this governed workflow.",
+        request: "Classify this sensitive request.",
+      });
+      setRun(result);
+      setNodes(workflow.graph.nodes.map((node) => graphNodeToFlow(node, result.steps || [])));
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const inspectRun = async (runId: string) => {
+    try {
+      const detail = await getRun(runId);
+      let activeWorkflow = workflow;
+      if (detail.workflow_id !== workflow?.id) {
+        activeWorkflow = await loadWorkflow(detail.workflow_id);
+      }
+      setRun(detail);
+      if (activeWorkflow) {
+        setNodes(activeWorkflow.graph.nodes.map((node) => graphNodeToFlow(node, detail.steps || [])));
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const runEvals = async () => {
+    if (!workflow) {
+      setError("Select a saved workflow before running evals.");
+      return;
+    }
+    setBusy("evals");
+    setError(null);
+    try {
+      const result = await runWorkflowEvals(workflow.id);
+      setEvalRun(result);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const stage = async () => {
+    if (!workflow || evalRun?.overall_status !== "staged_ready") {
+      setError("Run passing publish-readiness evals before staging.");
+      return;
+    }
+    setBusy("stage");
+    setError(null);
+    try {
+      const staged = await stageWorkflow(workflow.id);
+      setWorkflow(staged);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const promoteFailure = async () => {
+    if (!run) return;
+    setBusy("promote");
+    setError(null);
+    try {
+      await promoteRunFailure(run.id);
+      setPromotedRunIds((current) => current.includes(run.id) ? current : [...current, run.id]);
+      if (workflow) {
+        setEvalRun(await getWorkflowEvals(workflow.id));
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (loading) return <div style={{ padding: 24 }}><Loading /></div>;
+
+  const title = {
+    builder: "Agent Builder",
+    registry: "Agent Registry",
+    history: "Run History",
+    tools: "Tool Registry",
+    evals: "Evals",
+  }[tab];
+
+  return (
+    <div style={{ padding: 24, background: C.bg, minHeight: "100%", color: C.text }}>
+      <PageHeading
+        eyebrow="Agent Control Tower · governed workflows"
+        title={title}
+        blurb="Typed, permissioned, versioned, auditable agent workflows. MVP execution is synchronous, read-only, and dry-run only."
+        right={<Tag color={C.amber}>read-only MVP</Tag>}
+      />
+      {error && <div style={{ marginBottom: 12 }}><ErrorState message={error} /></div>}
+
+      {tab === "registry" && (
+        <RegistryView workflows={workflows} onOpen={(id) => { void loadWorkflow(id); onOpenBuilder(); }} />
+      )}
+      {tab === "history" && (
+        <div style={{ display: "grid", gap: 10 }}>
+          <RunHistoryView runs={runs} onInspect={(id) => void inspectRun(id)} />
+          {run && (
+            <Panel title={`Run trace · ${run.workflow_name}`} right={<Tag color={STATUS_COLOR[run.status] || C.dim}>{run.status}</Tag>}>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}>
+                <div>
+                  <div style={{ color: C.faint, fontFamily: C.mono, fontSize: 9, marginBottom: 7 }}>STEPS</div>
+                  {(run.steps || []).map((step) => (
+                    <div key={step.id} style={{ display: "flex", justifyContent: "space-between", fontFamily: C.mono, fontSize: 10, marginBottom: 5 }}>
+                      <span>{step.node_id}</span>
+                      <span style={{ color: STATUS_COLOR[step.status] || C.dim }}>{step.status}</span>
+                    </div>
+                  ))}
+                </div>
+                <div>
+                  <div style={{ color: C.faint, fontFamily: C.mono, fontSize: 9, marginBottom: 7 }}>RECEIPTS</div>
+                  {(run.receipts || []).map((receipt) => (
+                    <div key={receipt.id} style={{ fontFamily: C.mono, fontSize: 10, marginBottom: 5 }}>
+                      <span style={{ color: C.text }}>{receipt.node_id}</span>
+                      <span style={{ color: C.faint }}> · {receipt.receipt_type} · {receipt.id}</span>
+                    </div>
+                  ))}
+                  {["failed", "blocked", "not_available"].includes(run.status) && (
+                    <button
+                      type="button"
+                      style={{ ...buttonStyle(C.amber, busy === "promote" || promotedRunIds.includes(run.id)), marginTop: 9 }}
+                      disabled={busy === "promote" || promotedRunIds.includes(run.id)}
+                      onClick={() => void promoteFailure()}
+                    >
+                      {promotedRunIds.includes(run.id) ? "Promoted to regression" : "Promote failure to regression"}
+                    </button>
+                  )}
+                </div>
+              </div>
+            </Panel>
+          )}
+        </div>
+      )}
+      {tab === "tools" && <ToolRegistryView tools={tools} />}
+      {tab === "evals" && (
+        <EvalsView
+          workflow={workflow}
+          evalRun={evalRun}
+          busy={busy === "evals"}
+          onRun={() => void runEvals()}
+          onInspectTrace={(runId) => void inspectRun(runId)}
+        />
+      )}
+
+      {tab === "builder" && (
+        <>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, marginBottom: 12, flexWrap: "wrap" }}>
+            <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+              <select
+                aria-label="Saved workflow"
+                style={{ ...inputStyle, width: 300 }}
+                value={workflow?.id || ""}
+                onChange={(event) => void loadWorkflow(event.target.value)}
+              >
+                {workflows.map((item) => <option key={item.id} value={item.id}>{item.name} · v{item.version_number}</option>)}
+              </select>
+              {workflow && <Tag color={C.cyan}>owner {workflow.owner_user_id || "unknown"}</Tag>}
+            </div>
+            <div style={{ display: "flex", gap: 7, flexWrap: "wrap" }}>
+              <button type="button" style={buttonStyle(C.cyan, !!busy)} disabled={!!busy} onClick={() => void save()}>
+                {busy === "save" ? "Saving…" : "Save Draft"}
+              </button>
+              <button type="button" style={buttonStyle(C.green, !!busy)} disabled={!!busy} onClick={() => void validate()}>
+                Validate
+              </button>
+              <button type="button" style={buttonStyle(C.amber, !!busy)} disabled={!!busy} onClick={() => void dryRun()}>
+                {busy === "run" ? "Running…" : "Dry Run"}
+              </button>
+              <button
+                type="button"
+                title={evalRun?.overall_status === "staged_ready" ? "Stage the current immutable version" : "Passing publish-readiness evals are required"}
+                style={buttonStyle(C.green, !!busy || evalRun?.overall_status !== "staged_ready" || workflow?.status === "staged")}
+                disabled={!!busy || evalRun?.overall_status !== "staged_ready" || workflow?.status === "staged"}
+                onClick={() => void stage()}
+              >
+                {busy === "stage" ? "Staging…" : workflow?.status === "staged" ? "Staged" : "Stage"}
+              </button>
+              <button type="button" title="Deferred: production execution is out of scope" style={buttonStyle(C.faint, true)} disabled>Run</button>
+              <button type="button" title="Deferred: cancellation semantics are not implemented" style={buttonStyle(C.faint, true)} disabled>Cancel</button>
+            </div>
+          </div>
+
+          <div className="agent-builder-grid" style={{ display: "grid", gridTemplateColumns: "210px minmax(420px, 1fr) 290px", gap: 10, minHeight: 560 }}>
+            <Panel title="Node palette">
+              <div style={{ display: "grid", gap: 7 }}>
+                {palette.map((item) => (
+                  <button
+                    type="button"
+                    key={item.type}
+                    onClick={() => addNode(item)}
+                    style={{ ...buttonStyle(C.cyan), textAlign: "left", padding: 9 }}
+                  >
+                    <div>{item.label}</div>
+                    <div style={{ color: C.faint, fontSize: 9, marginTop: 3 }}>{item.category}</div>
+                  </button>
+                ))}
+              </div>
+            </Panel>
+
+            <div style={{ border: `1px solid ${C.border}`, borderRadius: 9, overflow: "hidden", background: "#080d14", minHeight: 520 }}>
+              <ReactFlow
+                nodes={nodes}
+                edges={edges}
+                nodeTypes={NODE_TYPES}
+                onNodesChange={onNodesChange}
+                onEdgesChange={onEdgesChange}
+                onConnect={onConnect}
+                onNodeClick={(_, node) => setSelectedId(node.id)}
+                fitView
+              >
+                <Background color="#273244" gap={18} />
+                <Controls />
+                <MiniMap nodeColor={(node) => String(node.style?.borderColor || C.faint)} />
+              </ReactFlow>
+            </div>
+
+            <Panel title="Configuration inspector">
+              {!selectedNode ? (
+                <EmptyState label="No node selected" hint="Select a node on the canvas to configure it." />
+              ) : (
+                <div style={{ display: "grid", gap: 10 }}>
+                  <div>
+                    <div style={{ color: C.faint, fontFamily: C.mono, fontSize: 9 }}>NODE TYPE</div>
+                    <Tag color={C.cyan}>{String(selectedNode.data.nodeType)}</Tag>
+                  </div>
+                  <label style={{ color: C.dim, fontFamily: C.mono, fontSize: 10 }}>
+                    Label
+                    <input
+                      style={{ ...inputStyle, marginTop: 4 }}
+                      value={String(selectedNode.data.displayLabel ?? selectedNode.data.nodeType)}
+                      onChange={(event) => updateSelected({ label: event.target.value })}
+                    />
+                  </label>
+                  {selectedNode.data.nodeType === "mcp_tool" && (
+                    <label style={{ color: C.dim, fontFamily: C.mono, fontSize: 10 }}>
+                      Read-only MCP tool
+                      <select
+                        style={{ ...inputStyle, marginTop: 4 }}
+                        value={String((selectedNode.data.config as Record<string, unknown>)?.tool_name || "")}
+                        onChange={(event) => {
+                          const tool = tools.find((item) => item.name === event.target.value);
+                          if (!tool) return;
+                          updateSelected({ config: { tool_name: tool.name, tool_schema_digest: tool.schema_digest, bindings: {} } });
+                        }}
+                      >
+                        {tools.map((tool) => (
+                          <option key={tool.name} value={tool.name} disabled={!tool.enabled}>
+                            {tool.name}{tool.enabled ? "" : " · blocked"}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                  {selectedNode.data.nodeType === "prompt_llm" && (
+                    <>
+                      <label style={{ color: C.dim, fontFamily: C.mono, fontSize: 10 }}>
+                        Prompt template
+                        <textarea
+                          style={{ ...inputStyle, marginTop: 4, minHeight: 100 }}
+                          value={String((selectedNode.data.config as Record<string, unknown>)?.prompt_template || "")}
+                          onChange={(event) => updateSelected({
+                            config: { ...(selectedNode.data.config as Record<string, unknown>), prompt_template: event.target.value },
+                          })}
+                        />
+                      </label>
+                      <label style={{ color: C.dim, fontFamily: C.mono, fontSize: 10 }}>
+                        Prompt version
+                        <input
+                          style={{ ...inputStyle, marginTop: 4 }}
+                          value={String((selectedNode.data.config as Record<string, unknown>)?.prompt_version || "")}
+                          onChange={(event) => updateSelected({
+                            config: { ...(selectedNode.data.config as Record<string, unknown>), prompt_version: event.target.value },
+                          })}
+                        />
+                      </label>
+                    </>
+                  )}
+                  <label style={{ color: C.dim, fontFamily: C.mono, fontSize: 10 }}>
+                    Config JSON
+                    <textarea
+                      style={{ ...inputStyle, marginTop: 4, minHeight: 160 }}
+                      value={JSON.stringify(selectedNode.data.config || {}, null, 2)}
+                      onChange={(event) => {
+                        try {
+                          updateSelected({ config: JSON.parse(event.target.value) });
+                          setError(null);
+                        } catch {
+                          setError("Configuration must be valid JSON.");
+                        }
+                      }}
+                    />
+                  </label>
+                </div>
+              )}
+            </Panel>
+          </div>
+
+          <div className="agent-builder-drawers" style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10, marginTop: 10 }}>
+            <Panel title="Validation / run trace" right={validation && <Tag color={validation.status === "pass" ? C.green : C.red}>{validation.status}</Tag>}>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 8, marginBottom: 10 }}>
+                <input style={inputStyle} value={runKey} onChange={(event) => setRunKey(event.target.value)} aria-label="run_key" />
+                <input style={inputStyle} value={channel} onChange={(event) => setChannel(event.target.value)} aria-label="channel" />
+                <select style={inputStyle} value={sample} onChange={(event) => setSample(event.target.value as "nominal" | "anomaly")}>
+                  <option value="anomaly">anomaly window</option>
+                  <option value="nominal">nominal window</option>
+                </select>
+              </div>
+              {validation?.issues.length ? (
+                validation.issues.map((issue) => (
+                  <div key={`${issue.code}-${issue.node_id || ""}`} style={{ color: issue.severity === "error" ? C.red : C.amber, fontFamily: C.mono, fontSize: 10, marginBottom: 5 }}>
+                    {issue.code}{issue.node_id ? ` · ${issue.node_id}` : ""}: {issue.message}
+                  </div>
+                ))
+              ) : (
+                <div style={{ color: C.dim, fontFamily: C.mono, fontSize: 11 }}>
+                  {run ? `Run ${run.status}${run.terminal_reason ? ` · ${run.terminal_reason}` : ""}` : "No validation issues or run trace selected."}
+                </div>
+              )}
+              {run?.steps && (
+                <div style={{ display: "grid", gap: 5, marginTop: 10 }}>
+                  {run.steps.map((step) => (
+                    <div key={step.id} style={{ display: "flex", justifyContent: "space-between", fontFamily: C.mono, fontSize: 10 }}>
+                      <span>{step.node_id}</span>
+                      <span style={{ color: STATUS_COLOR[step.status] || C.dim }}>{step.status}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </Panel>
+
+            <Panel title="Evidence drawer" right={run && <Tag color={STATUS_COLOR[run.status] || C.dim}>{run.status}</Tag>}>
+              {!run?.receipts?.length ? (
+                <EmptyState label="No receipts yet" hint="Every dry-run step writes a builder receipt; model calls also retain their dispatch receipt." />
+              ) : (
+                <div style={{ display: "grid", gap: 7, maxHeight: 280, overflow: "auto" }}>
+                  {run.receipts.map((receipt: AgentReceipt) => (
+                    <div key={receipt.id} style={{ border: `1px solid ${C.border}`, borderRadius: 7, padding: 8 }}>
+                      <div style={{ display: "flex", justifyContent: "space-between", fontFamily: C.mono, fontSize: 10 }}>
+                        <span>{receipt.node_id} · {receipt.receipt_type}</span>
+                        <span style={{ color: STATUS_COLOR[receipt.terminal_status] || C.dim }}>{receipt.terminal_status}</span>
+                      </div>
+                      <div style={{ color: C.faint, fontFamily: C.mono, fontSize: 9, marginTop: 4 }}>
+                        {receipt.id} {receipt.model_used ? `· ${receipt.model_used}` : ""}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </Panel>
+          </div>
+        </>
+      )}
+      <style>{`
+        @media (max-width: 900px) {
+          .agent-builder-grid,
+          .agent-builder-drawers {
+            grid-template-columns: 1fr !important;
+          }
+          .agent-run-row {
+            grid-template-columns: 1fr auto !important;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/repo-b/src/components/telemetry/ControlTower.test.tsx
+++ b/repo-b/src/components/telemetry/ControlTower.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@xyflow/react", () => ({
+  ReactFlow: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Background: () => null,
+  Controls: () => null,
+  MiniMap: () => null,
+  Handle: () => null,
+  Position: { Left: "left", Right: "right" },
+  addEdge: (connection: unknown, edges: unknown[]) => [...edges, connection],
+  useNodesState: (initial: unknown[]) => {
+    const [value, setValue] = React.useState(initial);
+    return [value, setValue, vi.fn()];
+  },
+  useEdgesState: (initial: unknown[]) => {
+    const [value, setValue] = React.useState(initial);
+    return [value, setValue, vi.fn()];
+  },
+}));
+
+vi.mock("@/lib/telemetry/controlTower-api", () => ({
+  listDecisions: vi.fn(async () => ({ decisions: [] })),
+  getGemmaState: vi.fn(async () => ({
+    status: "cold",
+    confirm_tokens: { warm: "", teardown: "" },
+    lifecycle_enabled: false,
+  })),
+  scoreAndGate: vi.fn(),
+  resolveDecision: vi.fn(),
+  probeGemma: vi.fn(),
+  warmGemma: vi.fn(),
+  teardownGemma: vi.fn(),
+  verifyReceipt: vi.fn(),
+}));
+
+vi.mock("@/lib/telemetry/agentBuilder-api", () => ({
+  getPalette: vi.fn(async () => ({ schema_version: "agent-graph/v1", nodes: [] })),
+  getMcpTools: vi.fn(async () => ({ tools: [] })),
+  getWorkflows: vi.fn(async () => ({ workflows: [] })),
+  getRuns: vi.fn(async () => ({ runs: [] })),
+  getWorkflow: vi.fn(),
+  createWorkflow: vi.fn(),
+  saveWorkflowDraft: vi.fn(),
+  validateWorkflow: vi.fn(),
+  dryRunWorkflow: vi.fn(),
+  getRun: vi.fn(),
+}));
+
+import ControlTower from "./ControlTower";
+
+describe("ControlTower tabs", () => {
+  it("preserves the Run Console and exposes all six governed modes", async () => {
+    const user = userEvent.setup();
+    render(<ControlTower />);
+    const labels = ["Run Console", "Agent Builder", "Agent Registry", "Run History", "Tool Registry", "Evals"];
+    for (const label of labels) {
+      expect(screen.getByRole("tab", { name: label })).toBeInTheDocument();
+    }
+    expect(await screen.findByText("Run go/no-go")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Agent Registry" }));
+    expect(await screen.findByRole("heading", { name: "Agent Registry" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Evals" }));
+    expect(await screen.findByText("Publish readiness")).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/ControlTower.tsx
+++ b/repo-b/src/components/telemetry/ControlTower.tsx
@@ -30,6 +30,7 @@ import {
   warmGemma,
 } from "@/lib/telemetry/controlTower-api";
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
+import AgentBuilder, { type ControlTowerTab } from "./AgentBuilder";
 
 // Truth label: every panel says where its data comes from. Never imply live execution over a fixture.
 function TruthLabel({ kind }: { kind: "fixture" | "staged" | "live" | "cold" | "unavailable" }) {
@@ -59,7 +60,7 @@ function sampleWindow(kind: "nominal" | "anomaly"): { t: number; value: number }
   return w;
 }
 
-export default function ControlTower() {
+function RunConsole() {
   const [decisions, setDecisions] = useState<Decision[]>([]);
   const [gemma, setGemma] = useState<GemmaState | null>(null);
   const [loading, setLoading] = useState(true);
@@ -408,6 +409,67 @@ export default function ControlTower() {
       </Panel>
 
       <DisclosureFooter />
+    </div>
+  );
+}
+
+type TopLevelTab = "run-console" | ControlTowerTab;
+
+const CONTROL_TOWER_TABS: Array<{ id: TopLevelTab; label: string }> = [
+  { id: "run-console", label: "Run Console" },
+  { id: "builder", label: "Agent Builder" },
+  { id: "registry", label: "Agent Registry" },
+  { id: "history", label: "Run History" },
+  { id: "tools", label: "Tool Registry" },
+  { id: "evals", label: "Evals" },
+];
+
+export default function ControlTower() {
+  const [tab, setTab] = useState<TopLevelTab>("run-console");
+  return (
+    <div style={{ background: C.bg, minHeight: "100%" }}>
+      <div
+        role="tablist"
+        aria-label="Agent Control Tower modes"
+        style={{
+          display: "flex",
+          gap: 4,
+          padding: "12px 24px 0",
+          borderBottom: `1px solid ${C.border}`,
+          overflowX: "auto",
+        }}
+      >
+        {CONTROL_TOWER_TABS.map((item) => {
+          const active = item.id === tab;
+          return (
+            <button
+              type="button"
+              role="tab"
+              aria-selected={active}
+              key={item.id}
+              onClick={() => setTab(item.id)}
+              style={{
+                border: 0,
+                borderBottom: `2px solid ${active ? C.cyan : "transparent"}`,
+                background: "transparent",
+                color: active ? C.text : C.dim,
+                padding: "9px 12px",
+                fontFamily: C.mono,
+                fontSize: 11,
+                whiteSpace: "nowrap",
+                cursor: "pointer",
+              }}
+            >
+              {item.label}
+            </button>
+          );
+        })}
+      </div>
+      {tab === "run-console" ? (
+        <RunConsole />
+      ) : (
+        <AgentBuilder tab={tab} onOpenBuilder={() => setTab("builder")} />
+      )}
     </div>
   );
 }

--- a/repo-b/src/lib/telemetry/agentBuilder-api.ts
+++ b/repo-b/src/lib/telemetry/agentBuilder-api.ts
@@ -1,0 +1,257 @@
+"use client";
+
+import { apiFetch } from "@/lib/api";
+
+const BASE = "/api/agent-builder";
+
+export type AgentNodeType =
+  | "manual_trigger"
+  | "context_loader"
+  | "mcp_tool"
+  | "prompt_llm"
+  | "policy_gate"
+  | "cost_guardrail"
+  | "human_approval"
+  | "receipt_writer"
+  | "output"
+  | "eval_assertion";
+
+export interface AgentGraphNode {
+  id: string;
+  type: AgentNodeType;
+  label?: string;
+  position: { x: number; y: number };
+  config: Record<string, unknown>;
+}
+
+export interface AgentGraphEdge {
+  id?: string;
+  source: string;
+  target: string;
+  source_handle?: string | null;
+  target_handle?: string | null;
+  data_type?: string;
+}
+
+export interface AgentGraph {
+  schema_version: "agent-graph/v1";
+  nodes: AgentGraphNode[];
+  edges: AgentGraphEdge[];
+  limits: {
+    max_runtime_seconds: number;
+    max_tool_calls: number;
+    max_cost_usd: number;
+  };
+  model_route_policy: Record<string, unknown>;
+}
+
+export interface PaletteNode {
+  type: AgentNodeType;
+  label: string;
+  category: string;
+  description: string;
+}
+
+export interface McpTool {
+  name: string;
+  description: string;
+  module: string;
+  permission: string;
+  effective_permission: string;
+  side_effect_class: string;
+  input_schema: Record<string, unknown>;
+  output_schema: Record<string, unknown> | null;
+  schema_digest: string;
+  enabled: boolean;
+  disabled_reason: string | null;
+}
+
+export interface ValidationIssue {
+  code: string;
+  message: string;
+  node_id?: string | null;
+  severity: string;
+}
+
+export interface ValidationResult {
+  status: "pass" | "fail";
+  checks: Record<string, boolean>;
+  issues: ValidationIssue[];
+  topological_order: string[];
+}
+
+export interface WorkflowSummary {
+  id: string;
+  name: string;
+  description: string | null;
+  owner_user_id: string | null;
+  status: string;
+  tags: string[];
+  is_template: boolean;
+  template_key: string | null;
+  version_id: string;
+  version_number: number;
+  validation_status: string;
+  validation_results: ValidationResult;
+  publish_status: string;
+  last_run_status: string | null;
+  eval_overall_status: "staged_ready" | "blocked" | null;
+  eval_summary: EvalSummary | null;
+  updated_at: string;
+}
+
+export interface WorkflowDetail extends WorkflowSummary {
+  graph: AgentGraph;
+  versions: Array<{
+    id: string;
+    version_number: number;
+    validation_status: string;
+    publish_status: string;
+    publish_blockers: Array<Record<string, unknown>>;
+    published_by: string | null;
+    published_at: string | null;
+    created_by: string | null;
+    created_at: string;
+  }>;
+  published_by: string | null;
+  published_at: string | null;
+  publish_blockers: Array<Record<string, unknown>>;
+}
+
+export interface AgentRunStep {
+  id: string;
+  node_id: string;
+  node_type: string;
+  status: string;
+  tool_name: string | null;
+  model_name: string | null;
+  output_json: Record<string, unknown> | null;
+  error_json: Record<string, unknown> | null;
+  receipt_id: string | null;
+}
+
+export interface AgentReceipt {
+  id: string;
+  node_id: string;
+  receipt_type: string;
+  tools_called: string[];
+  model_used: string | null;
+  terminal_status: string;
+  failure_reason: string | null;
+  created_at: string;
+}
+
+export interface AgentRun {
+  id: string;
+  workflow_id: string;
+  workflow_name: string;
+  workflow_version_id: string;
+  version_number: number;
+  status: string;
+  terminal_reason: string | null;
+  started_at: string;
+  finished_at: string | null;
+  actual_cost: string | number;
+  output_json?: Record<string, unknown>;
+  steps?: AgentRunStep[];
+  receipts?: AgentReceipt[];
+}
+
+export interface EvalSummary {
+  overall_status: "staged_ready" | "blocked";
+  by_class: Record<string, "pass" | "fail" | "not_applicable" | "not_run">;
+  blockers: Array<{ eval_class: string; reason: string }>;
+  counts: {
+    pass: number;
+    fail: number;
+    not_applicable: number;
+    total: number;
+  };
+}
+
+export interface AgentEvalResult {
+  id: string;
+  eval_case_id: string;
+  case_key: string;
+  eval_class: string;
+  title: string;
+  source: string;
+  status: "pass" | "fail" | "not_applicable";
+  input_json: Record<string, unknown>;
+  expected_json: Record<string, unknown>;
+  actual_json: Record<string, unknown>;
+  failed_assertion: string | null;
+  trace_run_id: string | null;
+}
+
+export interface AgentEvalRun {
+  id?: string;
+  workflow_id: string;
+  workflow_version_id: string;
+  workflow_name?: string;
+  version_number: number;
+  status: string;
+  overall_status: "staged_ready" | "blocked";
+  summary_json: EvalSummary;
+  started_at?: string;
+  finished_at?: string | null;
+  results: AgentEvalResult[];
+}
+
+const post = <T>(path: string, body: Record<string, unknown> = {}) =>
+  apiFetch<T>(`${BASE}${path}`, { method: "POST", body: JSON.stringify(body), timeoutMs: 120_000 });
+
+export const getPalette = () =>
+  apiFetch<{ schema_version: string; nodes: PaletteNode[] }>(`${BASE}/palette`);
+
+export const getMcpTools = () =>
+  apiFetch<{ tools: McpTool[] }>(`${BASE}/mcp-tools`);
+
+export const getWorkflows = () =>
+  apiFetch<{ workflows: WorkflowSummary[] }>(`${BASE}/workflows`, { timeoutMs: 60_000 });
+
+export const getWorkflow = (workflowId: string) =>
+  apiFetch<WorkflowDetail>(`${BASE}/workflows/${workflowId}`);
+
+export const createWorkflow = (body: {
+  name: string;
+  description?: string;
+  graph: AgentGraph;
+  tags?: string[];
+}) => post<WorkflowDetail>("/workflows", body);
+
+export const saveWorkflowDraft = (
+  workflowId: string,
+  body: { base_version_number: number; graph: AgentGraph; name?: string; description?: string },
+) =>
+  apiFetch<WorkflowDetail>(`${BASE}/workflows/${workflowId}/draft`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+
+export const validateWorkflow = (workflowId: string) =>
+  post<ValidationResult>(`/workflows/${workflowId}/validate`);
+
+export const dryRunWorkflow = (workflowId: string, input: Record<string, unknown>) =>
+  post<AgentRun>(`/workflows/${workflowId}/dry-run`, { input });
+
+export const getRuns = () =>
+  apiFetch<{ runs: AgentRun[] }>(`${BASE}/runs`);
+
+export const getRun = (runId: string) =>
+  apiFetch<AgentRun>(`${BASE}/runs/${runId}`);
+
+export const getWorkflowEvals = (workflowId: string) =>
+  apiFetch<AgentEvalRun>(`${BASE}/workflows/${workflowId}/evals`);
+
+export const runWorkflowEvals = (workflowId: string) =>
+  post<AgentEvalRun>(`/workflows/${workflowId}/evals/run`);
+
+export const getEvalRun = (evalRunId: string) =>
+  apiFetch<AgentEvalRun>(`${BASE}/eval-runs/${evalRunId}`);
+
+export const stageWorkflow = (workflowId: string) =>
+  post<WorkflowDetail>(`/workflows/${workflowId}/publish`, { status: "staged" });
+
+export const promoteRunFailure = (runId: string) =>
+  post<{ source_run_id: string; already_promoted: boolean }>(`/runs/${runId}/promote-failure`);


### PR DESCRIPTION
## What changed
- adds the governed Agent Builder canvas, immutable workflow versions, validation, read-only MCP execution, dry-run traces, receipts, registry, history, and six draft templates
- adds persisted eval suites/cases/runs/results, regression promotion, and a staged-only publish gate
- adds the read-only telemetry preview scoring tool without inserting `tel_predictions`
- preserves the existing Agent Control Tower Run Console and newer replay diagnostics
- adds additive migrations 10035 and 10036 with tenant RLS and append-only evidence guards

## Why
Feature #477 requires a typed, permissioned, auditable internal agent lifecycle rather than free-prompt production agents. This release closes Stories #478 and #735 while keeping production execution and write-capable nodes fail-closed.

## Verification
- backend focused suite: 79 passed
- Ruff: passed
- frontend focused suite: 15 passed
- frontend typecheck and focused lint: passed
- Next.js production build: passed
- migrations 10035/10036 applied to linked Novendor Supabase; verified 12 tables, 12 RLS tables, 12 tenant policies, 4 append-only triggers

## Safety
- production publish remains rejected; only staged status is supported
- no write-capable MCP tools are executable
- unrelated Stargate/telemetry working-tree changes were excluded by building this PR from current `origin/main`