### PR TITLE
fix(telemetry-9a-c): fail-closed product copy for raw exception/JSON warts

### DIFF
--- a/repo-b/src/components/telemetry/ModelEvidenceCard.tsx
+++ b/repo-b/src/components/telemetry/ModelEvidenceCard.tsx
@@ -77,7 +77,10 @@ function ModelCard({ m, psi }: { m: ModelRun; psi: number | null }) {
       </div>
       {gateEntries.length > 0 ? (
         gateEntries.map(([k, v]) => (
-          <MetricRow key={k} label={k} value={typeof v === "object" ? JSON.stringify(v) : String(v)} />
+          <MetricRow key={k} label={k}
+            value={v !== null && typeof v === "object"
+              ? Object.entries(v as Record<string, unknown>).map(([kk, vv]) => `${kk} ${vv}`).join(" · ")
+              : String(v)} />
         ))
       ) : (
         <MetricRow label="gate" value="—" />

--- a/repo-b/src/components/telemetry/RegistryConsole.test.tsx
+++ b/repo-b/src/components/telemetry/RegistryConsole.test.tsx
@@ -19,7 +19,7 @@ const champion: RegistryModel = {
   metrics: {
     f1: 0.6387, f1_pointwise: 0.312953, event_recall: 0.769231,
     alarm_precision: 0.3279, affiliation_f1: 0.474634,
-    vus_status: "pending: import failed",
+    vus_status: "pending: import failed (ModuleNotFoundError: No module named 'vus')",
     honest_gate: {
       thresholds: { f1_pointwise: 0.10, affiliation_f1: 0.25 },
       values: { f1_pointwise: 0.312953, affiliation_f1: 0.474634 },
@@ -73,7 +73,10 @@ describe("RegistryConsole rendering", () => {
     expect(promote).toBeDisabled();
     expect(screen.getByText(/none registered/)).toBeInTheDocument();                 // challenger absent → explicit
     expect(screen.getByText(/null_reason: no non-promoted run/)).toBeInTheDocument();
-    expect(screen.getByText(/pending: import failed/)).toBeInTheDocument();   // honest VUS status
+    // VUS status is honest but shown as fail-closed product copy, not a raw Python traceback (9A-C).
+    expect(screen.getByText(/optional VUS library not installed/)).toBeInTheDocument();
+    expect(screen.queryByText(/ModuleNotFoundError/)).toBeNull();
+    expect(screen.queryByText(/pending: import failed/)).toBeNull();
   });
 
   it("links the run, fails closed on the UC model link, marks absent metadata, and exports (8D-2)", async () => {

--- a/repo-b/src/components/telemetry/RegistryConsole.tsx
+++ b/repo-b/src/components/telemetry/RegistryConsole.tsx
@@ -115,6 +115,14 @@ function num(v: unknown): number | null {
   return typeof v === "number" && Number.isFinite(v) ? v : null;
 }
 
+// vus_status is a captured Python exception string (e.g. "pending: import failed (ModuleNotFoundError:
+// No module named 'vus')"). Map it to fail-closed product copy so the limitation stays visible but the
+// raw traceback never reaches the screen.
+function vusUnavailableReason(status: string): string {
+  if (status.includes("import failed")) return "optional VUS library not installed";
+  return "VUS computation unavailable in this environment";
+}
+
 function MetricBars({ label, higherBetter, champ, chall }: {
   label: string; higherBetter: boolean; champ: number | null; chall: number | null;
 }) {
@@ -276,8 +284,8 @@ export default function RegistryConsole() {
               Anomaly quality is reported range-aware (affiliation F1) beside the honest point-wise
               metrics; the point-adjusted legacy F1 is shown last and labeled inflated.
               {typeof vusStatus === "string" && vusStatus.startsWith("pending") && (
-                <> VUS-PR/ROC: <span style={{ color: RS.amber }}>{vusStatus}</span> — shown only when a
-                vetted library computes them.</>
+                <> VUS-PR/ROC: <span style={{ color: RS.amber }}>unavailable in this environment</span>{" "}
+                (null_reason: {vusUnavailableReason(vusStatus)}). Shown only when a vetted library computes them.</>
               )}
             </div>
           </RsPanel>


### PR DESCRIPTION
Phase 9A Workstream C. Frontend-only render fixes; no backend, no DB, no evidence-JSON, no deploy.

- **Model Registry vus wart:** the VUS-PR caption rendered a raw captured Python exception verbatim (`pending: import failed (ModuleNotFoundError: No module named 'vus')`). Now mapped to fail-closed product copy: *"VUS-PR/ROC: unavailable in this environment (null_reason: optional VUS library not installed). Shown only when a vetted library computes them."* The limitation stays visible and intentional; the traceback no longer reaches the screen. Stray em dash in that sentence removed.
- **ModelEvidenceCard gate JSON (Evidence page = demo deep-link):** promotion-gate entries with object values rendered raw `JSON.stringify`; now a readable `key value · key value` join.
- **Left intentional patterns untouched:** `MetricLineageExplorer` already wraps fetch errors in a null_reason + retry product frame (raw message is a subordinate "Detail:"); the standalone `—` empty-value placeholders are an established in-app UI convention, not exception strings.

**Tests:** RegistryConsole.test asserts the product copy + that `ModuleNotFoundError` / `pending: import failed` are NOT rendered (fixture now carries the realistic full traceback). Full telemetry suite **225**; typecheck + lint clean; **frozen-evidence 8/8** (no ML value changed). Deploy: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)