### PR TITLE
feat(stargate-enrich): source-kind chip + in-flight streaming-context strip

### DIFF
--- a/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
+++ b/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
@@ -17,8 +17,9 @@ import TempVibrationChart from "./TempVibrationChart";
 import StreamLineageDrawer from "./StreamLineageDrawer";
 import { useStargateStream } from "@/lib/lab/stargateStream";
 import type { AnomalyRow } from "@/lib/lab/stargateStream";
-import { ExportToCsvButton } from "../drill";
+import { ExportToCsvButton, SOURCE_KIND_TAG } from "../drill";
 import { ANOMALY_EXPORT_COLUMNS, anomalyExportRows } from "./streamExportRows";
+import StreamContextStrip from "./StreamContextStrip";
 import { TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID } from "@/lib/telemetry/api";
 import { useIsMobile } from "@/hooks/useIsMobile";
 
@@ -189,6 +190,7 @@ export default function StargateConsole() {
             )}
             <Tag color={stream.connected ? C.green : C.red}>{stream.connected ? "stream live" : "reconnecting"}</Tag>
             <Tag color={badge.color}>{badge.label}</Tag>
+            <Tag color={C.amber}>{SOURCE_KIND_TAG.fixture} · recorded capture</Tag>
           </>
         }
       />
@@ -212,6 +214,8 @@ export default function StargateConsole() {
           value={anomalies.length} sub="temp<1400°C ∧ vib>0.08g" />
         <MetricCard label="Dead letters" accent={stream.dlqCount ? C.red : C.green} value={stream.dlqCount} />
       </div>
+
+      <StreamContextStrip health={stream.health} latestAgg={printerAgg.at(-1) ?? agg.at(-1) ?? null} />
 
       {printers.length > 1 && (
         <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginBottom: 14 }}>

--- a/repo-b/src/components/telemetry/stargate/StreamContextStrip.test.tsx
+++ b/repo-b/src/components/telemetry/stargate/StreamContextStrip.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import StreamContextStrip from "./StreamContextStrip";
+import type { AggRow, BridgeHealth } from "@/lib/lab/stargateStream";
+
+const HEALTH: BridgeHealth = {
+  mode: "capture", aggregation_source: "flink", consumer_alive: true,
+  msgs_in_total: 1200, msgs_in_per_sec: 40, last_message_age_ms: 800, dlq_count: 0, uptime_s: 125,
+};
+const AGG: AggRow = {
+  printer_id: "printer-1", window_start_ms: 1_000_000, window_end_ms: 1_005_000,
+  avg_temp_c: 1380, max_vibration_g: 0.094, n: 200,
+};
+
+describe("StreamContextStrip", () => {
+  it("surfaces the real in-flight window + engine + freshness from bridge health", () => {
+    render(<StreamContextStrip health={HEALTH} latestAgg={AGG} />);
+    expect(screen.getByText("flink")).toBeInTheDocument();              // aggregation engine
+    expect(screen.getByText("5.0s · 200 msg")).toBeInTheDocument();      // window span + msg count
+    expect(screen.getByText("1380°C")).toBeInTheDocument();             // window avg temp (real value)
+    expect(screen.getByText("0.094g")).toBeInTheDocument();             // window max vibration
+    expect(screen.getByText("live (<1.5s)")).toBeInTheDocument();        // 800ms -> fresh
+    expect(screen.getByText("alive")).toBeInTheDocument();              // consumer
+  });
+
+  it("fails closed with a reason when the bridge has not reported a frame (no fabricated zeros)", () => {
+    render(<StreamContextStrip health={null} latestAgg={null} />);
+    // several fields share each reason (engine/consumer/uptime; window/temp/vibration) -> getAllByText
+    expect(screen.getAllByText(/not available — health not reported/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/not available — no aggregation window yet/).length).toBeGreaterThanOrEqual(1);
+    // never a bare "0" standing in for missing data
+    expect(screen.queryByText("0°C")).toBeNull();
+  });
+
+  it("ages the last message honestly when the stream goes quiet", () => {
+    render(<StreamContextStrip health={{ ...HEALTH, last_message_age_ms: 45_000 }} latestAgg={AGG} />);
+    expect(screen.getByText("45.0s ago")).toBeInTheDocument();
+    expect(screen.queryByText("live (<1.5s)")).toBeNull();
+  });
+});

--- a/repo-b/src/components/telemetry/stargate/StreamContextStrip.tsx
+++ b/repo-b/src/components/telemetry/stargate/StreamContextStrip.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+// In-flight streaming context: the windowed-aggregation engine, the most recent aggregation window, and
+// stream freshness. Every value comes from the bridge health frame (BridgeHealth) and the latest AggRow -
+// nothing is fabricated. Each field fails closed to "not available" with a reason when the bridge frame
+// has not carried it yet, so the strip never shows a zero that looks like real data.
+
+import { C } from "../primitives";
+import type { AggRow, BridgeHealth } from "@/lib/lab/stargateStream";
+
+function Field({ label, value, reason, accent }: {
+  label: string; value?: React.ReactNode; reason?: string; accent?: string;
+}) {
+  const available = value !== undefined && value !== null && value !== "";
+  return (
+    <div style={{ minWidth: 0 }}>
+      <div style={{ fontFamily: C.mono, fontSize: 9.5, letterSpacing: "0.1em", textTransform: "uppercase",
+        color: C.faint }}>
+        {label}
+      </div>
+      <div style={{ fontFamily: C.mono, fontSize: 13, color: available ? (accent || C.text) : C.faint, marginTop: 3 }}>
+        {available ? value : `not available — ${reason ?? "no frame yet"}`}
+      </div>
+    </div>
+  );
+}
+
+function ageLabel(ms: number | null): string | undefined {
+  if (ms == null) return undefined;
+  if (ms < 1500) return "live (<1.5s)";
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s ago`;
+  return `${Math.round(ms / 60_000)}m ago`;
+}
+
+export default function StreamContextStrip({ health, latestAgg }: {
+  health: BridgeHealth | null | undefined;
+  latestAgg: AggRow | null | undefined;
+}) {
+  const windowMs = latestAgg ? latestAgg.window_end_ms - latestAgg.window_start_ms : null;
+  const ageMs = health?.last_message_age_ms ?? null;
+  const fresh = ageMs != null && ageMs < 1500;
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 14,
+      padding: "12px 14px", marginBottom: 16, borderRadius: 9,
+      background: C.panel, border: `1px solid ${C.border}` }}>
+      <Field label="Aggregation engine" reason="health not reported"
+        value={health?.aggregation_source} />
+      <Field label="In-flight window" reason="no aggregation window yet"
+        value={windowMs != null ? `${(windowMs / 1000).toFixed(1)}s · ${latestAgg!.n} msg` : undefined} />
+      <Field label="Window avg temp" reason="no aggregation window yet"
+        value={latestAgg ? `${latestAgg.avg_temp_c.toFixed(0)}°C` : undefined}
+        accent={latestAgg && latestAgg.avg_temp_c < 1400 ? C.amber : undefined} />
+      <Field label="Window max vibration" reason="no aggregation window yet"
+        value={latestAgg ? `${latestAgg.max_vibration_g.toFixed(3)}g` : undefined} />
+      <Field label="Last message" reason="no frame yet"
+        value={ageLabel(ageMs)} accent={fresh ? C.green : C.amber} />
+      <Field label="Consumer" reason="health not reported"
+        value={health ? (health.consumer_alive ? "alive" : "down") : undefined}
+        accent={health?.consumer_alive ? C.green : C.red} />
+      <Field label="Uptime" reason="health not reported"
+        value={health ? `${Math.floor(health.uptime_s / 60)}m ${Math.round(health.uptime_s % 60)}s` : undefined} />
+    </div>
+  );
+}


### PR DESCRIPTION
Stargate enrichment 1 of 2. The streaming surface was only given CSV export in 8C; this resumes the deeper enrichment the other pages got in 8D–8G. **Frontend-only, surfaces existing bridge data, no fabrication, no backend, no deploy.**

- **Source-kind chip** in the header (`SOURCE_KIND_TAG.fixture` · "recorded capture") so the streaming surface carries the same honesty-framework chip as the other pages, matching its existing "recorded capture, not a live printer" prose.
- **New `StreamContextStrip`:** surfaces the in-flight windowed-aggregation context that the bridge computed but the UI never showed — the **aggregation engine** (flink / local-emulation / capture), the most recent `AggRow` **window** (span + message count), the window **avg temp** and **max vibration**, **last-message freshness**, **consumer-alive**, and **uptime**. Every value comes from the real `BridgeHealth` frame + the latest `AggRow`; each field **fails closed** to "not available — <reason>" when the bridge has not carried it yet — never a zero standing in for missing data.

**Tests:** new `StreamContextStrip.test` (real-value rendering, fail-closed reasons, honest message-aging) + existing **38** stargate tests; full telemetry suite green; typecheck + lint clean; **frozen-evidence 8/8**.

Next (enrichment 2 of 2): a DLQ inspection drawer (parity with the anomaly drawer) + a temp/vibration series CSV export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)