### PR TITLE
feat(telemetry-8d2): Model Registry — run/artifact links, explicit null_reason metadata, CSV/XLSX export

### DIFF
--- a/repo-b/src/components/telemetry/RegistryConsole.test.tsx
+++ b/repo-b/src/components/telemetry/RegistryConsole.test.tsx
@@ -71,7 +71,34 @@ describe("RegistryConsole rendering", () => {
     await waitFor(() => expect(screen.getByText(/CHAMPION v1/)).toBeInTheDocument());
     const promote = screen.getByRole("button", { name: /Promote — requires reviewer approval/ });
     expect(promote).toBeDisabled();
-    expect(screen.getByText(/no challenger registered/)).toBeInTheDocument();
+    expect(screen.getByText(/none registered/)).toBeInTheDocument();                 // challenger absent → explicit
+    expect(screen.getByText(/null_reason: no non-promoted run/)).toBeInTheDocument();
     expect(screen.getByText(/pending: import failed/)).toBeInTheDocument();   // honest VUS status
+  });
+
+  it("links the run, fails closed on the UC model link, marks absent metadata, and exports (8D-2)", async () => {
+    getRegistry.mockResolvedValueOnce({
+      models: [champion],
+      drift: {
+        USLAB000058: [
+          { psi: 0.08, window_label: "w1", computed_at: "2026-05-21T00:00:00Z" },
+          { psi: 0.12, window_label: "w2", computed_at: "2026-05-22T00:00:00Z" },
+        ],
+      },
+      lifecycle: [], null_reason: null,
+    } satisfies RegistryResponse);
+    render(<RegistryConsole />);
+    await waitFor(() => expect(screen.getByText(/CHAMPION v1/)).toBeInTheDocument());
+    // The run id is now a live MLflow link, not raw text.
+    const runLink = screen.getByRole("link", { name: /Open MLflow Run/i });
+    expect(runLink.getAttribute("href")).toContain("4a48cb6a");
+    // The UC model link fails closed for the seed registry name.
+    expect(screen.getAllByText(/Unavailable —/i).length).toBeGreaterThan(0);
+    // Absent lifecycle metadata renders an explicit null_reason, not a blank cell.
+    expect(screen.getByText("Training window")).toBeInTheDocument();
+    expect(screen.getAllByText(/not recorded in tel_model_runs/i).length).toBeGreaterThan(0);
+    // Registry rows + drift are exportable; source-kind is labeled live rows.
+    expect(screen.getByRole("button", { name: /Models CSV/i })).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: /Drift CSV/i })).not.toBeDisabled();
   });
 });

--- a/repo-b/src/components/telemetry/RegistryConsole.tsx
+++ b/repo-b/src/components/telemetry/RegistryConsole.tsx
@@ -13,8 +13,43 @@ import {
 } from "@/lib/telemetry/api";
 import { RS, RS_MONO, RS_SANS, RsChip, RsPanel } from "./rsTokens";
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
+import {
+  DatabricksRunLink, ModelArtifactLink, ExportToCsvButton, ExportToExcelButton, exportXlsxUrl,
+} from "./drill";
 
 const PSI_WARN = 0.15;
+
+// CSV column sets for the registry exports — mirror the displayed live rows (metrics/gate jsonb are
+// JSON-stringified by the CSV writer, not flattened, so no value is altered).
+const REGISTRY_COLS = [
+  "model_name", "model_kind", "model_version", "model_alias", "promotion_state",
+  "mlflow_run_id", "experiment_id", "metrics", "gate", "created_at",
+];
+const DRIFT_COLS = ["channel", "psi", "window_label", "computed_at"];
+
+function driftRows(drift: RegistryResponse["drift"]): Array<Record<string, unknown>> {
+  return Object.entries(drift).flatMap(([channel, series]) =>
+    series.map((s) => ({ channel, psi: s.psi, window_label: s.window_label, computed_at: s.computed_at })));
+}
+
+// One model-metadata field. Fields that are not columns in tel_model_runs render an explicit
+// null_reason (+ the run link is the place to find them), never a blank/"n/a" cell.
+function MetaField({ label, value }: { label: string; value?: string }) {
+  return (
+    <div>
+      <div style={{ color: RS.faint, letterSpacing: "0.06em", textTransform: "uppercase", fontSize: 8.5, marginBottom: 2 }}>
+        {label}
+      </div>
+      {value ? (
+        <div style={{ color: RS.dim, fontSize: 10.5, lineHeight: 1.4 }}>{value}</div>
+      ) : (
+        <div style={{ color: RS.faint, fontSize: 9.5, lineHeight: 1.4 }}>
+          null_reason: not recorded in tel_model_runs — see the MLflow run
+        </div>
+      )}
+    </div>
+  );
+}
 
 export interface GateRow { rule: string; observed: string; pass: boolean }
 
@@ -253,21 +288,43 @@ export default function RegistryConsole() {
             : "NO PROMOTED CHAMPION"}>
             {champion && (
               <div style={{ padding: "8px 12px", borderBottom: `1px solid ${RS.line}`,
-                display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8,
-                fontFamily: RS_MONO, fontSize: 10, color: RS.faint }}>
-                <div>
-                  <div style={{ color: RS.teal }}>champion: {champion.model_name} v{champion.model_version}</div>
-                  <div>mlflow {champion.mlflow_run_id}</div>
+                display: "flex", flexDirection: "column", gap: 12, fontFamily: RS_MONO, fontSize: 10 }}>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+                  <div>
+                    <div style={{ color: RS.teal }}>champion: {champion.model_name} v{champion.model_version}</div>
+                    <div style={{ marginTop: 6, display: "flex", gap: 8, flexWrap: "wrap" }}>
+                      <DatabricksRunLink runId={champion.mlflow_run_id} />
+                      <ModelArtifactLink modelName={champion.model_name} />
+                    </div>
+                  </div>
+                  <div>
+                    {challenger ? (
+                      <>
+                        <div style={{ color: RS.violet }}>challenger: {challenger.model_name} v{challenger.model_version}</div>
+                        <div style={{ marginTop: 6, display: "flex", gap: 8, flexWrap: "wrap" }}>
+                          <DatabricksRunLink runId={challenger.mlflow_run_id} />
+                          <ModelArtifactLink modelName={challenger.model_name} />
+                        </div>
+                      </>
+                    ) : (
+                      <div>
+                        <div style={{ color: RS.violet }}>challenger: <span style={{ color: RS.amber }}>none registered</span></div>
+                        <div style={{ color: RS.faint, fontSize: 9.5, marginTop: 4 }}>
+                          null_reason: no non-promoted run for this kind
+                        </div>
+                      </div>
+                    )}
+                  </div>
                 </div>
-                <div>
-                  {challenger ? (
-                    <>
-                      <div style={{ color: RS.violet }}>challenger: {challenger.model_name} v{challenger.model_version}</div>
-                      <div>mlflow {challenger.mlflow_run_id}</div>
-                    </>
-                  ) : (
-                    <div style={{ color: RS.faint }}>no challenger registered for this kind</div>
-                  )}
+                {/* Lifecycle metadata not held in the serving table → explicit null_reason, never blank */}
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: "8px 14px",
+                  borderTop: `1px solid ${RS.line}`, paddingTop: 10 }}>
+                  <MetaField label="Training window" />
+                  <MetaField label="Validation method" />
+                  <MetaField label="Operational use" value="Champion serves the live go/no-go verdict; the challenger is the held comparison." />
+                </div>
+                <div style={{ color: RS.faint, fontSize: 9, letterSpacing: "0.04em" }}>
+                  metric bars below: &quot;n/a&quot; = the metric was not logged on that run (not a UI error).
                 </div>
               </div>
             )}
@@ -367,6 +424,23 @@ export default function RegistryConsole() {
               </div>
             </RsPanel>
           </div>
+        </div>
+      )}
+
+      {data && data.models.length > 0 && (
+        <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap", padding: "12px 4px 4px" }}>
+          <RsChip color={RS.green}>live rows</RsChip>
+          <span style={{ fontFamily: RS_MONO, fontSize: 10, color: RS.faint }}>
+            tel_model_runs · tel_drift_metrics (lifecycle = derived) — export reflects the registry rows
+          </span>
+          <ExportToCsvButton filename="telemetry_model_registry" columns={REGISTRY_COLS}
+            rows={data.models as unknown as Array<Record<string, unknown>>}
+            label="Models CSV" disabledReason="No model rows" />
+          <ExportToExcelButton
+            url={exportXlsxUrl("model_runs", { envId: TELEMETRY_DEMO_ENV_ID, businessId: TELEMETRY_DEMO_BUSINESS_ID })}
+            label="Models XLSX" />
+          <ExportToCsvButton filename="telemetry_drift_psi" columns={DRIFT_COLS}
+            rows={driftRows(data.drift)} label="Drift CSV" disabledReason="No PSI history" />
         </div>
       )}
 


### PR DESCRIPTION
Phase 8 / **PR 8D-2** (plan `0012`, the Model-Registry slice of 8D). **Frontend-only, no backend, no deploy** — reuses the 8A link/export primitives + the already-deployed `model_runs` XLSX dataset. `RegistryConsole.tsx` only. **8D-3 (backend `tel_anomaly_events` dataset + deploy) kept separate.**

## Fields added / changed
- **Run/artifact links** — replaced the raw **`mlflow {run_id}` text** (champion + challenger) with a live **`DatabricksRunLink`** per `mlflow_run_id` + a **fail-closed `ModelArtifactLink`**.
- **Model metadata section** — `training_window` / `validation_method` (not columns in `tel_model_runs`) now render an **explicit null_reason**, not a blank cell; `operational_use` is an honest description.
- **Challenger** — when no non-promoted run exists: **"none registered" + an explicit null_reason**, not a vague message. Champion/challenger/status semantics from 8D-1 preserved.
- **Metric-bar legend** — clarifies "n/a" = the metric wasn't logged on that run (not a UI error).

## Links added / unavailable behavior
- **Added:** live MLflow run links for champion + challenger (where a run id exists).
- **Fail-closed (intentional):** the UC registered-model link — `tel_*` model names are seed keys, not 3-part UC paths → "Unavailable — seed registry key" + a copy chip. **No fabricated URLs.**

## Explicit null_reason
- `training_window` / `validation_method` → "not recorded in tel_model_runs — see the MLflow run".
- Missing challenger → "null_reason: no non-promoted run for this kind".

## Export behavior
- **Models CSV** (the displayed registry rows), **Models XLSX** (reusing the `model_runs` dataset — same `tel_model_runs`, honestly labeled), **Drift CSV** (client-side from the displayed PSI series). Disabled-with-reason when empty (no fake files).

## Source-kind treatment
A "live rows" chip — `tel_model_runs` / `tel_drift_metrics`; the lifecycle timeline is labeled **derived**. No fixture/computed values misrepresented.

## Evidence preserved
The honest-vs-point-adjusted framing (affiliation F1 beside honest point-wise; point-adjusted F1 labeled "inflated legacy"), the honest_gate, and the drift honesty are unchanged. **Frozen-evidence 8/8 green.** No ML value/caveat/schema/notebook change.

## Tests
- `RegistryConsole.test.tsx` extended (run link href, fail-closed UC link, null_reason metadata, exports enabled) + the challenger assertion updated to the new explicit text. **5 passed.**
- Full telemetry suite **219 passed / 50 files**; typecheck + lint clean.

## Deploy
**None required** — frontend-only; the `model_runs` XLSX dataset was already deployed in 8A.

## Scope
Only `RegistryConsole.tsx` (+ its test). No backend route / Mission Control / RUL / Factory / Flight / Test-Runs / nav touched. Rebased on main (no concurrent conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)