### PR TITLE
feat(telemetry): residual-vs-threshold chart on Replay (Ticket 6a)

### DIFF
--- a/repo-b/src/components/telemetry/ReplayConsole.tsx
+++ b/repo-b/src/components/telemetry/ReplayConsole.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { getReplayFeed, type ReplayFeed, type ReplayTick } from "@/lib/telemetry/api";
-import { computeReplayDiagnostics } from "@/lib/telemetry/replayDiagnostics";
+import { computeReplayDiagnostics, residualSeries } from "@/lib/telemetry/replayDiagnostics";
 import {
   C, Panel, Loading, ErrorState, DisclosureFooter, SplitGrid,
   Stat, StatGrid, MetricRow, StatusDot, Tag,
@@ -19,6 +19,15 @@ function pathFor(points: ReplayTick[], vMin: number, vMax: number, n: number): s
   const x = (i: number) => PAD + (i / Math.max(n - 1, 1)) * (W - 2 * PAD);
   const y = (v: number) => H - PAD - ((v - vMin) / span) * (H - 2 * PAD);
   return points.map((p, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(p.value).toFixed(1)}`).join(" ");
+}
+
+// Residual sub-chart (Ticket 6): plots |value - rmean| scaled to [0, yMax] over a shorter frame.
+const RH = 156;
+function residualPathFor(points: { residual: number }[], yMax: number, n: number): string {
+  if (points.length === 0) return "";
+  const x = (i: number) => PAD + (i / Math.max(n - 1, 1)) * (W - 2 * PAD);
+  const y = (r: number) => RH - PAD - (r / (yMax || 1)) * (RH - 2 * PAD);
+  return points.map((p, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(p.residual).toFixed(1)}`).join(" ");
 }
 
 type DrawerTab = "signal" | "model" | "evidence" | "operator" | "lineage";
@@ -57,6 +66,7 @@ export default function ReplayConsole() {
   const vMax = useMemo(() => (ticks.length ? Math.max(...ticks.map((p) => p.value)) : 1), [ticks]);
   // All honesty-sensitive math lives in the pure adapter; the component only renders it.
   const diag = useMemo(() => (feed ? computeReplayDiagnostics(feed) : null), [feed]);
+  const resSeries = useMemo(() => (feed ? residualSeries(feed) : null), [feed]);
 
   const heading = (
     <TelemetryPageHeader variant="compact" eyebrow="Replay test feed · NASA SMAP/MSL analog" title="Hot-fire-style replay → automated go/no-go"
@@ -70,6 +80,9 @@ export default function ReplayConsole() {
   const xAt = (idx: number) => PAD + (idx / Math.max(ticks.length - 1, 1)) * (W - 2 * PAD);
   const fireX = firstFireIdx >= 0 ? xAt(firstFireIdx) : -1;
   const cursorX = xAt(cursor);
+  const resThY = resSeries && resSeries.threshold != null
+    ? RH - PAD - (resSeries.threshold / (resSeries.yMax || 1)) * (RH - 2 * PAD)
+    : null;
   // NASA-labeled window overlay, revealed only up to the cursor (no spoiler ahead of playback).
   const labelStartX = labelStartIdx >= 0 ? xAt(labelStartIdx) : -1;
   const labelRevealedEndIdx = labelEndIdx >= 0 ? Math.min(labelEndIdx, cursor) : -1;
@@ -201,7 +214,8 @@ export default function ReplayConsole() {
             <MetricRow label="fired channel" value={firedSoFar ? "D-4" : "—"} tone={firedSoFar ? C.red : C.dim} />
             <MetricRow label="first fire" value={diag!.firstModelFireT != null ? `t=${diag!.firstModelFireT}` : "—"} />
             <MetricRow label="residual at fire" value={diag!.residualAtFire != null ? `${diag!.residualAtFire.toFixed(4)} ( |value−rmean| )` : "—"} />
-            <MetricRow label="score / threshold / margin" value="Not available (no calibrated score in payload)" tone={C.amber} />
+            <MetricRow label="serving threshold" value={diag!.scoringAvailable && diag!.threshold != null ? `${diag!.threshold.toFixed(4)} residual units · global-scale fallback` : "Not available (no calibrated score in payload)"} tone={diag!.scoringAvailable ? C.dim : C.amber} />
+            <MetricRow label="fired vs threshold" value={diag!.scoringAvailable && diag!.firedAboveThreshold != null && diag!.firedTicksScored != null ? `${diag!.firedAboveThreshold} of ${diag!.firedTicksScored} fired ticks above it` : "—"} tone={diag!.thresholdReproducesFiring === false ? C.amber : C.dim} />
             <MetricRow label="policy" value="frozen detector · model_pred flip" />
             <MetricRow label="basis" value="model output, not hand-authored" divider={false} />
             <div style={{ marginTop: 10, border: `1px solid ${(diag!.isPreLabel ? C.red : C.cyan)}33`,
@@ -241,6 +255,43 @@ export default function ReplayConsole() {
           </Panel>
         </div>
       </SplitGrid>
+
+      {/* Residual vs serving threshold (Ticket 6) — makes the scoringDiagnostics divergence VISIBLE:
+          on D-4 every model-fired tick (red) sits below the frozen redline, so the serving global-scale
+          fallback cannot reproduce the champion's firing. Residual, not the degenerate fixture score. */}
+      {resSeries && (
+        <Panel title="Model residual vs serving threshold" pad={12} style={{ marginTop: 16 }}>
+          <svg viewBox={`0 0 ${W} ${RH}`} style={{ width: "100%", display: "block" }} role="img" aria-label="Per-tick residual against the frozen serving threshold">
+            {resThY != null && resSeries.threshold != null && (
+              <>
+                <line x1={PAD} y1={resThY} x2={W - PAD} y2={resThY} stroke={C.red + "aa"} strokeDasharray="5 4" strokeWidth={1.3} />
+                <text x={W - PAD} y={resThY - 5} textAnchor="end" fontFamily={C.mono} fontSize={10} fill={C.red}>
+                  serving threshold {resSeries.threshold.toFixed(3)} (global-scale fallback)
+                </text>
+              </>
+            )}
+            {fireX >= 0 && cursorX >= fireX && (
+              <line x1={fireX} y1={PAD} x2={fireX} y2={RH - PAD} stroke={C.red + "70"} strokeDasharray="4 3" strokeWidth={1.2} />
+            )}
+            <path d={residualPathFor(resSeries.points.slice(0, cursor + 1), resSeries.yMax, resSeries.points.length)} fill="none" stroke={C.cyan} strokeWidth={1.5} />
+            {resSeries.points.slice(0, cursor + 1).filter((p) => p.fired).map((p) => (
+              <circle key={p.idx} cx={xAt(p.idx)} cy={RH - PAD - (p.residual / (resSeries.yMax || 1)) * (RH - 2 * PAD)} r={2.6} fill={C.red} />
+            ))}
+          </svg>
+          <div style={{ display: "flex", gap: 16, flexWrap: "wrap", marginTop: 8, paddingLeft: 4 }}>
+            <LegendSwatch color={C.cyan} label="residual |value − rmean|" />
+            <LegendSwatch color={C.red} label="model-fired tick (model_pred=1)" />
+            <LegendSwatch color={C.red} dashed label="serving threshold (frozen)" />
+          </div>
+          <p style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, marginTop: 8, lineHeight: 1.5, paddingLeft: 4 }}>
+            {resSeries.threshold == null
+              ? "Residual is the quantity the MAD rule thresholds. The serving threshold is not present in this payload, so no redline is drawn."
+              : resSeries.allFiredBelowThreshold
+                ? <span style={{ color: C.amber }}>{diag!.perChannelCaveat ?? `Every model-fired tick (${resSeries.firedCount}) sits below the serving global-scale fallback threshold — the champion fires on a tighter per-channel D-4 scale. model_pred is authoritative; this redline cannot reproduce D-4's firing.`}</span>
+                : `${resSeries.firedAboveThreshold} of ${resSeries.firedCount} model-fired ticks cross the serving threshold.`}
+          </p>
+        </Panel>
+      )}
 
       <Panel style={{ marginTop: 16 }} pad={14}>
         <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, lineHeight: 1.6 }}>

--- a/repo-b/src/lib/telemetry/replayDiagnostics.test.ts
+++ b/repo-b/src/lib/telemetry/replayDiagnostics.test.ts
@@ -6,7 +6,18 @@ import {
   computeReplayDiagnostics,
   inspectTick,
   NA_REASONS,
+  residualSeries,
 } from "./replayDiagnostics";
+
+// Minimal scoringDiagnostics body (threshold overridden per-test) for the residual-chart tests.
+const SCORING_BASE = {
+  mad_k: 4, global_train_scale: 0.0339, threshold_residual_units: 0.135467,
+  threshold_source: "serving global-scale fallback",
+  residual_definition: "residual = abs(value - rmean)",
+  fired_ticks: 3, fired_ticks_above_threshold: 0, max_fired_residual: 1.9,
+  threshold_reproduces_firing: false, per_channel_caveat: null,
+  fixture_score_degenerate: true, note: "test",
+} as const;
 
 // A small synthetic feed that reproduces the shape of the real fixture's load-bearing facts:
 // the model fires BEFORE the NASA-labeled window (pre-label false alarms), the labeled window comes
@@ -234,5 +245,35 @@ describe("computeReplayDiagnostics — scoring diagnostics (Ticket 2)", () => {
     // the removed per-tick verdict fields must not reappear on the shape
     expect((insp as Record<string, unknown>).verdict).toBeUndefined();
     expect((insp as Record<string, unknown>).realScore).toBeUndefined();
+  });
+});
+
+describe("residualSeries (Ticket 6 — residual vs threshold chart model)", () => {
+  it("maps every tick to abs(value-rmean) with a fired flag; no redline when threshold is absent", () => {
+    const s = residualSeries(feed); // `feed` carries no scoringDiagnostics
+    expect(s.threshold).toBeNull();
+    expect(s.points).toHaveLength(8);
+    expect(s.firedCount).toBe(3);
+    const fireTick = s.points.find((p) => p.t === 10)!; // |1.0-(-0.9)| = 1.9, fired
+    expect(fireTick.residual).toBeCloseTo(1.9, 6);
+    expect(fireTick.fired).toBe(true);
+    expect(s.allFiredBelowThreshold).toBe(false); // no threshold => never a divergence claim
+    expect(s.yMax).toBeGreaterThan(1.9); // ceiling sits above the largest residual
+  });
+
+  it("flags the divergence when every fired tick sits below the serving threshold (the D-4 case)", () => {
+    const divergent: ReplayFeed = { ...feed, scoringDiagnostics: { ...SCORING_BASE, threshold_residual_units: 5.0 } };
+    const s = residualSeries(divergent);
+    expect(s.threshold).toBe(5.0);
+    expect(s.firedAboveThreshold).toBe(0); // all fired residuals (1.9, 1.7, 0.8) < 5.0
+    expect(s.allFiredBelowThreshold).toBe(true); // the visible divergence
+    expect(s.yMax).toBeCloseTo(5.0 * 1.12, 6); // redline drives the ceiling
+  });
+
+  it("does NOT flag divergence when fired residuals exceed the threshold", () => {
+    const reproduces: ReplayFeed = { ...feed, scoringDiagnostics: { ...SCORING_BASE, threshold_residual_units: 0.135467 } };
+    const s = residualSeries(reproduces);
+    expect(s.firedAboveThreshold).toBe(3); // 1.9, 1.7, 0.8 all > 0.135467
+    expect(s.allFiredBelowThreshold).toBe(false);
   });
 });

--- a/repo-b/src/lib/telemetry/replayDiagnostics.ts
+++ b/repo-b/src/lib/telemetry/replayDiagnostics.ts
@@ -322,3 +322,50 @@ export function computeReplayDiagnostics(feed: ReplayFeed): ReplayDiagnostics {
     },
   };
 }
+
+// ── Residual-vs-threshold chart model (Ticket 6) ─────────────────────────────
+// The residual `|value - rmean|` is the quantity the MAD rule actually thresholds (unlike the degenerate
+// feed[].score). This pure model plots it against the frozen serving threshold so the divergence the
+// scoringDiagnostics block reports is also *visible*: on D-4 every model-fired tick sits BELOW the
+// serving global-fallback redline (the champion fires on a tighter per-channel scale). Pure + testable;
+// the component only renders it. `threshold` is null when the payload predates Ticket 2 (chart hides the redline).
+
+export interface ResidualPoint {
+  idx: number;
+  t: number;
+  residual: number; // abs(value - rmean)
+  fired: boolean; // model_pred === 1
+}
+
+export interface ResidualSeries {
+  points: ResidualPoint[];
+  threshold: number | null; // serving threshold in residual units, or null when unavailable
+  yMax: number; // chart y-axis ceiling: max(threshold, maxResidual) * 1.12, never 0
+  firedCount: number;
+  firedAboveThreshold: number; // model-fired ticks whose residual exceeds the threshold
+  allFiredBelowThreshold: boolean; // true => the visible divergence (fired, yet under the serving redline)
+}
+
+export function residualSeries(feed: ReplayFeed): ResidualSeries {
+  const ticks = feed.feed ?? [];
+  const threshold = thresholdOf(feed);
+  const points: ResidualPoint[] = ticks.map((p, idx) => ({
+    idx,
+    t: p.t,
+    residual: residualOf(p),
+    fired: p.model_pred === 1,
+  }));
+  const maxResidual = points.length ? Math.max(...points.map((p) => p.residual)) : 0;
+  const yMax = Math.max(threshold ?? 0, maxResidual) * 1.12 || 1;
+  const fired = points.filter((p) => p.fired);
+  const firedAboveThreshold =
+    threshold != null ? fired.filter((p) => p.residual > threshold).length : 0;
+  return {
+    points,
+    threshold,
+    yMax,
+    firedCount: fired.length,
+    firedAboveThreshold,
+    allFiredBelowThreshold: threshold != null && fired.length > 0 && firedAboveThreshold === 0,
+  };
+}


### PR DESCRIPTION
## What
Makes the Ticket-2 scoring divergence **visible** on the Replay surface — frontend-only, no migration, reads existing `/replay` data.

- **New "Model residual vs serving threshold" chart**: residual = `|value − rmean|` (the quantity the MAD rule thresholds — not the degenerate fixture score) plotted against the frozen serving-threshold redline, with model-fired ticks marked. On D-4 every fired tick sits **below** the redline → the serving global-scale fallback cannot reproduce the champion's firing (it fires on a tighter per-channel scale). Caption carries the per-channel caveat; redline hides when the payload has no `scoringDiagnostics`.
- **"Why this verdict" card**: the now-stale `score / threshold / margin: Not available` row is replaced with the real **serving threshold (0.1355)** + **"0 of 412 fired ticks above it"** — Ticket 2 made the threshold available.

## Tests / gates
- New pure `residualSeries()` adapter helper with 3 tests (no-threshold / D-4 divergence / reproduces-firing).
- typecheck + lint clean; adapter 20/20; full telemetry suite **232**.
- Visual gate at 1280×900 dark (local render against prod `/replay`): residual chart + fixed why-card verified.

Reads existing data only. No backend change, no deploy needed (the threshold already ships from Ticket 2's deployed backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)