### PR TITLE
feat(telemetry-8e): RUL Calibration — wider layout + unit-level drill/export

### DIFF
--- a/repo-b/src/components/telemetry/RulCalibration.test.tsx
+++ b/repo-b/src/components/telemetry/RulCalibration.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 import RulCalibration from "./RulCalibration";
 import { CALIBRATION_TRAJECTORY } from "@/lib/telemetry/calibrationEvidence";
@@ -37,6 +37,20 @@ describe("RulCalibration", () => {
     // the only mention of distance/embedding trust is the kill context — never as a live feature
     const body = document.body.textContent || "";
     expect(body).not.toMatch(/SupCon|analog retrieval|pgvector|novelty distance/i);
+  });
+
+  it("drills to per-cycle unit-level rows (fixture) with coverage + CSV export (8E)", () => {
+    render(<RulCalibration />);
+    // source-kind is labeled on the page
+    expect(screen.getByText(/computed evidence artifact/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Inspect the unit-level calibration rows and export/i }));
+    // the drawer labels the source kind honestly + exposes the unit-level columns
+    expect(screen.getByText(/computed-artifact \(conformal bands\)/i)).toBeInTheDocument();
+    expect(screen.getByText("covered_90")).toBeInTheDocument();
+    // flip/gate is honestly marked not-applicable here (the 100-unit aggregate lives on Evidence)
+    expect(screen.getByText(/100-unit gate-flip aggregate is on the Evidence/i)).toBeInTheDocument();
+    // CSV export of the displayed unit rows is enabled (fixture rows present)
+    expect(screen.getByRole("button", { name: /Export CSV/i })).not.toBeDisabled();
   });
 
   it("builds a deterministic trajectory with monotone non-increasing true RUL ending at 0", () => {

--- a/repo-b/src/components/telemetry/RulCalibration.tsx
+++ b/repo-b/src/components/telemetry/RulCalibration.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { C, Tag, Panel, MetricCard, StatGrid, SplitGrid, DisclosureFooter } from "./primitives";
+import { useState } from "react";
+
+import { C, Tag, Panel, MetricCard, StatGrid, SplitGrid, DisclosureFooter, TelemetryActionButton } from "./primitives";
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
+import { MetricInspectorDrawer } from "./drawerPrimitives";
+import { SourceRowsTable } from "./drill";
 import {
   CALIBRATION_EVIDENCE as E,
   CALIBRATION_TRAJECTORY as TRAJ,
@@ -9,9 +13,26 @@ import {
   type CalibrationPoint,
 } from "@/lib/telemetry/calibrationEvidence";
 
+// Unit-level rows for the drill/export: one row per cycle of the representative engine. point/bounds/
+// true are the displayed values; covered_80/90 is the per-point calibration hit (derived from the
+// shown bands, not fabricated). The 100-unit gate-flip status lives on the Evidence RUL conformal card.
+const DRILL_COLS = ["unit", "cycle", "true_rul", "point_pred", "lo80", "hi80", "lo90", "hi90", "covered_80", "covered_90"];
+const r1 = (v: number) => Math.round(v * 10) / 10;
+function drillRows(): Array<Record<string, unknown>> {
+  return TRAJ.map((p) => ({
+    unit: "FD001-representative",
+    cycle: p.cycle,
+    true_rul: p.trueRul,
+    point_pred: p.predRul,
+    lo80: r1(p.lo80), hi80: r1(p.hi80), lo90: r1(p.lo90), hi90: r1(p.hi90),
+    covered_80: p.trueRul >= p.lo80 && p.trueRul <= p.hi80,
+    covered_90: p.trueRul >= p.lo90 && p.trueRul <= p.hi90,
+  }));
+}
+
 // ---- Inline-SVG trajectory chart (no chart dependency) ----------------------------------------
 function TrajectoryChart({ pts }: { pts: CalibrationPoint[] }) {
-  const W = 720, H = 300, padL = 40, padR = 16, padT = 16, padB = 34;
+  const W = 900, H = 340, padL = 46, padR = 18, padT = 18, padB = 38;
   const xs = pts.map((p) => p.cycle);
   const x0 = Math.min(...xs), x1 = Math.max(...xs);
   const yMax = Math.max(...pts.map((p) => p.hi90)) * 1.05;
@@ -28,7 +49,7 @@ function TrajectoryChart({ pts }: { pts: CalibrationPoint[] }) {
 
   return (
     <div className="overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
-      <svg viewBox={`0 0 ${W} ${H}`} width="100%" style={{ minWidth: 520, display: "block" }}
+      <svg viewBox={`0 0 ${W} ${H}`} width="100%" style={{ minWidth: 640, display: "block" }}
         role="img" aria-label="RUL trajectory with 80% and 90% calibrated intervals">
         {yticks.map((t) => (
           <g key={t}>
@@ -84,9 +105,10 @@ function Note({ children, accent = C.dim }: { children: React.ReactNode; accent?
 
 export default function RulCalibration() {
   const i80 = E.intervals["80"], i90 = E.intervals["90"];
+  const [drillOpen, setDrillOpen] = useState(false);
 
   return (
-    <div style={{ maxWidth: 1180, margin: "0 auto" }}>
+    <div style={{ maxWidth: 1320, margin: "0 auto" }}>
       <TelemetryPageHeader
         variant="standard"
         eyebrow="Telemetry · Calibration"
@@ -111,6 +133,13 @@ export default function RulCalibration() {
         <MetricCard label="Interval width (MPIW)" value={`${i80.mpiw.toFixed(1)} / ${i90.mpiw.toFixed(1)}`} sub={`GBM ${E.gbmIntervals["80"].mpiw} / ${E.gbmIntervals["90"].mpiw}`} />
       </StatGrid>
 
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", margin: "0 0 14px" }}>
+        <Tag color={C.amber}>computed artifact</Tag>
+        <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint }}>
+          FD001 scalars + conformal bands are a computed evidence artifact · the per-cycle trajectory is a replay fixture · not live serving
+        </span>
+      </div>
+
       <SplitGrid variant="two-one" style={{ marginBottom: 12 }}>
         {/* 3 — trajectory chart */}
         <Panel title={`Trajectory · ${TRAJECTORY_ENGINE_LABEL}`}
@@ -122,6 +151,12 @@ export default function RulCalibration() {
               q₉₀ = −{i90.qLower.toFixed(1)}/+{i90.qUpper.toFixed(1)} cycles). Replay fixture from the committed evidence artifact — not live data.
             </span>
           </Note>
+          <div style={{ marginTop: 14 }}>
+            <TelemetryActionButton variant="secondary" onClick={() => setDrillOpen(true)}
+              aria-label="Inspect the unit-level calibration rows and export">
+              Unit-level rows + export ›
+            </TelemetryActionButton>
+          </div>
         </Panel>
 
         {/* 4 — calibration summary */}
@@ -203,6 +238,30 @@ export default function RulCalibration() {
           <Field label="Provenance" value={E.source} />
         </div>
       </Panel>
+
+      <MetricInspectorDrawer
+        open={drillOpen}
+        onClose={() => setDrillOpen(false)}
+        title="RUL calibration — unit-level rows"
+        description="Per-cycle calibration for the representative FD001 engine: point prediction, the 80/90% conformal bounds, the true label, and the per-point coverage hit. Computed-artifact + replay fixture, not live serving."
+        fields={[
+          { label: "Unit", value: "FD001-representative (replay)" },
+          { label: "Source kind", value: "computed-artifact (conformal bands) + fixture (per-cycle replay)" },
+          { label: "Cycles", value: TRAJ.length },
+          { label: "Flip status / gate decision (per cycle)", value: "not applicable here — the 100-unit gate-flip aggregate is on the Evidence RUL conformal card" },
+        ]}
+      >
+        <div style={{ marginTop: 14 }}>
+          <SourceRowsTable
+            kind="fixture"
+            columns={DRILL_COLS}
+            rows={drillRows()}
+            sourceLabel="FD001 representative engine (replay) · bands = real conformal quantiles"
+            filterContext="one representative engine, all observed cycles"
+            exportName="rul_calibration_unit_rows"
+          />
+        </div>
+      </MetricInspectorDrawer>
 
       <DisclosureFooter />
     </div>


### PR DESCRIPTION
Phase 8 / **PR 8E** (plan `0012`, RUL Calibration). **Frontend-only, no backend, no deploy** — the RUL evidence is a committed artifact (FD001 conformal scalars + a replay-fixture trajectory), not a `tel_*` table, so CSV-only. `RulCalibration.tsx` only; reuses the 8A `MetricInspectorDrawer` + `SourceRowsTable`.

## Layout changes
- Widened the container (`maxWidth 1180 → 1320`) and the trajectory chart (`720×300 → 900×340`, `minWidth 520 → 640`) for a less cramped, more scannable page. No caveat obscured; no site-wide redesign.

## Source-kind treatment
A chip + line: the **FD001 scalars + conformal bands are a computed evidence artifact**; the **per-cycle trajectory is a replay fixture**; **not live serving**. (The header already carried "Replay / evidence artifact".)

## Unit-level drill — fields exposed
"Unit-level rows + export ›" → `MetricInspectorDrawer` + `SourceRowsTable` over the representative engine's per-cycle rows: **unit · cycle · true_rul · point_pred · lo80 · hi80 · lo90 · hi90 · covered_80 · covered_90**. `covered_*` is the per-point coverage hit **derived from the shown bands** (not fabricated). **Flip-status / gate-decision** are honestly marked **not-applicable here** — the 100-unit gate-flip aggregate lives on the Evidence RUL conformal card (untouched). `null_reason` for that field.

## Export behavior
- **CSV** of the displayed unit rows (`kind=fixture`, the same context shown). Enabled when rows present.
- **Server XLSX disabled** with a reason — there's no `tel_*` dataset for this committed artifact (honest; no fake server export).

## Evidence preserved (unchanged)
RMSE **17.33**, PHM **742.4**, 80% PICP **0.778**, 90% PICP **0.903**, the reliability table, the late-side miss rate, and every "not SOTA / honest calibration, not a guarantee" caveat. **The Spin-3 RUL conformal card (PICP 0.86 / 15-of-100) on the Evidence page is NOT touched** (out of scope). **Frozen-evidence 8/8 green.** No claim strengthened beyond measured coverage.

## Tests / results
- `RulCalibration.test.tsx` +1 (drill drawer → fixture source-kind, `covered_90` column, not-applicable flip/gate, CSV enabled); existing value/caveat tests intact. Full telemetry suite **220 passed**; typecheck + lint clean.

## Deploy
**None required** — frontend-only; no backend dataset (the artifact isn't a `tel_*` table).

## Scope
Only `RulCalibration.tsx` (+ its test). No Overview/Mission Control/Model Performance/Model Registry/Factory/Flight/Test-Runs/nav/schema/notebook/evidence-JSON touched. Rebased on main (no concurrent conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)