### PR TITLE
feat(telemetry): conservative nav declutter — hide Trust Center, How This Works, Resume Evidence (PR 2.1)

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4443,6 +4443,15 @@ Scaffold for landing the raw Stargate printer Kafka stream into `novendor_1.tele
 - **`raw_value` is `base64(value)`** (lossless, ascii-safe) because the stream is binary/Avro; a plain `CAST(value AS STRING)` is lossy and breaks Windows console printing. `raw_value_bytes` keeps the true size.
 - **Lineage stays `not_available`** — bronze has data but the Postgres pointer columns are NOT stamped yet. That is Ticket B; do not stamp until bronze is verified (it now is).
 
+**Ticket B zero-match gate (2026-06-25):** the lineage flips ONLY for `tel_stream_kafka_rows` rows whose `(kafka_topic, kafka_partition, kafka_offset)` is also in bronze. Pull `TELEMETRY_DATABASE_URL` from Railway leak-free — `railway` is NOT on Python's subprocess PATH (Windows shim), so do it in bash: `railway link -p authentic-sparkle -e production -s authentic-sparkle` then `export X="$(railway variables --kv | grep '^TELEMETRY_DATABASE_URL=' | sed 's/^[^=]*=//')"` (the `$()` assignment never echoes the value); link leaves no `.railway` artifact in the repo. The serving slice was empty (6 rows, 0 on bronze topics) because the durable Kafka→Postgres consumer never ran against Stargate — so stamping was correctly a no-op. To get matches, run the durable consumer to populate the slice first.
+
+## Telemetry nav change blast radius (PR 2.1, 2026-06-25)
+
+Editing `telemetryNav.ts` (`TELEMETRY_NAV`) ripples to THREE test files — run the full telemetry suite, not just the nav test: `npx vitest run src/components/telemetry src/lib/telemetry`.
+- `telemetryNav.test.ts` — asserts the exact slug set + relabels.
+- `TelemetrySidebar.test.tsx` — asserts each nav item renders a routable link + specific relabels.
+- `telemetryArchitectureData.test.ts` — **the easy-to-miss one**: it validates every architecture-map node `slug` against `TELEMETRY_NAV` membership ("no dead deep-links"). Hiding a nav slug whose arch node still references it (e.g. `governance` → nodes `H_gov`, `ui_gov`) fails it. Fix honestly: the routes still resolve under hide-before-delete, so add the hidden-but-resolving slugs to the test's `VALID_SLUGS` (don't delete the arch nodes — they document real surfaces).
+
 ## Telemetry primitive drill + null-state pattern (PR 1.1, 2026-06-25)
 
 Reusable drill-down without per-page drawers, all in `repo-b/src/components/telemetry/`:

--- a/repo-b/src/components/telemetry/TelemetrySidebar.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetrySidebar.test.tsx
@@ -19,8 +19,9 @@ describe("TelemetrySidebar — 6-section rail", () => {
       const links = screen.getAllByRole("link", { name: new RegExp(`^${item.label}$`, "i") });
       expect(links.some((l) => l.getAttribute("href") === telemetryHref("env-1", item.slug))).toBe(true);
     }
-    // The four redesign relabels are present as links.
-    for (const label of ["Overview", "Agent Control Tower", "Trust Center", "Flight Readiness"]) {
+    // Redesign relabels are present as links. (Trust Center / governance is intentionally hidden by
+    // the PR 2.1 conservative declutter; its route still resolves.)
+    for (const label of ["Overview", "Agent Control Tower", "Flight Readiness"]) {
       expect(screen.getAllByRole("link", { name: new RegExp(`^${label}$`, "i") }).length).toBeGreaterThanOrEqual(1);
     }
   });

--- a/repo-b/src/components/telemetry/telemetryArchitectureData.test.ts
+++ b/repo-b/src/components/telemetry/telemetryArchitectureData.test.ts
@@ -6,8 +6,12 @@ import {
 } from "./telemetryArchitectureData";
 import { TELEMETRY_NAV } from "./telemetryNav";
 
-// Valid deep-link targets = the telemetry nav slugs (incl. "" for Overview).
-const VALID_SLUGS = new Set<string>(TELEMETRY_NAV.map((n) => n.slug));
+// Valid deep-link targets = the telemetry nav slugs (incl. "" for Overview) PLUS routes that are
+// intentionally hidden from the nav but still resolve (PR 2.1 hide-before-delete: Trust Center,
+// How This Works, Resume Evidence). Their page.tsx still exist, so an arch node pointing at them is
+// a real deep-link, not a dead one.
+const HIDDEN_BUT_RESOLVING = ["governance", "how-it-works", "evidence"];
+const VALID_SLUGS = new Set<string>([...TELEMETRY_NAV.map((n) => n.slug), ...HIDDEN_BUT_RESOLVING]);
 const ALL_NODES: ArchNode[] = ARCH_VIEWS.flatMap((v) => v.nodes);
 
 describe("telemetryArchitectureData — honest by construction", () => {

--- a/repo-b/src/components/telemetry/telemetryNav.test.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.test.ts
@@ -24,7 +24,10 @@ describe("telemetry navigation structure (6-section redesign + Data Engineering)
     }
   });
 
-  it("keeps every existing surface routable (regression guard — no slug dropped)", () => {
+  it("exposes exactly the presentation-nav slugs (governance/how-it-works/evidence hidden, routes still resolve)", () => {
+    // PR 2.1 conservative declutter: Trust Center (governance), How This Works (how-it-works), and
+    // Resume Evidence (evidence) are intentionally dropped from the nav. Their routes still resolve
+    // for deep links; they are simply not surfaced in the rail. Any OTHER slug change is a regression.
     const slugs = TELEMETRY_NAV.map((n) => n.slug).sort();
     expect(slugs).toEqual(
       [
@@ -40,11 +43,8 @@ describe("telemetry navigation structure (6-section redesign + Data Engineering)
         "data-engineering/sources",
         "data-engineering/workbench",
         "data-engineering/workflows",
-        "evidence",
         "factory",
         "factory-ml",
-        "governance",
-        "how-it-works",
         "metadata",
         "metric-lineage",
         "model-performance",
@@ -56,12 +56,15 @@ describe("telemetry navigation structure (6-section redesign + Data Engineering)
         "system-health",
       ].sort(),
     );
+    // The hidden slugs must NOT appear in the nav (but their page routes still exist on disk).
+    expect(slugs).not.toContain("governance");
+    expect(slugs).not.toContain("how-it-works");
+    expect(slugs).not.toContain("evidence");
   });
 
   it("applies the redesign relabels without changing slugs", () => {
     const labelOf = (slug: string) => TELEMETRY_NAV.find((n) => n.slug === slug)?.label;
     expect(labelOf("")).toBe("Overview");
-    expect(labelOf("governance")).toBe("Trust Center");
     expect(labelOf("control-tower")).toBe("Agent Control Tower");
     expect(labelOf("factory-ml")).toBe("Flight Readiness");
   });

--- a/repo-b/src/components/telemetry/telemetryNav.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.ts
@@ -55,11 +55,10 @@ export const TELEMETRY_NAV: TelemetryNavItem[] = [
   // Section 5 — Evidence & Lineage (where did this number come from / why trust it)
   { slug: "metric-lineage", label: "Metric Lineage", icon: "M4 2v12M4 6h6M4 11h5M10 4v4M9 9v3", group: "Evidence & Lineage" },
   { slug: "metadata", label: "Metadata Explorer", icon: "M2 3h5v4H2zM9 3h5v4H9zM5 9h6v4H5zM4.5 7v2M11.5 7v2M7 11H5M11 11h-1", group: "Evidence & Lineage" },
-  { slug: "governance", label: "Trust Center", icon: "M8 1l6 2v4c0 3.5-2.5 6-6 7-3.5-1-6-3.5-6-7V3z", group: "Evidence & Lineage" },
-  { slug: "how-it-works", label: "How This Works", icon: "M2 4l4-2 4 2 4-2v10l-4 2-4-2-4 2zM6 2v10M10 4v10", group: "Evidence & Lineage" },
-  // Resume-claim proof surface: aggregates the evidence cards (model/pipeline/feature
-  // contract/known-anomaly/AI/deploy) that back each resume claim with real data, fail-closed.
-  { slug: "evidence", label: "Resume Evidence", icon: "M3 2h7l3 3v9H3zM6 7h5M6 10h5M6 13h3", group: "Evidence & Lineage" },
+  // Hidden-before-delete (presentation declutter): "Trust Center" (governance), "How This Works"
+  // (how-it-works), and "Resume Evidence" (evidence) are dropped from the nav. Their /telemetry/<slug>
+  // routes still resolve for deep links; only the nav entries are removed. The How-This-Works framing
+  // and the resume-evidence cards live on the Overview / per-page EvidenceContract fields.
 
   // Section 6 — Agent Operations (approved execution)
   { slug: "control-tower", label: "Agent Control Tower", icon: "M8 1l6 3v4c0 3-2.5 5.5-6 7-3.5-1.5-6-4-6-7V4zM8 5v6M5 8h6", group: "Agent Operations" },


### PR DESCRIPTION
PR 2.1 (hide-before-delete), executed as a **conservative declutter** per the verify-then-build check.

## What's hidden
Three secondary "meta" surfaces dropped from the telemetry rail — **Trust Center** (`governance`), **How This Works** (`how-it-works`), **Resume Evidence** (`evidence`). Their `/telemetry/<slug>` routes still resolve (page.tsx untouched, confirmed on disk) — only the nav entries are removed, so deep links don't 404.

## Deviation from the plan (verify-then-build)
The plan also listed `copilot` and the Data Engineering group, but the reality check showed both should stay:
- **`copilot` renders the mobilePrimary "Test Intelligence"** — a real model-intelligence page, not the "Chat Copilot" the plan assumed.
- **The Data Engineering group was intentionally built in PR #337** (the ADE reframe).

Hiding those would remove wanted/recent surfaces, so they're kept. (Confirmed with the owner.)

## Receipts
- `vitest` telemetryNav + TelemetrySidebar + TelemetryOverview — **13 passed** (tests updated to the new nav set; the Overview's own "Resume Evidence" bridge link is independent of nav and unchanged).
- `npm run typecheck` clean; `eslint` clean.
- The 3 hidden routes (`governance`, `how-it-works`, `evidence`) confirmed present on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)