### PR TITLE
feat(telemetry-8f2): Flight Readiness — heatmap source-kind + CSV, z-explanation, honest weights null_reason

### DIFF
--- a/repo-b/src/components/telemetry/factory-ml/FactoryMlConsole.tsx
+++ b/repo-b/src/components/telemetry/factory-ml/FactoryMlConsole.tsx
@@ -9,7 +9,7 @@ import { C, EmptyState, Loading, Panel, Tag } from "../primitives";
 import { TelemetryPageHeader } from "../TelemetryPageHeader";
 import FactoryEvidenceDrawer from "./FactoryEvidenceDrawer";
 import FeatureImportancePanel from "./FeatureImportancePanel";
-import LayerHeatmap from "./LayerHeatmap";
+import LayerHeatmap, { HEATMAP_EXPORT_COLUMNS, heatmapExportRows } from "./LayerHeatmap";
 import NcrPanel from "./NcrPanel";
 import ReadinessGauge from "./ReadinessGauge";
 import RegistryPanel from "./RegistryPanel";
@@ -76,13 +76,26 @@ export default function FactoryMlConsole() {
                       </span>
                       <ExportToCsvButton filename="flight_readiness_vehicles" columns={cols} rows={rows}
                         label="Export readiness rows" />
+                      <span style={{ fontFamily: C.mono, fontSize: 10, color: C.faint }}>
+                        ingredients are counts; per-ingredient contribution weight is not published in the
+                        gold rollup (null_reason: weight_not_in_rollup)
+                      </span>
                     </div>
                   );
                 })()}
               </div>
             : <EmptyState label="readiness.json missing" hint="Re-run the export stage." />)}
           {section === "heatmap" && (data.heatmap
-            ? <LayerHeatmap data={data.heatmap} />
+            ? <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                <LayerHeatmap data={data.heatmap} />
+                <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+                  <span style={{ fontFamily: C.mono, fontSize: 10, color: C.faint }}>
+                    {SOURCE_KIND_LABEL.fixture} — public/labs/factory-ml/layer_heatmap.json
+                  </span>
+                  <ExportToCsvButton filename="layer_heatmap_cells" columns={HEATMAP_EXPORT_COLUMNS}
+                    rows={heatmapExportRows(data.heatmap)} label="Export heatmap cells" />
+                </div>
+              </div>
             : <EmptyState label="layer_heatmap.json missing" hint="Re-run the export stage." />)}
           {section === "model" && (data.importance
             ? <FeatureImportancePanel data={data.importance} onDrill={setDrill} />

--- a/repo-b/src/components/telemetry/factory-ml/LayerHeatmap.test.tsx
+++ b/repo-b/src/components/telemetry/factory-ml/LayerHeatmap.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+
+import { heatmapExportRows, HEATMAP_EXPORT_COLUMNS } from "./LayerHeatmap";
+import type { HeatmapExport } from "@/lib/lab/factoryMlData";
+
+const DATA: HeatmapExport = {
+  anchor_pair: ["TEST-HOTFIRE-2026-00041", "TEST-HOTFIRE-2026-00088"],
+  runs: [
+    { run_id: "TEST-HOTFIRE-2026-00041", pattern: "failed", scenario_id: "SCN-005",
+      cells: [{ w: 0, z: 0.2 }, { w: 1, z: 5.1 }] },
+    { run_id: "TEST-HOTFIRE-2026-00025", pattern: "false_positive", scenario_id: null,
+      cells: [{ w: 0, z: -0.4 }] },
+  ],
+};
+
+describe("heatmapExportRows (8F-2)", () => {
+  it("flattens to one long-form row per (run, window) cell with the anchor flag, no fabrication", () => {
+    const rows = heatmapExportRows(DATA);
+    expect(rows).toHaveLength(3); // 2 anchor cells + 1 other cell — exactly the cells shown
+    expect(HEATMAP_EXPORT_COLUMNS).toEqual(["run_id", "pattern", "scenario_id", "is_anchor", "window_w", "z"]);
+
+    const anchorCell = rows.find((r) => r.run_id === "TEST-HOTFIRE-2026-00041" && r.window_w === 1)!;
+    expect(anchorCell.is_anchor).toBe(true);
+    expect(anchorCell.z).toBe(5.1); // real z preserved, not clamped/rounded
+    expect(anchorCell.scenario_id).toBe("SCN-005");
+
+    // a non-anchor run: flag false, null scenario flattened to "" (no invented value)
+    const other = rows.find((r) => r.run_id === "TEST-HOTFIRE-2026-00025")!;
+    expect(other.is_anchor).toBe(false);
+    expect(other.scenario_id).toBe("");
+    expect(other.pattern).toBe("false_positive");
+  });
+
+  it("returns no rows when there are no runs (fail-closed, nothing invented)", () => {
+    expect(heatmapExportRows({ anchor_pair: [], runs: [] })).toEqual([]);
+  });
+});

--- a/repo-b/src/components/telemetry/factory-ml/LayerHeatmap.tsx
+++ b/repo-b/src/components/telemetry/factory-ml/LayerHeatmap.tsx
@@ -9,6 +9,22 @@ import { useState } from "react";
 import { C, Panel, Tag } from "../primitives";
 import type { HeatmapExport } from "@/lib/lab/factoryMlData";
 
+// Long-form flatten for CSV export: one row per (run, window) cell — the exact cells shown.
+export const HEATMAP_EXPORT_COLUMNS = ["run_id", "pattern", "scenario_id", "is_anchor", "window_w", "z"];
+export function heatmapExportRows(data: HeatmapExport): Array<Record<string, unknown>> {
+  const anchorSet = new Set(data.anchor_pair);
+  const rows: Array<Record<string, unknown>> = [];
+  for (const run of data.runs) {
+    for (const cell of run.cells) {
+      rows.push({
+        run_id: run.run_id, pattern: run.pattern, scenario_id: run.scenario_id ?? "",
+        is_anchor: anchorSet.has(run.run_id), window_w: cell.w, z: cell.z,
+      });
+    }
+  }
+  return rows;
+}
+
 function zColor(z: number): string {
   // blue (calm) -> panel (neutral) -> red (agitated)
   const clamped = Math.max(-2.5, Math.min(2.5, z));
@@ -72,9 +88,11 @@ export default function LayerHeatmap({ data }: { data: HeatmapExport }) {
           </span>
         </div>
       )}
-      <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 10 }}>
-        Amber rows: the SCN-005 golden pair — the inconclusive run rhymes with the failed one
-        (shared PF-TPL-01 signature). Red cells: rolling variance well above fleet baseline.
+      <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 10, lineHeight: 1.6 }}>
+        Each cell is one layer-window&rsquo;s rolling-std z-score: 0 = fleet baseline, &gt;0 (red) = more
+        agitated, &lt;0 (blue) = calmer; the ±2.5 clamp is for color only. Amber rows: the SCN-005 golden
+        pair — the inconclusive run rhymes with the failed one (shared PF-TPL-01 signature). Click a row
+        for its pattern, scenario, and peak z.
       </div>
     </Panel>
   );


### PR DESCRIPTION
Phase 8 / **PR 8F-2** (plan `0012`, Flight Readiness) — completes 8F (8F-1 = NCR). **Frontend-only, no backend, no deploy** — the factory-ml console is fixture-backed (`public/labs/factory-ml/*.json`).

## Flight Readiness — source-kind & drill/export behavior
- **Source-kind:** fixture, labeled on **both** readiness (already) and now the **heatmap** (`layer_heatmap.json`). No live-row claim.
- **Readiness ingredients & drill:** the gauge already exposes the ingredient **counts** (open/blocking NCRs, inconclusive tests, unresolved anomalies, missing signoffs) and each vehicle drills via `FactoryEvidenceDrawer` (8A) — unchanged. Added an **honest null_reason**: per-ingredient **contribution weight is not published** in the gold rollup (`weight_not_in_rollup`) — no fabricated weights.
- **Export:** readiness CSV already existed; added **"Export heatmap cells"** CSV via a long-form flattener (`heatmapExportRows`) — one row per (run, window) cell: `run_id, pattern, scenario_id, is_anchor, window_w, z` (the **real z**, not the ±2.5 color clamp).

## Layer heat-map decision — KEPT (with reasoning)
It's **meaningful**: the SCN-005 golden-pair "rhyme" (`00088` inconclusive rhymes with `00041` failed via the shared PF-TPL-01 signature) is the whole argument for similarity-based anomaly review, and rows are already drillable (pattern / scenario / peak-z). It was missing only a source-kind label + export, now added. The caption now states exactly **what a cell means** (rolling-std z-score: 0 = fleet baseline, >0 red = agitated, <0 blue = calm; ±2.5 is color-only) and that rows are clickable. Not demoted, not replaced — no fabricated/“more convincing” values.

## Evidence preserved
Every frozen value unchanged: VEH-TR-003 `0.58` / yellow + its blockers (4 blocking NCRs, 11 inconclusive, 1 anomaly, 2 signoffs), the golden pair `00041`/`00088`, `defect_risk` pr_auc `0.84`, feature impact `0.331`, the AUC values. **No ML value changed; frozen-evidence 8/8.** No schema/backend/notebook/evidence-JSON change.

## Tests / results
- New `LayerHeatmap.test.tsx` (flattener: long-form rows, anchor flag, null scenario→"", empty→[]); existing `FactoryEvidenceDrawer.test.tsx` intact. Full telemetry suite **224 passed**; typecheck + lint clean.

## Deploy
**None required** — frontend-only.

## Scope
Only `FactoryMlConsole.tsx` + `LayerHeatmap.tsx` (+ new test). No NCR / Overview / Mission Control / Model / RUL / Test-Runs / nav / schema / notebook / evidence-JSON touched. Rebased on main (no concurrent conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)