### PR TITLE
fix: remove duplicate AgentBuilder import

### DIFF
--- a/repo-b/src/components/telemetry/ControlTower.tsx
+++ b/repo-b/src/components/telemetry/ControlTower.tsx
@@ -31,7 +31,6 @@ import {
 } from "@/lib/telemetry/controlTower-api";
 import AgentBuilder, { type ControlTowerTab } from "./AgentBuilder";
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
-import AgentBuilder, { type ControlTowerTab } from "./AgentBuilder";
 
 // Truth label: every panel says where its data comes from. Never imply live execution over a fixture.
 function TruthLabel({ kind }: { kind: "fixture" | "staged" | "live" | "cold" | "unavailable" }) {


### PR DESCRIPTION
## Fix
Removes the duplicate `AgentBuilder` / `ControlTowerTab` import introduced when the concurrent Stargate branch merged after Agent Builder PR #372.

## Evidence
- frontend typecheck passed
- AgentBuilder + ControlTower focused tests: 8 passed

No runtime behavior changes.