### PR TITLE
feat: register ten governed Agent Builder templates

### DIFF
--- a/backend/app/services/agent_builder.py
+++ b/backend/app/services/agent_builder.py
@@ -955,6 +955,41 @@ def _edge(source: str, target: str, source_handle: str | None = None) -> dict[st
     }
 
 
+def _deferred_capability_graph(*, capability: str) -> dict[str, Any]:
+    reason = (
+        f"{capability} is not registered as an executable read-only Agent Builder capability. "
+        "Operator review is required before enabling it."
+    )
+    return {
+        "schema_version": "agent-graph/v1",
+        "limits": {"max_runtime_seconds": 120, "max_tool_calls": 0, "max_cost_usd": 0},
+        "model_route_policy": {"sensitive_fallback": "fail_closed"},
+        "nodes": [
+            _node("trigger", "manual_trigger", 40, "Manual Trigger"),
+            _node("context", "context_loader", 260, "Load Governed Context"),
+            _node(
+                "capability_gate",
+                "human_approval",
+                500,
+                "Capability Gate",
+                {"reason": reason},
+            ),
+            _node(
+                "output",
+                "output",
+                760,
+                "Fail-Closed Result",
+                {"bindings": {"status": "NOT_AVAILABLE", "reason": reason}},
+            ),
+        ],
+        "edges": [
+            _edge("trigger", "context"),
+            _edge("context", "capability_gate"),
+            _edge("capability_gate", "output"),
+        ],
+    }
+
+
 def template_graphs() -> list[dict[str, Any]]:
     preview = registry.get("telemetry.preview_score_window")
     preview_digest = tool_schema_digest(preview) if preview else "not_available"
@@ -999,6 +1034,68 @@ def template_graphs() -> list[dict[str, Any]]:
         ("cost-guardrail-query", "Cost Guardrail Query Agent", "Draft shell that demonstrates deterministic budget branching.", None),
         ("sensitive-private-tier", "Sensitive Routing / Private Tier Agent", "Draft shell that fails closed without private model capacity.", None),
         ("ticket-to-pr-evidence", "Ticket-to-PR Evidence Agent", "Dry-run planning shell ending at simulated human approval.", None),
+    ]
+    governed_definitions = [
+        (
+            "governed-ticket-intake",
+            "Ticket Intake Agent",
+            "Governed intake and classification shell; ticket writes remain approval-gated and deferred.",
+            "Ticket intake system integration",
+        ),
+        (
+            "governed-analytics-engineer",
+            "Analytics Engineer Agent",
+            "Governed analytics implementation shell; warehouse and repository mutations remain deferred.",
+            "Analytics engineering execution",
+        ),
+        (
+            "governed-bigquery-sql",
+            "BigQuery SQL Agent",
+            "Governed BigQuery planning shell; query execution requires a registered read-only cost-aware tool.",
+            "BigQuery query execution",
+        ),
+        (
+            "governed-data-quality",
+            "Data Quality Agent",
+            "Governed data-quality shell; source-specific checks require registered deterministic contracts.",
+            "Data-quality source inspection",
+        ),
+        (
+            "governed-looker-dashboard",
+            "Looker Dashboard Agent",
+            "Governed Looker analysis shell; dashboard reads require a registered read-only connector.",
+            "Looker dashboard access",
+        ),
+        (
+            "governed-rag-knowledge",
+            "RAG Knowledge Agent",
+            "Governed retrieval shell; corpus retrieval and citation evaluation remain fail-closed until registered.",
+            "RAG corpus retrieval",
+        ),
+        (
+            "governed-ci-cd-evidence",
+            "CI/CD Evidence Agent",
+            "Governed delivery-evidence shell; CI provider access requires a registered read-only connector.",
+            "CI/CD evidence retrieval",
+        ),
+        (
+            "governed-cost-watchdog",
+            "Cost Watchdog Agent",
+            "Governed cost-monitoring shell; billing reads require a registered deterministic cost source.",
+            "Cost and billing telemetry",
+        ),
+        (
+            "governed-release-notes",
+            "Release Notes Agent",
+            "Governed release-note shell; repository and deployment evidence must be registered before synthesis.",
+            "Release evidence retrieval",
+        ),
+        (
+            "governed-executive-summary",
+            "Executive Summary Agent",
+            "Governed executive-summary shell; authoritative source retrieval must be registered before synthesis.",
+            "Executive source retrieval",
+        ),
     ]
     templates: list[dict[str, Any]] = []
     for index, (key, name, description, graph) in enumerate(definitions):
@@ -1057,6 +1154,17 @@ def template_graphs() -> list[dict[str, Any]]:
                 "edges": edges,
             }
         templates.append({"key": key, "name": name, "description": description, "graph": graph, "sort": index})
+    for offset, (key, name, description, capability) in enumerate(governed_definitions, start=len(definitions)):
+        templates.append(
+            {
+                "key": key,
+                "name": name,
+                "description": description,
+                "graph": _deferred_capability_graph(capability=capability),
+                "sort": offset,
+                "tags": ["template", "governed-agent", "read-only"],
+            }
+        )
     return templates
 
 
@@ -1076,7 +1184,7 @@ def seed_templates(*, env_id: str, business_id: str, actor: str) -> None:
                 env_id=env_id, business_id=business_id, actor=actor,
                 name=template["name"], description=template["description"],
                 graph=AgentGraph.model_validate(template["graph"]),
-                tags=["template", "read-only-mvp"], is_template=True,
+                tags=template.get("tags") or ["template", "read-only-mvp"], is_template=True,
                 template_key=template["key"],
             )
         except psycopg.errors.UniqueViolation:

--- a/backend/tests/test_agent_builder.py
+++ b/backend/tests/test_agent_builder.py
@@ -398,15 +398,77 @@ def test_prompt_budget_blocks_before_provider_call(monkeypatch):
         dispatch.stop()
 
 
-def test_templates_are_six_drafts_and_validate_with_registered_tools():
+def test_templates_include_six_demo_and_ten_governed_drafts():
     templates = agent_builder.template_graphs()
-    assert len(templates) == 6
+    assert len(templates) == 16
     assert templates[0]["key"] == "telemetry-triage"
+    governed = templates[6:]
+    assert [template["key"] for template in governed] == [
+        "governed-ticket-intake",
+        "governed-analytics-engineer",
+        "governed-bigquery-sql",
+        "governed-data-quality",
+        "governed-looker-dashboard",
+        "governed-rag-knowledge",
+        "governed-ci-cd-evidence",
+        "governed-cost-watchdog",
+        "governed-release-notes",
+        "governed-executive-summary",
+    ]
+    assert [template["name"] for template in governed] == [
+        "Ticket Intake Agent",
+        "Analytics Engineer Agent",
+        "BigQuery SQL Agent",
+        "Data Quality Agent",
+        "Looker Dashboard Agent",
+        "RAG Knowledge Agent",
+        "CI/CD Evidence Agent",
+        "Cost Watchdog Agent",
+        "Release Notes Agent",
+        "Executive Summary Agent",
+    ]
+    assert len({template["key"] for template in templates}) == 16
     results = [
         agent_builder.validate_graph(AgentGraph.model_validate(template["graph"]))["status"]
         for template in templates
     ]
-    assert results == ["pass"] * 6
+    assert results == ["pass"] * 16
+
+
+def test_governed_templates_are_zero_tool_fail_closed_graphs():
+    for template in agent_builder.template_graphs()[6:]:
+        candidate = AgentGraph.model_validate(template["graph"])
+        assert candidate.limits.max_tool_calls == 0
+        assert candidate.limits.max_cost_usd == 0
+        assert not any(node.type == "mcp_tool" for node in candidate.nodes)
+        approval = next(node for node in candidate.nodes if node.type == "human_approval")
+        assert "not registered" in approval.config["reason"]
+        output = next(node for node in candidate.nodes if node.type == "output")
+        assert output.config["bindings"]["status"] == "NOT_AVAILABLE"
+
+
+def test_seed_templates_is_idempotent_when_catalog_already_exists(monkeypatch):
+    template_keys = [template["key"] for template in agent_builder.template_graphs()]
+
+    class ExistingTemplatesCursor:
+        def execute(self, *_args, **_kwargs):
+            return None
+
+        def fetchall(self):
+            return [{"template_key": key} for key in template_keys]
+
+    @contextmanager
+    def existing_templates_cursor():
+        yield ExistingTemplatesCursor()
+
+    monkeypatch.setattr(agent_builder, "get_cursor", existing_templates_cursor)
+    create = patch.object(agent_builder, "create_workflow")
+    mocked = create.start()
+    try:
+        agent_builder.seed_templates(env_id=ENV, business_id=BIZ, actor="seed")
+        mocked.assert_not_called()
+    finally:
+        create.stop()
 
 
 def test_deterministic_eval_suite_is_staged_ready_for_valid_read_only_graph():

--- a/docs/plans/03-implementation-plans/active/0009-agent-builder-read-only-mvp.md
+++ b/docs/plans/03-implementation-plans/active/0009-agent-builder-read-only-mvp.md
@@ -2,7 +2,7 @@
 
 **ADO:** Story #478 under Feature #477 / Epic #476
 **Risk:** High
-**Status:** Implemented locally; superseded for active work by Story #735 eval/publish gate
+**Status:** Deployed to production; authenticated visual verification blocked by empty reviewer credentials
 **Last updated:** 2026-06-25
 
 ## Outcome
@@ -56,15 +56,16 @@ The Next.js same-origin proxy forwards authenticated platform-session scope head
 
 ## Verification status
 
-- Backend Agent Builder/MCP/AI dispatch/Control Tower regressions: 87 passed.
-- Frontend telemetry, proxy, schema-order, and Control Tower regressions: 172 passed.
-- Frontend typecheck: passed.
-- Frontend lint: passed with existing repository warnings.
-- Migrations 10035 and 10036 targeted dry-run: 65 statements parsed; no statements executed.
-- Full frontend suite remains red from three pre-existing REPE fund-page tests stuck on
-  `Loading fund...`; the initial baseline had five failures in the same file. The operator approved
-  proceeding with that recorded exception.
-- Full backend suite exceeded ten minutes; the focused owning-surface suite is green.
+- PR #372 and integration hotfix PR #374 merged to `main`.
+- GitHub main CI run `28192467071`: passed.
+- Vercel production deployment `dpl_6ncptiPffmvGK84wbK5nUqzTRghS`: Ready and aliased to
+  `novendor.ai`.
+- Railway production deployment `08bbf248-f39c-4fa4-8669-bffe6d51a014`: healthy.
+- Migrations 10035 and 10036 applied to the linked Supabase project.
+- Production telemetry dry-run `afe01788-530b-4f79-8e1d-ca1331996523`: succeeded with five steps,
+  twelve events, and five receipts.
+- Authenticated desktop/mobile visual smoke is blocked because the production
+  `TELEMETRY_REVIEWER_USERNAME` and `TELEMETRY_REVIEWER_PASSWORD` values currently export empty.
 
 ## Deferred
 
@@ -74,7 +75,7 @@ The Next.js same-origin proxy forwards authenticated platform-session scope head
 - Production-only visual/smoke evidence and production publication.
 - Vector retrieval and Databricks analytics export.
 - Write-capable MCP nodes.
-- Applying migration 10035 or deploying any service.
+- Authenticated visual smoke after reviewer credential repair.
 
 ## Next ticket
 

--- a/docs/plans/03-implementation-plans/active/0010-agent-builder-eval-publish-gate.md
+++ b/docs/plans/03-implementation-plans/active/0010-agent-builder-eval-publish-gate.md
@@ -2,7 +2,7 @@
 
 **ADO:** Story #735 under Feature #477 / Epic #476  
 **Risk:** High  
-**Status:** Implemented locally; database application and authenticated browser verification pending  
+**Status:** Deployed and production-verified through API/data evidence; authenticated visual verification pending
 **Last updated:** 2026-06-25
 
 ## Outcome
@@ -68,19 +68,15 @@ Added:
 
 ## Verification
 
-- Focused backend Agent Builder/MCP/AI dispatch/Control Tower suite: 79 passed.
-- Backend Agent Builder persistence/route suite: 26 passed.
-- Ruff: passed.
-- Frontend focused Agent Builder/Control Tower/proxy/schema-order suite: 15 passed.
-- Frontend Agent Builder component suite: 7 passed.
-- Frontend typecheck: passed.
-- Frontend lint: passed.
-- Targeted migration dry-run: migrations 10035 and 10036, 65 statements parsed, none executed.
-- Database application: blocked because no local `DATABASE_URL` or `SUPABASE_DB_URL` is configured.
-- Authenticated browser screenshots: pending database application and a usable local platform session.
+- Migration 10036 is applied in production with tenant RLS and append-only guards.
+- Production eval run `e06f0dcc-2ee8-411c-9ef0-7bc1792feade` completed `staged_ready` with ten
+  results: seven PASS, three explicit N/A, and zero blockers.
+- Staged publish succeeded for immutable workflow `2d28240d-1f89-45a5-95b3-7f45c2979a2e`.
+- GitHub main CI run `28192467071`, Railway health, and Vercel production deployment are green.
+- Authenticated browser screenshots remain blocked until the production telemetry reviewer
+  credentials are populated.
 
 ## Next production ticket
 
-Apply and verify migrations 10035/10036 in an authorized non-production Supabase environment, run
-authenticated desktop/mobile smoke, and attach eval/run/receipt database evidence. After that,
-implement durable approval resume and cancellation before considering production execution.
+Repair the production reviewer credentials and complete authenticated desktop/mobile smoke. After
+that, implement durable approval resume and cancellation before considering production execution.

--- a/docs/plans/03-implementation-plans/active/0011-governed-agent-registry.md
+++ b/docs/plans/03-implementation-plans/active/0011-governed-agent-registry.md
@@ -1,0 +1,55 @@
+# Governed Agent Registry
+
+**ADO:** Story #479 under Feature #477 / Epic #476  
+**Risk:** Medium  
+**Status:** Implemented locally; PR, deployment, and production registry smoke pending  
+**Last updated:** 2026-06-25
+
+## Outcome
+
+Register the ten named governed agents as tenant-scoped Agent Builder draft templates without
+introducing write-capable execution or parallel registry infrastructure:
+
+1. Ticket Intake
+2. Analytics Engineer
+3. BigQuery SQL
+4. Data Quality
+5. Looker Dashboard
+6. RAG Knowledge
+7. CI/CD Evidence
+8. Cost Watchdog
+9. Release Notes
+10. Executive Summary
+
+The six existing demonstration workflows remain intact. The ten new graphs use `agent-graph/v1`,
+bounded zero-tool/zero-cost limits, and a simulated capability gate. Until each integration has a
+registered read-only contract, dry-runs block with an explicit reason and retain a
+`NOT_AVAILABLE` terminal output definition.
+
+## Implementation
+
+- Extend the existing Agent Builder template catalog with stable `governed-*` keys.
+- Reuse the tenant-scoped additive seeder and immutable version creation path.
+- Tag new entries as `template`, `governed-agent`, and `read-only`.
+- Keep runtime permissions, schemas, API routes, and frontend contracts unchanged.
+- Preserve idempotency when registry access repeats or templates already exist.
+
+## Verification
+
+- Agent Builder backend suite: 28 passed.
+- Isolated telemetry MCP suite: 8 passed.
+- Isolated MCP registry/audit/context suite: 17 passed.
+- Isolated AI dispatch and Control Tower suite: 41 passed.
+- Ruff: passed.
+- Frontend Agent Builder/Control Tower/proxy suite: 12 passed.
+- Frontend typecheck: passed.
+- Focused frontend lint: passed.
+- A combined local backend command exposed pre-existing global MCP registry test pollution; the
+  same tests pass when run in isolated processes, matching CI job behavior.
+- Merge through CI, deploy, and verify the ten new tenant-scoped templates in production.
+
+## Known production QA dependency
+
+Authenticated visual smoke remains blocked until the production
+`TELEMETRY_REVIEWER_USERNAME` and `TELEMETRY_REVIEWER_PASSWORD` values are populated. Production
+API and persistence smoke remain available through scoped platform-session headers.

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4356,6 +4356,9 @@ claims as fact unless sourced; keep era framing general (access → cost → reu
   generated Claude wrapper is missing.
 - Never store credential values in instructions, reports, transcripts, tips, or
   automatic memory.
+- `vercel env ls production` proves only that a variable name exists, not that it has a usable
+  value. Before authenticated production smoke, pull the environment to a temporary file, verify
+  required reviewer values are non-empty without logging them, and delete the file immediately.
 
 ## Overview pages as thesis pages (telemetry Overview redesign)
 


### PR DESCRIPTION
## Summary
- add the ten Story #479 governed agents to the existing tenant-scoped Agent Builder catalog
- preserve the six demonstration workflows and immutable additive seeding path
- fail closed through zero-tool, zero-cost capability gates until read-only integrations are registered
- update active implementation plans and reusable production-auth guidance

## Verification
- Agent Builder backend: 28 passed
- telemetry MCP: 8 passed
- MCP registry/audit/context: 17 passed
- AI dispatch + Control Tower: 41 passed
- frontend Agent Builder/Control Tower/proxy: 12 passed
- backend ruff, frontend typecheck, focused lint: passed

ADO: Story #479 under Feature #477 / Epic #476