### PR TITLE
feat(telemetry-8b): Overview polish — true-scale green-wave axis, Big Number drill, richer event framing, bridge links

### DIFF
--- a/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 
 // Stub the heavy Bottleneck Map (recharts) — its own tests cover its behavior.
@@ -27,7 +27,29 @@ describe("TelemetryOverview — thesis-led Overview", () => {
     expect(screen.getByText(/Launch source ETL not connected/i)).toBeInTheDocument();
     expect(screen.getByText("Continue the demo")).toBeInTheDocument();
     expect(screen.getByText("Stargate Live").closest("a")).toHaveAttribute("href", "/lab/env/env-test/telemetry/stargate");
-    expect(screen.getByText("Resume Evidence").closest("a")).toHaveAttribute("href", "/lab/env/env-test/telemetry/evidence");
+    expect(screen.getByText("Evidence").closest("a")).toHaveAttribute("href", "/lab/env/env-test/telemetry/evidence");
+    // 8B bridge additions: Mission Control, Metric Lineage, Model Performance (Governance dropped).
+    expect(screen.getByText("Mission Control").closest("a")).toHaveAttribute("href", "/lab/env/env-test/telemetry/stream");
+    expect(screen.getByText("Metric Lineage").closest("a")).toHaveAttribute("href", "/lab/env/env-test/telemetry/metric-lineage");
+    expect(screen.getByText("Model Performance").closest("a")).toHaveAttribute("href", "/lab/env/env-test/telemetry/model-performance");
+    expect(screen.queryByText("Trust & Lineage")).not.toBeInTheDocument();
+  });
+
+  it("makes a Big Number drillable to its honest fixture source (no live-rows claim)", () => {
+    render(<TelemetryOverview />);
+    fireEvent.click(screen.getByRole("button", { name: /Cost per kg to LEO.*inspect source/i }));
+    // Drawer opens labeling the source kind honestly + shows an underlying public-data row.
+    expect(screen.getByText(/fixture — curated public data/i)).toBeInTheDocument();
+    expect(screen.getByText("Saturn V")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Export CSV/i })).not.toBeDisabled();
+  });
+
+  it("renders a clear no-rows state for a derived Big Number rather than a dead click", () => {
+    render(<TelemetryOverview />);
+    fireEvent.click(screen.getByRole("button", { name: /Timeline.*inspect source/i }));
+    // The null reason appears in the empty state and the disabled export reasons — good UX, multiple nodes.
+    expect(screen.getAllByText(/Derived range/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /Export CSV/i })).toBeDisabled();
   });
 
   it("does not render the serving KPI strip, the Trace-lineage CTA, or Mission Summary scaffolding", () => {

--- a/repo-b/src/components/telemetry/TelemetryOverview.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.tsx
@@ -8,12 +8,15 @@
 
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import { useState } from "react";
 
 import { C, TelemetryPageShell } from "./primitives";
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
+import { MetricInspectorDrawer } from "./drawerPrimitives";
+import { SourceRowsTable } from "./drill";
 import { telemetryHref } from "./telemetryNav";
 import BottleneckMap from "./context/BottleneckMap/BottleneckMap";
-import { computeBigNumbers, type BigNumberAccent } from "./context/BottleneckMap/data";
+import { computeBigNumbers, type BigNumber, type BigNumberAccent } from "./context/BottleneckMap/data";
 
 // Big Numbers accent → C palette. Rendered locally (not via the shared header metric row) so the
 // numerals can be materially larger narrative anchors without touching the shared header component.
@@ -23,7 +26,7 @@ function accentColor(a: BigNumberAccent): string {
 
 // Large editorial Big Numbers — historical context anchors, not operating KPIs. Bigger numerals +
 // cleaner uppercase labels than the old inline header metric row.
-function BigNumbersBand() {
+function BigNumbersBand({ onDrill }: { onDrill: (b: BigNumber) => void }) {
   const numbers = computeBigNumbers();
   return (
     <div style={{
@@ -32,15 +35,17 @@ function BigNumbersBand() {
       borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}`, padding: "22px 0",
     }}>
       {numbers.map((b) => (
-        <div key={b.label}>
+        <button key={b.label} type="button" onClick={() => onDrill(b)}
+          aria-label={`${b.label}: ${b.value} — inspect source`}
+          style={{ display: "block", textAlign: "left", background: "transparent", border: "none", padding: 0, cursor: "pointer" }}>
           <div style={{ fontFamily: C.mono, fontSize: 10.5, letterSpacing: "0.14em", textTransform: "uppercase", color: C.faint, marginBottom: 8 }}>
-            {b.label}
+            {b.label} <span aria-hidden style={{ color: C.faint, fontSize: 12 }}>›</span>
           </div>
           <div style={{ fontFamily: C.mono, fontWeight: 700, fontSize: "clamp(2rem, 4.4vw, 2.85rem)", lineHeight: 1, letterSpacing: "-0.02em", color: accentColor(b.accent) }}>
             {b.value}
           </div>
           {b.sub && <div style={{ fontFamily: C.sans, fontSize: 12, color: C.dim, marginTop: 7 }}>{b.sub}</div>}
-        </div>
+        </button>
       ))}
     </div>
   );
@@ -68,9 +73,11 @@ function SourceHonestyStrip() {
 // Bridge into the rest of the demo — the Overview's job is to make the other surfaces feel necessary.
 const BRIDGE: { slug: string; label: string; blurb: string }[] = [
   { slug: "stargate", label: "Stargate Live", blurb: "Recorded test-stand capture, replayed through the real Kafka/SSE bridge" },
-  { slug: "evidence", label: "Resume Evidence", blurb: "The ML findings, each backed by a reproducible artifact" },
+  { slug: "stream", label: "Mission Control", blurb: "Live channel strips, anomalies, and the GO / REVIEW / NO-GO verdict" },
   { slug: "replay", label: "Replay", blurb: "Model score → ranked channels → GO / REVIEW / NO-GO" },
-  { slug: "governance", label: "Trust & Lineage", blurb: "Where every number comes from; refusals and audit" },
+  { slug: "evidence", label: "Evidence", blurb: "The ML findings, each backed by a reproducible artifact" },
+  { slug: "metric-lineage", label: "Metric Lineage", blurb: "Where every number comes from — the governed metric catalog" },
+  { slug: "model-performance", label: "Model Performance", blurb: "Champions, honest metrics, and the promotion gate" },
 ];
 
 function DemoBridge({ envId }: { envId: string }) {
@@ -103,6 +110,7 @@ export default function TelemetryOverview() {
   const envId = typeof params?.envId === "string"
     ? params.envId
     : Array.isArray(params?.envId) ? params.envId[0] : "";
+  const [drillNum, setDrillNum] = useState<BigNumber | null>(null);
 
   // Thesis-first: the dominant hero states the argument once (Big Numbers render below it as larger
   // narrative anchors, not in the header metric row), then the integrated Bottleneck Map carries it.
@@ -123,10 +131,35 @@ export default function TelemetryOverview() {
 
   return (
     <TelemetryPageShell heading={heading}>
-      <BigNumbersBand />
-      <BottleneckMap />
+      <BigNumbersBand onDrill={setDrillNum} />
+      <BottleneckMap envId={envId} />
       <SourceHonestyStrip />
       {envId && <DemoBridge envId={envId} />}
+      <MetricInspectorDrawer
+        open={drillNum !== null}
+        onClose={() => setDrillNum(null)}
+        title={drillNum?.label ?? ""}
+        description={drillNum ? `${drillNum.value} — a curated public-data anchor, not operational telemetry.` : ""}
+        fields={drillNum ? [
+          { label: "Value", value: drillNum.value },
+          { label: "Source kind", value: "fixture — curated public data" },
+          { label: "Source", value: drillNum.drill.sourceLabel },
+          { label: "Note", value: drillNum.drill.note },
+        ] : []}
+      >
+        {drillNum && (
+          <div style={{ marginTop: 14 }}>
+            <SourceRowsTable
+              kind={drillNum.drill.sourceKind}
+              columns={drillNum.drill.columns}
+              rows={drillNum.drill.rows}
+              sourceLabel={drillNum.drill.sourceLabel}
+              nullReason={drillNum.drill.nullReason}
+              exportName={`telemetry_overview_${drillNum.label.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`}
+            />
+          </div>
+        )}
+      </MetricInspectorDrawer>
     </TelemetryPageShell>
   );
 }

--- a/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.test.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.test.tsx
@@ -44,6 +44,18 @@ describe("BottleneckMap rendering", () => {
     expect(screen.getByText("Scaling printed production to a reusable medium-heavy vehicle")).toBeInTheDocument();
   });
 
+  it("shows the selected-event framing strip: the harder question + a real downstream link", () => {
+    render(<BottleneckMap envId="env-x" />);
+    expect(screen.getByText(/tie a printed part to its build and inspection history/i)).toBeInTheDocument();
+    const link = screen.getByText(/Factory.*NCR/).closest("a");
+    expect(link).toHaveAttribute("href", "/lab/env/env-x/telemetry/factory");
+  });
+
+  it("fails closed on the strip's downstream link when envId is absent", () => {
+    render(<BottleneckMap />);
+    expect(screen.getByText(/downstream link unavailable/i)).toBeInTheDocument();
+  });
+
   it("enters presenter mode from the button, steps with the on-screen controls, exits on Escape", () => {
     render(<BottleneckMap />);
     fireEvent.click(screen.getByRole("button", { name: "Play guided walkthrough" }));

--- a/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.tsx
@@ -5,11 +5,13 @@
 // decision velocity, a data platform problem. Four linked panels derive from one event model.
 // This is a context module, not an operational view: static public data, no network calls.
 import React, { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 
 import { RS, RS_MONO, RS_SANS } from "../../rsTokens";
+import { telemetryHref } from "../../telemetryNav";
 import styles from "./BottleneckMap.module.css";
 import {
-  COLOR_DIMENSIONS, EVENTS, EVENTS_CHRONO, SIZE_MODES,
+  COLOR_DIMENSIONS, EVENT_NARRATIVE, EVENTS, EVENTS_CHRONO, SIZE_MODES,
   eventDimension, eventDimensionKey,
 } from "./data";
 import EventRecord from "./EventRecord";
@@ -35,7 +37,19 @@ function decorate(e: LaunchEvent, colorBy: ColorByKey, sizeMode: SizeModeKey): D
   };
 }
 
-export default function BottleneckMap() {
+// One framing line in the selected-event narrative strip.
+function NarrLine({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div style={{ fontFamily: RS_MONO, fontSize: 8.5, letterSpacing: 0.6, textTransform: "uppercase", color: RS.faint, marginBottom: 3 }}>
+        {label}
+      </div>
+      <div style={{ fontFamily: RS_SANS, fontSize: 12.5, color: RS.text, lineHeight: 1.45 }}>{value}</div>
+    </div>
+  );
+}
+
+export default function BottleneckMap({ envId }: { envId?: string }) {
   const [selectedId, setSelectedId] = useState<string | null>("terran1");
   const [chipFilter, setChipFilter] = useState<string | null>(null);
   const [sizeMode, setSizeMode] = useState<SizeModeKey>("scale");
@@ -188,6 +202,40 @@ export default function BottleneckMap() {
           focused dimmed={false}
           onHoverYear={onHoverYear} onSelect={onSelect} />
       </div>
+
+      {/* selected-event framing strip: the two questions the record below does not answer — the
+          operational question this era created, and which downstream page proves the pattern next. The
+          bottleneck solved and the new data burden are in the event record (the relay cells) just below;
+          this strip carries the forward-looking framing without repeating them. */}
+      {selected && (() => {
+        const n = EVENT_NARRATIVE[selected.id];
+        return (
+          <div style={{ marginTop: 14, border: `1px solid ${selected.color}33`, borderLeft: `2px solid ${selected.color}`,
+            borderRadius: 9, background: `${selected.color}0a`, padding: "12px 15px" }}>
+            <div style={{ fontFamily: RS_MONO, fontSize: 9, letterSpacing: 0.8, textTransform: "uppercase", color: RS.faint, marginBottom: 10 }}>
+              {selected.name} — the operational question this era created
+            </div>
+            <div style={{ display: "grid", gridTemplateColumns: "minmax(220px, 2fr) minmax(180px, 1fr)", gap: "11px 22px", alignItems: "start" }}>
+              <NarrLine label="Question that got harder" value={n?.harderQuestion ?? "—"} />
+              <div>
+                <div style={{ fontFamily: RS_MONO, fontSize: 8.5, letterSpacing: 0.6, textTransform: "uppercase", color: RS.faint, marginBottom: 5 }}>
+                  Proves the pattern next
+                </div>
+                {n && envId ? (
+                  <Link href={telemetryHref(envId, n.provesNextSlug)}
+                    style={{ display: "inline-flex", alignItems: "center", gap: 6, textDecoration: "none",
+                      fontFamily: RS_MONO, fontSize: 11.5, color: RS.cyan, border: `1px solid ${RS.cyan}55`,
+                      background: `${RS.cyan}12`, borderRadius: 6, padding: "5px 11px" }}>
+                    {n.provesNextLabel} →
+                  </Link>
+                ) : (
+                  <span style={{ fontFamily: RS_MONO, fontSize: 10.5, color: RS.faint }}>downstream link unavailable</span>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })()}
 
       {/* panel 4: pinned event record */}
       {selected && <EventRecord event={selected} presenting={presenting} focusPanel={focusPanel} />}

--- a/repo-b/src/components/telemetry/context/BottleneckMap/MapPanel.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/MapPanel.tsx
@@ -131,16 +131,26 @@ export default function MapPanel({
               ticks={[0, 165, 330]}
               tick={{ fill: RS.crosshair, fontSize: 9, fontFamily: RS_MONO }}
               width={34} stroke={RS.line} tickLine={false} />
-            {/* Hidden axis for the commercial-share underlay: 0-100% mapped low so the wave reads as a
-                subordinate context band behind the bars and bubbles, never the primary series. */}
-            <YAxis yAxisId="share" hide type="number" domain={[0, 260]} />
+            {/* Commercial-share underlay axis: a TRUE 0-100% scale (0% bottom, 100% top). The observed
+                wave only reaches ~70%, so it naturally sits in the lower-to-mid chart on its own scale —
+                no rescaling to full height. The gutter axis stays hidden; faint labeled reference lines
+                at 0/50/100 (below) give the reading without crowding the band/cadence axes. */}
+            <YAxis yAxisId="share" hide type="number" domain={[0, 100]} />
             <Tooltip content={<MapTip />} cursor={false} />
             {/* Commercial-share contextual underlay (rendered first = painted behind everything). The
                 rising wave is the story backdrop: cadence and commercialization climbed together, and the
                 data/interpretation burden climbed with them. Honest label in the sub + footnote. */}
             <Area yAxisId="share" dataKey="commercialPct" stroke={RS.green} strokeWidth={1}
-              strokeOpacity={0.35} fill={RS.green} fillOpacity={0.07} connectNulls
+              strokeOpacity={0.32} fill={RS.green} fillOpacity={0.06} connectNulls
               isAnimationActive={false} />
+            {/* Faint labeled true-scale gridlines for the share underlay (0/50/100%). Drawn after the
+                Area but before the bars/bubbles so the wave's own scale is readable yet subordinate. */}
+            {[0, 50, 100].map((pct) => (
+              <ReferenceLine key={`share-${pct}`} yAxisId="share" y={pct} stroke={RS.green}
+                strokeOpacity={pct === 0 ? 0.1 : 0.16} strokeDasharray="2 7"
+                label={{ value: `${pct}%`, position: "insideLeft", fill: RS.green, fontSize: 9,
+                  fontFamily: RS_MONO, opacity: 0.5 }} />
+            ))}
             <Bar yAxisId="cadence" dataKey="attempts" barSize={5} radius={[2, 2, 0, 0]} isAnimationActive={false}>
               {YEAR_SERIES.map((d) => (
                 <Cell key={d.year}
@@ -183,7 +193,7 @@ export default function MapPanel({
       </div>
       <div style={{ display: "flex", justifyContent: "space-between", padding: "2px 16px 8px",
         fontFamily: RS_MONO, fontSize: 9, color: RS.faint }}>
-        <span style={{ color: RS.green }}>green wave = commercial share of attempts (contextual underlay, 0–70%)</span>
+        <span style={{ color: RS.green }}>green wave = commercial share of attempts · true 0–100% axis (observed ≈0–70%) · contextual underlay</span>
         <span>border: solid = flown · dashed = partial · dotted = planned · size = {sizeModeLabel.toLowerCase()}</span>
       </div>
     </PanelShell>

--- a/repo-b/src/components/telemetry/context/BottleneckMap/data.ts
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/data.ts
@@ -4,6 +4,7 @@
 // are computed once at module scope.
 
 import { RS } from "../../rsTokens";
+import type { SourceKind } from "../../drill/sourceKind";
 import type {
   ColorByKey, CostPoint, DimensionEntry, DimensionKey, LaunchEvent, SizeModeKey, TimeWindow,
   YearPoint,
@@ -364,7 +365,22 @@ export function fmtCost(v: number): string {
 // window (inflation-adjusted cost). Presented as inline editorial text under the Overview thesis,
 // not as a dashboard strip. Mirrors the windowed KPI logic that used to live in BottleneckMap.
 export type BigNumberAccent = "text" | "share" | "cost";
-export interface BigNumber { label: string; value: string; sub: string; accent: BigNumberAccent }
+
+// Drill payload for a Big Number. These are curated public-data anchors (GCAT / Wikipedia /
+// company-stated), not operational telemetry — so the source kind is always "fixture" and the rows
+// are the underlying public series, never row-level serving data. `rows: []` renders the honest
+// "no row-level series" state (e.g. the derived timeline range) instead of a dead click.
+export interface BigNumberDrill {
+  sourceKind: SourceKind;
+  sourceLabel: string;
+  note: string;
+  nullReason?: string;
+  columns: string[];
+  rows: Array<Record<string, unknown>>;
+}
+export interface BigNumber {
+  label: string; value: string; sub: string; accent: BigNumberAccent; drill: BigNumberDrill;
+}
 
 export function computeBigNumbers(): BigNumber[] {
   const attempts = YEAR_SERIES.reduce((s, d) => s + (d.attempts || 0), 0);
@@ -377,11 +393,68 @@ export function computeBigNumbers(): BigNumber[] {
   const costLabel = first?.costMeta && last?.costMeta
     ? `${first.costMeta.v} to ${last.costMeta.v}, 2025 $` : "";
   return [
-    { label: "Timeline", value: `${FULL_WINDOW[0]} – ${FULL_WINDOW[1]}`, sub: "full range", accent: "text" },
-    { label: "Launch attempts", value: attempts.toLocaleString(), sub: "orbital, total", accent: "text" },
-    { label: "Commercial share",
+    {
+      label: "Timeline", value: `${FULL_WINDOW[0]} – ${FULL_WINDOW[1]}`, sub: "full range", accent: "text",
+      drill: {
+        sourceKind: "fixture", sourceLabel: "GCAT / Wikipedia spaceflight series",
+        note: "The window spanned by the cadence series.", columns: [], rows: [],
+        nullReason: "Derived range — no separate row-level table; see Launch attempts for the per-year cadence rows.",
+      },
+    },
+    {
+      label: "Launch attempts", value: attempts.toLocaleString(), sub: "orbital, total", accent: "text",
+      drill: {
+        sourceKind: "fixture", sourceLabel: "CADENCE (GCAT / Wikipedia yearly spaceflight series)",
+        note: "Annual world orbital launch attempts. Pre-2000 are close approximations; 2018+ are exact.",
+        columns: ["year", "attempts"],
+        rows: CADENCE.map(([year, n]) => ({ year, attempts: n })),
+      },
+    },
+    {
+      label: "Commercial share",
       value: lastReal?.commercialPct != null ? `${Math.round(lastReal.commercialPct)}%` : "n/a",
-      sub: lastReal ? `as of ${lastReal.year}` : "", accent: "share" },
-    { label: "Cost per kg to LEO", value: cost, sub: costLabel, accent: "cost" },
+      sub: lastReal ? `as of ${lastReal.year}` : "", accent: "share",
+      drill: {
+        sourceKind: "fixture", sourceLabel: "SHARE_ANCHORS (commercial share of attempts)",
+        note: "2022-2025 reported; earlier anchors are coarse estimates, interpolated between.",
+        columns: ["year", "commercial_share_pct"],
+        rows: SHARE_ANCHORS.map(([year, pct]) => ({ year, commercial_share_pct: pct })),
+      },
+    },
+    {
+      label: "Cost per kg to LEO", value: cost, sub: costLabel, accent: "cost",
+      drill: {
+        sourceKind: "fixture", sourceLabel: "COST_POINTS (per-launch price ÷ LEO capacity)",
+        note: "Per-launch sticker/marginal price ÷ LEO capacity, one consistent basis; 2025$ via approx CPI. Terran R is company-stated.",
+        columns: ["year", "vehicle", "usd_per_kg_nominal", "usd_per_kg_2025", "basis"],
+        rows: Object.entries(COST_POINTS).map(([year, cp]) => ({
+          year: Number(year), vehicle: cp.v, usd_per_kg_nominal: cp.nominal, usd_per_kg_2025: cp.adj, basis: cp.basis,
+        })),
+      },
+    },
   ];
 }
+
+// Per-event narrative for the selected-event explanation strip (PR 8B). The bottleneck solved + the
+// new data burden come from the event itself (bottleneckSolved / bottleneckCreated / dataProduct);
+// this map adds the two framing fields the demo wants: the operational question that got harder, and
+// which downstream telemetry page proves the pattern next. Slugs are real telemetry routes.
+export interface EventNarrative { harderQuestion: string; provesNextSlug: string; provesNextLabel: string }
+export const EVENT_NARRATIVE: Record<string, EventNarrative> = {
+  sputnik: { harderQuestion: "Once you have a signal, what do you do with it?", provesNextSlug: "stream", provesNextLabel: "Mission Control" },
+  vostok: { harderQuestion: "How do you trust a life-critical reading in real time?", provesNextSlug: "stream", provesNextLabel: "Mission Control" },
+  apollo11: { harderQuestion: "How do thousands of subsystems resolve into one go/no-go?", provesNextSlug: "replay", provesNextLabel: "Replay" },
+  shuttle: { harderQuestion: "How do you inspect a reused vehicle between flights?", provesNextSlug: "factory-ml", provesNextLabel: "Flight Readiness" },
+  iss: { harderQuestion: "How do you run a system for decades on a continuous feed?", provesNextSlug: "stream", provesNextLabel: "Mission Control" },
+  falcon1: { harderQuestion: "How does a small team validate a vehicle from sparse data?", provesNextSlug: "evidence", provesNextLabel: "Evidence" },
+  falcon9: { harderQuestion: "How do you drive cost down with data, not just hardware?", provesNextSlug: "model-performance", provesNextLabel: "Model Performance" },
+  dragon: { harderQuestion: "How do you certify a service on its operating data?", provesNextSlug: "evidence", provesNextLabel: "Evidence" },
+  f9landing: { harderQuestion: "How do you decide a recovered booster is safe to refly?", provesNextSlug: "factory-ml", provesNextLabel: "Flight Readiness" },
+  falconheavy: { harderQuestion: "How do you carry evidence across vehicle variants?", provesNextSlug: "metric-lineage", provesNextLabel: "Metric Lineage" },
+  crewdragon: { harderQuestion: "How do you show human-rated reliability from test data?", provesNextSlug: "evidence", provesNextLabel: "Evidence" },
+  terran1: { harderQuestion: "How do you tie a printed part to its build and inspection history?", provesNextSlug: "factory", provesNextLabel: "Factory · NCR" },
+  starshipcatch: { harderQuestion: "How do you learn fast when each flight floods you with data?", provesNextSlug: "stargate", provesNextLabel: "Stargate Live" },
+  fleetscale: { harderQuestion: "How do you keep judgment fast as cadence climbs?", provesNextSlug: "stream", provesNextLabel: "Mission Control" },
+  terranR: { harderQuestion: "How do you trust a model's call before a test you can't cheaply repeat?", provesNextSlug: "calibration", provesNextLabel: "RUL Calibration" },
+  artemis: { harderQuestion: "How do you trace every number a supply-chain decision rests on?", provesNextSlug: "metric-lineage", provesNextLabel: "Metric Lineage" },
+};


### PR DESCRIPTION
Phase 8 / **PR 8B** (plan `0012`). Focused Overview polish — **touches only** `TelemetryOverview.tsx`, `context/BottleneckMap/{BottleneckMap,MapPanel,data}.tsx` + their tests. Reuses the 8A drill primitives (no rebuild). No bleed into Model/RUL/Registry/Factory/Flight, no backend, no schema, no evidence JSON.

## Green-wave axis (before → after)
**Before:** hidden share axis with `domain={[0,260]}` — the 0–70% wave compressed into the bottom ~27% of the chart, unlabeled.
**After:** a **true 0–100% scale** (`domain={[0,100]}`) with **faint labeled reference lines at 0 / 50 / 100%** — 0% bottom, 50% middle, 100% top. The observed wave naturally reaches ~70% height (no rescale to full height) and stays **subordinate** (low opacity, painted behind the bars/bubbles). Footnote updated to "true 0–100% axis (observed ≈0–70%)".

## Big Number drill-through + source-kind honesty
Each Big Number is now a button → `MetricInspectorDrawer` + `SourceRowsTable` over the underlying public series (`CADENCE` / `SHARE_ANCHORS` / `COST_POINTS`), labeled **source kind = "fixture — curated public data"** (GCAT / Wikipedia / company-stated) — **no live-rows claim**. CSV export of the shown series; XLSX not wired for these fixture anchors. **Timeline** has no row-level series → an honest no-rows state with a `null_reason`, **not a dead click**.

## Selected-event explanation fields added
A new `EVENT_NARRATIVE` map (data.ts) adds, per event: the **operational question that got harder** + **which downstream page proves the pattern next** (a real telemetry route). Rendered as a focused strip; the **bottleneck solved + new data burden stay in the event record below** (no duplication). Fails closed when `envId` is absent ("downstream link unavailable").

## Bridge links updated
Stargate Live · **Mission Control** (`stream`) · Replay · **Evidence** · **Metric Lineage** · **Model Performance**. Governance dropped (folded later in 8F); "Resume Evidence" → "Evidence".

## Tests run / results
- Overview + BottleneckMap tests updated/extended (Big Number drill → fixture source + CSV; Timeline no-rows state; new bridge hrefs; event-framing strip + downstream link + fail-closed): **15 passed**.
- Full telemetry suite: **209 passed / 47 files**. typecheck + lint clean.
- **Frozen ML evidence: 8 passed** — no shipped value or caveat changed.

## Evidence values/caveats preserved
Confirmed unchanged: Spin 1/2/3/5/6 values, autoencoder-as-judgment-artifact, honest-vs-point-adjusted framing. My changes are the Overview **context module** (curated public-data anchors), not the ML evidence surfaces.

## Route notes (no browser automation in this env)
- Green axis: `/telemetry` Overview → the Bottleneck Map hero; faint green 0/50/100% gridlines, wave low + behind bars.
- Big Number drill: click any Big Number → drawer with the fixture source + a CSV export (Timeline shows the no-rows state).
- Event framing: select an event → the "operational question this era created" strip + the "Proves the pattern next →" link.

Rebased on main (no concurrent conflict). Stayed strictly within the four scoped files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)