### PR TITLE
feat(telemetry-8d1): Model Performance — champion/challenger clarity, per-model run/artifact links

### DIFF
--- a/repo-b/src/components/telemetry/ModelPerformance.test.tsx
+++ b/repo-b/src/components/telemetry/ModelPerformance.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { getModelPerformance } = vi.hoisted(() => ({ getModelPerformance: vi.fn() }));
+vi.mock("@/lib/telemetry/api", () => ({
+  getModelPerformance,
+  TELEMETRY_DEMO_ENV_ID: "telemetry-demo",
+  TELEMETRY_DEMO_BUSINESS_ID: "7e1eb000-0000-4000-a000-000000000001",
+}));
+
+import ModelPerformance from "./ModelPerformance";
+
+const models = [
+  {
+    model_name: "tel_anomaly_mad", model_kind: "anomaly", model_version: "3", model_alias: "champion",
+    mlflow_run_id: "run-abc", experiment_id: "exp-1", promotion_state: "promoted",
+    metrics: {
+      precision: 0.33, recall: 0.30, f1: 0.645, f1_pointwise: 0.313, precision_pointwise: 0.328,
+      recall_pointwise: 0.299, event_recall: 0.769, alarm_precision: 0.475,
+      honest_metrics_note: "Honest pointwise F1 is lower than the point-adjusted benchmark.",
+    },
+    gate: { decision: "pass" },
+  },
+  {
+    model_name: "tel_anomaly_pca", model_kind: "anomaly", model_version: "2", model_alias: null,
+    mlflow_run_id: "run-pca", experiment_id: "exp-1", promotion_state: "baseline",
+    metrics: { precision: 0.2, recall: 0.2, f1: 0.4 }, gate: { decision: "fail" },
+  },
+  {
+    model_name: "tel_rul_gbr", model_kind: "rul", model_version: "1", model_alias: "champion",
+    mlflow_run_id: "run-rul", experiment_id: "exp-2", promotion_state: "promoted",
+    metrics: { rmse: 20.96, phm: 742.4 }, gate: { decision: "pass" },
+  },
+];
+
+describe("ModelPerformance — champion/challenger + links + export (8D-1)", () => {
+  it("labels champion vs challenger, states operational use, tags the source kind, keeps honest framing", async () => {
+    getModelPerformance.mockResolvedValue({ models, null_reason: null });
+    render(<ModelPerformance />);
+    expect(await screen.findByText("tel_anomaly_mad")).toBeInTheDocument();
+    expect(screen.getAllByText("champion").length).toBeGreaterThan(0);          // role made explicit
+    expect(screen.getByText(/challenger · baseline/i)).toBeInTheDocument();
+    expect(screen.getByText(/Operational use: scores each window/i)).toBeInTheDocument();
+    expect(screen.getByText(/tel_model_runs · metrics \+ promotion gate/i)).toBeInTheDocument();
+    expect(screen.getByText("F1 (point-wise — honest)")).toBeInTheDocument();   // honest framing preserved
+  });
+
+  it("drills to per-model MLflow run links (live) + fail-closed UC artifact links + CSV export", async () => {
+    getModelPerformance.mockResolvedValue({ models, null_reason: null });
+    render(<ModelPerformance />);
+    await screen.findByText("tel_anomaly_mad");
+    fireEvent.click(screen.getByRole("button", { name: /Inspect the model rows and export/i }));
+    const runLinks = screen.getAllByRole("link", { name: /Open MLflow Run/i });
+    expect(runLinks.length).toBeGreaterThanOrEqual(3);                          // one per model with a run id
+    expect(runLinks[0].getAttribute("href")).toContain("run-");
+    // The UC model link fails closed for the seed registry name (not a 3-part UC path).
+    expect(screen.getAllByText(/Unavailable —/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /Export CSV/i })).not.toBeDisabled();
+  });
+});

--- a/repo-b/src/components/telemetry/ModelPerformance.tsx
+++ b/repo-b/src/components/telemetry/ModelPerformance.tsx
@@ -7,7 +7,7 @@ import {
 import { C, Tag, Panel, Loading, ErrorState, DisclosureFooter, ScrollTable, TelemetryActionButton } from "./primitives";
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
 import { MetricInspectorDrawer } from "./drawerPrimitives";
-import { SourceRowsTable, DatabricksRunLink, exportXlsxUrl } from "./drill";
+import { SourceRowsTable, DatabricksRunLink, ModelArtifactLink, exportXlsxUrl } from "./drill";
 
 // Columns surfaced when drilling into the model rows. Mirrors the server XLSX export
 // (telemetry_export.py "model_runs") so the CSV preview and the .xlsx match.
@@ -21,17 +21,22 @@ function metric(m: ModelRun, k: string): string {
   return v == null ? "—" : Number(v).toFixed(k === "rmse" || k === "phm" ? 2 : 4);
 }
 
+// Champion = promoted alias; everything else is a challenger/alternative shown by its registry state
+// so the role is explicit, not just "promoted".
 function StatusTag({ m }: { m: ModelRun }) {
   return m.model_alias === "champion" || m.promotion_state === "promoted"
-    ? <Tag color={C.green}>promoted</Tag>
-    : <Tag color={C.faint}>{m.promotion_state}</Tag>;
+    ? <Tag color={C.green}>champion</Tag>
+    : <Tag color={C.faint}>challenger · {m.promotion_state}</Tag>;
 }
 
-function Table({ title, cols, rows }: { title: string; cols: string[]; rows: ModelRun[] }) {
+function Table({ title, cols, rows, note }: { title: string; cols: string[]; rows: ModelRun[]; note?: string }) {
   const isRul = rows[0]?.model_kind === "rul";
   const grid = "1.4fr 0.8fr 0.8fr 0.9fr 0.9fr";
   return (
     <Panel title={title}>
+      {note && (
+        <div style={{ fontFamily: C.sans, fontSize: 12, color: C.dim, lineHeight: 1.5, marginBottom: 10 }}>{note}</div>
+      )}
       <ScrollTable minWidth={560}>
         <div style={{ display: "grid", gridTemplateColumns: grid, gap: 8, fontFamily: C.mono, fontSize: 10,
           color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase", paddingBottom: 8 }}>
@@ -114,11 +119,19 @@ export default function ModelPerformance() {
     <>
       {heading}
       <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <Tag color={C.green}>live rows</Tag>
+          <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint }}>
+            tel_model_runs · metrics + promotion gate logged per run · champion vs challenger below
+          </span>
+        </div>
         <Table title="Anomaly detection — SMAP/MSL (legacy baseline · point-adjusted, labeled test split)"
-          cols={["Model", "Precision", "Recall", "F1 (legacy)", "Status"]} rows={anomaly} />
+          cols={["Model", "Precision", "Recall", "F1 (legacy)", "Role"]} rows={anomaly}
+          note="Operational use: scores each window; a NO-GO verdict routes the print for review. The promoted champion is the rolling-MAD detector." />
         <HonestMetrics rows={anomaly} />
         <Table title="Remaining useful life — C-MAPSS FD001 (100 test units)"
-          cols={["Model", "RMSE", "PHM", "", "Status"]} rows={rul} />
+          cols={["Model", "RMSE", "PHM", "", "Role"]} rows={rul}
+          note="Operational use: estimates remaining useful life; the go/no-go gate clears on the conformal lower bound (see RUL Calibration)." />
         <Panel pad={14}>
           <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, lineHeight: 1.6 }}>
             Gates declared before training: anomaly F1 ≥ 0.30, RUL RMSE ≤ 25. Values fetched live from the
@@ -157,15 +170,20 @@ export default function ModelPerformance() {
               businessId: TELEMETRY_DEMO_BUSINESS_ID,
             })}
           />
-          {(() => {
-            const champ = models.find((m) => m.model_alias === "champion") ?? models[0];
-            return champ?.mlflow_run_id ? (
-              <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
-                <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint }}>Champion run:</span>
-                <DatabricksRunLink runId={champ.mlflow_run_id} />
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint }}>
+              Runs &amp; artifacts (per model) — MLflow link where a run id is logged; UC model link fails closed for seed registry names
+            </span>
+            {models.map((m) => (
+              <div key={`${m.model_name}-${m.model_version}`} style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+                <span style={{ fontFamily: C.mono, fontSize: 11, color: C.text, minWidth: 170 }}>
+                  {m.model_name} <span style={{ color: C.faint }}>v{m.model_version}</span>
+                </span>
+                <DatabricksRunLink runId={m.mlflow_run_id} />
+                <ModelArtifactLink modelName={m.model_name} />
               </div>
-            ) : null;
-          })()}
+            ))}
+          </div>
         </div>
       </MetricInspectorDrawer>
       <DisclosureFooter />


### PR DESCRIPTION
Phase 8 / **PR 8D-1** (plan `0012`, the Model-Performance slice of 8D). **Frontend-only, no backend, no deploy** — reuses the 8A drill drawer + the already-deployed `model_runs` XLSX dataset.

Enriches the existing Model Performance surface (dashboard metric → model explanation → source/artifact link → drill rows → export):

- **Champion vs challenger explicit** — the role tag reads **"champion"** (promoted) or **"challenger · &lt;state&gt;"**, not just "promoted"; the column is **"Role"**.
- **Operational use** per model kind — anomaly: scores each window, NO-GO routes the print for review; RUL: feeds the conformal lower-bound go/no-go gate.
- **Source-kind chip** — "live rows · tel_model_runs · metrics + promotion gate logged per run".
- **Per-model run/artifact links** in the drill drawer — a **live MLflow run link** where a run id is logged (`DatabricksRunLink`), and a **fail-closed** UC model link for seed registry names (`ModelArtifactLink` → "Unavailable — seed registry key" + copy). **No fabricated links.**
- The **gate** is already surfaced (the pre-training-gates note + the exportable `gate` column in the drawer's `SourceRowsTable`).

## Links added / intentionally unavailable
- Added: per-model MLflow run links (live, all rows carry `mlflow_run_id`).
- Intentionally fail-closed: the UC registered-model link (the `tel_*` model names are seed keys, not 3-part UC paths) — shows the reason + a copy chip, never a dead/fabricated link.

## Source-kind treatment
All Model Performance metrics are `live-rows` from `tel_model_runs` (labeled). No computed/fixture values on this surface.

## Evidence preserved
The honest-vs-point-adjusted framing (F1 point-wise 0.313 honest vs 0.645 legacy), the honest-metrics note, and the MAD-champion caveat are unchanged. **Frozen-evidence 8/8 green.** No ML value/caveat/schema/notebook change.

## Tests
- New `ModelPerformance.test.tsx`: champion/challenger labeling + operational-use + source-kind chip + honest framing; drawer per-model live MLflow links + fail-closed UC links + CSV export enabled. **2 passed.**
- Full telemetry suite **218 passed / 50 files**; typecheck + lint clean.

## Deploy
**None required** — frontend-only; the `model_runs` XLSX dataset was already deployed in 8A.

## Scope
Only `ModelPerformance.tsx` (+ its test). No Registry/RUL/Factory/Flight/Test-Runs touched (those are 8D-2 / 8E / 8F / 8G). Rebased on main (no concurrent conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)