### PR TITLE
chore(cleanup): remove unused import trades_broker.Order (vulture slice)

### DIFF
--- a/backend/app/services/trades_broker.py
+++ b/backend/app/services/trades_broker.py
@@ -9,11 +9,11 @@ from typing import Any, Protocol
 from app.config import IBKR_CLIENT_ID, IBKR_HOST, IBKR_LIVE_PORT, IBKR_PAPER_PORT
 
 try:  # pragma: no cover - optional runtime dependency
-    from ib_insync import Contract, IB, LimitOrder, MarketOrder, Order, StopLimitOrder, StopOrder, Stock
+    from ib_insync import Contract, IB, LimitOrder, MarketOrder, StopLimitOrder, StopOrder, Stock
 except Exception:  # pragma: no cover - optional runtime dependency
     Contract = object  # type: ignore[assignment]
     IB = None  # type: ignore[assignment]
-    LimitOrder = MarketOrder = StopLimitOrder = StopOrder = Stock = Order = None  # type: ignore[assignment]
+    LimitOrder = MarketOrder = StopLimitOrder = StopOrder = Stock = None  # type: ignore[assignment]
 
 
 class BrokerService(Protocol):

--- a/detectors/README.md
+++ b/detectors/README.md
@@ -30,8 +30,16 @@ Baselines captured 2026-06-25: `baseline-knip.txt`, `baseline-vulture.txt`, `bas
   the Next.js App Router pages are entrypoints, many components are dynamically/string-referenced, and
   the telemetry primitives intentionally export aliases (`Panel`/`TelemetryPanel`, etc.). Treat the
   **duplicate exports** and **unused deps** as the highest-signal starting points.
-- **vulture (≥80% confidence):** ~10 findings — small + high-signal (genuine unused vars/imports,
-  one unreachable-after-return). The likeliest real cleanups.
+- **vulture (≥90% confidence):** ~16 findings — but verified 2026-06-25, **most "unused variable"
+  hits are unused FUNCTION PARAMETERS** (e.g. `winston_assist`, `re_scenario_engine_v2`,
+  `credit_decisioning`, `ai_gateway`, the adapter stubs) — removing those changes signatures (unsafe;
+  some are interface contracts or latent bugs), so they are NOT bulk cleanups. Genuinely safe + done:
+  `trades_broker.py` unused import `Order`. **SURFACED (not auto-fixed): `re_env_portfolio.py` has a
+  `return` at line ~74 followed by ~178 lines of UNREACHABLE legacy SQL** (orphaned by the
+  authoritative-state migration — the function now returns `get_released_portfolio_kpis()` early). It
+  is dead and a good cleanup, BUT it is REPE financial-read code under the Authoritative State
+  Lockdown — its removal needs its own reviewed PR (read `docs/SYSTEM_RULES_AUTHORITATIVE_STATE.md`;
+  confirm `no_legacy_repe_reads.py` + `test_state_lock_invariants.py` stay green).
 - **deptry:** 36 issues. Mostly **false positives**: `DEP002` flags `pytest`/`ruff`/`respx`/
   `python-multipart`/`pgvector`/`redis` (used via CLI / runtime / FastAPI form-parsing, not a plain
   `import`); `DEP001` flags optional-feature imports guarded by `try/except` (`twilio`, `sendgrid`,


### PR DESCRIPTION
The one genuinely-safe finding from the vulture slice — surgical, verified.

- ✅ **Removed unused `Order`** from `trades_broker.py` (the `ib_insync` optional import at line 12 + its `except` fallback at line 16). `Order` was never used as a symbol — line 217 is the word "Order" in an error-message f-string. ruff green.

## Why this slice is small (verify-then-build)
Most vulture "unused variable" findings are **unused function parameters** (`winston_assist`, `re_scenario_engine_v2`, `credit_decisioning`, `ai_gateway`, adapter stubs) — removing those changes signatures (interface-contract / latent-bug risk), so they're **not** bulk cleanups.

## Surfaced, not auto-fixed
`re_env_portfolio.py` has a `return` at line ~74 followed by **~178 lines of unreachable legacy SQL** (orphaned by the authoritative-state migration — the function now returns `get_released_portfolio_kpis()` early). It's genuinely dead and a good cleanup, **but it's REPE financial-read code under the Authoritative State Lockdown** — it needs its own reviewed PR (read `docs/SYSTEM_RULES_AUTHORITATIVE_STATE.md`; confirm `no_legacy_repe_reads.py` + `test_state_lock_invariants.py` stay green). Flagged in `detectors/README.md` + the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)