### PR TITLE
feat(telemetry-9b): grouped collapsible sidebar with icon-rail collapse

### DIFF
--- a/repo-b/src/components/telemetry/TelemetryShell.tsx
+++ b/repo-b/src/components/telemetry/TelemetryShell.tsx
@@ -7,15 +7,28 @@ import TelemetryBottomNav from "./TelemetryBottomNav";
 import { C } from "./primitives";
 import { telemetrySectionLabel } from "./telemetryNav";
 
-// Option B "Lab Workbench" shell. Desktop: a single 224px rail (TEL ANOMALY / WORKBENCH
-// identity, grouped sections, serving + auth status pinned at the bottom) and a full-bleed
-// main column. Mobile: sticky top header (identity + current section + hamburger), a
-// slide-over drawer reusing the rail, and a bottom tab bar with the four primary sections.
+const COLLAPSE_KEY = "telemetry.sidebar.collapsed";
+
+// Option B "Lab Workbench" shell. Desktop: a single rail (TEL ANOMALY / WORKBENCH identity, grouped
+// sections, serving + auth status pinned at the bottom) that collapses to a 64px icon rail, and a
+// full-bleed main column. Mobile: sticky top header (identity + current section + hamburger), a
+// slide-over drawer reusing the rail (always expanded), and a bottom tab bar with the primary sections.
 // No executive chrome (the lab shell yields full-bleed for /telemetry).
 export default function TelemetryShell({ envId, children }: { envId: string; children: React.ReactNode }) {
   const pathname = usePathname();
   const [drawerOpen, setDrawerOpen] = useState(false);
+  // Desktop rail collapse. Default expanded so SSR/first paint is deterministic; hydrate the stored
+  // preference after mount to avoid a hydration mismatch.
+  const [collapsed, setCollapsed] = useState(false);
   useEffect(() => { setDrawerOpen(false); }, [pathname]);
+  useEffect(() => {
+    try { if (localStorage.getItem(COLLAPSE_KEY) === "1") setCollapsed(true); } catch { /* no-op */ }
+  }, []);
+  const toggleCollapsed = () => setCollapsed((c) => {
+    const next = !c;
+    try { localStorage.setItem(COLLAPSE_KEY, next ? "1" : "0"); } catch { /* no-op */ }
+    return next;
+  });
 
   // Lock body scroll while the drawer is open (same pattern as ConsultingWorkspaceShell).
   useEffect(() => {
@@ -25,16 +38,20 @@ export default function TelemetryShell({ envId, children }: { envId: string; chi
     return () => { document.body.style.overflow = prev; };
   }, [drawerOpen]);
 
+  const BrandMark = (
+    <div style={{ width: 28, height: 28, borderRadius: 7, border: "1px solid #B040FF66",
+      background: "linear-gradient(135deg, rgba(176,64,255,0.22), rgba(63,177,232,0.20))",
+      boxShadow: "0 0 14px rgba(176,64,255,0.25)",
+      display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+      <svg width="15" height="15" viewBox="0 0 14 14">
+        <path d="M1 10l3-4 2.5 2L9 4l4 6" stroke={C.cyan} strokeWidth="1.4" fill="none" strokeLinejoin="round" />
+      </svg>
+    </div>
+  );
+
   const Brand = (
     <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-      <div style={{ width: 28, height: 28, borderRadius: 7, border: "1px solid #B040FF66",
-        background: "linear-gradient(135deg, rgba(176,64,255,0.22), rgba(63,177,232,0.20))",
-        boxShadow: "0 0 14px rgba(176,64,255,0.25)",
-        display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
-        <svg width="15" height="15" viewBox="0 0 14 14">
-          <path d="M1 10l3-4 2.5 2L9 4l4 6" stroke={C.cyan} strokeWidth="1.4" fill="none" strokeLinejoin="round" />
-        </svg>
-      </div>
+      {BrandMark}
       <div>
         <div style={{ fontFamily: C.mono, fontSize: 11, fontWeight: 600, letterSpacing: "0.04em", color: C.text }}>TEL ANOMALY</div>
         <div style={{ fontFamily: C.mono, fontSize: 9, color: C.faint, letterSpacing: "0.1em" }}>WORKBENCH</div>
@@ -42,24 +59,52 @@ export default function TelemetryShell({ envId, children }: { envId: string; chi
     </div>
   );
 
-  const Rail = (
-    <aside style={{ width: 224, flexShrink: 0, background: C.rail, borderRight: `1px solid ${C.border}`,
-      display: "flex", flexDirection: "column", padding: "20px 14px", minHeight: "100%" }}>
-      <div style={{ padding: "0 6px 18px" }}>{Brand}</div>
-      <TelemetrySidebar envId={envId} onNavigate={() => setDrawerOpen(false)} />
+  // Rail body — parametrized by collapse so the desktop rail can shrink to icons while the mobile drawer
+  // always renders the full expanded rail.
+  const renderRail = (railCollapsed: boolean, showToggle: boolean) => (
+    <aside style={{ width: railCollapsed ? 64 : 224, flexShrink: 0, background: C.rail,
+      borderRight: `1px solid ${C.border}`, display: "flex", flexDirection: "column",
+      padding: railCollapsed ? "20px 8px" : "20px 14px", minHeight: "100%",
+      overflow: "hidden", transition: "width 200ms ease" }}>
+      <div style={{ padding: railCollapsed ? "0 0 18px" : "0 6px 18px",
+        display: "flex", justifyContent: railCollapsed ? "center" : "flex-start" }}>
+        {railCollapsed ? BrandMark : Brand}
+      </div>
+      <TelemetrySidebar envId={envId} collapsed={railCollapsed}
+        onNavigate={() => setDrawerOpen(false)}
+        onExpandRequest={() => setCollapsed(false)} />
       <div style={{ marginTop: "auto", paddingTop: 18, borderTop: `1px solid ${C.border}` }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
-          <span style={{ width: 6, height: 6, borderRadius: 999, background: C.green, boxShadow: `0 0 8px ${C.green}` }} />
-          <span style={{ fontFamily: C.mono, fontSize: 10, color: C.dim }}>serving · prod</span>
-        </div>
-        <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 8 }}>reviewer access · auth</div>
+        {railCollapsed ? (
+          <div style={{ display: "flex", justifyContent: "center" }} title="serving · prod">
+            <span style={{ width: 8, height: 8, borderRadius: 999, background: C.green, boxShadow: `0 0 8px ${C.green}` }} />
+          </div>
+        ) : (
+          <>
+            <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+              <span style={{ width: 6, height: 6, borderRadius: 999, background: C.green, boxShadow: `0 0 8px ${C.green}` }} />
+              <span style={{ fontFamily: C.mono, fontSize: 10, color: C.dim }}>serving · prod</span>
+            </div>
+            <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 8 }}>reviewer access · auth</div>
+          </>
+        )}
+        {showToggle && (
+          <button type="button" onClick={toggleCollapsed}
+            aria-label={railCollapsed ? "Expand sidebar" : "Collapse sidebar"} aria-pressed={railCollapsed}
+            style={{ marginTop: 14, width: railCollapsed ? 40 : "100%", marginLeft: railCollapsed ? "auto" : 0,
+              marginRight: railCollapsed ? "auto" : 0, display: "flex", alignItems: "center",
+              justifyContent: "center", gap: 8, height: 36, borderRadius: 8, cursor: "pointer",
+              background: "transparent", border: `1px solid ${C.border}`, color: C.dim, fontFamily: C.mono, fontSize: 12 }}>
+            <span aria-hidden style={{ fontSize: 14, lineHeight: 1 }}>{railCollapsed ? "›" : "‹"}</span>
+            {!railCollapsed && <span>Collapse</span>}
+          </button>
+        )}
       </div>
     </aside>
   );
 
   return (
     <div style={{ display: "flex", background: C.bg, minHeight: "100vh", fontFamily: C.sans, color: C.text }}>
-      <div className="hidden lg:flex">{Rail}</div>
+      <div className="hidden lg:flex">{renderRail(collapsed, true)}</div>
 
       <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}>
         {/* mobile top header — display lives in classes so lg:hidden can win */}
@@ -93,7 +138,8 @@ export default function TelemetryShell({ envId, children }: { envId: string; chi
             style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.6)", border: "none" }} />
           <div className="max-w-[88vw]"
             style={{ position: "absolute", left: 0, top: 0, height: "100%", overflowY: "auto", overflowX: "hidden", display: "flex" }}>
-            {Rail}
+            {/* drawer always shows the full expanded rail (no collapse on mobile) */}
+            {renderRail(false, false)}
           </div>
         </div>
       )}

--- a/repo-b/src/components/telemetry/TelemetrySidebar.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetrySidebar.test.tsx
@@ -1,34 +1,78 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePathname } from "next/navigation";
+
 import TelemetrySidebar from "./TelemetrySidebar";
 import { TELEMETRY_NAV, TELEMETRY_NAV_GROUPS, telemetryHref } from "./telemetryNav";
 
-// Render receipt for the 6-section restructure (ADO #692): the rail consumes the nav
-// list, so this proves all six section headers and every item link render without error.
-describe("TelemetrySidebar — 6-section rail", () => {
-  it("renders all six section headers", () => {
+afterEach(() => { vi.mocked(usePathname).mockReturnValue("/"); });
+
+// Expand every collapsed accordion group so all child links are in the DOM (Operations is already open).
+function expandAllGroups() {
+  for (const btn of screen.getAllByRole("button")) {
+    if (btn.getAttribute("aria-expanded") === "false") fireEvent.click(btn);
+  }
+}
+
+describe("TelemetrySidebar — grouped collapsible icon rail (Phase 9B)", () => {
+  it("renders every nav group as a row", () => {
     render(<TelemetrySidebar envId="env-1" />);
     for (const group of TELEMETRY_NAV_GROUPS) {
-      // "Mission Summary" is both a section header and an item label, so allow >=1.
       expect(screen.getAllByText(group).length).toBeGreaterThanOrEqual(1);
     }
   });
 
-  it("renders a routable link for every nav item with the relabels applied", () => {
+  it("opens Operations by default and keeps other multi-item groups collapsed", () => {
     render(<TelemetrySidebar envId="env-1" />);
+    expect(screen.getByRole("link", { name: /^Mission Control$/i })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /^Model Performance$/i })).toBeNull();
+  });
+
+  it("toggles a group's children when its row is clicked", () => {
+    render(<TelemetrySidebar envId="env-1" />);
+    const groupBtn = screen.getByRole("button", { name: /Models & Intelligence/i });
+    expect(groupBtn).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(groupBtn);
+    expect(groupBtn).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("link", { name: /^Model Performance$/i })).toBeInTheDocument();
+    fireEvent.click(groupBtn);
+    expect(screen.queryByRole("link", { name: /^Model Performance$/i })).toBeNull();
+  });
+
+  it("renders single-item groups as direct links (Overview, Agent Operations)", () => {
+    render(<TelemetrySidebar envId="env-1" />);
+    expect(screen.getByRole("link", { name: /^Overview$/i }))
+      .toHaveAttribute("href", telemetryHref("env-1", ""));
+    expect(screen.getByRole("link", { name: /^Agent Operations$/i }))
+      .toHaveAttribute("href", telemetryHref("env-1", "control-tower"));
+  });
+
+  it("keeps every nav surface routable once its group is expanded (no slug dropped)", () => {
+    render(<TelemetrySidebar envId="env-1" />);
+    expandAllGroups();
+    const hrefs = new Set(screen.getAllByRole("link").map((l) => l.getAttribute("href")));
     for (const item of TELEMETRY_NAV) {
-      const links = screen.getAllByRole("link", { name: new RegExp(`^${item.label}$`, "i") });
-      expect(links.some((l) => l.getAttribute("href") === telemetryHref("env-1", item.slug))).toBe(true);
+      expect(hrefs.has(telemetryHref("env-1", item.slug))).toBe(true);
     }
-    // Redesign relabels are present as links. (Trust Center / governance is intentionally hidden by
-    // the PR 2.1 conservative declutter; its route still resolves.)
-    for (const label of ["Overview", "Agent Control Tower", "Flight Readiness"]) {
-      expect(screen.getAllByRole("link", { name: new RegExp(`^${label}$`, "i") }).length).toBeGreaterThanOrEqual(1);
-    }
+  });
+
+  it("marks the active item with aria-current", () => {
+    vi.mocked(usePathname).mockReturnValue("/lab/env/env-1/telemetry/replay");
+    render(<TelemetrySidebar envId="env-1" />);
+    expect(screen.getByRole("link", { name: /^Replay$/i })).toHaveAttribute("aria-current", "page");
+  });
+
+  it("collapsed mode shows only group icon buttons — no labels, no links — and asks to expand on click", () => {
+    const onExpandRequest = vi.fn();
+    render(<TelemetrySidebar envId="env-1" collapsed onExpandRequest={onExpandRequest} />);
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+    expect(screen.queryByText(/^Mission Control$/i)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Expand sidebar and open Operations/i }));
+    expect(onExpandRequest).toHaveBeenCalledWith("Operations");
   });
 
   it("no longer renders the Automated Data Engineering rail cross-link (8H — telemetry-only rail)", () => {
     render(<TelemetrySidebar envId="env-1" />);
     expect(screen.queryByRole("link", { name: /Automated Data Engineering/i })).toBeNull();
-    // the route itself is NOT asserted here — it still resolves directly for deep links.
   });
 });

--- a/repo-b/src/components/telemetry/TelemetrySidebar.tsx
+++ b/repo-b/src/components/telemetry/TelemetrySidebar.tsx
@@ -2,71 +2,163 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 import { C } from "./primitives";
 import {
-  TELEMETRY_NAV, TELEMETRY_NAV_GROUPS, isTelemetryItemActive, telemetryHref,
-  type TelemetryNavGroup,
+  TELEMETRY_NAV, TELEMETRY_NAV_GROUPS, TELEMETRY_NAV_GROUP_META,
+  isTelemetryItemActive, telemetryHref,
+  type TelemetryNavGroup, type TelemetryNavItem,
 } from "./telemetryNav";
 
 // Brand fluorescent purple (shared with the Overview thesis); the active-item glow blends
 // the section accent into this purple.
 const NV_PURPLE = "#B040FF";
 
-// Per-section accent — section labels and item icons take their group's color so the rail
-// reads as a color-coded map. Purple/pink are from the cyberpunk accent token range.
-const GROUP_ACCENT: Record<TelemetryNavGroup, string> = {
-  Overview: C.cyan,
-  Operations: C.cyan,
-  "Models & Intelligence": "#a855f7",
-  "Factory & Quality": C.amber,
-  "Evidence & Lineage": C.green,
-  "Agent Operations": "#f472b6",
-  "Data Engineering": "#a855f7",
-};
+// Group containing the active route (or null). Drives default-open + active highlighting.
+function activeGroupFor(pathname: string, envId: string): TelemetryNavGroup | null {
+  return TELEMETRY_NAV.find((n) => isTelemetryItemActive(pathname, envId, n.slug))?.group ?? null;
+}
 
-// Grouped navigation rail. Rendered in the desktop rail and inside the mobile
-// drawer (TelemetryShell), so item height stays >=40px for touch.
-export default function TelemetrySidebar({ envId, onNavigate }: { envId: string; onNavigate?: () => void }) {
-  const pathname = usePathname() || "";
+function NavIcon({ d, color, size = 15 }: { d: string; color: string; size?: number }) {
   return (
-    <nav style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      {TELEMETRY_NAV_GROUPS.map((group, gi) => {
-        const accent = GROUP_ACCENT[group];
+    <svg width={size} height={size} viewBox="0 0 16 16" style={{ flexShrink: 0 }} aria-hidden>
+      <path d={d} stroke={color} strokeWidth="1.3" fill="none" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+// A routable row (a multi-item group's child, or a single-item group's leaf). Active rows get the
+// glowing pill that blends the section accent into brand purple.
+function NavLinkRow({ href, label, icon, accent, active, onNavigate, indented }: {
+  href: string; label: string; icon: string; accent: string; active: boolean;
+  onNavigate?: () => void; indented?: boolean;
+}) {
+  return (
+    <Link href={href} onClick={onNavigate} aria-current={active ? "page" : undefined}
+      style={{ display: "flex", alignItems: "center", gap: 10, textDecoration: "none",
+        minHeight: 40, padding: "9px 10px", borderRadius: 8,
+        color: active ? C.text : C.dim,
+        background: active ? `linear-gradient(90deg, ${accent}26, ${NV_PURPLE}1f)` : "transparent",
+        border: `1px solid ${active ? `${accent}66` : "transparent"}`,
+        boxShadow: active ? `0 0 16px ${accent}33` : "none" }}>
+      <NavIcon d={icon} color={active ? accent : `${accent}b3`} size={indented ? 14 : 15} />
+      <span style={{ fontFamily: C.mono, fontSize: 12 }}>{label}</span>
+      {active && <span aria-hidden style={{ marginLeft: "auto", color: accent, fontSize: 13, lineHeight: 1 }}>›</span>}
+    </Link>
+  );
+}
+
+// Grouped, collapsible navigation rail (Phase 9B). Each group is its own icon row; multi-item groups
+// are accordions (one open by default); single-item groups are direct links. When `collapsed`, only the
+// group icons render as an icon rail — clicking one asks the shell to expand and opens that group
+// (never an immediate navigation). Rendered in the desktop rail and the mobile drawer (always expanded).
+export default function TelemetrySidebar({ envId, onNavigate, collapsed = false, onExpandRequest }: {
+  envId: string;
+  onNavigate?: () => void;
+  collapsed?: boolean;
+  onExpandRequest?: (g: TelemetryNavGroup) => void;
+}) {
+  const pathname = usePathname() || "";
+  const activeGroup = activeGroupFor(pathname, envId);
+  const itemsOf = (g: TelemetryNavGroup): TelemetryNavItem[] => TELEMETRY_NAV.filter((n) => n.group === g);
+
+  // One group is open by default (Operations) plus the group owning the active route.
+  const [expanded, setExpanded] = useState<Set<TelemetryNavGroup>>(() => {
+    const s = new Set<TelemetryNavGroup>(["Operations"]);
+    if (activeGroup) s.add(activeGroup);
+    return s;
+  });
+  // Keep the active group open as the route changes.
+  useEffect(() => {
+    if (!activeGroup) return;
+    setExpanded((prev) => (prev.has(activeGroup) ? prev : new Set(prev).add(activeGroup)));
+  }, [activeGroup]);
+
+  const openGroup = (g: TelemetryNavGroup) =>
+    setExpanded((prev) => (prev.has(g) ? prev : new Set(prev).add(g)));
+  const toggleGroup = (g: TelemetryNavGroup) =>
+    setExpanded((prev) => {
+      const s = new Set(prev);
+      if (s.has(g)) s.delete(g); else s.add(g);
+      return s;
+    });
+
+  // Collapsed icon rail: only group icons, centered. Each is a button that expands the rail and opens
+  // its group — no navigation on the first click, so the user can never jump routes while just opening
+  // the sidebar during a demo.
+  if (collapsed) {
+    return (
+      <nav aria-label="Telemetry sections" style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
+        {TELEMETRY_NAV_GROUPS.map((group) => {
+          if (itemsOf(group).length === 0) return null;
+          const meta = TELEMETRY_NAV_GROUP_META[group];
+          const active = activeGroup === group;
+          return (
+            <button key={group} type="button" title={group}
+              aria-label={`Expand sidebar and open ${group}`}
+              onClick={() => { openGroup(group); onExpandRequest?.(group); }}
+              style={{ width: 44, height: 44, display: "flex", alignItems: "center", justifyContent: "center",
+                borderRadius: 9, cursor: "pointer",
+                background: active ? `${meta.accent}1f` : "transparent",
+                border: `1px solid ${active ? `${meta.accent}66` : "transparent"}`,
+                boxShadow: active ? `0 0 12px ${meta.accent}33` : "none" }}>
+              <NavIcon d={meta.icon} color={active ? meta.accent : `${meta.accent}b3`} size={16} />
+            </button>
+          );
+        })}
+      </nav>
+    );
+  }
+
+  // Expanded rail: group rows with labels + collapsible children.
+  return (
+    <nav aria-label="Telemetry sections" style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      {TELEMETRY_NAV_GROUPS.map((group) => {
+        const items = itemsOf(group);
+        if (items.length === 0) return null;
+        const meta = TELEMETRY_NAV_GROUP_META[group];
+        const accent = meta.accent;
+
+        // Single-item group → a direct link labeled with the group name (the row is the nav target).
+        if (items.length === 1) {
+          const item = items[0];
+          const active = isTelemetryItemActive(pathname, envId, item.slug);
+          return (
+            <div key={group} style={{ marginTop: 4 }}>
+              <NavLinkRow href={telemetryHref(envId, item.slug)} label={group} icon={meta.icon}
+                accent={accent} active={active} onNavigate={onNavigate} />
+            </div>
+          );
+        }
+
+        // Multi-item group → accordion.
+        const open = expanded.has(group);
+        const groupActive = activeGroup === group;
         return (
-        <div key={group} style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-          <div style={{ fontFamily: C.mono, fontSize: 9, letterSpacing: "0.16em", color: accent,
-            textTransform: "uppercase", padding: gi === 0 ? "2px 10px 4px" : "14px 10px 4px" }}>
-            {group}
+          <div key={group} style={{ display: "flex", flexDirection: "column", gap: 2, marginTop: 4 }}>
+            <button type="button" aria-expanded={open} onClick={() => toggleGroup(group)}
+              style={{ display: "flex", alignItems: "center", gap: 10, width: "100%", textAlign: "left",
+                minHeight: 40, padding: "9px 10px", borderRadius: 8, cursor: "pointer",
+                background: groupActive && !open ? `${accent}14` : "transparent",
+                border: `1px solid ${groupActive ? `${accent}40` : "transparent"}`, color: C.text }}>
+              <NavIcon d={meta.icon} color={accent} size={16} />
+              <span style={{ fontFamily: C.mono, fontSize: 12, letterSpacing: "0.02em", color: open ? C.text : C.dim }}>{group}</span>
+              <span aria-hidden style={{ marginLeft: "auto", color: accent, fontSize: 13, lineHeight: 1,
+                transform: open ? "rotate(90deg)" : "none", transition: "transform 150ms ease" }}>›</span>
+            </button>
+            {open && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 2,
+                marginLeft: 18, paddingLeft: 10, borderLeft: `1px solid ${accent}2e` }}>
+                {items.map((item) => (
+                  <NavLinkRow key={item.slug || "overview"} href={telemetryHref(envId, item.slug)}
+                    label={item.label} icon={item.icon} accent={accent} indented
+                    active={isTelemetryItemActive(pathname, envId, item.slug)} onNavigate={onNavigate} />
+                ))}
+              </div>
+            )}
           </div>
-          {TELEMETRY_NAV.filter((n) => n.group === group).map((n) => {
-            const active = isTelemetryItemActive(pathname, envId, n.slug);
-            return (
-              <Link key={n.slug || "overview"} href={telemetryHref(envId, n.slug)} onClick={onNavigate}
-                aria-current={active ? "page" : undefined}
-                style={{ display: "flex", alignItems: "center", gap: 10, textDecoration: "none",
-                  minHeight: 40, padding: "9px 10px", borderRadius: 8,
-                  color: active ? C.text : C.dim,
-                  // Active item: a glowing pill that blends the section accent into brand purple,
-                  // with a soft outer glow. Inactive items stay flat.
-                  background: active ? `linear-gradient(90deg, ${accent}26, ${NV_PURPLE}1f)` : "transparent",
-                  border: `1px solid ${active ? `${accent}66` : "transparent"}`,
-                  boxShadow: active ? `0 0 16px ${accent}33` : "none" }}>
-                <svg width="15" height="15" viewBox="0 0 16 16" style={{ flexShrink: 0 }}>
-                  <path d={n.icon} stroke={active ? accent : `${accent}b3`} strokeWidth="1.3" fill="none" strokeLinejoin="round" />
-                </svg>
-                <span style={{ fontFamily: C.mono, fontSize: 12 }}>{n.label}</span>
-                {active && (
-                  <span aria-hidden style={{ marginLeft: "auto", color: accent, fontSize: 13, lineHeight: 1 }}>›</span>
-                )}
-              </Link>
-            );
-          })}
-        </div>
         );
       })}
-      {/* The Automated Data Engineering control room is its own portable product; its rail cross-link was
-          removed (8H) to keep the telemetry sidebar telemetry-only. The /automated-data-engineering route
-          still resolves directly for deep links. */}
     </nav>
   );
 }

--- a/repo-b/src/components/telemetry/telemetryNav.test.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.test.ts
@@ -1,6 +1,7 @@
 import {
   TELEMETRY_NAV,
   TELEMETRY_NAV_GROUPS,
+  TELEMETRY_NAV_GROUP_META,
   isTelemetryItemActive,
   telemetryHref,
 } from "./telemetryNav";
@@ -82,6 +83,15 @@ describe("telemetry navigation structure (6 presentation sections)", () => {
         "metadata",
       ),
     ).toBe(true);
+  });
+
+  it("provides icon + accent metadata for every displayed nav group (collapsible icon rail)", () => {
+    for (const group of TELEMETRY_NAV_GROUPS) {
+      const meta = TELEMETRY_NAV_GROUP_META[group];
+      expect(meta).toBeDefined();
+      expect(meta.icon).toMatch(/^M/); // SVG path data
+      expect(meta.accent).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
   });
 
   it("no longer surfaces any Data Engineering nav items (group hidden; routes still resolve)", () => {

--- a/repo-b/src/components/telemetry/telemetryNav.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.ts
@@ -79,6 +79,20 @@ export const TELEMETRY_NAV_GROUPS: TelemetryNavGroup[] = [
   // no longer a displayed group — its items are hidden from the nav (routes still resolve).
 ];
 
+// Per-group identity for the collapsible icon rail (Phase 9B): the group's own icon (a representative
+// child glyph) + accent color. Accents mirror the telemetry `C` palette (cyan #67e8f9, amber #f5b452,
+// green #6ee7a0) plus the cyberpunk purple/pink; kept as literals so this data module stays
+// dependency-free. Single source of truth — TelemetrySidebar reads icon + accent from here.
+export const TELEMETRY_NAV_GROUP_META: Record<TelemetryNavGroup, { icon: string; accent: string }> = {
+  Overview:                { accent: "#67e8f9", icon: "M2 9h3v5H2zM7 4h3v10H7zM12 7h3v7h-3z" },
+  Operations:              { accent: "#67e8f9", icon: "M2 12c2-6 10-6 12 0M8 3v3M8 8l3 3" },
+  "Models & Intelligence": { accent: "#a855f7", icon: "M2 13l4-5 3 2 5-7" },
+  "Factory & Quality":     { accent: "#f5b452", icon: "M2 13V7l4 3V7l4 3V4h4v9z" },
+  "Evidence & Lineage":    { accent: "#6ee7a0", icon: "M4 2v12M4 6h6M4 11h5M10 4v4M9 9v3" },
+  "Agent Operations":      { accent: "#f472b6", icon: "M8 1l6 3v4c0 3-2.5 5.5-6 7-3.5-1.5-6-4-6-7V4zM8 5v6M5 8h6" },
+  "Data Engineering":      { accent: "#a855f7", icon: "M3 3h4v4H3zM9 9h4v4H9zM7 5h2M5 7v2M11 7V5M9 11H7" },
+};
+
 export function telemetryHref(envId: string, slug: string): string {
   const base = `/lab/env/${envId}/telemetry`;
   return slug ? `${base}/${slug}` : base;


### PR DESCRIPTION
## Phase 9B-B — Sidebar icon-rail redesign

Redesigns the telemetry left rail per the Phase 9B mockups, on top of post-8H main (telemetry-only nav).

### Behavior
- **Group rows with their own icons.** Each nav group renders as an icon + label row, color-coded by its accent (colors preserved from the existing rail).
- **Collapsible children.** Multi-item groups (Operations, Models & Intelligence, Factory & Quality, Evidence & Lineage) are accordions; **Operations is open by default** and the group owning the active route auto-opens. Single-item groups (Overview, Agent Operations) are direct links.
- **Whole-rail collapse.** The desktop rail collapses to a 64px icon-only column and expands back to labels (animated width). Brand → mark only; footer → status dot; a collapse toggle (‹ / ›) sits at the bottom. Preference persists in `localStorage`, hydrated post-mount so SSR/first paint stays deterministic.
- **No accidental navigation.** In collapsed mode, group icons are buttons labeled "Expand sidebar and open <group>" — the first click expands the rail and opens that group rather than jumping routes (safer during a live demo).
- **Mobile untouched.** The drawer always renders the full expanded rail; `TelemetryBottomNav` is unchanged.

### Guardrails
- **8H stays intact** — no Automated Data Engineering cross-link is reintroduced (regression-guarded by a test).
- `aria-current="page"` preserved on the active item; group rows are real `<button aria-expanded>`.

### Tests
`TelemetrySidebar.test.tsx` rewritten to the new contract — group rows, default-open Operations, accordion toggle, **routability preserved** (every nav slug still reachable once its group is expanded), single-item direct links, collapsed-mode icon buttons, active-item aria-current, and the 8H no-ADE guard. `telemetryNav.test.ts` asserts `TELEMETRY_NAV_GROUP_META` covers every group. Green: vitest (16), `tsc -p tsconfig.typecheck.json`, `next lint`.

Pairs with **PR 9B-A** (Overview event backdrop, #434). Plan: `docs/plans/.../0014-telemetry-phase-9b-...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)