### PR TITLE
feat(relativity-mes): honest Databricks/Unity Catalog deep links on the Lineage page

### DIFF
--- a/repo-b/src/components/telemetry/relativity-mes/LineageSourceConsole.tsx
+++ b/repo-b/src/components/telemetry/relativity-mes/LineageSourceConsole.tsx
@@ -9,7 +9,11 @@
 import { C, EmptyState, ErrorState, Loading, Panel, ScrollTable, StatGrid, Stat, Tag } from "../primitives";
 import { TelemetryPageHeader } from "../TelemetryPageHeader";
 import { ExportToCsvButton } from "../drill";
+import { EvidenceLink } from "../drill";
 import { getLineage, useRel, type LineageResp, type Row } from "@/lib/telemetry/relativityMes";
+import {
+  REL_GOLD_TABLES, catalogLink, goldTableLink, schemaLink, workspaceLink,
+} from "@/lib/telemetry/relativityMesDatabricks";
 import { REL_ACCENT, RelSourceDrill, ServingStrip, SyntheticBanner, useDrill } from "./relMesShared";
 
 const str = (r: Row, k: string) => (r[k] == null ? "—" : String(r[k]));
@@ -55,6 +59,25 @@ export default function LineageSourceConsole() {
               <span style={{ color: dbxLive ? C.green : REL_ACCENT }}>
                 {dbxLive ? "databricks-gold (synced from Databricks Gold)" : "seed-bootstrap (deterministic gold load; Databricks backfill flips this to databricks-gold)"}
               </span>.
+            </div>
+          </Panel>
+
+          <Panel title="Databricks medallion & Unity Catalog" style={{ marginBottom: 14 }}>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 10 }}>
+              <EvidenceLink link={workspaceLink()} />
+              <EvidenceLink link={catalogLink()} />
+              <EvidenceLink link={schemaLink(dbxLive)} />
+            </div>
+            <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginBottom: 10, lineHeight: 1.5 }}>
+              Gold Delta tables in <span style={{ color: C.dim }}>{`novendor_1.relativity_mes`}</span> (workspace
+              dbc-2504bec5-b5ab). {dbxLive
+                ? "Live links — the medallion has materialized these tables."
+                : "Fail-closed below: the medallion has not run (serverless warehouse health=FAILED), so these tables do not exist yet. Each becomes a live ↗ link once serving_provenance flips to databricks-gold. Copy the catalog path to inspect when the warehouse is healthy."}
+            </div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              {REL_GOLD_TABLES.map((t) => (
+                <EvidenceLink key={t} link={goldTableLink(t, dbxLive)} />
+              ))}
             </div>
           </Panel>
 

--- a/repo-b/src/components/telemetry/relativity-mes/consoles.test.tsx
+++ b/repo-b/src/components/telemetry/relativity-mes/consoles.test.tsx
@@ -141,4 +141,21 @@ describe("LineageSourceConsole", () => {
     expect(await screen.findByText("rel_mes_vehicle")).toBeTruthy();
     expect(screen.getByText(/Live serving/)).toBeTruthy();
   });
+
+  it("renders honest Databricks deep links: live catalog, fail-closed gold tables (bootstrap)", async () => {
+    (lib.getLineage as Mock).mockResolvedValue({
+      ...META, // serving_provenance = seed-bootstrap -> medallion not materialized
+      rows: [{ object_name: "rel_mes_vehicle", layer: "source", source_system: "MES", row_count: 3,
+        dashboard_consumers: "[]", ingest_batch_id: "rel-mes-seed-v1", source_system_layer: "rel_*" }],
+      serving: { rel_build_overview: { row_count: 3, serving_provenance: "seed-bootstrap" } },
+    });
+    render(<LineageSourceConsole />);
+    expect(await screen.findByText("Databricks medallion & Unity Catalog")).toBeTruthy();
+    // catalog (novendor_1) exists now -> a live anchor to the workspace
+    const catalog = await screen.findByText(/Open catalog novendor_1/);
+    expect(catalog.closest("a")?.getAttribute("href")).toContain("dbc-2504bec5-b5ab");
+    // gold tables not materialized -> fail-closed (disabled + reason), NOT a live link
+    expect(screen.getByText("gold_rel_build_overview").closest("a")).toBeNull();
+    expect(screen.getAllByText(/Medallion not materialized/).length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/repo-b/src/lib/telemetry/relativityMesDatabricks.ts
+++ b/repo-b/src/lib/telemetry/relativityMesDatabricks.ts
@@ -1,0 +1,65 @@
+// Honest Databricks / Unity Catalog deep links for the Relativity MES Sandbox lineage page.
+//
+// Built on the same workspace resolver as the Factory ML links (resolveWorkspace() ->
+// dbc-2504bec5-b5ab, org 7474657239253594). The honesty rule mirrors factoryEvidenceLinks: a link is
+// live ONLY when its target actually exists. The catalog (novendor_1) and the workspace exist now, so
+// those are live. The medallion schema (novendor_1.relativity_mes) and the gold_rel_* Delta tables are
+// materialized only when the medallion runs — until then `serving_provenance` is 'seed-bootstrap' and
+// these links render FAIL-CLOSED (disabled + reason + a copy chip of the UC path). They auto-upgrade
+// to live ↗ anchors the moment serving flips to 'databricks-gold'. We never link to a table that does
+// not exist yet.
+
+import { resolveWorkspace, type ExternalEvidenceLink } from "@/lib/lab/factoryEvidenceLinks";
+
+const ORG = "7474657239253594";
+export const REL_CATALOG = "novendor_1";
+export const REL_SCHEMA = "relativity_mes";
+
+// The five flat serving marts -> their Databricks gold Delta tables.
+export const REL_GOLD_TABLES = [
+  "rel_build_overview",
+  "rel_as_built_genealogy",
+  "rel_ncr_traceability",
+  "rel_build_cost_rollup",
+  "rel_mes_erp_reconciliation",
+] as const;
+
+const NOT_MATERIALIZED =
+  "Medallion not materialized yet (serverless warehouse health=FAILED). This becomes a live link once " +
+  "the medallion runs and serving_provenance flips to databricks-gold.";
+const NO_WORKSPACE = "Databricks workspace URL is not configured for this environment.";
+
+function ucExploreHref(path: string): string | null {
+  const ws = resolveWorkspace();
+  return ws ? `${ws}/explore/data/${path}?o=${ORG}` : null;
+}
+
+function link(label: string, href: string | null, copyText: string, reason?: string): ExternalEvidenceLink {
+  return { label, kind: "delta_table", href, copyText, unavailableReason: href ? null : reason ?? NO_WORKSPACE };
+}
+
+/** Databricks workspace home (always exists when configured). */
+export function workspaceLink(): ExternalEvidenceLink {
+  const ws = resolveWorkspace();
+  return link("Open Databricks workspace", ws ? `${ws}/?o=${ORG}` : null, ws || REL_CATALOG);
+}
+
+/** Unity Catalog `novendor_1` (exists now — the telemetry catalog that governs serving + medallion). */
+export function catalogLink(): ExternalEvidenceLink {
+  return link(`Open catalog ${REL_CATALOG} in Unity Catalog`, ucExploreHref(REL_CATALOG), REL_CATALOG);
+}
+
+/** Schema `novendor_1.relativity_mes` — created by the medallion; fail-closed until it runs. */
+export function schemaLink(dbxLive: boolean): ExternalEvidenceLink {
+  const uc = `${REL_CATALOG}.${REL_SCHEMA}`;
+  if (!dbxLive) return link(`Open schema ${uc}`, null, uc, NOT_MATERIALIZED);
+  return link(`Open schema ${uc}`, ucExploreHref(`${REL_CATALOG}/${REL_SCHEMA}`), uc);
+}
+
+/** Gold Delta table `novendor_1.relativity_mes.gold_<servingTable>`; fail-closed until the medallion runs. */
+export function goldTableLink(servingTable: string, dbxLive: boolean): ExternalEvidenceLink {
+  const tbl = `gold_${servingTable}`;
+  const uc = `${REL_CATALOG}.${REL_SCHEMA}.${tbl}`;
+  if (!dbxLive) return link(tbl, null, uc, NOT_MATERIALIZED);
+  return link(tbl, ucExploreHref(`${REL_CATALOG}/${REL_SCHEMA}/${tbl}`), uc);
+}


### PR DESCRIPTION
Adds the missing Databricks hyperlinks (planned but not delivered earlier). The Lineage page now has a **Databricks medallion & Unity Catalog** panel:

- **Live** ↗ links to the Databricks workspace (`dbc-2504bec5-b5ab`) and the `novendor_1` Unity Catalog — they exist now.
- **Fail-closed** links for the schema `novendor_1.relativity_mes` + the five `gold_rel_*` Delta tables: disabled + "Medallion not materialized (serverless warehouse health=FAILED)" + a copy chip of the UC path. They auto-upgrade to live ↗ anchors the moment the medallion runs and `serving_provenance` flips to `databricks-gold`.

Same honesty rule as `factoryEvidenceLinks` — never link to a table that doesn't exist yet. 7 console tests pass; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)