### PR TITLE
feat(stargate-enrich): DLQ inspection drawer + telemetry series export

### DIFF
--- a/repo-b/src/components/telemetry/stargate/DlqInspectionDrawer.test.tsx
+++ b/repo-b/src/components/telemetry/stargate/DlqInspectionDrawer.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import DlqInspectionDrawer from "./DlqInspectionDrawer";
+import type { DlqRow } from "@/lib/lab/stargateStream";
+
+const ROW: DlqRow = {
+  ts_ms: 1_700_000_000_000, topic: "stargate.raw.v1", reason: "protobuf_decode_error",
+  raw_preview: "0x0a14...corrupt", raw_bytes: 248,
+};
+
+describe("DlqInspectionDrawer", () => {
+  it("is closed when no row is selected", () => {
+    render(<DlqInspectionDrawer row={null} onClose={() => {}} />);
+    expect(screen.queryByText("Dead letter inspection")).toBeNull();
+  });
+
+  it("shows the full dead-letter record + the fail-closed framing", () => {
+    render(<DlqInspectionDrawer row={ROW} onClose={() => {}} />);
+    expect(screen.getByText("Dead letter inspection")).toBeInTheDocument();
+    expect(screen.getByText("stargate.raw.v1")).toBeInTheDocument();      // topic
+    expect(screen.getAllByText("248B").length).toBeGreaterThanOrEqual(1);  // raw bytes (tag + row)
+    expect(screen.getByText("0x0a14...corrupt")).toBeInTheDocument();      // full raw preview
+    expect(screen.getByText(/routed to the dead letter queue rather than crashing ingestion/i)).toBeInTheDocument();
+  });
+
+  it("fails closed on a missing topic / preview (no blank, no fabrication)", () => {
+    render(<DlqInspectionDrawer row={{ ...ROW, topic: "", raw_preview: "" }} onClose={() => {}} />);
+    expect(screen.getByText(/not available - topic not on the dead-letter record/)).toBeInTheDocument();
+    expect(screen.getByText(/not available - no preview captured/)).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/stargate/DlqInspectionDrawer.tsx
+++ b/repo-b/src/components/telemetry/stargate/DlqInspectionDrawer.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+// Dead-letter inspection drawer - parity with the anomaly inspection drawer. A dead letter is a payload the
+// bridge could not decode; this shows its full record (topic, reason, byte size, full raw preview, time) so a
+// corrupted payload is auditable, not a one-line ticker entry. Routed here instead of crashing ingestion -
+// bad data is visible and fail-closed, never silently dropped.
+
+import * as Dialog from "@radix-ui/react-dialog";
+
+import { C, Tag } from "../primitives";
+import type { DlqRow } from "@/lib/lab/stargateStream";
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "120px 1fr", gap: 10, alignItems: "baseline",
+      padding: "7px 0", borderBottom: `1px solid ${C.border}` }}>
+      <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint }}>{label}</span>
+      <span style={{ fontFamily: C.mono, fontSize: 12, color: C.text, wordBreak: "break-all" }}>{value}</span>
+    </div>
+  );
+}
+
+export default function DlqInspectionDrawer({ row, onClose }: {
+  row: DlqRow | null;
+  onClose: () => void;
+}) {
+  return (
+    <Dialog.Root open={Boolean(row)} onOpenChange={(open) => !open && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.52)", zIndex: 70 }} />
+        <Dialog.Content
+          className="fixed bottom-0 left-0 right-0 z-[80] max-h-[88vh] rounded-t-xl lg:bottom-auto lg:left-auto lg:right-0 lg:top-0 lg:h-screen lg:max-h-none lg:w-[460px] lg:rounded-none lg:rounded-l-xl"
+          style={{ background: C.rail, border: `1px solid ${C.borderHi}`, color: C.text,
+            overflowY: "auto", padding: 20, boxShadow: "-18px 0 50px rgba(0,0,0,0.38)" }}
+        >
+          {row && (
+            <>
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 16 }}>
+                <div style={{ minWidth: 0 }}>
+                  <Dialog.Title style={{ fontFamily: C.sans, fontSize: 18, fontWeight: 700 }}>
+                    Dead letter inspection
+                  </Dialog.Title>
+                  <Dialog.Description style={{ color: C.dim, fontFamily: C.mono, fontSize: 10,
+                    lineHeight: 1.5, marginTop: 6 }}>
+                    {new Date(row.ts_ms).toLocaleTimeString([], { hour12: false })} · routed, not dropped
+                  </Dialog.Description>
+                </div>
+                <Dialog.Close asChild>
+                  <button type="button" aria-label="Close dead letter inspection"
+                    style={{ width: 36, height: 36, borderRadius: 7, border: `1px solid ${C.borderHi}`,
+                      background: C.panel, color: C.dim, cursor: "pointer", flexShrink: 0 }}>x</button>
+                </Dialog.Close>
+              </div>
+
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 7, marginTop: 12 }}>
+                <Tag color={C.red}>{row.reason}</Tag>
+                <Tag color={C.dim}>{row.raw_bytes}B</Tag>
+              </div>
+
+              <div style={{ marginTop: 16 }}>
+                <Row label="Reason" value={row.reason} />
+                <Row label="Topic" value={row.topic || "not available - topic not on the dead-letter record"} />
+                <Row label="Raw bytes" value={`${row.raw_bytes}B`} />
+                <Row label="Received" value={new Date(row.ts_ms).toLocaleString([], { hour12: false })} />
+              </div>
+
+              <div style={{ marginTop: 16 }}>
+                <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, letterSpacing: "0.1em",
+                  textTransform: "uppercase", marginBottom: 6 }}>Raw payload preview</div>
+                <pre style={{ fontFamily: C.mono, fontSize: 11, color: C.dim, lineHeight: 1.5,
+                  background: C.panel, border: `1px solid ${C.border}`, borderRadius: 7, padding: 12,
+                  whiteSpace: "pre-wrap", wordBreak: "break-all", margin: 0 }}>
+                  {row.raw_preview || "not available - no preview captured"}
+                </pre>
+              </div>
+
+              <p style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, lineHeight: 1.6, marginTop: 14 }}>
+                This payload could not be decoded against the protobuf schema, so it was routed to the dead
+                letter queue rather than crashing ingestion. Bad data is visible and fails closed; it is never
+                silently discarded.
+              </p>
+            </>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/repo-b/src/components/telemetry/stargate/DlqPanel.tsx
+++ b/repo-b/src/components/telemetry/stargate/DlqPanel.tsx
@@ -13,7 +13,9 @@ function fmtTime(tsMs: number): string {
   return new Date(tsMs).toLocaleTimeString([], { hour12: false });
 }
 
-export default function DlqPanel({ rows, count }: { rows: DlqRow[]; count: number }) {
+export default function DlqPanel({ rows, count, onInspect }: {
+  rows: DlqRow[]; count: number; onInspect?: (row: DlqRow) => void;
+}) {
   const newestMs = rows.length ? rows[rows.length - 1].ts_ms : 0;
   const hot = newestMs > 0 && Date.now() - newestMs < 3000;
   return (
@@ -30,15 +32,19 @@ export default function DlqPanel({ rows, count }: { rows: DlqRow[]; count: numbe
       ) : (
         <div style={{ maxHeight: 220, overflowY: "auto" }}>
           {[...rows].reverse().map((row, i) => (
-            <div key={`${row.ts_ms}-${i}`} style={{ display: "flex", gap: 12, alignItems: "baseline",
-              padding: "8px 14px", borderBottom: `1px solid ${C.border}` }}>
+            <button key={`${row.ts_ms}-${i}`} type="button"
+              onClick={onInspect ? () => onInspect(row) : undefined}
+              aria-label={onInspect ? `Inspect dead letter: ${row.reason}` : undefined}
+              style={{ display: "flex", gap: 12, alignItems: "baseline", width: "100%", textAlign: "left",
+                background: "transparent", border: "none", borderBottom: `1px solid ${C.border}`,
+                padding: "8px 14px", cursor: onInspect ? "pointer" : "default" }}>
               <span style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, flexShrink: 0 }}>{fmtTime(row.ts_ms)}</span>
               <span style={{ fontFamily: C.mono, fontSize: 11, color: C.red, flexShrink: 0 }}>{row.reason}</span>
               <span style={{ fontFamily: C.mono, fontSize: 10, color: C.dim, overflow: "hidden",
                 textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                 {row.raw_bytes}B · {row.raw_preview}
               </span>
-            </div>
+            </button>
           ))}
         </div>
       )}

--- a/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
+++ b/repo-b/src/components/telemetry/stargate/StargateConsole.tsx
@@ -12,13 +12,14 @@ import { C, EmptyState, MetricCard, Panel, RowCard, SplitGrid, Tag } from "../pr
 import { TelemetryPageHeader } from "../TelemetryPageHeader";
 import AnomalyInspectionDrawer from "./AnomalyInspectionDrawer";
 import DlqPanel from "./DlqPanel";
+import DlqInspectionDrawer from "./DlqInspectionDrawer";
 import RulesVsBaselineLane from "./RulesVsBaselineLane";
 import TempVibrationChart from "./TempVibrationChart";
 import StreamLineageDrawer from "./StreamLineageDrawer";
 import { useStargateStream } from "@/lib/lab/stargateStream";
-import type { AnomalyRow } from "@/lib/lab/stargateStream";
+import type { AnomalyRow, DlqRow } from "@/lib/lab/stargateStream";
 import { ExportToCsvButton, SOURCE_KIND_TAG } from "../drill";
-import { ANOMALY_EXPORT_COLUMNS, anomalyExportRows } from "./streamExportRows";
+import { ANOMALY_EXPORT_COLUMNS, anomalyExportRows, SERIES_EXPORT_COLUMNS, seriesExportRows } from "./streamExportRows";
 import StreamContextStrip from "./StreamContextStrip";
 import { TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID } from "@/lib/telemetry/api";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -62,6 +63,7 @@ export default function StargateConsole() {
   const [starting, setStarting] = useState(false);
   const [startMsg, setStartMsg] = useState<string | null>(null);
   const [inspected, setInspected] = useState<AnomalyRow | null>(null);
+  const [dlqInspected, setDlqInspected] = useState<DlqRow | null>(null);
   const [highlight, setHighlight] = useState<{ start: number; end: number } | null>(null);
   // The three.js canvas only mounts on desktop, and only after hydration —
   // useIsMobile defaults to desktop on the server, so an unguarded render
@@ -256,7 +258,10 @@ export default function StargateConsole() {
             </>
           )}
         </Panel>
-        <Panel title="Melt pool vs arm vibration — 60s window" pad={10}>
+        <Panel title="Melt pool vs arm vibration — 60s window" pad={10}
+          right={<ExportToCsvButton filename={`stargate_series_${printer ?? "all"}`}
+            columns={SERIES_EXPORT_COLUMNS} rows={seriesExportRows(printerPoints)} label="Export series CSV"
+            disabled={printerPoints.length === 0} disabledReason="No telemetry points in the window" />}>
           <TempVibrationChart points={printerPoints} agg={printerAgg} anomalies={printerAnomalies}
             highlight={highlight} />
         </Panel>
@@ -313,7 +318,7 @@ export default function StargateConsole() {
               disabledReason="No routed anomalies yet" />
           </div>
         </Panel>
-        <DlqPanel rows={dlq} count={stream.dlqCount} />
+        <DlqPanel rows={dlq} count={stream.dlqCount} onInspect={setDlqInspected} />
       </SplitGrid>
 
       <AnomalyInspectionDrawer
@@ -330,6 +335,7 @@ export default function StargateConsole() {
         routeEnvId={TELEMETRY_DEMO_ENV_ID}
         onClose={() => setLineageAnomalyId(null)}
       />
+      <DlqInspectionDrawer row={dlqInspected} onClose={() => setDlqInspected(null)} />
     </div>
   );
 }

--- a/repo-b/src/components/telemetry/stargate/streamExportRows.test.ts
+++ b/repo-b/src/components/telemetry/stargate/streamExportRows.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { AnomalyRow, DlqRow } from "@/lib/lab/stargateStream";
+import type { TelemetryPoint } from "@/lib/lab/stargateStream";
 import {
-  ANOMALY_EXPORT_COLUMNS, DLQ_EXPORT_COLUMNS, anomalyExportRows, dlqExportRows,
+  ANOMALY_EXPORT_COLUMNS, DLQ_EXPORT_COLUMNS, SERIES_EXPORT_COLUMNS,
+  anomalyExportRows, dlqExportRows, seriesExportRows,
 } from "./streamExportRows";
 
 const base: AnomalyRow = {
@@ -49,5 +51,19 @@ describe("dlqExportRows", () => {
     const [row] = dlqExportRows([dlq]);
     expect(row).toEqual(dlq);
     expect(DLQ_EXPORT_COLUMNS).toContain("raw_bytes");
+  });
+});
+
+describe("seriesExportRows", () => {
+  it("flattens the raw telemetry window points (the chart data is exportable)", () => {
+    const pt: TelemetryPoint = {
+      printer_id: "P1", ts_us: 1_700_000_000_000_000, layer: 7, print_job_id: "job-3",
+      melt_pool_temp_c: 1500, arm_vibration_g: 0.05, x_mm: 1, y_mm: 2, z_mm: 3,
+    } as TelemetryPoint;
+    const [row] = seriesExportRows([pt]);
+    expect(row.printer_id).toBe("P1");
+    expect(row.melt_pool_temp_c).toBe(1500);
+    expect(row.arm_vibration_g).toBe(0.05);
+    for (const c of SERIES_EXPORT_COLUMNS) expect(c in row).toBe(true);
   });
 });

--- a/repo-b/src/components/telemetry/stargate/streamExportRows.ts
+++ b/repo-b/src/components/telemetry/stargate/streamExportRows.ts
@@ -2,7 +2,7 @@
 // affordances. These are REAL rows pushed over the SSE bridge during a recorded-capture replay — not
 // fixtures and not live printer hardware. The nested enrichment (rule / scorer / routing / provenance)
 // is flattened to the most useful scalar columns; missing enrichment → null (never fabricated).
-import type { AnomalyRow, DlqRow } from "@/lib/lab/stargateStream";
+import type { AnomalyRow, DlqRow, TelemetryPoint } from "@/lib/lab/stargateStream";
 
 export const ANOMALY_EXPORT_COLUMNS = [
   "printer_id", "ts_us", "layer", "print_job_id", "melt_pool_temp_c", "arm_vibration_g",
@@ -35,5 +35,20 @@ export const DLQ_EXPORT_COLUMNS = ["ts_ms", "topic", "reason", "raw_preview", "r
 export function dlqExportRows(dlq: DlqRow[]): Array<Record<string, unknown>> {
   return dlq.map((d) => ({
     ts_ms: d.ts_ms, topic: d.topic, reason: d.reason, raw_preview: d.raw_preview, raw_bytes: d.raw_bytes,
+  }));
+}
+
+// The underlying telemetry window series (the temp/vibration chart data) — the raw decoded points, so the
+// chart is exportable, not just the anomalies routed off it.
+export const SERIES_EXPORT_COLUMNS = ["printer_id", "ts_us", "layer", "print_job_id", "melt_pool_temp_c", "arm_vibration_g"];
+
+export function seriesExportRows(points: TelemetryPoint[]): Array<Record<string, unknown>> {
+  return points.map((p) => ({
+    printer_id: p.printer_id,
+    ts_us: p.ts_us,
+    layer: p.layer,
+    print_job_id: p.print_job_id,
+    melt_pool_temp_c: p.melt_pool_temp_c,
+    arm_vibration_g: p.arm_vibration_g,
   }));
 }


### PR DESCRIPTION
Stargate enrichment 2 of 2. **Frontend-only, surfaces existing SSE data, no fabrication, no backend, no deploy.**

- **DLQ inspection drawer (parity with the anomaly drawer):** dead-letter rows are now clickable → a Radix drawer showing the full record (reason, topic, raw bytes, received time, **full raw-payload preview**) + the fail-closed framing ("routed here rather than crashing ingestion; never silently dropped"). Absent topic / preview **fail closed** with a reason. Previously the DLQ was a read-only ticker with no drill — the anomaly side had a drawer, the DLQ side did not.
- **Telemetry series CSV export:** the temp/vibration window chart now has an "Export series CSV" affordance over the raw decoded points (`printer_id, ts_us, layer, print_job_id, melt_pool_temp_c, arm_vibration_g`) via a new `seriesExportRows` flattener. Before, only the anomalies routed *off* the series were exportable, not the series itself.

**Tests:** `DlqInspectionDrawer.test` (full record, fail-closed missing fields, closed-when-no-row) + `seriesExportRows` coverage + existing **42** stargate tests; full telemetry suite green; typecheck + lint clean; **frozen-evidence 8/8**.

With #436, this completes the Stargate enrichment: source-kind chip + in-flight streaming context, DLQ drill, and series export — bringing the streaming surface to drill/export/source-kind parity with the pages enriched in 8D–8G.

🤖 Generated with [Claude Code](https://claude.com/claude-code)