### PR TITLE
feat(telemetry-8d3): tel_anomaly_events XLSX export dataset + Mission Control XLSX button

### DIFF
--- a/backend/app/routes/telemetry_export.py
+++ b/backend/app/routes/telemetry_export.py
@@ -60,6 +60,17 @@ def _extract_model_runs(env_id: str, business_id: UUID) -> tuple[list[dict], str
     return list(data.get("models") or []), data.get("null_reason")
 
 
+def _extract_anomaly_events(env_id: str, business_id: UUID) -> tuple[list[dict], str | None]:
+    # Reuse the same scoped read the Mission Control page uses (stream_live), so the export equals the
+    # screen's live anomaly events. No new SQL; stream_live is read-only and already env/business/run
+    # scoped and bounded (LIMIT 20). Empty → an honest null_reason, never a fabricated row.
+    from app.services import telemetry_stream_etl
+    data = telemetry_stream_etl.stream_live(env_id=env_id, business_id=business_id)
+    events = list(data.get("events") or [])
+    null_reason = None if events else (data.get("null_reason") or "no_live_anomaly_events")
+    return events, null_reason
+
+
 # Allowlist. Add a dataset here (mapped to an existing scoped service) to expose it.
 TELEMETRY_EXPORT_DATASETS: dict[str, ExportDataset] = {
     "model_runs": ExportDataset(
@@ -71,6 +82,14 @@ TELEMETRY_EXPORT_DATASETS: dict[str, ExportDataset] = {
             "promotion_state", "mlflow_run_id", "experiment_id", "metrics", "gate",
         ),
         extract=_extract_model_runs,
+    ),
+    "anomaly_events": ExportDataset(
+        label="Live anomaly events",
+        source="tel_anomaly_events",
+        source_kind="live-rows",
+        columns=("channel_name", "start_t", "end_t", "anomaly_class", "confidence"),
+        extract=_extract_anomaly_events,
+        default_limit=20, max_limit=200,
     ),
 }
 

--- a/backend/tests/test_telemetry_export.py
+++ b/backend/tests/test_telemetry_export.py
@@ -30,6 +30,7 @@ from fastapi.responses import JSONResponse, Response  # noqa: E402
 from openpyxl import load_workbook  # noqa: E402
 
 from app.routes import telemetry_export as te  # noqa: E402
+from app.services import telemetry_stream_etl  # noqa: E402
 
 BIZ = UUID("00000000-0000-0000-0000-000000000002")
 COLS = te.TELEMETRY_EXPORT_DATASETS["model_runs"].columns
@@ -115,9 +116,9 @@ def _fake_stream_live(events, null_reason=None):
 
 
 def _stub_stream_etl(monkeypatch, events, null_reason=None):
-    stub = types.ModuleType("app.services.telemetry_stream_etl")
-    stub.stream_live = _fake_stream_live(events, null_reason)
-    monkeypatch.setitem(sys.modules, "app.services.telemetry_stream_etl", stub)
+    # Patch the attribute on the REAL module so the extract's `from app.services import
+    # telemetry_stream_etl` picks it up regardless of import order in the full suite.
+    monkeypatch.setattr(telemetry_stream_etl, "stream_live", _fake_stream_live(events, null_reason))
 
 
 ANOMALY_COLS = list(te.TELEMETRY_EXPORT_DATASETS["anomaly_events"].columns)

--- a/backend/tests/test_telemetry_export.py
+++ b/backend/tests/test_telemetry_export.py
@@ -103,4 +103,59 @@ def test_list_datasets_exposes_allowlist_no_data():
     out = te.list_export_datasets()
     names = {d["dataset"] for d in out["datasets"]}
     assert "model_runs" in names
+    assert "anomaly_events" in names
     assert all("source_kind" in d for d in out["datasets"])
+
+
+# ── anomaly_events dataset (8D-3): reuses the read-only stream_live scoped path ──────────────────
+def _fake_stream_live(events, null_reason=None):
+    def _f(*, env_id, business_id, **kw):
+        return {"events": events, "null_reason": null_reason, "channels": [], "source": "db_tail"}
+    return _f
+
+
+def _stub_stream_etl(monkeypatch, events, null_reason=None):
+    stub = types.ModuleType("app.services.telemetry_stream_etl")
+    stub.stream_live = _fake_stream_live(events, null_reason)
+    monkeypatch.setitem(sys.modules, "app.services.telemetry_stream_etl", stub)
+
+
+ANOMALY_COLS = list(te.TELEMETRY_EXPORT_DATASETS["anomaly_events"].columns)
+
+
+def test_anomaly_events_streams_xlsx_with_fixed_columns(monkeypatch):
+    _stub_stream_etl(monkeypatch, [
+        {"channel_name": "USLAB000058", "start_t": 1, "end_t": 2, "anomaly_class": "point", "confidence": 0.9},
+    ])
+    resp = te.export_dataset_xlsx("anomaly_events", env_id="telemetry-demo", business_id=BIZ, limit=None)
+    assert isinstance(resp, Response)
+    assert resp.headers["X-Telemetry-Export-Rows"] == "1"
+    assert resp.headers["X-Telemetry-Export-Source"] == "tel_anomaly_events"
+    assert resp.headers["X-Telemetry-Export-Source-Kind"] == "live-rows"
+    ws = load_workbook(io.BytesIO(resp.body)).active
+    assert [c.value for c in ws[1]] == ANOMALY_COLS
+    assert ws.cell(row=2, column=1).value == "USLAB000058"
+
+
+def test_anomaly_events_row_limit_capped(monkeypatch):
+    many = [{"channel_name": f"c{i}", "start_t": i, "end_t": i + 1, "anomaly_class": "point", "confidence": 0.5}
+            for i in range(10)]
+    _stub_stream_etl(monkeypatch, many)
+    resp = te.export_dataset_xlsx("anomaly_events", env_id="telemetry-demo", business_id=BIZ, limit=3)
+    assert resp.headers["X-Telemetry-Export-Rows"] == "3"
+
+
+def test_anomaly_events_empty_is_header_only_with_null_reason(monkeypatch):
+    _stub_stream_etl(monkeypatch, [], null_reason="stream_worker_disabled")
+    resp = te.export_dataset_xlsx("anomaly_events", env_id="telemetry-demo", business_id=BIZ, limit=None)
+    assert resp.headers["X-Telemetry-Export-Rows"] == "0"
+    assert resp.headers["X-Telemetry-Null-Reason"] == "stream_worker_disabled"
+    ws = load_workbook(io.BytesIO(resp.body)).active
+    assert [c.value for c in ws[1]] == ANOMALY_COLS
+    assert ws.max_row == 1
+
+
+def test_anomaly_events_empty_no_stream_reason_uses_specific_null_reason(monkeypatch):
+    _stub_stream_etl(monkeypatch, [], null_reason=None)
+    resp = te.export_dataset_xlsx("anomaly_events", env_id="telemetry-demo", business_id=BIZ, limit=None)
+    assert resp.headers["X-Telemetry-Null-Reason"] == "no_live_anomaly_events"

--- a/repo-b/src/components/telemetry/MissionControlStream.test.tsx
+++ b/repo-b/src/components/telemetry/MissionControlStream.test.tsx
@@ -158,5 +158,7 @@ describe("MissionControlStream — actionable fail-closed states (hardening)", (
     // Live anomaly events are exportable, honestly labeled as tel_anomaly_events rows.
     expect(screen.getByText(/live tel_anomaly_events/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Export CSV/i })).not.toBeDisabled();
+    // 8D-3: the server XLSX export (anomaly_events dataset) is wired next to the CSV.
+    expect(screen.getByRole("button", { name: /Export XLSX/i })).not.toBeDisabled();
   });
 });

--- a/repo-b/src/components/telemetry/MissionControlStream.tsx
+++ b/repo-b/src/components/telemetry/MissionControlStream.tsx
@@ -17,7 +17,7 @@ import {
 import { SplitGrid } from "./primitives";
 import { RS, RS_MONO, RS_SANS, RsChip, RsPanel } from "./rsTokens";
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
-import { ExportToCsvButton } from "./drill";
+import { ExportToCsvButton, ExportToExcelButton, exportXlsxUrl } from "./drill";
 
 const WINDOW_S = 120;
 const MAX_STRIPS = 4;
@@ -312,6 +312,14 @@ export default function MissionControlStream() {
                   columns={["channel_name", "start_t", "end_t", "anomaly_class", "confidence"]}
                   rows={live.events as unknown as Array<Record<string, unknown>>}
                   label="Export CSV"
+                  disabledReason="No anomaly events on the live window"
+                />
+                <ExportToExcelButton
+                  url={exportXlsxUrl("anomaly_events", {
+                    envId: TELEMETRY_DEMO_ENV_ID, businessId: TELEMETRY_DEMO_BUSINESS_ID,
+                  })}
+                  label="Export XLSX"
+                  disabled={live.events.length === 0}
                   disabledReason="No anomaly events on the live window"
                 />
               </div>


### PR DESCRIPTION
Phase 8 / **PR 8D-3** (plan `0012`) — the deploy-bearing slice of 8D (the 8C defer). Backend dataset + a one-line frontend wire. **Needs a controlled backend deploy after merge.**

## Dataset key added
**`anomaly_events`** → `tel_anomaly_events`.

## Backend dataset (read-only, allowlisted, bounded — no new SQL)
The extractor reuses the existing **read-only scoped path**: it calls `telemetry_stream_etl.stream_live` (the same query the Mission Control page uses — env/business/run scoped, `source='model'`, bounded `LIMIT 20`), so **the export equals the screen**. No request-controlled table/SQL; the dataset name is an allowlist key.
- Fixed columns: `channel_name, start_t, end_t, anomaly_class, confidence` (stable order).
- Bounded: `default 20 / max 200`, request limit capped.
- Empty → a **valid header-only XLSX + honest `X-Telemetry-Null-Reason`** (`no_live_anomaly_events` or the stream reason).
- Unknown dataset stays **404 + null_reason** (`model_runs` still works).

## Route examples
- `GET /api/telemetry/export/anomaly_events.xlsx?env_id=telemetry-demo&business_id=7e1eb000-0000-4000-a000-000000000001` → xlsx binary
- `GET /api/telemetry/export/datasets` → now lists `anomaly_events` + `model_runs`
- `GET /api/telemetry/export/bogus.xlsx` → 404 `export_dataset_not_allowed`

## Mission Control button behavior
An `ExportToExcelButton` next to the existing CSV in the LIVE ANOMALY EVENTS panel → `/api/telemetry/export/anomaly_events.xlsx` with the **same env/business context**, labeled **live `tel_anomaly_events`**; **disabled-with-reason when no events**. CSV unchanged; Stargate recorded-capture CSVs untouched.

## Tests run / results
- Backend `test_telemetry_export.py`: **11 passed** (+4 new: anomaly_events fixed-columns, row-limit cap, empty→header-only+null_reason, no-stream-reason→specific null_reason; dataset list now asserts `anomaly_events`). Reuses `stream_live` via a stubbed module (no DB).
- Frontend `MissionControlStream.test.tsx`: the XLSX button present + enabled (6 passed).
- Full telemetry suite **219 passed**; frozen-evidence **8/8**; ruff + typecheck + lint clean.

## Evidence preserved
No ML value/caveat, no schema/migration, no evidence JSON, no Databricks notebook change. No Model/RUL/Registry/Factory/Flight touched.

## Deploy
**Required after merge** (new backend dataset). I'll run the controlled procedure: capture `/api/version` + health + verify_lineage; deploy clean main via `scripts/deploy_backend.sh`; verify the SHA flip, health, verify_lineage posture, the new `anomaly_events` XLSX binary through the proxy, the unknown-dataset 404, and that `model_runs` XLSX still works; roll back on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)