### PR TITLE
feat(telemetry-8h2): remove the Automated Data Engineering rail cross-link

### DIFF
--- a/repo-b/src/components/telemetry/TelemetrySidebar.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetrySidebar.test.tsx
@@ -25,4 +25,10 @@ describe("TelemetrySidebar — 6-section rail", () => {
       expect(screen.getAllByRole("link", { name: new RegExp(`^${label}$`, "i") }).length).toBeGreaterThanOrEqual(1);
     }
   });
+
+  it("no longer renders the Automated Data Engineering rail cross-link (8H — telemetry-only rail)", () => {
+    render(<TelemetrySidebar envId="env-1" />);
+    expect(screen.queryByRole("link", { name: /Automated Data Engineering/i })).toBeNull();
+    // the route itself is NOT asserted here — it still resolves directly for deep links.
+  });
 });

--- a/repo-b/src/components/telemetry/TelemetrySidebar.tsx
+++ b/repo-b/src/components/telemetry/TelemetrySidebar.tsx
@@ -64,19 +64,9 @@ export default function TelemetrySidebar({ envId, onNavigate }: { envId: string;
         </div>
         );
       })}
-      {/* Cross-surface link: the ADE control room is its own portable package mounted in this env. */}
-      <div style={{ fontFamily: C.mono, fontSize: 9, letterSpacing: "0.16em", color: C.faint,
-        textTransform: "uppercase", padding: "14px 10px 4px" }}>
-        Platform
-      </div>
-      <Link href={`/lab/env/${envId}/automated-data-engineering`} onClick={onNavigate}
-        style={{ display: "flex", alignItems: "center", gap: 10, textDecoration: "none",
-          minHeight: 40, padding: "9px 10px", borderRadius: 7, color: C.dim }}>
-        <svg width="15" height="15" viewBox="0 0 16 16" style={{ flexShrink: 0 }}>
-          <path d="M2 3h4v4H2zM10 9h4v4h-4zM6 5h4M8 5v4M8 11H6" stroke={C.faint} strokeWidth="1.3" fill="none" strokeLinejoin="round" />
-        </svg>
-        <span style={{ fontFamily: C.mono, fontSize: 12 }}>Automated Data Engineering</span>
-      </Link>
+      {/* The Automated Data Engineering control room is its own portable product; its rail cross-link was
+          removed (8H) to keep the telemetry sidebar telemetry-only. The /automated-data-engineering route
+          still resolves directly for deep links. */}
     </nav>
   );
 }


### PR DESCRIPTION
Phase 8 / **PR 8H-2** (plan 0012). Owner decisions from the 8H-1 inventory: **keep Agent Control Tower visible** (no change), **remove the ADE "Platform" sidebar cross-link**. Frontend-only, no deploy. `TelemetrySidebar.tsx` only.

- Removed the "Platform / Automated Data Engineering" cross-link (+ its now-unused section label) from the telemetry rail so the sidebar is **telemetry-only**. The `/lab/env/[envId]/automated-data-engineering` route **still resolves directly** for deep links — link removed, route untouched (hide-before-delete).
- `Link` import stays used (nav items); no other change.

**Tests:** `TelemetrySidebar.test.tsx` +1 (the ADE rail link is gone; route not asserted — still resolves); existing sidebar + nav tests intact (9). No ML value changed; **frozen-evidence 8/8**. No schema/backend/route/evidence-JSON change; no other page touched.

**Deploy:** none required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)