### PR TITLE
feat(telemetry-8a): shared drill-through/export framework + XLSX route + two examples

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,6 +81,7 @@ from app.routes.admin_prompt_receipts import router as admin_prompt_receipts_rou
 from app.routes import website_content, website_rankings, website_analytics
 from app.routes import consulting
 from app.routes import telemetry
+from app.routes import telemetry_export
 from app.routes import telemetry_copilot
 from app.routes import telemetry_control_tower
 from app.routes import agent_builder
@@ -591,6 +592,7 @@ app.include_router(website_rankings.router)
 app.include_router(website_analytics.router)
 app.include_router(consulting.router)
 app.include_router(telemetry.router)
+app.include_router(telemetry_export.router)
 app.include_router(telemetry_copilot.router)
 app.include_router(telemetry_control_tower.router)
 app.include_router(agent_builder.router)

--- a/backend/app/routes/telemetry_export.py
+++ b/backend/app/routes/telemetry_export.py
@@ -1,0 +1,136 @@
+"""Read-only telemetry XLSX export (Phase 8 / PR 8A).
+
+Safety model — this route never builds SQL from request input:
+
+- The dataset name is a key into a fixed allowlist (`TELEMETRY_EXPORT_DATASETS`).
+  An unknown dataset is a 404 with an explicit null_reason, never a query.
+- Each dataset maps to an existing, already-tenant-scoped read service in
+  `telemetry_serving`. We reuse that service, so the export reflects exactly the
+  rows the page shows and there is no new query surface to inject into.
+- Columns are a fixed per-dataset tuple, not request input.
+- Row count is bounded by the dataset's `max_limit`.
+- Empty results return a valid header-only workbook plus an honest
+  `X-Telemetry-Null-Reason` header — never a fabricated row.
+
+The frontend reaches this through the same `/api/telemetry/[...path]` proxy as the
+other telemetry reads; the proxy forwards the binary body for download content types.
+"""
+from __future__ import annotations
+
+import io
+import json
+from dataclasses import dataclass
+from typing import Callable
+from uuid import UUID
+
+from fastapi import APIRouter, Query
+from fastapi.responses import JSONResponse, Response
+from openpyxl import Workbook
+
+from app.services import telemetry_serving
+
+router = APIRouter(prefix="/api/telemetry", tags=["telemetry-export"])
+
+XLSX_MEDIA_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+
+@dataclass(frozen=True)
+class ExportDataset:
+    """One allowlisted export. `extract` reuses an existing scoped read service and
+    returns (rows, null_reason); `columns` is the fixed flat column order."""
+    label: str
+    source: str  # human-readable source pointer (e.g. the tel_* table)
+    source_kind: str  # live-rows | computed-artifact | fixture
+    columns: tuple[str, ...]
+    extract: Callable[[str, UUID], tuple[list[dict], str | None]]
+    default_limit: int = 500
+    max_limit: int = 5000
+
+
+def _scalar(value: object) -> object:
+    """Flatten jsonb/dict/list cells to a stable string so the cell is honest and
+    spreadsheet-safe; pass scalars through unchanged (no value is altered)."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return json.dumps(value, default=str, separators=(",", ":"))
+
+
+def _extract_model_runs(env_id: str, business_id: UUID) -> tuple[list[dict], str | None]:
+    data = telemetry_serving.model_performance(env_id=env_id, business_id=business_id)
+    return list(data.get("models") or []), data.get("null_reason")
+
+
+# Allowlist. Add a dataset here (mapped to an existing scoped service) to expose it.
+TELEMETRY_EXPORT_DATASETS: dict[str, ExportDataset] = {
+    "model_runs": ExportDataset(
+        label="Model runs",
+        source="tel_model_runs",
+        source_kind="live-rows",
+        columns=(
+            "model_name", "model_kind", "model_version", "model_alias",
+            "promotion_state", "mlflow_run_id", "experiment_id", "metrics", "gate",
+        ),
+        extract=_extract_model_runs,
+    ),
+}
+
+
+def _workbook_bytes(columns: tuple[str, ...], rows: list[dict]) -> bytes:
+    """Build a single-sheet XLSX: a header row of the fixed columns, then one row per
+    record (jsonb/dict cells flattened, no value altered). Empty rows → header only."""
+    wb = Workbook()
+    ws = wb.active
+    ws.append(list(columns))
+    for row in rows:
+        ws.append([_scalar(row.get(col)) for col in columns])
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+@router.get("/export/datasets")
+def list_export_datasets() -> dict:
+    """Discoverability: the allowlisted datasets + their source kind (no data)."""
+    return {
+        "datasets": [
+            {"dataset": k, "label": d.label, "source": d.source,
+             "source_kind": d.source_kind, "max_limit": d.max_limit}
+            for k, d in TELEMETRY_EXPORT_DATASETS.items()
+        ]
+    }
+
+
+@router.get("/export/{dataset}.xlsx")
+def export_dataset_xlsx(
+    dataset: str,
+    env_id: str = Query(...),
+    business_id: UUID = Query(...),
+    limit: int | None = Query(default=None, ge=1),
+):
+    spec = TELEMETRY_EXPORT_DATASETS.get(dataset)
+    if spec is None:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "null_reason": "export_dataset_not_allowed",
+                "dataset": dataset,
+                "allowed": sorted(TELEMETRY_EXPORT_DATASETS.keys()),
+            },
+        )
+
+    eff_limit = min(limit or spec.default_limit, spec.max_limit)
+    rows, null_reason = spec.extract(env_id, business_id)
+    rows = rows[:eff_limit]
+
+    payload = _workbook_bytes(spec.columns, rows)
+
+    headers = {
+        "Content-Disposition": f'attachment; filename="telemetry_{dataset}.xlsx"',
+        "X-Telemetry-Export-Rows": str(len(rows)),
+        "X-Telemetry-Export-Source": spec.source,
+        "X-Telemetry-Export-Source-Kind": spec.source_kind,
+        "X-Telemetry-Export-Limit": str(eff_limit),
+    }
+    if null_reason:
+        headers["X-Telemetry-Null-Reason"] = null_reason
+    return Response(content=payload, media_type=XLSX_MEDIA_TYPE, headers=headers)

--- a/backend/tests/test_telemetry_export.py
+++ b/backend/tests/test_telemetry_export.py
@@ -1,0 +1,106 @@
+"""Tests for the read-only telemetry XLSX export route (Phase 8 / PR 8A).
+
+Covers: allowed dataset, denied dataset, row-limit bound, empty result, and the
+generated file shape. No DB — the underlying read service is monkeypatched, which also
+proves the route never builds SQL from request input (it only calls the allowlisted
+service)."""
+import io
+import os
+import sys
+import types
+from uuid import UUID
+
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test")
+os.environ.setdefault("SUPABASE_URL", "https://test.supabase.co")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test-key")
+os.environ.setdefault("_BM_SKIP_DB_CHECK", "1")
+
+if "psycopg" not in sys.modules:
+    psycopg_stub = types.ModuleType("psycopg")
+    psycopg_stub.connect = lambda *a, **k: None
+    psycopg_stub.Connection = object
+    psycopg_stub.rows = types.SimpleNamespace(dict_row=None)
+    sys.modules["psycopg"] = psycopg_stub
+if "dotenv" not in sys.modules:
+    dotenv_stub = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda *a, **k: None
+    sys.modules["dotenv"] = dotenv_stub
+
+from fastapi.responses import JSONResponse, Response  # noqa: E402
+from openpyxl import load_workbook  # noqa: E402
+
+from app.routes import telemetry_export as te  # noqa: E402
+
+BIZ = UUID("00000000-0000-0000-0000-000000000002")
+COLS = te.TELEMETRY_EXPORT_DATASETS["model_runs"].columns
+
+
+def _fake_models(rows, null_reason=None):
+    return lambda **kw: {"models": rows, "null_reason": null_reason}
+
+
+def test_workbook_shape_header_then_rows():
+    rows = [{"model_name": "cnn-lstm", "model_kind": "rul", "metrics": {"rmse": 17.33}}]
+    data = te._workbook_bytes(COLS, rows)
+    ws = load_workbook(io.BytesIO(data)).active
+    assert [c.value for c in ws[1]] == list(COLS)            # header row = fixed columns
+    assert ws.cell(row=2, column=1).value == "cnn-lstm"       # data row
+    # jsonb cell is flattened to a string, value preserved (rmse 17.33 present)
+    metrics_idx = list(COLS).index("metrics") + 1
+    assert "17.33" in str(ws.cell(row=2, column=metrics_idx).value)
+
+
+def test_denied_dataset_is_404_with_null_reason():
+    resp = te.export_dataset_xlsx("totally_made_up", env_id="telemetry-demo", business_id=BIZ, limit=None)
+    assert isinstance(resp, JSONResponse)
+    assert resp.status_code == 404
+    import json
+    body = json.loads(bytes(resp.body))
+    assert body["null_reason"] == "export_dataset_not_allowed"
+    assert "model_runs" in body["allowed"]
+
+
+def test_allowed_dataset_streams_xlsx_with_row_header(monkeypatch):
+    monkeypatch.setattr(te.telemetry_serving, "model_performance",
+                        _fake_models([{"model_name": "cnn", "model_kind": "rul"}]))
+    resp = te.export_dataset_xlsx("model_runs", env_id="telemetry-demo", business_id=BIZ, limit=None)
+    assert isinstance(resp, Response)
+    assert resp.media_type == te.XLSX_MEDIA_TYPE
+    assert resp.headers["X-Telemetry-Export-Rows"] == "1"
+    assert resp.headers["X-Telemetry-Export-Source-Kind"] == "live-rows"
+    assert "attachment" in resp.headers["Content-Disposition"]
+    ws = load_workbook(io.BytesIO(resp.body)).active   # body is the real xlsx
+    assert ws.cell(row=2, column=1).value == "cnn"
+
+
+def test_row_limit_is_bounded(monkeypatch):
+    many = [{"model_name": f"m{i}", "model_kind": "rul"} for i in range(10)]
+    monkeypatch.setattr(te.telemetry_serving, "model_performance", _fake_models(many))
+    resp = te.export_dataset_xlsx("model_runs", env_id="telemetry-demo", business_id=BIZ, limit=3)
+    assert resp.headers["X-Telemetry-Export-Rows"] == "3"
+    assert resp.headers["X-Telemetry-Export-Limit"] == "3"
+
+
+def test_max_limit_caps_request(monkeypatch):
+    monkeypatch.setattr(te.telemetry_serving, "model_performance", _fake_models([]))
+    resp = te.export_dataset_xlsx("model_runs", env_id="telemetry-demo", business_id=BIZ, limit=999999)
+    # eff_limit is capped at the dataset max_limit regardless of the request
+    assert int(resp.headers["X-Telemetry-Export-Limit"]) == te.TELEMETRY_EXPORT_DATASETS["model_runs"].max_limit
+
+
+def test_empty_result_is_valid_workbook_with_null_reason(monkeypatch):
+    monkeypatch.setattr(te.telemetry_serving, "model_performance",
+                        _fake_models([], null_reason="model_not_promoted"))
+    resp = te.export_dataset_xlsx("model_runs", env_id="telemetry-demo", business_id=BIZ, limit=None)
+    assert resp.headers["X-Telemetry-Export-Rows"] == "0"
+    assert resp.headers["X-Telemetry-Null-Reason"] == "model_not_promoted"
+    ws = load_workbook(io.BytesIO(resp.body)).active
+    assert [c.value for c in ws[1]] == list(COLS)   # header-only, still a valid file
+    assert ws.max_row == 1
+
+
+def test_list_datasets_exposes_allowlist_no_data():
+    out = te.list_export_datasets()
+    names = {d["dataset"] for d in out["datasets"]}
+    assert "model_runs" in names
+    assert all("source_kind" in d for d in out["datasets"])

--- a/repo-b/src/app/api/telemetry/[...path]/route.ts
+++ b/repo-b/src/app/api/telemetry/[...path]/route.ts
@@ -93,10 +93,26 @@ async function forward(request: NextRequest, context: { params: { path: string[]
       },
       body,
     });
+    const contentType = upstream.headers.get("content-type") || "application/json";
+    // Binary/download responses (e.g. the XLSX export) must not go through .text(),
+    // which corrupts non-text bytes. Forward the raw body and the disposition header.
+    const isDownload =
+      !contentType.includes("json") &&
+      !contentType.startsWith("text/") &&
+      (contentType.includes("spreadsheetml") ||
+        contentType.includes("octet-stream") ||
+        upstream.headers.has("content-disposition"));
+    if (isDownload) {
+      const buffer = await upstream.arrayBuffer();
+      const headers: Record<string, string> = { "Content-Type": contentType };
+      const disposition = upstream.headers.get("content-disposition");
+      if (disposition) headers["Content-Disposition"] = disposition;
+      return new NextResponse(buffer, { status: upstream.status, headers });
+    }
     const payload = await upstream.text();
     return new NextResponse(payload, {
       status: upstream.status,
-      headers: { "Content-Type": upstream.headers.get("content-type") || "application/json" },
+      headers: { "Content-Type": contentType },
     });
   } catch {
     return NextResponse.json(

--- a/repo-b/src/components/telemetry/ModelPerformance.tsx
+++ b/repo-b/src/components/telemetry/ModelPerformance.tsx
@@ -4,8 +4,17 @@ import { useEffect, useState } from "react";
 import {
   getModelPerformance, type ModelRun, TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID,
 } from "@/lib/telemetry/api";
-import { C, Tag, Panel, Loading, ErrorState, DisclosureFooter, ScrollTable } from "./primitives";
+import { C, Tag, Panel, Loading, ErrorState, DisclosureFooter, ScrollTable, TelemetryActionButton } from "./primitives";
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
+import { MetricInspectorDrawer } from "./drawerPrimitives";
+import { SourceRowsTable, DatabricksRunLink, exportXlsxUrl } from "./drill";
+
+// Columns surfaced when drilling into the model rows. Mirrors the server XLSX export
+// (telemetry_export.py "model_runs") so the CSV preview and the .xlsx match.
+const MODEL_ROW_COLS = [
+  "model_name", "model_kind", "model_version", "model_alias",
+  "promotion_state", "mlflow_run_id", "metrics", "gate",
+];
 
 function metric(m: ModelRun, k: string): string {
   const v = (m.metrics || {})[k];
@@ -84,6 +93,7 @@ export default function ModelPerformance() {
   const [models, setModels] = useState<ModelRun[] | null>(null);
   const [nullReason, setNullReason] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [drillOpen, setDrillOpen] = useState(false);
 
   useEffect(() => {
     getModelPerformance(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID)
@@ -116,7 +126,48 @@ export default function ModelPerformance() {
             so it was promoted, recorded honestly rather than forcing a fancier model to win.
           </span>
         </Panel>
+        <div>
+          <TelemetryActionButton variant="secondary" onClick={() => setDrillOpen(true)}
+            aria-label="Inspect the model rows and export">
+            Source rows + export ›
+          </TelemetryActionButton>
+        </div>
       </div>
+      <MetricInspectorDrawer
+        open={drillOpen}
+        onClose={() => setDrillOpen(false)}
+        title="Model runs — source rows"
+        description="The rows behind these metrics, straight from the registry-backed serving API. Export reflects this exact set."
+        fields={[
+          { label: "Source", value: "tel_model_runs" },
+          { label: "Scope", value: `env ${TELEMETRY_DEMO_ENV_ID}` },
+          { label: "Models", value: models.length },
+        ]}
+      >
+        <div style={{ marginTop: 14, display: "flex", flexDirection: "column", gap: 12 }}>
+          <SourceRowsTable
+            kind="live-rows"
+            columns={MODEL_ROW_COLS}
+            rows={models as unknown as Array<Record<string, unknown>>}
+            sourceLabel="tel_model_runs"
+            filterContext="all model kinds"
+            exportName="telemetry_model_runs"
+            xlsxUrl={exportXlsxUrl("model_runs", {
+              envId: TELEMETRY_DEMO_ENV_ID,
+              businessId: TELEMETRY_DEMO_BUSINESS_ID,
+            })}
+          />
+          {(() => {
+            const champ = models.find((m) => m.model_alias === "champion") ?? models[0];
+            return champ?.mlflow_run_id ? (
+              <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+                <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint }}>Champion run:</span>
+                <DatabricksRunLink runId={champ.mlflow_run_id} />
+              </div>
+            ) : null;
+          })()}
+        </div>
+      </MetricInspectorDrawer>
       <DisclosureFooter />
     </>
   );

--- a/repo-b/src/components/telemetry/drill/ExportButtons.tsx
+++ b/repo-b/src/components/telemetry/drill/ExportButtons.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { C, TelemetryActionButton } from "../primitives";
+import { downloadCsv } from "./exportCsv";
+
+function DisabledReason({ reason }: { reason?: string | null }) {
+  if (!reason) return null;
+  return (
+    <span style={{ fontFamily: C.mono, fontSize: 9.5, color: C.faint, lineHeight: 1.5 }}>
+      {reason}
+    </span>
+  );
+}
+
+// CSV export of the exact rows/columns shown on screen (same filter context). Disabled —
+// with a reason — when there are no rows, so it never produces an empty/fake file silently.
+export function ExportToCsvButton({
+  filename,
+  columns,
+  rows,
+  label = "Export CSV",
+  disabled,
+  disabledReason,
+}: {
+  filename: string;
+  columns: string[];
+  rows: Array<Record<string, unknown>>;
+  label?: string;
+  disabled?: boolean;
+  disabledReason?: string | null;
+}) {
+  const noRows = rows.length === 0;
+  const isDisabled = Boolean(disabled) || noRows;
+  const reason = isDisabled
+    ? disabledReason ?? (noRows ? "No rows to export" : "Export unavailable")
+    : null;
+  return (
+    <span style={{ display: "inline-flex", flexDirection: "column", gap: 3 }}>
+      <TelemetryActionButton
+        variant="secondary"
+        disabled={isDisabled}
+        onClick={() => downloadCsv(filename, columns, rows)}
+        aria-label={`${label} (${rows.length} rows)`}
+      >
+        {label}
+      </TelemetryActionButton>
+      <DisabledReason reason={reason} />
+    </span>
+  );
+}
+
+// XLSX export via the server route. `url` is null when the tenant context is missing or
+// the source has no server export, in which case the button is disabled with a reason.
+export function ExportToExcelButton({
+  url,
+  label = "Export XLSX",
+  disabled,
+  disabledReason,
+}: {
+  url: string | null;
+  label?: string;
+  disabled?: boolean;
+  disabledReason?: string | null;
+}) {
+  const isDisabled = Boolean(disabled) || !url;
+  const reason = isDisabled ? disabledReason ?? "Server export unavailable for this source" : null;
+  return (
+    <span style={{ display: "inline-flex", flexDirection: "column", gap: 3 }}>
+      <TelemetryActionButton
+        variant="secondary"
+        disabled={isDisabled}
+        onClick={() => {
+          if (url) window.open(url, "_blank", "noopener,noreferrer");
+        }}
+        aria-label={label}
+      >
+        {label}
+      </TelemetryActionButton>
+      <DisabledReason reason={reason} />
+    </span>
+  );
+}

--- a/repo-b/src/components/telemetry/drill/SourceRowsTable.tsx
+++ b/repo-b/src/components/telemetry/drill/SourceRowsTable.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { C, EmptyState, ScrollTable, Tag } from "../primitives";
+import { SOURCE_KIND_LABEL, SOURCE_KIND_TAG, type SourceKind } from "./sourceKind";
+import { ExportToCsvButton, ExportToExcelButton } from "./ExportButtons";
+
+function cell(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+// The rows behind a drilled metric, with an honest source-kind header, provenance, and
+// CSV/XLSX export of the same filter context shown. When the kind is `unavailable` (or
+// there are no rows) it renders the fail-closed empty state with the null_reason and
+// disables export — never an empty/fake file.
+export function SourceRowsTable({
+  kind,
+  columns,
+  rows,
+  rowCount,
+  asOf,
+  filterContext,
+  nullReason,
+  sourceLabel,
+  exportName = "telemetry-export",
+  xlsxUrl,
+  maxPreview = 50,
+}: {
+  kind: SourceKind;
+  columns: string[];
+  rows: Array<Record<string, unknown>>;
+  rowCount?: number;
+  asOf?: string | null;
+  filterContext?: string;
+  nullReason?: string | null;
+  sourceLabel?: string;
+  exportName?: string;
+  xlsxUrl?: string | null;
+  maxPreview?: number;
+}) {
+  const isUnavailable = kind === "unavailable" || rows.length === 0;
+  const kindColor = kind === "live-rows" ? C.green : kind === "unavailable" ? C.red : C.amber;
+  const total = rowCount ?? rows.length;
+  const shown = rows.slice(0, maxPreview);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 8, fontFamily: C.mono, fontSize: 10.5, color: C.faint }}>
+        <Tag color={kindColor}>{SOURCE_KIND_TAG[kind]}</Tag>
+        <span>{SOURCE_KIND_LABEL[kind]}</span>
+        {sourceLabel && <span>· source {sourceLabel}</span>}
+        {!isUnavailable && <span>· {total} rows</span>}
+        {asOf && <span>· as of {asOf}</span>}
+        {filterContext && <span>· {filterContext}</span>}
+      </div>
+
+      {isUnavailable ? (
+        <EmptyState
+          label={SOURCE_KIND_LABEL.unavailable}
+          hint="No row-level data for this metric in the current scope."
+          nullReason={nullReason ?? undefined}
+        />
+      ) : (
+        <ScrollTable minWidth={Math.max(640, columns.length * 130)}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontFamily: C.mono, fontSize: 11 }}>
+            <thead>
+              <tr>
+                {columns.map((c) => (
+                  <th key={c} style={{ textAlign: "left", color: C.dim, fontWeight: 600, padding: "6px 10px", borderBottom: `1px solid ${C.border}`, position: "sticky", top: 0, background: C.panel }}>
+                    {c}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {shown.map((row, i) => (
+                <tr key={i}>
+                  {columns.map((c) => (
+                    <td key={c} style={{ color: C.text, padding: "5px 10px", borderBottom: `1px solid ${C.border}`, whiteSpace: "nowrap" }}>
+                      {cell(row[c])}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </ScrollTable>
+      )}
+
+      {!isUnavailable && total > shown.length && (
+        <span style={{ fontFamily: C.mono, fontSize: 10, color: C.faint }}>
+          Showing {shown.length} of {total}. Export for the full set.
+        </span>
+      )}
+
+      <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+        <ExportToCsvButton
+          filename={exportName}
+          columns={columns}
+          rows={rows}
+          disabled={isUnavailable}
+          disabledReason={isUnavailable ? nullReason ?? "Row-level data unavailable" : null}
+        />
+        <ExportToExcelButton
+          url={isUnavailable ? null : xlsxUrl ?? null}
+          disabledReason={
+            isUnavailable
+              ? nullReason ?? "Row-level data unavailable"
+              : "Server export not configured for this source"
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/telemetry/drill/drillExport.test.tsx
+++ b/repo-b/src/components/telemetry/drill/drillExport.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SourceRowsTable } from "./SourceRowsTable";
+import { DatabricksRunLink, ModelArtifactLink } from "./evidenceLinks";
+import { ExportToExcelButton } from "./ExportButtons";
+
+describe("SourceRowsTable", () => {
+  it("renders live rows, the kind label, and an enabled CSV export", () => {
+    render(
+      <SourceRowsTable
+        kind="live-rows"
+        columns={["model_name", "rmse"]}
+        rows={[{ model_name: "cnn-lstm", rmse: 17.33 }]}
+        sourceLabel="tel_model_runs"
+      />,
+    );
+    expect(screen.getAllByText(/live rows/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("cnn-lstm")).toBeInTheDocument();
+    expect(screen.getByText(/tel_model_runs/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Export CSV/i })).not.toBeDisabled();
+  });
+
+  it("labels a computed artifact honestly (not live serving)", () => {
+    render(<SourceRowsTable kind="computed-artifact" columns={["picp"]} rows={[{ picp: 0.86 }]} />);
+    expect(screen.getByText(/not live serving/i)).toBeInTheDocument();
+  });
+
+  it("unavailable kind shows the null_reason and disables both exports", () => {
+    render(
+      <SourceRowsTable kind="unavailable" columns={["a"]} rows={[]} nullReason="model_not_promoted" />,
+    );
+    expect(screen.getAllByText(/model_not_promoted/).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /Export CSV/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Export XLSX/i })).toBeDisabled();
+  });
+});
+
+describe("evidence links (fail-closed)", () => {
+  it("renders a live MLflow run link when a run id is present", () => {
+    render(<DatabricksRunLink runId="run-abc123" />);
+    const a = screen.getByRole("link", { name: /Open MLflow Run/i });
+    expect(a.getAttribute("href")).toContain("run-abc123");
+  });
+
+  it("fail-closed (disabled + reason) when the run id is missing", () => {
+    render(<DatabricksRunLink runId={null} />);
+    expect(screen.getByText(/Unavailable —/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Open MLflow Run/i })).toBeDisabled();
+  });
+
+  it("model artifact link is fail-closed for a non-UC seed key", () => {
+    render(<ModelArtifactLink modelName="seed_key_no_dots" />);
+    expect(screen.getByText(/Unavailable —/i)).toBeInTheDocument();
+  });
+});
+
+describe("ExportToExcelButton", () => {
+  it("is disabled with a reason when no server url is available", () => {
+    render(<ExportToExcelButton url={null} />);
+    expect(screen.getByRole("button", { name: /Export XLSX/i })).toBeDisabled();
+  });
+  it("is enabled when a url is present", () => {
+    render(<ExportToExcelButton url="/api/telemetry/export/model_runs.xlsx?env_id=x&business_id=y" />);
+    expect(screen.getByRole("button", { name: /Export XLSX/i })).not.toBeDisabled();
+  });
+});

--- a/repo-b/src/components/telemetry/drill/evidenceLinks.tsx
+++ b/repo-b/src/components/telemetry/drill/evidenceLinks.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState } from "react";
+import { C } from "../primitives";
+import {
+  mlflowRunLink,
+  registeredModelLink,
+  deltaTableLink,
+  type ExternalEvidenceLink,
+} from "@/lib/lab/factoryEvidenceLinks";
+
+// Self-contained copy chip (the factory drawer's is private to that file; we keep this
+// shared component independent of it).
+function CopyChip({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        navigator.clipboard?.writeText(text).then(
+          () => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1200);
+          },
+          () => {},
+        );
+      }}
+      style={{
+        fontFamily: C.mono, fontSize: 9.5, color: C.dim, background: C.panel,
+        border: `1px solid ${C.border}`, borderRadius: 5, padding: "2px 6px", cursor: "pointer",
+      }}
+    >
+      {copied ? "copied" : `copy ${text.length > 18 ? `${text.slice(0, 16)}…` : text}`}
+    </button>
+  );
+}
+
+// Shared renderer for a fail-closed external evidence link. Live → an anchor; missing →
+// a disabled button + the unavailable reason + a copy chip for the raw id. Mirrors the
+// factory drawer's private EvidenceLinkButton so any page can render Databricks/MLflow
+// links over the same builders without re-implementing (or fabricating) them.
+export function EvidenceLink({ link }: { link: ExternalEvidenceLink }) {
+  if (link.href) {
+    return (
+      <a
+        href={link.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          display: "inline-flex", alignItems: "center", gap: 6, fontFamily: C.mono, fontSize: 11,
+          color: C.cyan, background: `${C.cyan}12`, border: `1px solid ${C.cyan}55`,
+          borderRadius: 6, padding: "6px 11px", textDecoration: "none",
+        }}
+      >
+        {link.label} ↗
+      </a>
+    );
+  }
+  return (
+    <span style={{ display: "inline-flex", flexDirection: "column", gap: 4 }}>
+      <button
+        type="button"
+        disabled
+        aria-disabled
+        style={{
+          display: "inline-flex", alignItems: "center", gap: 6, fontFamily: C.mono, fontSize: 11,
+          color: C.faint, background: C.panel, border: `1px dashed ${C.border}`, borderRadius: 6,
+          padding: "6px 11px", cursor: "not-allowed", alignSelf: "flex-start",
+        }}
+      >
+        {link.label}
+      </button>
+      <span style={{ fontFamily: C.mono, fontSize: 9.5, color: C.faint, lineHeight: 1.5, display: "inline-flex", alignItems: "center", gap: 7, flexWrap: "wrap" }}>
+        <span>Unavailable — {link.unavailableReason}</span>
+        {link.copyText && <CopyChip text={link.copyText} />}
+      </span>
+    </span>
+  );
+}
+
+export function DatabricksRunLink({ runId }: { runId?: string | null }) {
+  return <EvidenceLink link={mlflowRunLink(runId)} />;
+}
+
+export function ModelArtifactLink({ modelName }: { modelName?: string | null }) {
+  return <EvidenceLink link={registeredModelLink(modelName)} />;
+}
+
+export function DeltaTableLink({ tableName }: { tableName?: string | null }) {
+  return <EvidenceLink link={deltaTableLink(tableName)} />;
+}
+
+// Inline "open lineage" affordance. The caller supplies either an `href` (deep-link to
+// the Metric Lineage explorer) or an `onClick` (open a LineageDrawer in place). When
+// neither is available it renders fail-closed (disabled + reason), never a dead link.
+export function LineageLink({
+  href,
+  onClick,
+  label = "Open lineage",
+  unavailableReason,
+}: {
+  href?: string | null;
+  onClick?: () => void;
+  label?: string;
+  unavailableReason?: string | null;
+}) {
+  const style = {
+    display: "inline-flex" as const, alignItems: "center" as const, gap: 6,
+    fontFamily: C.mono, fontSize: 11, borderRadius: 6, padding: "6px 11px",
+  };
+  if (href) {
+    return (
+      <a href={href} style={{ ...style, color: C.cyan, background: `${C.cyan}12`, border: `1px solid ${C.cyan}55`, textDecoration: "none" }}>
+        {label} →
+      </a>
+    );
+  }
+  if (onClick) {
+    return (
+      <button type="button" onClick={onClick} style={{ ...style, color: C.cyan, background: `${C.cyan}12`, border: `1px solid ${C.cyan}55`, cursor: "pointer" }}>
+        {label} →
+      </button>
+    );
+  }
+  return (
+    <span style={{ display: "inline-flex", flexDirection: "column", gap: 4 }}>
+      <button type="button" disabled aria-disabled style={{ ...style, color: C.faint, background: C.panel, border: `1px dashed ${C.border}`, cursor: "not-allowed", alignSelf: "flex-start" }}>
+        {label}
+      </button>
+      <span style={{ fontFamily: C.mono, fontSize: 9.5, color: C.faint }}>
+        Unavailable — {unavailableReason ?? "no lineage node for this metric"}
+      </span>
+    </span>
+  );
+}

--- a/repo-b/src/components/telemetry/drill/exportCsv.test.ts
+++ b/repo-b/src/components/telemetry/drill/exportCsv.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { csvCell, toCsv } from "./exportCsv";
+
+describe("csvCell", () => {
+  it("passes scalars through", () => {
+    expect(csvCell("cnn")).toBe("cnn");
+    expect(csvCell(17.33)).toBe("17.33");
+  });
+  it("empty for null/undefined", () => {
+    expect(csvCell(null)).toBe("");
+    expect(csvCell(undefined)).toBe("");
+  });
+  it("quotes + escapes comma, quote, newline", () => {
+    expect(csvCell("a,b")).toBe('"a,b"');
+    expect(csvCell('a"b')).toBe('"a""b"');
+    expect(csvCell("a\nb")).toBe('"a\nb"');
+  });
+  it("JSON-stringifies object cells (value preserved)", () => {
+    expect(csvCell({ rmse: 17.33 })).toBe('"{""rmse"":17.33}"');
+  });
+});
+
+describe("toCsv", () => {
+  it("builds header + rows in column order", () => {
+    expect(toCsv(["a", "b"], [{ a: 1, b: 2 }, { a: 3, b: 4 }])).toBe("a,b\n1,2\n3,4");
+  });
+  it("header-only when there are no rows", () => {
+    expect(toCsv(["a", "b"], [])).toBe("a,b");
+  });
+  it("missing keys become empty cells", () => {
+    expect(toCsv(["a", "b"], [{ a: 1 }])).toBe("a,b\n1,");
+  });
+});

--- a/repo-b/src/components/telemetry/drill/exportCsv.ts
+++ b/repo-b/src/components/telemetry/drill/exportCsv.ts
@@ -1,0 +1,30 @@
+// Pure CSV helpers (Phase 8 / PR 8A). Lifted from the winston ChatTableBlock pattern
+// into a reusable, testable module. No React, no fabrication: object/array cells are
+// JSON-stringified (the same value, made spreadsheet-safe); null/undefined → "".
+
+export function csvCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const str = typeof value === "object" ? JSON.stringify(value) : String(value);
+  return /[",\n\r]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+}
+
+export function toCsv(columns: string[], rows: Array<Record<string, unknown>>): string {
+  const header = columns.map(csvCell).join(",");
+  const body = rows.map((row) => columns.map((c) => csvCell(row[c])).join(",")).join("\n");
+  return body ? `${header}\n${body}` : header;
+}
+
+export function downloadCsv(
+  filename: string,
+  columns: string[],
+  rows: Array<Record<string, unknown>>,
+): void {
+  const csv = toCsv(columns, rows);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename.endsWith(".csv") ? filename : `${filename}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/repo-b/src/components/telemetry/drill/index.ts
+++ b/repo-b/src/components/telemetry/drill/index.ts
@@ -1,0 +1,15 @@
+// Phase 8 shared drill-through / export framework (PR 8A). Compose with the existing
+// onDrill (primitives), MetricInspectorDrawer (drawerPrimitives), LineageDrawer, and
+// FactoryEvidenceDrawer — these add export + source-rows + shared links on top.
+export { type SourceKind, SOURCE_KIND_LABEL, SOURCE_KIND_TAG } from "./sourceKind";
+export { csvCell, toCsv, downloadCsv } from "./exportCsv";
+export { exportXlsxUrl } from "./telemetryExport";
+export { ExportToCsvButton, ExportToExcelButton } from "./ExportButtons";
+export { SourceRowsTable } from "./SourceRowsTable";
+export {
+  EvidenceLink,
+  DatabricksRunLink,
+  ModelArtifactLink,
+  DeltaTableLink,
+  LineageLink,
+} from "./evidenceLinks";

--- a/repo-b/src/components/telemetry/drill/sourceKind.ts
+++ b/repo-b/src/components/telemetry/drill/sourceKind.ts
@@ -1,0 +1,19 @@
+// Source-kind honesty framework (Phase 8). Every drill-through / export carries one
+// of these so a surface never implies more than its data has. See plan 0012.
+
+export type SourceKind = "live-rows" | "computed-artifact" | "fixture" | "unavailable";
+
+export const SOURCE_KIND_LABEL: Record<SourceKind, string> = {
+  "live-rows": "Live rows",
+  "computed-artifact": "Computed evidence artifact — not live serving",
+  fixture: "Committed export / replay fixture",
+  unavailable: "Row-level data unavailable",
+};
+
+// A short tag-style label for chips.
+export const SOURCE_KIND_TAG: Record<SourceKind, string> = {
+  "live-rows": "live rows",
+  "computed-artifact": "computed artifact",
+  fixture: "fixture",
+  unavailable: "unavailable",
+};

--- a/repo-b/src/components/telemetry/drill/telemetryExport.ts
+++ b/repo-b/src/components/telemetry/drill/telemetryExport.ts
@@ -1,0 +1,15 @@
+// Same-origin URL for the server XLSX export route (Phase 8 / PR 8A). The route is
+// proxied to the backend through /api/telemetry/[...path]; the backend allowlists the
+// dataset, scopes by env/business, and bounds the row count. We only build the URL —
+// the backend owns safety. Returns null when the tenant context is missing (the button
+// then renders disabled with a reason, never a broken download).
+
+export function exportXlsxUrl(
+  dataset: string,
+  params: { envId: string | null | undefined; businessId: string | null | undefined; limit?: number },
+): string | null {
+  if (!dataset || !params.envId || !params.businessId) return null;
+  const q = new URLSearchParams({ env_id: params.envId, business_id: params.businessId });
+  if (params.limit) q.set("limit", String(params.limit));
+  return `/api/telemetry/export/${encodeURIComponent(dataset)}.xlsx?${q.toString()}`;
+}

--- a/repo-b/src/components/telemetry/factory-ml/FactoryMlConsole.tsx
+++ b/repo-b/src/components/telemetry/factory-ml/FactoryMlConsole.tsx
@@ -15,6 +15,7 @@ import ReadinessGauge from "./ReadinessGauge";
 import RegistryPanel from "./RegistryPanel";
 import type { DrillObject } from "./factoryDrill";
 import { useFactoryMlData } from "@/lib/lab/factoryMlData";
+import { ExportToCsvButton, SOURCE_KIND_LABEL } from "../drill";
 
 const SECTIONS = [
   { id: "readiness", label: "Readiness" },
@@ -63,7 +64,22 @@ export default function FactoryMlConsole() {
           </div>
 
           {section === "readiness" && (data.readiness
-            ? <ReadinessGauge data={data.readiness} onDrill={setDrill} />
+            ? <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                <ReadinessGauge data={data.readiness} onDrill={setDrill} />
+                {(() => {
+                  const rows = data.readiness.vehicles as unknown as Array<Record<string, unknown>>;
+                  const cols = rows.length ? Object.keys(rows[0]) : [];
+                  return (
+                    <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+                      <span style={{ fontFamily: C.mono, fontSize: 10, color: C.faint }}>
+                        {SOURCE_KIND_LABEL.fixture} — public/labs/factory-ml/readiness.json
+                      </span>
+                      <ExportToCsvButton filename="flight_readiness_vehicles" columns={cols} rows={rows}
+                        label="Export readiness rows" />
+                    </div>
+                  );
+                })()}
+              </div>
             : <EmptyState label="readiness.json missing" hint="Re-run the export stage." />)}
           {section === "heatmap" && (data.heatmap
             ? <LayerHeatmap data={data.heatmap} />


### PR DESCRIPTION
Phase 8 / **PR 8A** (plan `0012`). Builds the reusable drill-through/export foundation, then wires only the two representative examples. Reuses existing foundations — `onDrill`, `MetricInspectorDrawer`, `LineageDrawer`, `FactoryEvidenceDrawer`, and the fail-closed `factoryEvidenceLinks` builders — rather than rebuilding any drawer.

## Files changed
**New shared primitives** (`repo-b/src/components/telemetry/drill/`): `sourceKind.ts`, `exportCsv.ts`, `telemetryExport.ts`, `ExportButtons.tsx`, `SourceRowsTable.tsx`, `evidenceLinks.tsx`, `index.ts`.
**Backend**: `app/routes/telemetry_export.py` (new), `main.py` (router registration), `tests/test_telemetry_export.py` (new).
**Proxy**: `api/telemetry/[...path]/route.ts` — forward binary download bodies via `arrayBuffer` (the `.text()` path corrupts xlsx); JSON path unchanged.
**Wiring (minimal additive)**: `ModelPerformance.tsx`, `factory-ml/FactoryMlConsole.tsx`.

## Primitives added / reused
- **Added**: `ExportToCsvButton`, `ExportToExcelButton`, `SourceRowsTable`, shared `EvidenceLink` + `DatabricksRunLink` + `ModelArtifactLink` + `DeltaTableLink` + `LineageLink`, the `SourceKind` framework, `exportXlsxUrl`.
- **Reused (not rebuilt)**: `MetricRow`/`Stat` `onDrill`, `MetricInspectorDrawer`, `LineageDrawer`, `FactoryEvidenceDrawer`, `factoryEvidenceLinks` builders, the `ChatTableBlock` CSV pattern.

## Live-rows example — Model Performance
A "Source rows + export ›" button opens a `MetricInspectorDrawer` → `SourceRowsTable` (`kind="live-rows"`, `tel_model_runs`) with **CSV** (the rows) + **XLSX** (`/api/telemetry/export/model_runs.xlsx`) + the champion's **MLflow run link** (fail-closed if no run id).

## Fixture example — Flight Readiness
A CSV export of the committed `readiness.json` vehicles, **honestly labeled** "Committed export / replay fixture — public/labs/factory-ml/readiness.json". Columns derived from the real fixture keys (no guessing).

## XLSX route behavior + safety limits
`GET /api/telemetry/export/{dataset}.xlsx` (+ `/export/datasets`). Read-only. **No SQL is built from request input** — the dataset name is a key into a fixed allowlist, and each entry maps to an existing tenant-scoped read service (`telemetry_serving.model_performance`), so the export equals the page data. Fixed columns, row-limit bounded (`default 500 / max 5000`, request capped), `openpyxl`. Empty result → a valid header-only workbook + an honest `X-Telemetry-Null-Reason` header. Unknown dataset → 404 + `null_reason`.

## Unavailable / fail-closed
`SourceRowsTable kind="unavailable"` (or zero rows) renders the empty state + `null_reason` and disables both exports. Evidence links render disabled + reason + a copy chip when an id is missing. No fabricated rows, links, or success states.

## Tests run / results
- Backend `test_telemetry_export.py`: **7 passed** (allowed dataset, denied→404, row-limit, max-limit cap, empty→null_reason header, file shape, dataset list).
- Frontend `exportCsv.test.ts` + `drillExport.test.tsx`: **15 passed** (CSV quoting/empty/missing-keys, SourceRowsTable live/artifact/unavailable, evidence links live vs fail-closed, XLSX button enabled/disabled).
- Full telemetry suite: **205 passed / 47 files**. `typecheck` + `lint` clean. ruff clean.

## Route notes (in lieu of browser screenshots — no browser automation in this env)
- **Drawer**: `/telemetry/model-performance` → "Source rows + export ›" → drawer with the source-rows table.
- **CSV**: the "Export CSV" button in that drawer (client Blob, the shown rows).
- **XLSX**: the "Export XLSX" button → `/api/telemetry/export/model_runs.xlsx?env_id=telemetry-demo&business_id=…`.
- **Unavailable**: when `model_performance` returns `null_reason`, the table shows it + disabled exports (covered by `drillExport.test.tsx`).

## Deploy
The XLSX route is a **new read-only backend endpoint** → it needs a `scripts/deploy_backend.sh` deploy to go live in prod (additive, low-risk). **Not deployed automatically.** The frontend (drill primitives + wiring + proxy) auto-deploys on merge; the XLSX button will return until the backend is deployed (the proxy then forwards the file). Recorded in plan 0012.

## Constraints honored
No ML value / caveat / claim-strength change · no schema · no Databricks notebook · no evidence-JSON change · no deferred Spin 6/2 card files touched · rebased on main (no concurrent conflict) · hide-before-delete (no page/nav removed in 8A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)