### PR TITLE
chore(deps): remove unused @tanstack/react-virtual (verified knip slice)

### DIFF
--- a/detectors/README.md
+++ b/detectors/README.md
@@ -20,6 +20,11 @@ Baselines captured 2026-06-25: `baseline-knip.txt`, `baseline-vulture.txt`, `bas
 
 ## Baseline summary
 
+- **knip unused-deps are FP-prone — verified 2026-06-25 (2 of 3 were false positives):**
+  `@tanstack/react-virtual` = genuinely unused (0 refs) → removed. `nodemailer` = **actively imported**
+  in `src/lib/marketing/mailer.ts` (knip missed the server-lib chain) → KEPT. `iconoir-react` = no
+  import but a design-intent comment + the CLAUDE.md icon system → KEPT (conservative). Always grep
+  before removing a knip-flagged dep.
 - **knip:** 169 unused files · 427 unused exports · 41 unused exported types · 24 duplicate exports ·
   3 unused deps · 1 unused devDep · 1 unlisted · 1 unresolved import. Expect heavy false positives:
   the Next.js App Router pages are entrypoints, many components are dynamically/string-referenced, and

--- a/repo-b/package-lock.json
+++ b/repo-b/package-lock.json
@@ -17,7 +17,6 @@
         "@react-three/fiber": "^8.18.0",
         "@remixicon/react": "^4.9.0",
         "@supabase/supabase-js": "^2.98.0",
-        "@tanstack/react-virtual": "^3.13.6",
         "@types/leaflet": "^1.9.21",
         "@xyflow/react": "^12.10.2",
         "clsx": "^2.1.1",
@@ -2373,33 +2372,6 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.23",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
-      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/virtual-core": "3.13.23"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.23",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
-      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/repo-b/package.json
+++ b/repo-b/package.json
@@ -35,7 +35,6 @@
     "@react-three/fiber": "^8.18.0",
     "@remixicon/react": "^4.9.0",
     "@supabase/supabase-js": "^2.98.0",
-    "@tanstack/react-virtual": "^3.13.6",
     "@types/leaflet": "^1.9.21",
     "@xyflow/react": "^12.10.2",
     "clsx": "^2.1.1",


### PR DESCRIPTION
High-signal/low-risk cleanup from the knip baseline — **deps slice, verified one-by-one** (not bulk-trusted). Of knip's 3 "unused dependencies", only one was genuinely unused:

- ✅ **Removed `@tanstack/react-virtual`** — 0 references in `src` (no import, no `useVirtualizer`, no string ref). `package-lock.json` updated lock-only: **−28 lines, only `react-virtual` + transitive `virtual-core`**, no other packages touched.
- ❌ **Kept `nodemailer`** — actively imported in `src/lib/marketing/mailer.ts` (knip false positive; missed the server-lib chain).
- ❌ **Kept `@types/nodemailer`** (pairs with nodemailer) and **`iconoir-react`** (no import but a design-intent comment + the icon system; conservative).

Duplicate-exports slice **deferred** — knip's 24 are mostly intentional named+default export pairs + the deliberate telemetry aliases (`Panel`/`TelemetryPanel`), not safe to bulk-remove.

Proof per your rules: no runtime import, no dynamic string reference, lockfile minimal + valid JSON; CI's `npm ci` + typecheck + build + unit is the definitive green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)