### PR TITLE
feat(telemetry): hide Data Engineering + Test Intelligence from nav (owner correction)

### DIFF
--- a/repo-b/src/components/telemetry/telemetryArchitectureData.test.ts
+++ b/repo-b/src/components/telemetry/telemetryArchitectureData.test.ts
@@ -10,7 +10,7 @@ import { TELEMETRY_NAV } from "./telemetryNav";
 // intentionally hidden from the nav but still resolve (PR 2.1 hide-before-delete: Trust Center,
 // How This Works, Resume Evidence). Their page.tsx still exist, so an arch node pointing at them is
 // a real deep-link, not a dead one.
-const HIDDEN_BUT_RESOLVING = ["governance", "how-it-works", "evidence"];
+const HIDDEN_BUT_RESOLVING = ["governance", "how-it-works", "evidence", "copilot"];
 const VALID_SLUGS = new Set<string>([...TELEMETRY_NAV.map((n) => n.slug), ...HIDDEN_BUT_RESOLVING]);
 const ALL_NODES: ArchNode[] = ARCH_VIEWS.flatMap((v) => v.nodes);
 

--- a/repo-b/src/components/telemetry/telemetryNav.test.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.test.ts
@@ -5,8 +5,8 @@ import {
   telemetryHref,
 } from "./telemetryNav";
 
-describe("telemetry navigation structure (6-section redesign + Data Engineering)", () => {
-  it("exposes the redesign sections in order, with Data Engineering last", () => {
+describe("telemetry navigation structure (6 presentation sections)", () => {
+  it("exposes the six presentation sections in order (Data Engineering hidden from nav)", () => {
     expect(TELEMETRY_NAV_GROUPS).toEqual([
       "Overview",
       "Operations",
@@ -14,7 +14,6 @@ describe("telemetry navigation structure (6-section redesign + Data Engineering)
       "Factory & Quality",
       "Evidence & Lineage",
       "Agent Operations",
-      "Data Engineering",
     ]);
   });
 
@@ -24,25 +23,16 @@ describe("telemetry navigation structure (6-section redesign + Data Engineering)
     }
   });
 
-  it("exposes exactly the presentation-nav slugs (governance/how-it-works/evidence hidden, routes still resolve)", () => {
-    // PR 2.1 conservative declutter: Trust Center (governance), How This Works (how-it-works), and
-    // Resume Evidence (evidence) are intentionally dropped from the nav. Their routes still resolve
-    // for deep links; they are simply not surfaced in the rail. Any OTHER slug change is a regression.
+  it("exposes exactly the presentation-nav slugs (hidden surfaces dropped, routes still resolve)", () => {
+    // Hidden-before-delete: Trust Center (governance), How This Works (how-it-works), Resume Evidence
+    // (evidence), Test Intelligence (copilot), and the whole Data Engineering group are intentionally
+    // dropped from the nav. Their routes still resolve for deep links. Any OTHER slug change is a regression.
     const slugs = TELEMETRY_NAV.map((n) => n.slug).sort();
     expect(slugs).toEqual(
       [
         "",
         "calibration",
         "control-tower",
-        "copilot",
-        "data-engineering",
-        "data-engineering/autopsy",
-        "data-engineering/grain",
-        "data-engineering/pipelines",
-        "data-engineering/relationships",
-        "data-engineering/sources",
-        "data-engineering/workbench",
-        "data-engineering/workflows",
         "factory",
         "factory-ml",
         "metadata",
@@ -57,9 +47,10 @@ describe("telemetry navigation structure (6-section redesign + Data Engineering)
       ].sort(),
     );
     // The hidden slugs must NOT appear in the nav (but their page routes still exist on disk).
-    expect(slugs).not.toContain("governance");
-    expect(slugs).not.toContain("how-it-works");
-    expect(slugs).not.toContain("evidence");
+    for (const hidden of ["governance", "how-it-works", "evidence", "copilot", "data-engineering"]) {
+      expect(slugs).not.toContain(hidden);
+    }
+    expect(slugs.some((s) => s.startsWith("data-engineering/"))).toBe(false);
   });
 
   it("applies the redesign relabels without changing slugs", () => {
@@ -76,7 +67,8 @@ describe("telemetry navigation structure (6-section redesign + Data Engineering)
       group: "Evidence & Lineage",
     });
     expect(item?.mobilePrimary).not.toBe(true);
-    expect(TELEMETRY_NAV.filter((entry) => entry.mobilePrimary)).toHaveLength(4);
+    // Three mobile-primary tabs remain after Test Intelligence (copilot) was hidden.
+    expect(TELEMETRY_NAV.filter((entry) => entry.mobilePrimary)).toHaveLength(3);
   });
 
   it("builds and recognizes the env-scoped metadata route", () => {
@@ -92,29 +84,15 @@ describe("telemetry navigation structure (6-section redesign + Data Engineering)
     ).toBe(true);
   });
 
-  it("registers the seven Data Engineering items under their group", () => {
-    const slugs = TELEMETRY_NAV.filter((n) => n.group === "Data Engineering").map((n) => n.slug);
-    expect(slugs).toEqual([
-      "data-engineering",
-      "data-engineering/grain",
-      "data-engineering/relationships",
-      "data-engineering/pipelines",
-      "data-engineering/workflows",
-      "data-engineering/workbench",
-      "data-engineering/autopsy",
-      "data-engineering/sources",
-    ]);
-  });
-
-  it("builds and recognizes a nested data-engineering route", () => {
+  it("no longer surfaces any Data Engineering nav items (group hidden; routes still resolve)", () => {
+    expect(TELEMETRY_NAV.filter((n) => n.group === "Data Engineering")).toHaveLength(0);
+    // The nested route still builds/recognizes for deep links even though it is not in the nav.
     expect(telemetryHref("env-1", "data-engineering/grain")).toBe(
       "/lab/env/env-1/telemetry/data-engineering/grain",
     );
     expect(
       isTelemetryItemActive(
-        "/lab/env/env-1/telemetry/data-engineering/grain",
-        "env-1",
-        "data-engineering/grain",
+        "/lab/env/env-1/telemetry/data-engineering/grain", "env-1", "data-engineering/grain",
       ),
     ).toBe(true);
   });

--- a/repo-b/src/components/telemetry/telemetryNav.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.ts
@@ -46,7 +46,7 @@ export const TELEMETRY_NAV: TelemetryNavItem[] = [
   { slug: "model-performance", label: "Model Performance", icon: "M2 13l4-5 3 2 5-7", group: "Models & Intelligence" },
   { slug: "calibration", label: "RUL Calibration", icon: "M2 13h12M4 13V7m4 6V4m4 9V9", group: "Models & Intelligence" },
   { slug: "registry", label: "Model Registry", icon: "M3 2h10v3H3zM3 7h10v3H3zM3 12h6v2H3z", group: "Models & Intelligence" },
-  { slug: "copilot", label: "Test Intelligence", icon: "M8 1l2 4 4 1-3 3 1 4-4-2-4 2 1-4-3-3 4-1z", group: "Models & Intelligence", mobilePrimary: true },
+  // "Test Intelligence" (copilot) hidden from the nav (per owner). Its /telemetry/copilot route still resolves.
 
   // Section 4 — Factory & Quality (what's broken / needs intervention)
   { slug: "factory", label: "Factory · NCR", icon: "M2 13V7l4 3V7l4 3V4h4v9z", group: "Factory & Quality" },
@@ -63,18 +63,9 @@ export const TELEMETRY_NAV: TelemetryNavItem[] = [
   // Section 6 — Agent Operations (approved execution)
   { slug: "control-tower", label: "Agent Control Tower", icon: "M8 1l6 3v4c0 3-2.5 5.5-6 7-3.5-1.5-6-4-6-7V4zM8 5v6M5 8h6", group: "Agent Operations" },
 
-  // Section 7 — Data Engineering (the governed fabric between operational data and trusted AI).
-  // Composed surface: data-semantics pages reuse the telemetry metadata catalog; the agent/governance
-  // pages read the portable ADE endpoints (/api/ade/*). Replaces the old standalone
-  // /automated-data-engineering domain route (which now redirects here).
-  { slug: "data-engineering", label: "Data Engineering", icon: "M3 3h4v4H3zM9 9h4v4H9zM7 5h2M5 7v2M11 7V5M9 11H7", group: "Data Engineering" },
-  { slug: "data-engineering/grain", label: "Data Map & Grain", icon: "M2 3h12v3H2zM2 8h12v3H2zM2 13h7v1H2z", group: "Data Engineering" },
-  { slug: "data-engineering/relationships", label: "Relationships & Lineage", icon: "M4 2v12M4 6h6M4 11h5M10 4v4M9 9v3", group: "Data Engineering" },
-  { slug: "data-engineering/pipelines", label: "Pipelines & Quality", icon: "M2 8h3l2-4 2 8 2-4h3", group: "Data Engineering" },
-  { slug: "data-engineering/workflows", label: "Workflow Registry", icon: "M3 3h3v3H3zM10 3h3v3h-3zM3 10h3v3H3zM10 10h3v3h-3zM6 4.5h4M11.5 6v4M6 11.5h4M4.5 6v4", group: "Data Engineering" },
-  { slug: "data-engineering/workbench", label: "Agent Workbench", icon: "M8 1l2 4 4 1-3 3 1 4-4-2-4 2 1-4-3-3 4-1z", group: "Data Engineering" },
-  { slug: "data-engineering/autopsy", label: "Run Autopsy", icon: "M3 2h8l2 2v10H3zM5 6h6M5 9h6M5 12h4", group: "Data Engineering" },
-  { slug: "data-engineering/sources", label: "Source & Platform Map", icon: "M3 3h4v4H3zM9 3h4v4H9zM3 9h4v4H3zM9 9h4v4H9z", group: "Data Engineering" },
+  // The Data Engineering group is hidden from the nav (per owner). The
+  // /telemetry/data-engineering[/grain|relationships|pipelines|workflows|workbench|autopsy|sources]
+  // routes still resolve for deep links; only the nav entries are removed (hide-before-delete).
 ];
 
 export const TELEMETRY_NAV_GROUPS: TelemetryNavGroup[] = [
@@ -84,7 +75,8 @@ export const TELEMETRY_NAV_GROUPS: TelemetryNavGroup[] = [
   "Factory & Quality",
   "Evidence & Lineage",
   "Agent Operations",
-  "Data Engineering",
+  // "Data Engineering" stays in the TelemetryNavGroup union (the sidebar color map keys on it) but is
+  // no longer a displayed group — its items are hidden from the nav (routes still resolve).
 ];
 
 export function telemetryHref(envId: string, slug: string): string {


### PR DESCRIPTION
Follow-up to #385 per the owner's correction: **Data Engineering** and **Test Intelligence** (`copilot`) should also be hidden from the telemetry nav (the conservative subset in #385 kept them). Hide-before-delete — their `/telemetry/<slug>` routes still resolve (page.tsx untouched, confirmed on disk).

## Changes
- `telemetryNav.ts`: remove the `copilot` item and the 8 `data-engineering*` items; drop `"Data Engineering"` from `TELEMETRY_NAV_GROUPS`. Kept `"Data Engineering"` in the `TelemetryNavGroup` union (the `TelemetrySidebar` color map keys on it).
- `telemetryNav.test.ts`: trimmed slug set; 6 displayed groups; mobilePrimary 4→3 (copilot was primary); DE test now asserts the group is empty while the nested route still builds/recognizes.
- `telemetryArchitectureData.test.ts`: `copilot` added to `HIDDEN_BUT_RESOLVING` (arch node `H_mcp → copilot` is a real resolving deep-link, just not nav-surfaced).

**Now hidden from nav:** governance, how-it-works, evidence, copilot, data-engineering (+ children). All routes still resolve.

## Receipts
- `npx vitest run src/components/telemetry src/lib/telemetry` — **239 passed**.
- `npm run typecheck` + `eslint` clean.
- `copilot`, `data-engineering`, `data-engineering/grain` routes confirmed present on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)