### PR TITLE
feat(telemetry): drill affordance + null-reason on primitives + MetricInspectorDrawer (PR 1.1)

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4436,6 +4436,15 @@ Scaffold for landing the raw Stargate printer Kafka stream into `novendor_1.tele
 - **Bronze table created + verified:** `bronze_ddl()` via `DatabricksClient.execute_sql` made `novendor_1.telemetry.bronze_stargate_printer` at Delta **version 0** (managed, partitioned by `ingest_date`, 0 rows, columns match the contract). `CREATE TABLE IF NOT EXISTS` is idempotent, so the loader can re-run it harmlessly.
 - **The Kafka read is the real gate, not Databricks.** `CONFLUENT_API_KEY`/`CONFLUENT_API_SECRET` are absent in shell env, `backend/.env`, and Railway `authentic-sparkle` (which only has `TELEMETRY_KAFKA_CONSUMER_ENABLED=0`). The cluster `lkc-gqpvvyv` is reachable (confluent CLI is authed; broker `pkc-619z3.us-east1.gcp.confluent.cloud:9092`), but `confluent_kafka` (2.14.2, importable) fails closed without SASL creds: `KafkaError _INVALID_ARG "sasl.username and sasl.password must be set"`. The CLI's SSO session is NOT SASL creds — the Python/Spark client needs a minted API key+secret. To land data: mint a scoped read API key → store in a Databricks secret scope → submit the loader as a bounded one-shot job with broker egress.
 
+## Telemetry primitive drill + null-state pattern (PR 1.1, 2026-06-25)
+
+Reusable drill-down without per-page drawers, all in `repo-b/src/components/telemetry/`:
+
+- **`MetricRow` / `Stat` take an optional `onDrill?: () => void` (+ `drillLabel` for the aria-label).** When set they render as a `<button>` with a subtle `›` affordance; when absent the markup is byte-identical to before, so existing call sites are untouched (no migration). Drive a drawer's open-state from `onDrill`.
+- **`MetricInspectorDrawer({ open, onClose, title, description, fields, children })`** in `drawerPrimitives.tsx` is the standard drill target — `DrawerWrapper` + `DrawerHeader` + a `FieldRow` list + optional extra sections. Don't hand-build a drawer per metric; compose this. Each missing field value fails closed to "Not available" via `FieldRow`.
+- **`EmptyState` takes optional `nullReason`** — surface `EvidenceContract.null_reason` (the specific reason) on its own line instead of a generic message. Keep the existing `label`/`hint`.
+- **Tests:** `npx vitest run src/components/telemetry/primitivesDrill.test.tsx` (button fires `onDrill`; no button without it; `nullReason` shows/omits; drawer renders title+fields and fail-closes missing values). Radix Dialog renders into a portal, so `screen.getByText` finds drawer content when `open`.
+
 ## Evidence-freeze guard for the frozen ML artifacts (PR 0.2, 2026-06-25)
 
 The five `telemetry-platform/*_evidence.json` (rul_conformal, regime_anomaly, competence_envelope, lead_lag_attribution, event_windowed_analog) carry the numbers + caveats the telemetry surface presents as proof. `backend/tests/test_evidence_freeze.py` locks them so any refactor that drifts a number or weakens a caveat fails CI.

--- a/repo-b/src/components/telemetry/drawerPrimitives.tsx
+++ b/repo-b/src/components/telemetry/drawerPrimitives.tsx
@@ -79,3 +79,24 @@ export function DrawerWrapper({ open, onClose, children }: {
     </Dialog.Root>
   );
 }
+
+// Reusable metric-inspector drawer: header + a fail-closed FieldRow list + optional
+// extra sections (provenance, formulas, a chart). The standard drill target for a
+// MetricRow/Stat `onDrill` — compose, don't build a new drawer per page. Each missing
+// field renders "Not available" via FieldRow, never blank.
+export function MetricInspectorDrawer({ open, onClose, title, description, fields, children }: {
+  open: boolean; onClose: () => void; title: ReactNode; description?: ReactNode;
+  fields: { label: string; value: unknown }[]; children?: ReactNode;
+}) {
+  return (
+    <DrawerWrapper open={open} onClose={onClose}>
+      <DrawerHeader title={title} description={description} />
+      <div style={{ marginTop: 16 }}>
+        {fields.map((f) => (
+          <FieldRow key={f.label} label={f.label} value={f.value} />
+        ))}
+      </div>
+      {children}
+    </DrawerWrapper>
+  );
+}

--- a/repo-b/src/components/telemetry/primitives.tsx
+++ b/repo-b/src/components/telemetry/primitives.tsx
@@ -66,7 +66,9 @@ export function MetricCard({ label, value, sub, accent }: {
 
 // Intentional "fail-closed / nothing here yet" state — a designed card with an amber status dot,
 // NOT a broken-looking dashed box. Used wherever a real value is honestly unavailable.
-export function EmptyState({ label, hint }: { label: string; hint: string }) {
+// `nullReason` (when provided) surfaces the SPECIFIC fail-closed reason from the data contract
+// (e.g. EvidenceContract.null_reason) on its own line — never invents a generic message.
+export function EmptyState({ label, hint, nullReason }: { label: string; hint: string; nullReason?: string | null }) {
   return (
     <div style={{ border: `1px solid ${C.amber}33`, background: `${C.amber}0d`, borderRadius: 9, padding: "16px 18px" }}>
       <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
@@ -74,6 +76,11 @@ export function EmptyState({ label, hint }: { label: string; hint: string }) {
         <span style={{ fontFamily: C.mono, fontSize: 13, color: C.amber, letterSpacing: "0.02em" }}>{label}</span>
       </div>
       <div style={{ fontFamily: C.mono, fontSize: 11.5, color: C.dim, marginTop: 8, lineHeight: 1.55, paddingLeft: 17 }}>{hint}</div>
+      {nullReason ? (
+        <div style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, marginTop: 8, paddingLeft: 17, overflowWrap: "anywhere" }}>
+          <span style={{ color: C.dim }}>reason: </span>{nullReason}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -257,27 +264,63 @@ export function StatusDot({ color, size = 8, glow = true }: { color: string; siz
 }
 
 // Mono label/value row (the most-duplicated card/console line). border-bottom
-// optional so it composes into lists.
-export function MetricRow({ label, value, tone, divider = true }: {
+// optional so it composes into lists. When `onDrill` is set the row becomes a
+// button with a subtle "›" drill affordance (use with MetricInspectorDrawer);
+// without it the markup is unchanged (existing call sites are untouched).
+export function MetricRow({ label, value, tone, divider = true, onDrill, drillLabel }: {
   label: ReactNode; value: ReactNode; tone?: string; divider?: boolean;
+  onDrill?: () => void; drillLabel?: string;
 }) {
-  return (
-    <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12,
-      padding: "7px 0", borderBottom: divider ? `1px solid ${C.border}` : undefined }}>
-      <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint }}>{label}</span>
-      <span style={{ fontFamily: C.mono, fontSize: 12, color: tone || C.text, textAlign: "right" }}>{value}</span>
-    </div>
+  const rowStyle: CSSProperties = {
+    display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12,
+    padding: "7px 0", borderBottom: divider ? `1px solid ${C.border}` : undefined,
+  };
+  const labelEl = <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint }}>{label}</span>;
+  const valueEl = (
+    <span style={{ fontFamily: C.mono, fontSize: 12, color: tone || C.text, textAlign: "right",
+      display: "inline-flex", alignItems: "center", gap: 6 }}>
+      {value}
+      {onDrill && <span aria-hidden style={{ color: C.faint, fontSize: 13, lineHeight: 1 }}>›</span>}
+    </span>
   );
+  if (onDrill) {
+    return (
+      <button type="button" onClick={onDrill} aria-label={drillLabel}
+        style={{ ...rowStyle, width: "100%", background: "transparent", border: "none", cursor: "pointer", textAlign: "left" }}>
+        {labelEl}
+        {valueEl}
+      </button>
+    );
+  }
+  return <div style={rowStyle}>{labelEl}{valueEl}</div>;
 }
 
-// Stacked label-over-value stat (used in metric blocks / strips).
-export function Stat({ label, value, tone }: { label: ReactNode; value: ReactNode; tone?: string }) {
-  return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+// Stacked label-over-value stat (used in metric blocks / strips). Optional
+// `onDrill` makes it an inspectable button with a "›" affordance; otherwise the
+// markup is unchanged.
+export function Stat({ label, value, tone, onDrill, drillLabel }: {
+  label: ReactNode; value: ReactNode; tone?: string; onDrill?: () => void; drillLabel?: string;
+}) {
+  const inner = (
+    <>
       <span style={{ fontFamily: C.mono, fontSize: 9, color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase" }}>{label}</span>
-      <span style={{ fontFamily: C.mono, fontSize: 16, fontWeight: 600, color: tone || C.text }}>{value}</span>
-    </div>
+      <span style={{ fontFamily: C.mono, fontSize: 16, fontWeight: 600, color: tone || C.text,
+        display: "inline-flex", alignItems: "center", gap: 6 }}>
+        {value}
+        {onDrill && <span aria-hidden style={{ color: C.faint, fontSize: 12, lineHeight: 1 }}>›</span>}
+      </span>
+    </>
   );
+  const colStyle: CSSProperties = { display: "flex", flexDirection: "column", gap: 3 };
+  if (onDrill) {
+    return (
+      <button type="button" onClick={onDrill} aria-label={drillLabel}
+        style={{ ...colStyle, alignItems: "flex-start", background: "transparent", border: "none", padding: 0, cursor: "pointer", textAlign: "left" }}>
+        {inner}
+      </button>
+    );
+  }
+  return <div style={colStyle}>{inner}</div>;
 }
 
 // Mono inline code for ids / null_reason / formulas / version strings.

--- a/repo-b/src/components/telemetry/primitivesDrill.test.tsx
+++ b/repo-b/src/components/telemetry/primitivesDrill.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { EmptyState, MetricRow, Stat } from "./primitives";
+import { MetricInspectorDrawer } from "./drawerPrimitives";
+
+describe("MetricRow drill affordance", () => {
+  it("renders a plain row (no button) when onDrill is absent", () => {
+    render(<MetricRow label="PICP" value="86%" />);
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByText("86%")).toBeInTheDocument();
+  });
+
+  it("renders an inspectable button and fires onDrill", () => {
+    const onDrill = vi.fn();
+    render(<MetricRow label="PICP" value="86%" onDrill={onDrill} drillLabel="Inspect PICP" />);
+    const btn = screen.getByRole("button", { name: "Inspect PICP" });
+    fireEvent.click(btn);
+    expect(onDrill).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Stat drill affordance", () => {
+  it("fires onDrill when set", () => {
+    const onDrill = vi.fn();
+    render(<Stat label="Coverage" value="0.90" onDrill={onDrill} drillLabel="Inspect coverage" />);
+    fireEvent.click(screen.getByRole("button", { name: "Inspect coverage" }));
+    expect(onDrill).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders no button without onDrill", () => {
+    render(<Stat label="Coverage" value="0.90" />);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});
+
+describe("EmptyState null reason", () => {
+  it("surfaces the specific null_reason when provided", () => {
+    render(<EmptyState label="No waterfall" hint="Carry requires the waterfall." nullReason="out_of_scope_requires_waterfall" />);
+    expect(screen.getByText(/out_of_scope_requires_waterfall/)).toBeInTheDocument();
+    expect(screen.getByText(/reason:/)).toBeInTheDocument();
+  });
+
+  it("omits the reason line when null_reason is absent", () => {
+    render(<EmptyState label="Nothing yet" hint="Awaiting data." />);
+    expect(screen.queryByText(/reason:/)).toBeNull();
+  });
+});
+
+describe("MetricInspectorDrawer", () => {
+  it("renders title and fields when open, fail-closing missing values", () => {
+    render(
+      <MetricInspectorDrawer
+        open
+        onClose={() => {}}
+        title="PICP inspector"
+        description="empirical coverage"
+        fields={[
+          { label: "value", value: "0.86" },
+          { label: "target", value: "0.90" },
+          { label: "absent", value: null },
+        ]}
+      />,
+    );
+    expect(screen.getByText("PICP inspector")).toBeInTheDocument();
+    expect(screen.getByText("0.86")).toBeInTheDocument();
+    expect(screen.getByText("0.90")).toBeInTheDocument();
+    // missing value fails closed via FieldRow
+    expect(screen.getByText("Not available")).toBeInTheDocument();
+  });
+
+  it("renders nothing when closed", () => {
+    render(
+      <MetricInspectorDrawer open={false} onClose={() => {}} title="hidden" fields={[{ label: "x", value: "1" }]} />,
+    );
+    expect(screen.queryByText("hidden")).toBeNull();
+  });
+});


### PR DESCRIPTION
PR 1.1 from the integrated master plan — the foundational primitive extension that lets metrics drill into an inspector and null states surface their specific reason. Prerequisite for the Overview redesign (PR 1.2) and page-card wiring (PR 3.x). Additive only; existing call sites untouched.

## Changes (all in `repo-b/src/components/telemetry/`)
- **`MetricRow` / `Stat`** gained optional `onDrill` (+ `drillLabel`): renders an inspectable `<button>` with a subtle `›` affordance; **markup is unchanged when `onDrill` is absent**, so no call-site migration.
- **`EmptyState`** gained optional `nullReason`: surfaces the specific fail-closed reason (e.g. `EvidenceContract.null_reason`) on its own line instead of a generic message.
- **`MetricInspectorDrawer`** (new, in `drawerPrimitives.tsx`): the standard drill target — `DrawerWrapper` + `DrawerHeader` + a fail-closed `FieldRow` list + optional extra sections. Composed from existing primitives; no new design primitive. Missing field values render "Not available".

## Receipts
- `npx vitest run primitivesDrill.test.tsx RulConformalCard.test.tsx RegimeAnomalyCard.test.tsx` — **10 passed** (8 new + 2 existing consumers, no regression).
- `npm run typecheck` — clean.
- `eslint` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)