### PR TITLE
feat(telemetry-8g1): Test Runs — source-kind, per-run drill, CSV export

### DIFF
--- a/repo-b/src/components/telemetry/RunsExplorer.test.tsx
+++ b/repo-b/src/components/telemetry/RunsExplorer.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+import RunsExplorer from "./RunsExplorer";
+import type { TestRun } from "@/lib/telemetry/api";
+
+const { getRuns } = vi.hoisted(() => ({ getRuns: vi.fn() }));
+
+vi.mock("@/lib/telemetry/api", () => ({
+  getRuns,
+  TELEMETRY_DEMO_ENV_ID: "telemetry-demo",
+  TELEMETRY_DEMO_BUSINESS_ID: "7e1eb000-0000-4000-a000-000000000001",
+}));
+
+const RUNS: TestRun[] = [
+  { id: "run-1", run_key: "iss_live:rul:FD001-unit-7", dataset: "C-MAPSS FD001",
+    unit_or_channel: "unit_7", spacecraft: null, row_count: 1234,
+    ingest_at: "2026-06-10T12:00:00Z", status: "ingested", created_at: "2026-06-10T11:59:00Z" },
+];
+
+describe("RunsExplorer (8G)", () => {
+  beforeEach(() => getRuns.mockReset());
+
+  it("labels the live source-kind and exports the displayed runs as CSV", async () => {
+    getRuns.mockResolvedValueOnce(RUNS);
+    render(<RunsExplorer />);
+    await waitFor(() => expect(screen.getByText("live rows · tel_test_runs")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /Export CSV/i })).not.toBeDisabled();
+  });
+
+  it("drills a run and fail-closes the absent run-link/model fields without fabricating a URL", async () => {
+    getRuns.mockResolvedValueOnce(RUNS);
+    render(<RunsExplorer />);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Inspect run iss_live:rul:FD001-unit-7/i })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /Inspect run iss_live:rul:FD001-unit-7/i }));
+    // drawer-unique field labels (present + the fail-closed run-link fields)
+    expect(screen.getByText("Run key")).toBeInTheDocument();
+    expect(screen.getByText("MLflow / Databricks run")).toBeInTheDocument();
+    expect(screen.getByText("Model / evidence artifact")).toBeInTheDocument();
+    // explicit null_reason, no fabricated run URL
+    expect(screen.getByText(/no run URL is fabricated/i)).toBeInTheDocument();
+  });
+
+  it("fail-closed: no runs disables the CSV export (no fake file)", async () => {
+    getRuns.mockResolvedValueOnce([]);
+    render(<RunsExplorer />);
+    await waitFor(() => expect(screen.getByText(/0 runs/i)).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /Export CSV/i })).toBeDisabled();
+  });
+});

--- a/repo-b/src/components/telemetry/RunsExplorer.tsx
+++ b/repo-b/src/components/telemetry/RunsExplorer.tsx
@@ -4,10 +4,23 @@ import { useEffect, useState } from "react";
 import { getRuns, type TestRun, TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID } from "@/lib/telemetry/api";
 import { C, Tag, Panel, Loading, ErrorState, DisclosureFooter, ResponsiveSwap, RowCard } from "./primitives";
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
+import { MetricInspectorDrawer } from "./drawerPrimitives";
+import { ExportToCsvButton } from "./drill";
+
+// CSV/drill row grain = exactly the ingested test-run fields (no fabricated run-link/model columns).
+const RUN_COLS = ["id", "run_key", "dataset", "unit_or_channel", "spacecraft", "row_count", "status", "ingest_at", "created_at"];
+function runRows(runs: TestRun[]): Array<Record<string, unknown>> {
+  return runs.map((r) => ({
+    id: r.id, run_key: r.run_key, dataset: r.dataset, unit_or_channel: r.unit_or_channel,
+    spacecraft: r.spacecraft ?? "", row_count: r.row_count, status: r.status,
+    ingest_at: r.ingest_at ?? "", created_at: r.created_at,
+  }));
+}
 
 export default function RunsExplorer() {
   const [runs, setRuns] = useState<TestRun[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [drillRun, setDrillRun] = useState<TestRun | null>(null);
 
   useEffect(() => {
     getRuns(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID).then(setRuns).catch((e) => setError(String(e)));
@@ -22,12 +35,20 @@ export default function RunsExplorer() {
   return (
     <>
       {heading}
-      <Panel title="Ingested test runs" right={<Tag color={C.cyan}>{runs.length} runs</Tag>}>
+      <Panel title="Ingested test runs"
+        right={
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+            <Tag color={C.cyan}>live rows · tel_test_runs</Tag>
+            <Tag color={C.dim}>{runs.length} runs</Tag>
+            <ExportToCsvButton filename="telemetry_test_runs" columns={RUN_COLS} rows={runRows(runs)}
+              label="Export CSV" disabled={runs.length === 0} disabledReason="No runs ingested" />
+          </div>
+        }>
         <ResponsiveSwap
           mobile={
             <div style={{ maxHeight: 560, overflowY: "auto", display: "flex", flexDirection: "column", gap: 8 }}>
               {runs.map((r) => (
-                <RowCard key={r.id} title={r.run_key}
+                <RowCard key={r.id} title={r.run_key} onClick={() => setDrillRun(r)}
                   tags={<><Tag color={C.dim}>{r.dataset}</Tag><Tag color={C.green}>{r.status}</Tag></>}
                   fields={[
                     { label: "Unit / craft", value: `${r.unit_or_channel}${r.spacecraft ? ` · ${r.spacecraft}` : ""}` },
@@ -44,23 +65,57 @@ export default function RunsExplorer() {
               </div>
               <div style={{ borderTop: `1px solid ${C.border}`, maxHeight: 560, overflowY: "auto" }}>
                 {runs.map((r) => (
-                  <div key={r.id} style={{ display: "grid", gridTemplateColumns: grid, gap: 8, alignItems: "center",
-                    fontFamily: C.mono, fontSize: 12, color: C.text, padding: "8px 0", borderBottom: `1px solid ${C.border}` }}>
+                  <button key={r.id} type="button" onClick={() => setDrillRun(r)}
+                    aria-label={`Inspect run ${r.run_key}`}
+                    style={{ display: "grid", gridTemplateColumns: grid, gap: 8, alignItems: "center", width: "100%",
+                      textAlign: "left", cursor: "pointer", background: "transparent", border: "none",
+                      borderBottom: `1px solid ${C.border}`,
+                      fontFamily: C.mono, fontSize: 12, color: C.text, padding: "8px 0" }}>
                     <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{r.run_key}</span>
                     <span style={{ color: C.dim }}>{r.dataset}</span>
                     <span style={{ color: C.dim }}>{r.unit_or_channel}{r.spacecraft ? ` · ${r.spacecraft}` : ""}</span>
                     <span>{r.row_count.toLocaleString()}</span>
                     <span><Tag color={C.green}>{r.status}</Tag></span>
-                  </div>
+                  </button>
                 ))}
               </div>
             </>
           } />
         <div style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, marginTop: 12 }}>
           Runs served from the Supabase serving layer (tel_test_runs). Row counts are the real ingested
-          window counts from Databricks Gold.
+          window counts from Databricks Gold. Click a run to inspect its fields and export.
         </div>
       </Panel>
+
+      <MetricInspectorDrawer
+        open={drillRun !== null}
+        onClose={() => setDrillRun(null)}
+        title={drillRun ? drillRun.run_key : "Test run"}
+        description="One ingested test run from the serving layer (tel_test_runs). This is a data-ingest run — model/training run identifiers (MLflow, Databricks, model + evidence artifacts) are not carried on this grain and fail-closed below, never fabricated."
+        fields={drillRun ? [
+          { label: "Run id", value: drillRun.id },
+          { label: "Run key", value: drillRun.run_key },
+          { label: "Dataset", value: drillRun.dataset },
+          { label: "Unit / channel", value: drillRun.unit_or_channel },
+          { label: "Spacecraft", value: drillRun.spacecraft },
+          { label: "Row count", value: drillRun.row_count.toLocaleString() },
+          { label: "Status", value: drillRun.status },
+          { label: "Ingested at", value: drillRun.ingest_at },
+          { label: "Created at", value: drillRun.created_at },
+          { label: "Run type / model kind", value: null },
+          { label: "MLflow / Databricks run", value: null },
+          { label: "Model / evidence artifact", value: null },
+        ] : []}
+      >
+        {drillRun && (
+          <div style={{ marginTop: 12, fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.55 }}>
+            null_reason: run-type, model kind, MLflow/Databricks run, and model/evidence artifact are not on
+            the ingest-run grain (tel_test_runs records the ingested window, not a training/scoring run). The
+            run_key above is the copyable identifier; no run URL is fabricated.
+          </div>
+        )}
+      </MetricInspectorDrawer>
+
       <DisclosureFooter />
     </>
   );


### PR DESCRIPTION
Phase 8 / **PR 8G-1** (plan `0012`, Test Runs). **Frontend-only, no backend, no deploy** — `RunsExplorer.tsx` is **live-rows**-backed (`/api/telemetry/runs` → `tel_test_runs`); the row grain carries no run links, so CSV satisfies the minimum. Reuses the 8A `MetricInspectorDrawer` + `ExportToCsvButton`. `RunsExplorer.tsx` only. *(8G split: this is Test Runs; Run Autopsy / Review = 8G-2 if warranted.)*

## Inventory (route-first)
| Surface | Route | Nav | Source kind | Run links on grain |
|---|---|---|---|---|
| **RunsExplorer** (this PR) | `/telemetry/runs` | **visible** | **live-rows** (`tel_test_runs`) | **none** — `{id, run_key, dataset, unit_or_channel, spacecraft, row_count, ingest_at, status, created_at}`; no mlflow/Databricks/artifact/evidence fields |
| RunAutopsy | `/telemetry/data-engineering/autopsy` | hidden-but-resolving | data-engineering receipts (not test runs) | out of demo scope — **not revived** |
| ReplayForensicsDrawer | embedded (replay) | n/a | computed-artifact/fixture; already has lineage + workspace links + honest nulls | separate surface — **untouched** (candidate 8G-2) |

## Source-kind treatment
A **"live rows · tel_test_runs"** chip + run count + CSV button in the panel header.

## Drill-through behavior + fields
Every run row (desktop **and** mobile) is clickable → `MetricInspectorDrawer` exposing the **present** fields (run id, run key, dataset, unit/channel, spacecraft, row count, status, ingested-at, created-at) and **fail-closing the absent** ones — **run-type/model-kind**, **MLflow/Databricks run**, **model/evidence artifact** — with an explicit `null_reason` (`tel_test_runs` is the ingested window, not a training/scoring run).

## Run/artifact links + unavailable behavior
**None invented** — the grain has no run identifiers. The **run_key is the copyable id**; the absent link fields render fail-closed "Not available" + null_reason. Honors "id without a resolvable URL → copyable id + unavailable, never a fabricated URL."

## Export behavior
**CSV** of the displayed runs (the exact ingest fields), **disabled-with-reason** when none ingested. No server XLSX (operational ingest rows; CSV is the honest minimum — no backend/deploy).

## Evidence preserved
Existing `tel_test_runs` provenance note kept. **No ML value changed; frozen-evidence 8/8.** No schema/backend/notebook/evidence-JSON change. **Nav unchanged** — no hidden Data Engineering page resurrected.

## Tests / results
- New `RunsExplorer.test.tsx` (source-kind + CSV; fail-closed record drill with no fabricated URL; empty → CSV disabled). Full telemetry suite **227 passed**; typecheck + lint clean.

## Deploy
**None required** — frontend-only.

## Scope
Only `RunsExplorer.tsx` (+ test). No Overview/Mission Control/Model/RUL/Factory/Flight/nav/schema/notebook/evidence-JSON touched. Rebased on main (no concurrent conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)