### PR TITLE
feat(telemetry-8c): stream controls relabel + anomalies/DLQ/live-events CSV export

### DIFF
--- a/repo-b/src/components/telemetry/MissionControlStream.test.tsx
+++ b/repo-b/src/components/telemetry/MissionControlStream.test.tsx
@@ -135,4 +135,28 @@ describe("MissionControlStream — actionable fail-closed states (hardening)", (
     expect(screen.getByText(/CAPTURE/)).toBeInTheDocument();
     expect(screen.getByText("USLAB000058")).toBeInTheDocument();
   });
+
+  it("relabels the poll control to Pause and exports the live anomaly events as CSV (8C)", async () => {
+    useStreamPoll.mockReturnValue({
+      live: live({
+        source: "capture",
+        pipeline: { status: "fresh", as_of_ts: "2026-06-10T18:00:00+00:00", reason: null, surfaces: {} },
+        channels: [{
+          channel_name: "USLAB000058", unit: "mmHg", redline_low: 700, redline_high: 790,
+          readings: [{ t: "2026-06-10T17:59:59+00:00", v: 752.1 }],
+          latest: { t: "2026-06-10T17:59:59+00:00", v: 752.1 },
+        }],
+        events: [{ channel_name: "USLAB000058", start_t: 1, end_t: 2, anomaly_class: "point", confidence: 0.9 }],
+      }),
+      error: null, clientNowMs: Date.parse("2026-06-10T18:00:01+00:00"),
+    });
+    render(<MissionControlStream />);
+    await waitFor(() => expect(screen.queryByTestId("stream-unavailable")).toBeNull());
+    // "Hold" → "Pause" relabel.
+    expect(screen.getByRole("button", { name: /Pause the live poll/i })).toBeInTheDocument();
+    expect(screen.queryByText("Hold")).toBeNull();
+    // Live anomaly events are exportable, honestly labeled as tel_anomaly_events rows.
+    expect(screen.getByText(/live tel_anomaly_events/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Export CSV/i })).not.toBeDisabled();
+  });
 });

--- a/repo-b/src/components/telemetry/MissionControlStream.tsx
+++ b/repo-b/src/components/telemetry/MissionControlStream.tsx
@@ -17,6 +17,7 @@ import {
 import { SplitGrid } from "./primitives";
 import { RS, RS_MONO, RS_SANS, RsChip, RsPanel } from "./rsTokens";
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
+import { ExportToCsvButton } from "./drill";
 
 const WINDOW_S = 120;
 const MAX_STRIPS = 4;
@@ -199,10 +200,12 @@ export default function MissionControlStream() {
               {starting ? "Starting…" : "Start stream"}
             </button>
             <button type="button" onClick={() => setHold((h) => !h)}
+              aria-label={hold ? "Resume the live poll" : "Pause the live poll"}
+              title={hold ? "Resume the 1s poll" : "Pause the 1s poll — freezes the view; the backend keeps ingesting"}
               style={{ fontFamily: RS_MONO, fontSize: 11, padding: "4px 10px", borderRadius: 4,
                 cursor: "pointer", color: hold ? RS.bg : RS.dim,
                 background: hold ? RS.amber : "transparent", border: `1px solid ${RS.line}` }}>
-              {hold ? "Resume" : "Hold"}
+              {hold ? "Resume" : "Pause"}
             </button>
           </>
         }
@@ -300,6 +303,18 @@ export default function MissionControlStream() {
                   ))}
                 </div>
               )}
+              <div style={{ padding: "0 12px 12px", display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+                <span style={{ fontFamily: RS_MONO, fontSize: 9.5, color: RS.faint }}>
+                  live tel_anomaly_events · {live.events.length} rows
+                </span>
+                <ExportToCsvButton
+                  filename="mission_control_anomaly_events"
+                  columns={["channel_name", "start_t", "end_t", "anomaly_class", "confidence"]}
+                  rows={live.events as unknown as Array<Record<string, unknown>>}
+                  label="Export CSV"
+                  disabledReason="No anomaly events on the live window"
+                />
+              </div>
             </RsPanel>
 
             <RsPanel title="LATENCY">

--- a/repo-b/src/components/telemetry/stargate/DlqPanel.test.tsx
+++ b/repo-b/src/components/telemetry/stargate/DlqPanel.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import DlqPanel from "./DlqPanel";
+
+describe("DlqPanel CSV export (8C)", () => {
+  it("labels the source honestly and disables export with a reason when empty", () => {
+    render(<DlqPanel rows={[]} count={0} />);
+    expect(screen.getByText(/recorded-capture replay/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Export CSV/i })).toBeDisabled();
+  });
+
+  it("enables the CSV export when there are dead letters", () => {
+    render(
+      <DlqPanel
+        rows={[{ ts_ms: 1700, topic: "stargate.printer.telemetry.v1", reason: "decode_error", raw_preview: "ab", raw_bytes: 12 }]}
+        count={1}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /Export CSV/i })).not.toBeDisabled();
+  });
+});

--- a/repo-b/src/components/telemetry/stargate/DlqPanel.tsx
+++ b/repo-b/src/components/telemetry/stargate/DlqPanel.tsx
@@ -6,6 +6,8 @@
 
 import { C, Panel, Tag } from "../primitives";
 import type { DlqRow } from "@/lib/lab/stargateStream";
+import { ExportToCsvButton } from "../drill";
+import { DLQ_EXPORT_COLUMNS, dlqExportRows } from "./streamExportRows";
 
 function fmtTime(tsMs: number): string {
   return new Date(tsMs).toLocaleTimeString([], { hour12: false });
@@ -40,6 +42,14 @@ export default function DlqPanel({ rows, count }: { rows: DlqRow[]; count: numbe
           ))}
         </div>
       )}
+      <div style={{ padding: "8px 14px", borderTop: `1px solid ${C.border}`, display: "flex",
+        alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+        <span style={{ fontFamily: C.mono, fontSize: 9.5, color: C.faint }}>
+          {count} routed · real SSE rows over a recorded-capture replay
+        </span>
+        <ExportToCsvButton filename="stargate_dead_letters" columns={DLQ_EXPORT_COLUMNS}
+          rows={dlqExportRows(rows)} label="Export CSV" disabledReason="No dead letters" />
+      </div>
     </Panel>
   );
 }

--- a/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
+++ b/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
@@ -17,6 +17,8 @@ import TempVibrationChart from "./TempVibrationChart";
 import StreamLineageDrawer from "./StreamLineageDrawer";
 import { useStargateStream } from "@/lib/lab/stargateStream";
 import type { AnomalyRow } from "@/lib/lab/stargateStream";
+import { ExportToCsvButton } from "../drill";
+import { ANOMALY_EXPORT_COLUMNS, anomalyExportRows } from "./streamExportRows";
 import { TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID } from "@/lib/telemetry/api";
 import { useIsMobile } from "@/hooks/useIsMobile";
 
@@ -297,6 +299,15 @@ export default function StargateConsole() {
               ))}
             </div>
           )}
+          <div style={{ padding: "8px 14px", borderTop: `1px solid ${C.border}`, display: "flex",
+            alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+            <span style={{ fontFamily: C.mono, fontSize: 9.5, color: C.faint }}>
+              {anomalies.length} routed · real SSE rows over a recorded-capture replay · all printers
+            </span>
+            <ExportToCsvButton filename="stargate_anomalies" columns={ANOMALY_EXPORT_COLUMNS}
+              rows={anomalyExportRows(anomalies)} label="Export CSV"
+              disabledReason="No routed anomalies yet" />
+          </div>
         </Panel>
         <DlqPanel rows={dlq} count={stream.dlqCount} />
       </SplitGrid>

--- a/repo-b/src/components/telemetry/stargate/streamExportRows.test.ts
+++ b/repo-b/src/components/telemetry/stargate/streamExportRows.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import type { AnomalyRow, DlqRow } from "@/lib/lab/stargateStream";
+import {
+  ANOMALY_EXPORT_COLUMNS, DLQ_EXPORT_COLUMNS, anomalyExportRows, dlqExportRows,
+} from "./streamExportRows";
+
+const base: AnomalyRow = {
+  printer_id: "P1", ts_us: 1_700_000_000_000_000, layer: 42, print_job_id: "job-9",
+  melt_pool_temp_c: 1450, arm_vibration_g: 0.12,
+};
+
+describe("anomalyExportRows", () => {
+  it("flattens core fields and nulls absent enrichment (no fabrication)", () => {
+    const [row] = anomalyExportRows([base]);
+    expect(row.printer_id).toBe("P1");
+    expect(row.melt_pool_temp_c).toBe(1450);
+    expect(row.rule_fired).toBeNull();
+    expect(row.scorer_verdict).toBeNull();
+    expect(row.kafka_offset).toBeNull();
+    expect(row.synthetic).toBeNull();
+  });
+
+  it("flattens nested enrichment to scalar columns", () => {
+    const enriched: AnomalyRow = {
+      ...base,
+      rule: { fired: true, predicate: "t>1400", temp_c: 1450, vib_g: 0.12 },
+      scorer: { name: "mad", version: "1", score: 0.9, verdict: "NO_GO", threshold: 0.8, model_not_configured: false, null_reason: null },
+      routing: { routed_to: "anomalies.v1", reason: "rule+scorer" },
+      provenance: { provenance_source: "recorded_capture", kafka_topic: "t", kafka_partition: 0, kafka_offset: 5, schema_id: 1, schema_null_reason: null, capture_id: "c1", synthetic: true },
+    };
+    const [row] = anomalyExportRows([enriched]);
+    expect(row.rule_fired).toBe(true);
+    expect(row.scorer_verdict).toBe("NO_GO");
+    expect(row.routing_routed_to).toBe("anomalies.v1");
+    expect(row.kafka_offset).toBe(5);
+    expect(row.synthetic).toBe(true);
+  });
+
+  it("every declared column is present on a flattened row", () => {
+    const [row] = anomalyExportRows([base]);
+    for (const c of ANOMALY_EXPORT_COLUMNS) expect(c in row).toBe(true);
+  });
+});
+
+describe("dlqExportRows", () => {
+  it("passes the flat DLQ fields through unchanged", () => {
+    const dlq: DlqRow = { ts_ms: 1700, topic: "x", reason: "decode_error", raw_preview: "ab", raw_bytes: 12 };
+    const [row] = dlqExportRows([dlq]);
+    expect(row).toEqual(dlq);
+    expect(DLQ_EXPORT_COLUMNS).toContain("raw_bytes");
+  });
+});

--- a/repo-b/src/components/telemetry/stargate/streamExportRows.ts
+++ b/repo-b/src/components/telemetry/stargate/streamExportRows.ts
@@ -1,0 +1,39 @@
+// Flatten the Stargate SSE buffer rows (AnomalyRow / DlqRow) into flat CSV rows for the 8C export
+// affordances. These are REAL rows pushed over the SSE bridge during a recorded-capture replay — not
+// fixtures and not live printer hardware. The nested enrichment (rule / scorer / routing / provenance)
+// is flattened to the most useful scalar columns; missing enrichment → null (never fabricated).
+import type { AnomalyRow, DlqRow } from "@/lib/lab/stargateStream";
+
+export const ANOMALY_EXPORT_COLUMNS = [
+  "printer_id", "ts_us", "layer", "print_job_id", "melt_pool_temp_c", "arm_vibration_g",
+  "rule_fired", "scorer_verdict", "scorer_score", "routing_routed_to",
+  "provenance_source", "kafka_topic", "kafka_partition", "kafka_offset", "synthetic",
+];
+
+export function anomalyExportRows(anomalies: AnomalyRow[]): Array<Record<string, unknown>> {
+  return anomalies.map((a) => ({
+    printer_id: a.printer_id,
+    ts_us: a.ts_us,
+    layer: a.layer,
+    print_job_id: a.print_job_id,
+    melt_pool_temp_c: a.melt_pool_temp_c,
+    arm_vibration_g: a.arm_vibration_g,
+    rule_fired: a.rule?.fired ?? null,
+    scorer_verdict: a.scorer?.verdict ?? null,
+    scorer_score: a.scorer?.score ?? null,
+    routing_routed_to: a.routing?.routed_to ?? null,
+    provenance_source: a.provenance?.provenance_source ?? null,
+    kafka_topic: a.provenance?.kafka_topic ?? null,
+    kafka_partition: a.provenance?.kafka_partition ?? null,
+    kafka_offset: a.provenance?.kafka_offset ?? null,
+    synthetic: a.provenance?.synthetic ?? null,
+  }));
+}
+
+export const DLQ_EXPORT_COLUMNS = ["ts_ms", "topic", "reason", "raw_preview", "raw_bytes"];
+
+export function dlqExportRows(dlq: DlqRow[]): Array<Record<string, unknown>> {
+  return dlq.map((d) => ({
+    ts_ms: d.ts_ms, topic: d.topic, reason: d.reason, raw_preview: d.raw_preview, raw_bytes: d.raw_bytes,
+  }));
+}


### PR DESCRIPTION
Phase 8 / **PR 8C** (plan `0012`). **Frontend-only, no backend, no deploy.** Reuses the 8A `ExportToCsvButton` (no framework rebuild). Touches only the streaming surfaces.

## Controls — before / after
Verified first that there are **no duplicate controls to merge**: Stargate `Start recorded capture` (POST `/stargate/replay/cycle`), Mission Control `Start stream` (starts the ingest worker), the poll toggle, and the display-only GO/NO-GO badge are all **distinct and already honest**.

| Control | Before | After |
|---|---|---|
| Mission Control poll toggle | "Hold" / "Resume" | **"Pause"** / "Resume" (+ aria-label/title: pauses the 1s poll; backend keeps ingesting) |
| Stargate "Start recorded capture" | already honest | unchanged |
| Mission Control "Start stream" | starts ingest worker | unchanged (it's not a replay — not renamed) |
| GO/NO-GO badge, source chips | display-only | unchanged |

**Removed/merged:** nothing (confirmed no duplicates). Every "recorded capture / not a live printer" label, source chip, and demo-honesty footnote preserved.

## Anomalies / DLQ — source-kind + export
All real rows, not fixtures:
- **Stargate anomalies** (SSE `CircularBuffer`, all printers) → CSV export, captioned **"real SSE rows over a recorded-capture replay"**. Drill already exists (`AnomalyInspectionDrawer`).
- **Stargate dead letters** (SSE buffer) → CSV export, same honest caption.
- **Mission Control anomalies** (`tel_anomaly_events` via `/stream/live`) → CSV export, labeled **"live tel_anomaly_events · N rows"**.
- New `stargate/streamExportRows.ts` flattens `AnomalyRow` (nested rule/scorer/routing/provenance → scalar columns; **absent enrichment → null, never fabricated**) + `DlqRow`.
- **Fail closed:** empty buffers → export disabled with a reason; never an empty/fake file.

The `tel_anomaly_events` **server XLSX dataset** is intentionally deferred to **8D** (batched with the other backend export datasets + one controlled deploy), keeping 8C frontend-only.

## Honesty / constraints
Never implies live printer hardware. No fabricated "less suspicious" values. No route/service deleted. **No Model/RUL/Registry/Factory/Flight pages touched.** No ML value/caveat changed — **frozen-evidence 8/8 green**. No schema, no 8A-framework change.

## Tests
- `streamExportRows.test.ts` (4): flatten core + nested enrichment, null absent enrichment, column coverage, DLQ passthrough.
- `DlqPanel.test.tsx` (2): export disabled+reason when empty, enabled with rows.
- `MissionControlStream.test.tsx` (+1): "Hold"→"Pause" relabel + live-events CSV enabled; existing tests still green.
- Full telemetry suite **216 passed / 49 files**; typecheck + lint clean.

## Route notes (no browser automation in this env)
- `/telemetry/stream`: the poll toggle reads **Pause/Resume**; the LIVE ANOMALY EVENTS panel has an Export-CSV with the `tel_anomaly_events` caption (disabled when no events).
- `/telemetry/stargate`: the Anomaly ticker + DLQ panels each have an Export-CSV with the "recorded-capture replay" caption (disabled when buffers are empty).

Rebased on main (no concurrent conflict). Stayed within the streaming surfaces only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)