### PR TITLE
feat(telemetry-9b): Overview era backdrop on Bottleneck Map selection

### DIFF
--- a/docs/plans/03-implementation-plans/active/0014-telemetry-phase-9b-overview-backdrop-and-sidebar.md
+++ b/docs/plans/03-implementation-plans/active/0014-telemetry-phase-9b-overview-backdrop-and-sidebar.md
@@ -1,0 +1,43 @@
+# 0014 — Telemetry Phase 9B: Overview Event Backdrop + Sidebar Icon-Rail
+
+Status: **9B-A shipped**, 9B-B planned. Two independently shippable PRs.
+
+## Why
+
+The telemetry Overview opens the demo with an editorial thesis and the Spaceflight Bottleneck Map. Two
+presentation-layer polishes, over existing/correct data and routing — no backend, schema, evidence, or
+export change:
+
+- **9B-A.** When a Bottleneck Map event is selected, the hero band transitions to an era-appropriate
+  illustrative backdrop (streaming-detail-preview polish, aerospace language — "Era context",
+  "Backdrop: illustrative"). Click/selection-driven only.
+- **9B-B.** The left rail becomes a grouped icon system: each group its own icon row, multi-item groups
+  collapsible (one open by default), and the whole rail collapses to an icon-only column.
+
+## PR 9B-A — Overview event backdrop (shipped)
+
+- `context/BottleneckMap/types.ts` — `EventBackdrop` interface; optional `LaunchEvent.backdrop`.
+- `context/BottleneckMap/data.ts` — `THEME_BACKDROPS` (keyed off `InnovationKey`, tones echo
+  `INNOVATION`) + `resolveBackdrop(event)` (per-event override → era theme → null).
+- `public/telemetry/backdrops/{mission,cost,reuse,manufacturing,dataops}.svg` + `README.md` —
+  hand-authored abstract vector motifs, labeled illustrative/generative (not photos, not evidence).
+- `OverviewBackdrop.tsx` + `.module.css` — base wash + keyed fade theme layer (`role="img"` + alt) +
+  scrim + honesty caption. **Scrim reaches full `C.bg` before the chart, so the Bottleneck Map plotting
+  area is never behind the backdrop** (contrast and selected-dot emphasis unchanged). CSS background
+  (not `<img>`) → missing asset degrades to the tone wash, no broken-image glyph. Motion CSS-only,
+  respects `prefers-reduced-motion`.
+- `BottleneckMap.tsx` — additive optional `onSelectedEventChange` callback (fires on mount + every
+  click/presenter change).
+- `TelemetryOverview.tsx` — holds `selectedEvent`, renders backdrop behind hero (zIndex 0), content at
+  zIndex 1. `SourceHonestyStrip`/`EventRecord` unchanged — no metric/evidence value moves.
+- Tests: `context/BottleneckMap/backdrop.test.ts`, `OverviewBackdrop.test.tsx`, extended
+  `TelemetryOverview.test.tsx`. Green: vitest, `tsc -p tsconfig.typecheck.json`, `next lint`.
+
+## PR 9B-B — Sidebar grouped icon rail (planned)
+
+Base on post-8H `main` (the ADE cross-link is already removed; **do not restore it**). Group icon
+metadata in `telemetryNav.ts`; accordion + collapse rewrite in `TelemetrySidebar.tsx`; collapse state +
+animated rail width (64↔224) + localStorage hydration in `TelemetryShell.tsx`. Collapsed group icons are
+buttons that expand the rail and open the group (no immediate navigation). Operations open by default;
+colors preserved; mobile drawer unchanged. Tests update `TelemetrySidebar.test.tsx` to the new contract
+(routability preserved by expanding groups) + an 8H regression guard asserting the ADE link stays absent.

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4609,3 +4609,31 @@ The telemetry nav was already hide-before-deleted in earlier phases, and **`tele
 ## A docs-only acceptance pass without a browser captures route notes, not fake screenshots (8I)
 
 No Playwright/screenshot tool in this env → the acceptance pass verifies routes by (a) **route file exists on disk** ⇒ the Next.js route resolves, and (b) render proven by the **component test suite** — never fabricate screenshots. Live prod posture is checkable headless: `/api/version` (SHA), `verify_lineage.py --base https://novendor.ai` (6/1/0 honest WARN posture), and the XLSX routes through the proxy (`model_runs` 200/rows, `anomaly_events` 200/header-only when the consumer is cold, unknown→404+null_reason). Validate the XLSX bytes with `openpyxl` — but print **ASCII only**: the Windows cp1252 console throws `UnicodeEncodeError` on `→`/`·` in a `python -c` print, which looks like a failure but isn't.
+
+---
+
+## Telemetry Overview era backdrop (Phase 9B-A, 2026-06-26)
+
+Lessons from making the Overview hero background follow the selected Bottleneck Map event:
+
+- **Surface internal component state with an additive optional callback, not a refactor.** `BottleneckMap`
+  owns `selected` privately; exposing it to the Overview was one prop + `useEffect(() => onSelectedEventChange?.(selected), [selected, onSelectedEventChange])`. Default-`{}` param means existing call sites and the mocked Overview test are untouched.
+- **Decorative imagery should use a CSS `background-image`, never an `<img>`.** A missing/renamed asset
+  then degrades to a tone wash instead of a broken-image glyph — the "no broken image" requirement is
+  satisfied structurally, not by error handling.
+- **Tie atmosphere to an existing semantic dimension.** Backdrops key off `event.type` (`InnovationKey`)
+  via `THEME_BACKDROPS` + `resolveBackdrop()` (override → theme → null), so 17 events get relevant
+  visuals from 5 assets with no per-event config, and the mapping is stable across the chart's color-by
+  toggle.
+- **Don't let a backdrop bleed under a chart.** The scrim gradient reaches full page-bg opacity *above*
+  where the chart starts (`height: min(60vh, 560px)` band + `…#070b11 100%`), keeping plot contrast and
+  the selected-dot emphasis unchanged. Looks-cool full-bleed hurts live explanation.
+- **Motion stays CSS-only** (no `useReducedMotion`, no `matchMedia` in JS) — a `.module.css`
+  `@media (prefers-reduced-motion: reduce)` guard plus the global guard neutralize the fade. Tests then
+  assert content (alt/label) renders independent of animation, dodging jsdom `matchMedia` stubs.
+- **Vector SVGs are committable "images."** Hand-authored abstract SVGs satisfy "commit illustrative
+  images" with zero binary/licensing/mass-asset concern (text, diff-able) and scale cleanly under
+  `background-size: cover`.
+- **Repo gotcha:** the CI typecheck is `tsc --noEmit -p tsconfig.typecheck.json` (excludes test files);
+  a bare `tsc --noEmit` surfaces unrelated pre-existing test-file errors (historyrhymes, replay
+  diagnostics) — judge by the `tsconfig.typecheck.json` run.

--- a/repo-b/public/telemetry/backdrops/README.md
+++ b/repo-b/public/telemetry/backdrops/README.md
@@ -1,0 +1,21 @@
+# Overview era backdrops (Phase 9B)
+
+These SVGs are **illustrative, generative vector art** — abstract aerospace motifs authored by hand,
+one per Bottleneck Map innovation era. They are **not historical photographs** and carry **no
+evidentiary meaning**. The Overview hero renders them behind a dark scrim purely to set era atmosphere;
+every backdrop is labeled "Backdrop: illustrative · generative asset" in the UI.
+
+| File | Era (`InnovationKey`) | Tone | Motif |
+|---|---|---|---|
+| `mission.svg` | mission | blue | analog launch pad + telemetry-room beep traces |
+| `cost.svg` | cost | green | descending cost curve + downward booster |
+| `reuse.svg` | reuse | amber | reusable-booster recovery arcs + landing pad |
+| `manufacturing.svg` | manufacturing | violet | additive-manufacturing lattice + inspection grid |
+| `dataops.svg` | dataops | cyan | dense signal field + mission-control glass |
+
+Mapping and fallback live in `repo-b/src/components/telemetry/context/BottleneckMap/data.ts`
+(`THEME_BACKDROPS`, `resolveBackdrop`). A missing/renamed asset degrades to the `tone` wash — the
+component uses a CSS `background-image`, never an `<img>`, so there is no broken-image state.
+
+Safe to relabel or replace with other licensed/curated assets later; keep the illustrative labeling and
+never imply a backdrop is a real photo of the event.

--- a/repo-b/public/telemetry/backdrops/cost.svg
+++ b/repo-b/public/telemetry/backdrops/cost.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Illustrative cost-decline and reusable-booster motif">
+  <defs>
+    <radialGradient id="c-bg" cx="30%" cy="30%" r="90%">
+      <stop offset="0%" stop-color="#0e2419"/>
+      <stop offset="55%" stop-color="#091611"/>
+      <stop offset="100%" stop-color="#05080e"/>
+    </radialGradient>
+    <linearGradient id="c-fill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#6ee7a0" stop-opacity="0.22"/>
+      <stop offset="100%" stop-color="#6ee7a0" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#c-bg)"/>
+  <!-- faint grid -->
+  <g stroke="#6ee7a0" stroke-opacity="0.08" stroke-width="1">
+    <line x1="0" y1="240" x2="1600" y2="240"/><line x1="0" y1="450" x2="1600" y2="450"/><line x1="0" y1="660" x2="1600" y2="660"/>
+  </g>
+  <!-- descending cost curve -->
+  <path d="M120 180 C 360 200, 470 520, 720 620 S 1180 770, 1500 800 L 1500 880 L 120 880 Z" fill="url(#c-fill)"/>
+  <path d="M120 180 C 360 200, 470 520, 720 620 S 1180 770, 1500 800" fill="none" stroke="#6ee7a0" stroke-opacity="0.6" stroke-width="3"/>
+  <!-- step markers -->
+  <g fill="#6ee7a0" fill-opacity="0.5">
+    <circle cx="120" cy="180" r="6"/><circle cx="720" cy="620" r="6"/><circle cx="1500" cy="800" r="6"/>
+  </g>
+  <!-- downward arrow -->
+  <g stroke="#6ee7a0" stroke-opacity="0.45" stroke-width="3" fill="none">
+    <line x1="1280" y1="300" x2="1280" y2="560"/>
+    <polyline points="1250,520 1280,575 1310,520"/>
+  </g>
+</svg>

--- a/repo-b/public/telemetry/backdrops/dataops.svg
+++ b/repo-b/public/telemetry/backdrops/dataops.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Illustrative mission-control dense-signal-field motif">
+  <defs>
+    <radialGradient id="d-bg" cx="42%" cy="30%" r="92%">
+      <stop offset="0%" stop-color="#0b2a31"/>
+      <stop offset="55%" stop-color="#08171c"/>
+      <stop offset="100%" stop-color="#05080e"/>
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#d-bg)"/>
+  <!-- dense signal field -->
+  <g fill="none" stroke="#67e8f9" stroke-opacity="0.32" stroke-width="1.6">
+    <polyline points="0,300 160,300 200,250 280,250 320,330 440,330 480,270 600,270 640,300 1600,300"/>
+    <polyline points="0,420 220,420 260,380 360,380 400,470 520,470 560,410 700,410 740,440 1600,440"/>
+    <polyline points="0,540 140,540 180,500 300,500 340,590 460,590 500,520 660,520 700,560 1600,560"/>
+    <polyline points="0,660 240,660 280,620 380,620 420,700 560,700 600,640 760,640 800,670 1600,670"/>
+  </g>
+  <!-- mission-control glass panels -->
+  <g stroke="#67e8f9" stroke-opacity="0.4" stroke-width="2" fill="#67e8f9" fill-opacity="0.05">
+    <rect x="1120" y="200" width="320" height="150" rx="8"/>
+    <rect x="1120" y="380" width="150" height="150" rx="8"/>
+    <rect x="1290" y="380" width="150" height="150" rx="8"/>
+  </g>
+  <g fill="#67e8f9" fill-opacity="0.5"><circle cx="1140" cy="222" r="4"/><circle cx="1140" cy="402" r="4"/><circle cx="1310" cy="402" r="4"/></g>
+</svg>

--- a/repo-b/public/telemetry/backdrops/manufacturing.svg
+++ b/repo-b/public/telemetry/backdrops/manufacturing.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Illustrative additive-manufacturing inspection-grid motif">
+  <defs>
+    <radialGradient id="f-bg" cx="50%" cy="28%" r="95%">
+      <stop offset="0%" stop-color="#1e1733"/>
+      <stop offset="55%" stop-color="#120e20"/>
+      <stop offset="100%" stop-color="#05080e"/>
+    </radialGradient>
+    <pattern id="f-grid" width="64" height="64" patternUnits="userSpaceOnUse" patternTransform="rotate(0)">
+      <path d="M64 0 L0 0 0 64" fill="none" stroke="#A78BFA" stroke-opacity="0.16" stroke-width="1"/>
+    </pattern>
+  </defs>
+  <rect width="1600" height="900" fill="url(#f-bg)"/>
+  <rect width="1600" height="900" fill="url(#f-grid)"/>
+  <!-- additive lattice (hex-ish build cells) -->
+  <g stroke="#A78BFA" stroke-opacity="0.5" stroke-width="2" fill="#A78BFA" fill-opacity="0.06">
+    <path d="M900 360 l60 -34 60 34 0 68 -60 34 -60 -34 Z"/>
+    <path d="M1020 360 l60 -34 60 34 0 68 -60 34 -60 -34 Z"/>
+    <path d="M960 462 l60 -34 60 34 0 68 -60 34 -60 -34 Z"/>
+    <path d="M1080 462 l60 -34 60 34 0 68 -60 34 -60 -34 Z"/>
+  </g>
+  <!-- inspection scan line -->
+  <line x1="0" y1="560" x2="1600" y2="560" stroke="#A78BFA" stroke-opacity="0.4" stroke-width="2" stroke-dasharray="14 8"/>
+  <g fill="#A78BFA" fill-opacity="0.35">
+    <circle cx="300" cy="560" r="5"/><circle cx="620" cy="560" r="5"/><circle cx="980" cy="560" r="5"/>
+  </g>
+</svg>

--- a/repo-b/public/telemetry/backdrops/mission.svg
+++ b/repo-b/public/telemetry/backdrops/mission.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Illustrative analog launch-pad and telemetry-room motif">
+  <defs>
+    <radialGradient id="m-bg" cx="32%" cy="34%" r="85%">
+      <stop offset="0%" stop-color="#13243b"/>
+      <stop offset="55%" stop-color="#0a1320"/>
+      <stop offset="100%" stop-color="#05080e"/>
+    </radialGradient>
+    <linearGradient id="m-glow" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#6CA8F0" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#6CA8F0" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#m-bg)"/>
+  <!-- horizon -->
+  <rect x="0" y="640" width="1600" height="260" fill="url(#m-glow)"/>
+  <line x1="0" y1="640" x2="1600" y2="640" stroke="#6CA8F0" stroke-opacity="0.35" stroke-width="1.5"/>
+  <!-- launch gantry silhouette -->
+  <g stroke="#6CA8F0" stroke-opacity="0.5" stroke-width="3" fill="none">
+    <line x1="1180" y1="640" x2="1180" y2="150"/>
+    <line x1="1280" y1="640" x2="1280" y2="190"/>
+    <line x1="1180" y1="240" x2="1280" y2="210"/>
+    <line x1="1180" y1="350" x2="1280" y2="330"/>
+    <line x1="1180" y1="470" x2="1280" y2="455"/>
+    <path d="M1110 640 L1130 300 L1150 300 L1170 640 Z" fill="#6CA8F0" fill-opacity="0.10" stroke-opacity="0.4"/>
+  </g>
+  <!-- analog beep traces -->
+  <g stroke="#9fc4f5" stroke-opacity="0.5" stroke-width="2" fill="none">
+    <polyline points="120,730 240,730 260,700 290,700 310,730 520,730 540,760 580,760 600,730 820,730"/>
+    <polyline points="120,800 360,800 380,772 420,772 440,800 680,800 700,828 740,828 760,800 980,800"/>
+  </g>
+  <g fill="#6CA8F0" fill-opacity="0.25">
+    <circle cx="270" cy="700" r="4"/><circle cx="560" cy="760" r="4"/><circle cx="400" cy="772" r="4"/><circle cx="720" cy="828" r="4"/>
+  </g>
+</svg>

--- a/repo-b/public/telemetry/backdrops/reuse.svg
+++ b/repo-b/public/telemetry/backdrops/reuse.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Illustrative reusable-booster recovery motif">
+  <defs>
+    <radialGradient id="r-bg" cx="34%" cy="32%" r="90%">
+      <stop offset="0%" stop-color="#2a2012"/>
+      <stop offset="55%" stop-color="#16100a"/>
+      <stop offset="100%" stop-color="#05080e"/>
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#r-bg)"/>
+  <!-- recovery arcs (launch out, land back) -->
+  <g fill="none" stroke="#f5b452" stroke-opacity="0.45" stroke-width="2.5" stroke-dasharray="2 10" stroke-linecap="round">
+    <path d="M300 760 C 520 240, 980 240, 1180 720"/>
+    <path d="M340 780 C 560 340, 940 340, 1140 740"/>
+  </g>
+  <!-- booster silhouette -->
+  <g fill="#f5b452" fill-opacity="0.12" stroke="#f5b452" stroke-opacity="0.55" stroke-width="3">
+    <path d="M1140 720 L1140 360 Q1160 300 1180 360 L1180 720 Z"/>
+    <path d="M1140 720 L1110 790 L1140 760 Z"/>
+    <path d="M1180 720 L1210 790 L1180 760 Z"/>
+    <line x1="1160" y1="360" x2="1160" y2="300"/>
+  </g>
+  <!-- landing pad -->
+  <g stroke="#f5b452" stroke-opacity="0.4" stroke-width="2" fill="none">
+    <ellipse cx="1160" cy="800" rx="120" ry="22"/>
+    <line x1="1100" y1="800" x2="1220" y2="800"/><line x1="1160" y1="780" x2="1160" y2="820"/>
+  </g>
+</svg>

--- a/repo-b/src/components/telemetry/OverviewBackdrop.module.css
+++ b/repo-b/src/components/telemetry/OverviewBackdrop.module.css
@@ -1,0 +1,15 @@
+/* Overview era backdrop cross-fade (Phase 9B). Decorative only; the global
+   prefers-reduced-motion guard in globals.css also neutralizes this, but the
+   explicit guard keeps the behavior local and obvious. */
+.backdropFade {
+  animation: ob-fade 360ms ease both;
+}
+
+@keyframes ob-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .backdropFade { animation: none; }
+}

--- a/repo-b/src/components/telemetry/OverviewBackdrop.test.tsx
+++ b/repo-b/src/components/telemetry/OverviewBackdrop.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import OverviewBackdrop from "./OverviewBackdrop";
+import { THEME_BACKDROPS } from "./context/BottleneckMap/data";
+import type { DecoratedEvent, InnovationKey } from "./context/BottleneckMap/types";
+
+// Only the innovation `type` drives the backdrop; build a minimal event for the unit test.
+const ev = (type: InnovationKey): DecoratedEvent => ({ type } as unknown as DecoratedEvent);
+
+describe("OverviewBackdrop (Phase 9B)", () => {
+  it("renders the resolved era backdrop with its accessible label, image, and honesty caption", () => {
+    render(<OverviewBackdrop event={ev("mission")} />);
+    const layer = screen.getByRole("img", { name: THEME_BACKDROPS.mission.alt });
+    expect(layer.style.backgroundImage).toContain("/telemetry/backdrops/mission.svg");
+    expect(screen.getByText(/Backdrop: illustrative · generative asset/i)).toBeInTheDocument();
+  });
+
+  it("changes backdrop metadata when the selected event's era changes", () => {
+    const { rerender } = render(<OverviewBackdrop event={ev("mission")} />);
+    expect(screen.getByRole("img").getAttribute("aria-label")).toBe(THEME_BACKDROPS.mission.alt);
+    rerender(<OverviewBackdrop event={ev("dataops")} />);
+    const layer = screen.getByRole("img");
+    expect(layer.getAttribute("aria-label")).toBe(THEME_BACKDROPS.dataops.alt);
+    expect(layer.style.backgroundImage).toContain("/telemetry/backdrops/dataops.svg");
+  });
+
+  it("falls back safely with no event — no image layer, no broken image, no caption", () => {
+    const { container } = render(<OverviewBackdrop event={null} />);
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.queryByText(/Backdrop:/)).toBeNull();
+    expect(container.innerHTML).not.toContain("/telemetry/backdrops/");
+    expect(container.innerHTML).not.toContain('url("")');
+  });
+
+  it("keeps the fade decorative — content renders independent of motion (reduced-motion safe)", () => {
+    render(<OverviewBackdrop event={ev("reuse")} />);
+    const layer = screen.getByRole("img", { name: THEME_BACKDROPS.reuse.alt });
+    // The transition is a CSS class the prefers-reduced-motion media query neutralizes; the alt/content
+    // do not depend on it.
+    expect(layer.className).toMatch(/backdropFade/);
+    expect(screen.getByText(/Backdrop: illustrative · generative asset/i)).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/OverviewBackdrop.tsx
+++ b/repo-b/src/components/telemetry/OverviewBackdrop.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+// Overview era backdrop (Phase 9B). When a Bottleneck Map event is selected, the hero band behind the
+// thesis transitions to an illustrative, era-appropriate backdrop. Strictly decorative: a dark scrim
+// keeps text readable and fades fully to the page background BEFORE the chart begins, so the Bottleneck
+// Map always renders on flat C.bg with its contrast and selected-dot emphasis unchanged. A missing
+// asset degrades to the tone wash (CSS background-image, never an <img>), so there is no broken-image
+// state. Motion is CSS-only and respects prefers-reduced-motion.
+
+import { C } from "./primitives";
+import { resolveBackdrop } from "./context/BottleneckMap/data";
+import type { DecoratedEvent } from "./context/BottleneckMap/types";
+import styles from "./OverviewBackdrop.module.css";
+
+// Scrim: darken toward the page background; reach full C.bg opacity by the bottom so the band blends
+// into the flat background the chart sits on. Tuned to keep hero text well above WCAG AA.
+const SCRIM = "linear-gradient(180deg, rgba(7,11,17,0.62) 0%, rgba(7,11,17,0.86) 55%, #070b11 100%)";
+// Persistent fallback wash (no selection / no theme) — subtle, never a hard edge.
+const BASE = `linear-gradient(180deg, ${C.panel}55 0%, ${C.bg} 78%)`;
+
+export default function OverviewBackdrop({ event }: { event: DecoratedEvent | null }) {
+  const bd = resolveBackdrop(event);
+  // Key the fading layer on the resolved asset/era so a new selection replays the fade-in.
+  const themeKey = bd ? bd.image ?? `tone:${bd.tone}` : null;
+
+  return (
+    <div
+      style={{
+        position: "absolute", top: 0, left: 0, right: 0, height: "min(60vh, 560px)",
+        zIndex: 0, overflow: "hidden", pointerEvents: "none",
+      }}
+    >
+      {/* persistent base wash */}
+      <div style={{ position: "absolute", inset: 0, background: BASE }} />
+
+      {/* era theme layer — keyed so each selection cross-fades; carries the accessible label */}
+      {bd && (
+        <div
+          key={themeKey ?? undefined}
+          className={styles.backdropFade}
+          role="img"
+          aria-label={bd.alt}
+          data-testid="overview-backdrop-theme"
+          style={{
+            position: "absolute", inset: 0,
+            backgroundColor: `${bd.tone}14`,
+            backgroundImage: [
+              `radial-gradient(120% 95% at 28% 16%, ${bd.tone}33, transparent 60%)`,
+              bd.image ? `url("${bd.image}")` : null,
+            ].filter(Boolean).join(", "),
+            backgroundSize: "cover",
+            backgroundPosition: bd.focus ?? "center",
+            backgroundRepeat: "no-repeat",
+          }}
+        />
+      )}
+
+      {/* scrim for readability + fade to background before the chart */}
+      <div style={{ position: "absolute", inset: 0, background: SCRIM }} />
+
+      {/* honesty label — these assets are illustrative/generative, never evidence */}
+      {bd && (
+        <div
+          style={{
+            position: "absolute", right: 14, bottom: 12,
+            fontFamily: C.mono, fontSize: 10, letterSpacing: "0.08em", color: C.faint,
+          }}
+        >
+          Backdrop: illustrative · {bd.sourceKind} asset{bd.credit ? ` · ${bd.credit}` : ""}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
@@ -1,8 +1,16 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 
-// Stub the heavy Bottleneck Map (recharts) — its own tests cover its behavior.
-vi.mock("./context/BottleneckMap/BottleneckMap", () => ({ default: () => <div data-testid="bottleneck-map">charts</div> }));
+// Stub the heavy Bottleneck Map (recharts) — its own tests cover its behavior. The stub exposes a
+// button that fires onSelectedEventChange so the Overview→backdrop wiring (Phase 9B) is testable.
+vi.mock("./context/BottleneckMap/BottleneckMap", () => ({
+  default: ({ onSelectedEventChange }: { onSelectedEventChange?: (e: unknown) => void }) => (
+    <div data-testid="bottleneck-map">
+      charts
+      <button type="button" onClick={() => onSelectedEventChange?.({ type: "mission" })}>select mission event</button>
+    </div>
+  ),
+}));
 // The Overview reads envId from the route to build the demo bridge links.
 vi.mock("next/navigation", () => ({ useParams: () => ({ envId: "env-test" }) }));
 
@@ -50,6 +58,16 @@ describe("TelemetryOverview — thesis-led Overview", () => {
     // The null reason appears in the empty state and the disabled export reasons — good UX, multiple nodes.
     expect(screen.getAllByText(/Derived range/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /Export CSV/i })).toBeDisabled();
+  });
+
+  it("drives the Overview era backdrop from the selected Bottleneck Map event (Phase 9B)", () => {
+    render(<TelemetryOverview />);
+    // No backdrop before any selection — the hero keeps its plain background.
+    expect(screen.queryByText(/Backdrop: illustrative/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /select mission event/i }));
+    // The mission-era backdrop appears, labeled honestly as illustrative/generative.
+    expect(screen.getByText(/Backdrop: illustrative · generative asset/i)).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: /illustrative analog launch-pad/i })).toBeInTheDocument();
   });
 
   it("does not render the serving KPI strip, the Trace-lineage CTA, or Mission Summary scaffolding", () => {

--- a/repo-b/src/components/telemetry/TelemetryOverview.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.tsx
@@ -16,7 +16,9 @@ import { MetricInspectorDrawer } from "./drawerPrimitives";
 import { SourceRowsTable } from "./drill";
 import { telemetryHref } from "./telemetryNav";
 import BottleneckMap from "./context/BottleneckMap/BottleneckMap";
+import OverviewBackdrop from "./OverviewBackdrop";
 import { computeBigNumbers, type BigNumber, type BigNumberAccent } from "./context/BottleneckMap/data";
+import type { DecoratedEvent } from "./context/BottleneckMap/types";
 
 // Big Numbers accent → C palette. Rendered locally (not via the shared header metric row) so the
 // numerals can be materially larger narrative anchors without touching the shared header component.
@@ -111,6 +113,8 @@ export default function TelemetryOverview() {
     ? params.envId
     : Array.isArray(params?.envId) ? params.envId[0] : "";
   const [drillNum, setDrillNum] = useState<BigNumber | null>(null);
+  // Phase 9B: the Bottleneck Map reports its selected event up so the hero backdrop can follow it.
+  const [selectedEvent, setSelectedEvent] = useState<DecoratedEvent | null>(null);
 
   // Thesis-first: the dominant hero states the argument once (Big Numbers render below it as larger
   // narrative anchors, not in the header metric row), then the integrated Bottleneck Map carries it.
@@ -130,12 +134,16 @@ export default function TelemetryOverview() {
   );
 
   return (
-    <TelemetryPageShell heading={heading}>
-      <BigNumbersBand onDrill={setDrillNum} />
-      <BottleneckMap envId={envId} />
-      <SourceHonestyStrip />
-      {envId && <DemoBridge envId={envId} />}
-      <MetricInspectorDrawer
+    <div style={{ position: "relative" }}>
+      {/* Era backdrop sits behind the hero band only; the scrim fades to C.bg before the chart. */}
+      <OverviewBackdrop event={selectedEvent} />
+      <div style={{ position: "relative", zIndex: 1 }}>
+        <TelemetryPageShell heading={heading}>
+          <BigNumbersBand onDrill={setDrillNum} />
+          <BottleneckMap envId={envId} onSelectedEventChange={setSelectedEvent} />
+          <SourceHonestyStrip />
+          {envId && <DemoBridge envId={envId} />}
+          <MetricInspectorDrawer
         open={drillNum !== null}
         onClose={() => setDrillNum(null)}
         title={drillNum?.label ?? ""}
@@ -160,6 +168,8 @@ export default function TelemetryOverview() {
           </div>
         )}
       </MetricInspectorDrawer>
-    </TelemetryPageShell>
+        </TelemetryPageShell>
+      </div>
+    </div>
   );
 }

--- a/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.tsx
@@ -49,7 +49,13 @@ function NarrLine({ label, value }: { label: string; value: string }) {
   );
 }
 
-export default function BottleneckMap({ envId }: { envId?: string }) {
+export default function BottleneckMap(
+  { envId, onSelectedEventChange }: {
+    envId?: string;
+    /** Phase 9B: surface the selected/presented event so the Overview can drive its hero backdrop. */
+    onSelectedEventChange?: (e: DecoratedEvent | null) => void;
+  } = {},
+) {
   const [selectedId, setSelectedId] = useState<string | null>("terran1");
   const [chipFilter, setChipFilter] = useState<string | null>(null);
   const [sizeMode, setSizeMode] = useState<SizeModeKey>("scale");
@@ -83,6 +89,10 @@ export default function BottleneckMap({ envId }: { envId?: string }) {
     const base = presenting ? presenterEvent : EVENTS.find((e) => e.id === selectedId) ?? null;
     return base ? decorate(base, colorBy, sizeMode) : null;
   }, [selectedId, presenting, presenterEvent, colorBy, sizeMode]);
+
+  // Surface the active event to the parent (Overview hero backdrop). Additive and optional — fires on
+  // mount and on every click/presenter change.
+  useEffect(() => { onSelectedEventChange?.(selected); }, [selected, onSelectedEventChange]);
 
 
   // Presenter keyboard controls. Never captures keys when focus is inside a form field, and never

--- a/repo-b/src/components/telemetry/context/BottleneckMap/backdrop.test.ts
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/backdrop.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { EVENTS, THEME_BACKDROPS, resolveBackdrop } from "./data";
+import type { EventBackdrop, InnovationKey } from "./types";
+
+// Phase 9B — the Overview hero backdrop resolver. Pure mapping over the existing event model; no new
+// source claims, no evidence values.
+describe("resolveBackdrop (Phase 9B era backdrops)", () => {
+  it("returns null when no event is selected (Overview falls back to its gradient)", () => {
+    expect(resolveBackdrop(null)).toBeNull();
+  });
+
+  it("maps an event to its era theme backdrop by innovation type", () => {
+    const mission = EVENTS.find((e) => e.type === "mission")!;
+    expect(resolveBackdrop(mission)).toBe(THEME_BACKDROPS.mission);
+    const dataops = EVENTS.find((e) => e.type === "dataops")!;
+    expect(resolveBackdrop(dataops)).toBe(THEME_BACKDROPS.dataops);
+  });
+
+  it("lets a per-event backdrop override win over the era theme", () => {
+    const base = EVENTS.find((e) => e.type === "mission")!;
+    const override: EventBackdrop = { alt: "custom override", tone: "#ffffff", sourceKind: "curated" };
+    expect(resolveBackdrop({ ...base, backdrop: override })).toBe(override);
+  });
+
+  it("provides an illustrative generative backdrop for every innovation era", () => {
+    const eras: InnovationKey[] = ["mission", "cost", "reuse", "manufacturing", "dataops"];
+    for (const era of eras) {
+      const bd = THEME_BACKDROPS[era];
+      expect(bd.sourceKind).toBe("generative");
+      expect(bd.alt).toMatch(/illustrative/i);
+      expect(bd.image).toMatch(/^\/telemetry\/backdrops\/.+\.svg$/);
+    }
+  });
+});

--- a/repo-b/src/components/telemetry/context/BottleneckMap/data.ts
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/data.ts
@@ -6,8 +6,8 @@
 import { RS } from "../../rsTokens";
 import type { SourceKind } from "../../drill/sourceKind";
 import type {
-  ColorByKey, CostPoint, DimensionEntry, DimensionKey, LaunchEvent, SizeModeKey, TimeWindow,
-  YearPoint,
+  ColorByKey, CostPoint, DimensionEntry, DimensionKey, EventBackdrop, InnovationKey,
+  LaunchEvent, SizeModeKey, TimeWindow, YearPoint,
 } from "./types";
 
 // Two color dimensions for the bubbles
@@ -34,6 +34,24 @@ export function eventDimensionKey(e: LaunchEvent, colorBy: ColorByKey): Dimensio
 }
 export function eventDimension(e: LaunchEvent, colorBy: ColorByKey): DimensionEntry {
   return colorBy === "type" ? INNOVATION[e.type] : FUNDING[e.funding];
+}
+
+// Overview hero backdrops (Phase 9B), keyed off the innovation dimension so the visual is tied to the
+// era and stays stable regardless of the chart's color-by toggle. Tones echo the INNOVATION palette
+// (dataops uses cyan rather than the near-white text token, which washes out). Assets are illustrative
+// generative vector art under /public/telemetry/backdrops — not historical photos, never evidence.
+export const THEME_BACKDROPS: Record<InnovationKey, EventBackdrop> = {
+  mission:       { image: "/telemetry/backdrops/mission.svg",       tone: RS.blue,   sourceKind: "generative", alt: "Illustrative analog launch-pad and telemetry-room motif" },
+  cost:          { image: "/telemetry/backdrops/cost.svg",          tone: RS.green,  sourceKind: "generative", alt: "Illustrative cost-decline and reusable-booster motif" },
+  reuse:         { image: "/telemetry/backdrops/reuse.svg",         tone: RS.amber,  sourceKind: "generative", alt: "Illustrative reusable-booster recovery motif" },
+  manufacturing: { image: "/telemetry/backdrops/manufacturing.svg", tone: RS.violet, sourceKind: "generative", alt: "Illustrative additive-manufacturing inspection-grid motif" },
+  dataops:       { image: "/telemetry/backdrops/dataops.svg",       tone: RS.cyan,   sourceKind: "generative", alt: "Illustrative mission-control dense-signal-field motif" },
+};
+
+// Per-event override wins; otherwise the era theme; otherwise null (Overview falls back to its gradient).
+export function resolveBackdrop(e: LaunchEvent | null): EventBackdrop | null {
+  if (!e) return null;
+  return e.backdrop ?? THEME_BACKDROPS[e.type] ?? null;
 }
 
 export const BANDS: { y: number; label: string }[] = [

--- a/repo-b/src/components/telemetry/context/BottleneckMap/types.ts
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/types.ts
@@ -15,6 +15,23 @@ export interface DimensionEntry {
   label: string;
 }
 
+// Optional era backdrop for the Overview hero (Phase 9B). Decorative/illustrative only — never a
+// historical photograph and never a source of evidence. Rendered as a CSS background behind a scrim,
+// so a missing `image` degrades to the `tone` wash (no broken-image glyph).
+export interface EventBackdrop {
+  /** Path under /public, e.g. "/telemetry/backdrops/dataops.svg". Optional — tone wash is the floor. */
+  image?: string;
+  /** Accessible description. Must not imply the asset is a real photo of the event. */
+  alt: string;
+  /** Base wash color, tied to the era for relevance. */
+  tone: string;
+  /** CSS background-position; defaults to "center". */
+  focus?: string;
+  /** Honesty label shown in the UI — these assets are generative/curated, never evidence. */
+  sourceKind: "generative" | "curated" | "illustrative";
+  credit?: string;
+}
+
 export interface CostPoint {
   v: string;
   nominal: number;
@@ -53,6 +70,8 @@ export interface LaunchEvent {
   bottleneckCreated: string;
   dataProduct: string;
   rhyme: string;
+  /** Optional per-event override for the Overview hero backdrop; falls back to the era theme. */
+  backdrop?: EventBackdrop;
 }
 
 // Event decorated with the values the active color/size dimension resolves to.


### PR DESCRIPTION
## Phase 9B-A — Overview event backdrop

When a Bottleneck Map dot is selected (click, the Play walkthrough, or presenter arrows), the Overview hero band transitions to an era-appropriate **illustrative** backdrop. Streaming-detail-preview polish, aerospace language ("Backdrop: illustrative · generative asset").

Presentation-layer only — no backend, schema, evidence, or export change.

### What's in it
- **Data model** (`context/BottleneckMap/types.ts`, `data.ts`): `EventBackdrop` + optional per-event `LaunchEvent.backdrop`; `THEME_BACKDROPS` keyed off `InnovationKey` (tones echo `INNOVATION`); `resolveBackdrop()` = override → era theme → null.
- **Assets** (`public/telemetry/backdrops/*.svg` + README): hand-authored abstract vector motifs, one per era, labeled illustrative/generative — **not photographs, not evidence**. Text/diff-able, no binary or licensing concern.
- **`OverviewBackdrop.tsx`** (+ module CSS): persistent base wash → keyed fade theme layer (`role="img"` + alt) → scrim → honesty caption.
- **Wiring**: additive optional `onSelectedEventChange` on `BottleneckMap`; `TelemetryOverview` holds `selectedEvent` and renders the backdrop behind the hero (zIndex 0), content at zIndex 1.

### Guardrails honored
- **Backdrop never sits behind the chart** — the scrim reaches full page-bg opacity above where the Bottleneck Map begins; plot contrast and selected-dot emphasis unchanged.
- **No broken-image state** — CSS `background-image` (not `<img>`); a missing asset degrades to the tone wash.
- **Reduced-motion safe** — motion is CSS-only (module `@media` + global guard); no `matchMedia` in JS.
- `SourceHonestyStrip` / `EventRecord` unchanged; no metric or source claim moves.

### Tests
`backdrop.test.ts` (resolver), `OverviewBackdrop.test.tsx` (4: render / metadata swap / null fallback / reduced-motion), extended `TelemetryOverview.test.tsx` (selection drives backdrop). Green: vitest (24 incl. BottleneckMap), `tsc -p tsconfig.typecheck.json`, `next lint` on changed files.

Sidebar redesign ships separately as **PR 9B-B** (plan doc `0014`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)