### PR TITLE
docs: Phase 6 consolidation — canonical docs map + tips canonicalization (non-destructive)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,79 @@
 # Documentation Index
 
-This folder contains all project documentation, organized by category. Start here to navigate the knowledge base.
+This folder contains all project documentation. The **Canonical Docs Map** below is the current, hand-maintained entry point to the source-of-truth doc for each area. The older folder-oriented index (March 2026) is preserved further down under **Historical index**.
+
+## Canonical Docs Map (current — maintained 2026-06-25)
+
+> Hand-maintained and freshness-tagged. **Not** in the morning-ops-digest auto-overwrite set (unlike `LATEST.md` / `CAPABILITY_INVENTORY.md`, which are regenerated daily). All paths are **relative to the repo root**. `CLAUDE.md` remains the top-level routing contract; this is a discoverability map, not a router.
+
+### Planning
+- `docs/plans/CONSOLIDATED_BACKLOG.md` — single source of truth for open work across workstreams
+- `docs/plans/00-dispatch/README.md` — routes every new idea/bug/feature to the right plan folder
+- `docs/plans/03-implementation-plans/active/` — numbered `NNNN-*` dispatch records (the active plans CLAUDE.md points at)
+- `docs/plans/PLAN_MAINTENANCE_RULES.md` — how plan folders are read/updated each session
+- `docs/plans/01-shared-standards/README.md` — platform-wide contracts every environment obeys
+
+### Architecture
+- `ARCHITECTURE.md` — durable architecture + DB guardrail contract (table prefixes, RLS/tenant rules); mandatory pre-read for SQL/schema work
+- `docs/AI_ARCHITECTURE_AND_WORKFLOWS.md` — map of the distinct AI systems and their workflows
+- `docs/REPE_ARCHITECTURE.md` — snapshot/rollup REPE platform architecture
+- `docs/adr/` — Architecture Decision Records, namespaced by subsystem (investment-engine, rs-analytics, automated-data-engineering, telemetry-lineage)
+- `PORTABILITY.MD` — the platform-core / environment-package / client-config three-layer portability contract
+
+### Telemetry
+- `docs/plans/telemetry-platform/architecture.md` — current telemetry platform architecture (Bronze/Silver/Gold Delta, models+gates, `tel_*` serving)
+- `docs/plans/telemetry-platform/README.md` — telemetry platform overview and scope
+- `docs/plans/telemetry-platform/control-tower-runbook.md` — control-tower operational runbook
+- `skills/telemetry-data-interrogation/SKILL.md` — read-only slices/pivots/freshness over `tel_*`
+
+### Lineage
+- `docs/runbooks/telemetry-confluent-databricks-lineage.md` — Confluent→Databricks→Postgres lineage runbook (start/check/shutdown, honesty boundary)
+- `docs/plans/03-implementation-plans/active/telemetry-confluent-databricks-supabase-lineage.md` — lineage workstream plan (Tickets A/B/C, ADR 0001)
+- `backend/app/services/telemetry_stream_lineage.py` — service backing the `/api/telemetry/stream/*` lineage routes
+
+### Deployment
+- `CLAUDE.md` (Infrastructure CLI Guardrails + Production Surface + credentials flow) — authoritative deploy contract (Vercel/Railway/Supabase/GitHub CLI, prod URLs, secret flow)
+- `docs/SHIP_STATUS.md` — what is in flight vs shipped, by what deploys when
+- `docs/LOCAL_DEV_PORTS.md` — local service/port map
+- `infra/k8s/README.md` — GKE event-sink worker deploy (recreate-from-IaC for the streaming spine)
+- `docs/ops-reports/deploy/` — daily post-deploy smoke-test results
+
+### Constraint / governance — **preserve, never delete or move**
+- `CLAUDE.md` — top-level router + governance (routing precedence, intent taxonomy, owning-surface map, mass-deletion protection, work-intake gate)
+- `docs/SYSTEM_RULES_AUTHORITATIVE_STATE.md` — non-negotiable REPE authoritative-state lockdown invariants (enforced by lint + tests)
+- `docs/WINSTON_CODING_SESSION_INSTRUCTIONS.md` — coding-session lifecycle (PLAN vs CODE, intake gate, trivial-bypass standard)
+- `docs/AUTONOMOUS_RELIABILITY_PROTOCOL.md` — anti-hallucination / refusal protocols for autonomous runs
+- `ARCHITECTURE.md`, `AGENTS.md`, `PORTABILITY.MD` — DB/agent-workspace/portability contracts
+- `docs/anti-ai-style.md` — mandatory writing-style constraints CLAUDE.md binds for all prose
+- `claim_coverage_matrix.md`, `PLAN_DIVERGENCE_REVIEW.md`, `DIVERGENCE_FINDINGS_DEMO_SCRIPT.md`, `DIVERGENCE_RECEIPTS_MANIFEST.md` — the claim→proof accuracy record + divergence program (load-bearing accuracy/provenance)
+- `docs/reference/RULES.MD` — Business OS core system rules
+- `.githooks/pre-commit`, `.githooks/pre-push` — local enforcement of the mass-deletion + merge-gate policies
+
+### Security / compliance
+- `docs/security-architecture.md` — SOC 2 MVP security architecture (evidence-first, append-only auditability)
+- `docs/soc2-gap-analysis.md` — SOC 2 Type II readiness inventory + gaps
+- `docs/identity-oidc.md` — identity/OIDC auth design
+- `compliance/README.md` — compliance evidence entry point
+
+### Intelligence / autonomous (auto-generated — read-first situational awareness)
+- `docs/LATEST.md` — daily manifest of every scheduled-task output (read first in a new session)
+- `docs/CAPABILITY_INVENTORY.md` — daily inventory of what's already built (read before suggesting new builds)
+- `docs/daily-intel/`, `docs/feature-radar/`, `docs/ops-reports/digests/` — daily market/feature/ops outputs
+
+### Tips
+- `docs/tips.md` is the **canonical repo-wide tips file**. See its top **"Tips files in this repo"** map for the domain-scoped tips (`docs/podcast-intelligence/tips.md`, `repo-b/tips.md`, `repo-b/src/components/ui/tips.md`).
+
+### Related indexes (different axes — not superseded by this map)
+- `docs/instruction-index.md` — routing registry for agents/skills/prompts (companion to `CLAUDE.md`)
+- `docs/LATEST.md` / `docs/CAPABILITY_INVENTORY.md` — auto-generated manifests (see Intelligence section; do not hand-edit, they are overwritten daily)
+
+---
+
+> ## ⚠️ Historical index (last updated 2026-03-02 — kept for reference)
+>
+> The sections below predate the current workstreams and reference the retired `paulmalmquist.com`
+> test environment and the "Wave 1 + Wave 2" status. They are preserved for provenance — use the
+> **Canonical Docs Map** above for current navigation.
 
 ## 📋 Quick Navigation
 

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4,6 +4,18 @@ This file is a repo inventory plus a pre-flight checklist for giving instruction
 
 The main repeat failure pattern here is simple: assistants assume there is one app, one backend, one API surface, and one database path. That is false in this repo.
 
+## Tips files in this repo (canonical map)
+
+This file (`docs/tips.md`) is the **canonical, repo-wide** tips file — `.gitignore` confirms it ("the tracked one is docs/tips.md"), and the session-bootstrap / feature-dev / azure-devops-intake skills all point here. The other `tips.md` files are domain-scoped and kept where they sit, co-located with their subarea's code:
+
+| File | Scope | Status |
+|---|---|---|
+| `docs/tips.md` (this file) | Repo-wide operational lessons | **Canonical** |
+| `docs/podcast-intelligence/tips.md` | Podcast Intelligence extraction playbook | Domain reference (cited by the historyrhymes skill + podcast meta-prompt) |
+| `repo-b/tips.md` | REPE / institutional-UI density patterns | Domain detail (condensed here under "REPE / institutional UI density (condensed)") |
+| `repo-b/src/components/ui/tips.md` | Motion & SVG animation (Winston Loader) | Domain detail (condensed here under "Motion & SVG animation (condensed)") |
+| `repo-b/docs/tips.md` | — | Redirect → this file (was a duplicate of "Domain Routing Notes (2026-05-19)") |
+
 ## Dashboard Intelligence Engines (depth-2 upgrade)
 
 Five TypeScript engines in `repo-b/src/lib/dashboards/` power smarter dashboard generation:
@@ -4507,3 +4519,22 @@ deptry `DEP003` = a package imported directly in the code but only present *tran
 - **Use a `>=` floor, never `==`.** These packages are also pulled transitively (e.g. `anyio` via httpx/starlette), so an `==` pin can fight the transitive resolver on a future bump. A floor declares the dependency without over-constraining. Pin to the version resolved at declaration time (record it in a comment); do **not** opportunistically upgrade.
 - **Verify before pinning:** `grep -rnE "^\s*(import X|from X[. ])" backend/app` to confirm a real direct import, and `grep -inE "^X([=<>!~ ]|$)" backend/requirements.txt` to confirm it isn't already declared. Lazy imports (inside a function / `try`) still count as direct use.
 - **deptry exits non-zero if ANY DEP00x finding remains** — it's not a per-package signal and it's report-only here (the `detectors` CI job is `continue-on-error`). Don't treat its exit code as a gate; check that *your* targeted packages dropped out of the output. Confirm the resolver is still happy with `python -m pip check` ("No broken requirements found").
+
+## REPE / institutional UI density (condensed) — folded from repo-b/tips.md (2026-06-25)
+
+The full version lives in `repo-b/tips.md`, co-located with repo-b UI code. Durable rules for institutional investment-analysis surfaces:
+
+- **Density over decoration.** `divide-y` row containers, not individually bordered cards (cards add ~16px overhead/item). Data rows at `py-2`–`py-2.5`, not `py-4`. Panels `rounded-md`/`rounded-lg` — avoid `rounded-[18px]+` (reads consumer, not institutional).
+- **Bars + numbers.** 5px `rounded-sm` bars over a bg track, normalized to the dataset max. `tabular-nums` is mandatory for any column of figures; lead labels with the number.
+- **Color carries data, not chrome.** Reserve hue for meaning (e.g. blue = called, green = distributed); don't decorate with it.
+- **Alignment + interaction.** `grid items-start` for side-by-side panels; a subtle `hover:bg` shift on dense rows (never a `border-color` hover in a dense grid). `WinstonShell` density: `xl:gap-5` / `px-6` / `py-2`.
+- **Telemetry Spike Inspector (evaluate-and-recommend):** `insufficient_evidence` is a first-class fail-closed state; keep *finding* separate from *recommendation*; no operational verbs on read-only surfaces; wire new pages through `TELEMETRY_NAV`.
+
+## Motion & SVG animation (condensed) — folded from repo-b/src/components/ui/tips.md (2026-06-25)
+
+The full version lives in `repo-b/src/components/ui/tips.md` (Winston Loader / bowtie physics), co-located with the UI component. Durable rules:
+
+- **Spin in place:** SVG `transform-origin` defaults to `0,0`. Set `transformBox: fill-box` + `transformOrigin: center` at the *usage site*, not in the SVG def, to rotate centered.
+- **Encode physics in keyframe SHAPES** (scale compression for inertia, overshoot + multi-step settle), and use easing only for between-keyframe speed — not to fake the physics.
+- **Stack entrance + loop:** a comma-separated CSS `animation` with a delayed second animation + `forwards` fill makes the spin-up read as the entrance.
+- **Loader phase model:** `idle → loading_fast → loading_slow → thinking → complete`, with 300ms auto-promote, an 800ms label delay, and the overlay only on `slow`/`thinking`.

--- a/repo-b/docs/tips.md
+++ b/repo-b/docs/tips.md
@@ -1,61 +1,15 @@
-# repo-b Repository Tips & Guardrails
+# repo-b Repository Tips → moved to the canonical tips file
 
-## Domain Routing Notes
+The dual-domain routing guidance that lived here is now consolidated in the canonical,
+repo-wide tips file:
 
-This repo serves **two domains** from the same Next.js project:
+➡️ **[`docs/tips.md`](../../docs/tips.md) → "Domain Routing Notes (2026-05-19)"**
 
-- **paulmalmquist.com** — Paul's personal portfolio and Evidence Ledger
-- **novendor.ai** — Novendor consulting app and marketing homepage
+That section is a superset of the former content here — same dual-domain split
+(`paulmalmquist.com` + `novendor.ai` on one `repo-b` Vercel project), the same key routes,
+the same `PersonalPageBody` shared-component pattern, the same "Do NOT" list, and the same
+smoke-test checklist — plus the root-route route-group pitfall (2026-05-20) and the shared
+backend / CORS notes.
 
-Both domains route through the same `repo-b` Vercel project. Routing is handled via Next.js App Router and optional middleware/rewrites.
-
-### Key Routes to Preserve
-
-| Route | Domain | Purpose | Status |
-|-------|--------|---------|--------|
-| `/` | paulmalmquist.com | Personal portfolio (Paul page) | Canonical |
-| `/paul` | paulmalmquist.com | Personal portfolio (alias) | Working |
-| `/paul/evidence` | paulmalmquist.com | Evidence Ledger (proof/credentials) | Working |
-| `/login` | paulmalmquist.com | Winston app login | Critical |
-| `/` | novendor.ai | Novendor marketing homepage | Critical |
-| `/app` | novendor.ai | Novendor dashboard (after login) | Critical |
-| `/login` | novendor.ai | Novendor app login | Critical |
-
-### Implementation Details
-
-- **Root route structure**: `src/app/page.tsx` serves paulmalmquist.com root (via Next.js default). The `(marketing)` route group handles other marketing routes.
-- **Paul page structure**: `src/app/paul/page.tsx` renders `PersonalPageBody.tsx` (extracted shared component) for DRY, so `/` and `/paul` render identical content.
-- **Paul layout**: `src/app/paul/layout.tsx` applies the ROS (Resume Operating System) theme with `<ResumeThemeInit />` and global metadata.
-- **Evidence page**: `src/app/paul/evidence/page.tsx` is a server component that renders `<EvidenceGraphPage />` (client component) with Evidence Ledger metadata.
-
-### Before Making Routing Changes
-
-Always inspect these files to understand the current routing setup:
-
-1. **`src/app/layout.tsx`** — Global layout; check for host-aware routing logic or middleware guards
-2. **`src/middleware.ts`** — Check for hostname-based routing rules or request rewrites
-3. **`vercel.json` or `.vercel/project.json`** — Check for domain-specific rewrites or environment routing
-4. **`src/app/(marketing)/`** — Verify it contains only Novendor routes, not personal portfolio
-5. **`src/app/paul/`** — Verify Paul-specific routes are in this directory, not duplicated elsewhere
-
-### Testing Routing Changes
-
-After any routing modification:
-
-1. **Local build**: `npm run build` must pass
-2. **Smoke test**: Visit `/`, `/paul`, `/paul/evidence`, `/login` — all should render without 404
-3. **Domain isolation**: Verify `novendor.ai/` still serves Novendor content; do not break `novendor.ai/login`
-4. **Metadata**: Confirm metadata (title, description, OG image) is correct for each route
-
-### Common Pitfalls
-
-- **Do not** move or rename `src/app/(marketing)/` routes without updating Vercel rewrites
-- **Do not** duplicate Paul content in the `(marketing)` group — use the shared `PersonalPageBody.tsx` component
-- **Do not** hardcode domain names in components — use Next.js routes and relative links instead
-- **Do not** break `/login` routes for either domain; both are critical
-
-### Related Files
-
-- `src/components/resume/PersonalPageBody.tsx` — Shared content for `/` and `/paul`
-- `src/components/resume/EvidenceGraphPage.tsx` — Evidence Ledger orchestrator
-- `src/app/paul/layout.tsx` — ROS theme setup for Paul routes
+See the **"Tips files in this repo"** map at the top of `docs/tips.md` for how all the
+tips files relate. (This stub is kept so any old link here still resolves.)

--- a/repo-b/src/components/ui/tips.md
+++ b/repo-b/src/components/ui/tips.md
@@ -2,6 +2,10 @@
 
 Lessons learned building the Winston Loader — bowtie physics animation system.
 
+> **Domain-scoped tips**, co-located with the UI component. For general repo-wide tips see the
+> canonical [`docs/tips.md`](../../../../docs/tips.md) (a condensed version of these motion
+> lessons also lives there under "Motion & SVG animation (condensed)").
+
 ---
 
 ## 1. Centered SVG rotation in CSS context

--- a/repo-b/tips.md
+++ b/repo-b/tips.md
@@ -2,6 +2,10 @@
 
 Lessons from building institutional-grade investment analysis surfaces.
 
+> **Domain-scoped tips**, co-located with repo-b UI code. For general repo-wide tips see the
+> canonical [`docs/tips.md`](../docs/tips.md) (a condensed version of these density lessons
+> also lives there under "REPE / institutional UI density (condensed)").
+
 ## Density Over Decoration
 
 - Use `divide-y` row containers instead of individually bordered cards. Cards add ~16px of visual overhead per item (border + padding + gap). Rows in a single bordered table recover that.


### PR DESCRIPTION
Slice 2 of the overnight block. **Docs-only, non-destructive, link-preserving** (5 files, +124/−58). Driven by a 3-agent inventory workflow (canonical docs by category · all 5 tips.md classified with references · constraint-doc enumeration).

## Docs index
None of the 4 existing indexes was a clean host (README stale March-2026 + retired domain; `LATEST.md`/`CAPABILITY_INVENTORY.md` auto-overwritten daily; `instruction-index.md` scoped to routing). So I prepended a fresh **Canonical Docs Map** to `docs/README.md`:
- 8 categories: planning · architecture · telemetry · lineage · deployment · **constraint/governance (preserve, never delete)** · security/compliance · intelligence/autonomous
- repo-root-relative code-span paths (zero broken-link risk) — **all 45 verified to exist**, no phantom docs
- stale content demoted under a clearly-marked **"Historical index"** banner — nothing removed

## Tips canonicalization
- `docs/tips.md` confirmed canonical (added a top **"Tips files in this repo"** map)
- `repo-b/docs/tips.md` — pure duplicate (canonical's "Domain Routing Notes (2026-05-19)" is a superset) → **redirect stub**
- `repo-b/tips.md` (REPE density) + `repo-b/src/components/ui/tips.md` (motion/SVG) — genuinely domain-scoped + co-located → **kept** with a header pointer to canonical; durable highlights **folded** into canonical as two condensed subsections
- `docs/podcast-intelligence/tips.md` (5 references) → **untouched**

## Verification
- **0 references** to any changed/stubbed `repo-b` file (inventory + my own grep) → nothing to re-link
- the 3 stub/header relative links all resolve to `docs/tips.md` (checked)
- constraint docs enumerated + preserved; no doc deleted or moved

🤖 Generated with [Claude Code](https://claude.com/claude-code)