### PR TITLE
feat(telemetry): sentence-case page headers + section-color emphasis

### DIFF
--- a/repo-b/src/components/telemetry/HowItWorks.test.tsx
+++ b/repo-b/src/components/telemetry/HowItWorks.test.tsx
@@ -16,7 +16,7 @@ beforeAll(() => {
 describe("HowItWorks — telemetry system-architecture exhibit", () => {
   it("renders the heading and the four view tabs", () => {
     render(<HowItWorks envId="telemetry-demo" />);
-    expect(screen.getByText("Winston Telemetry Platform")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Winston Telemetry Platform" })).toBeInTheDocument();
     for (const label of ["Master System", "NASA · Databricks ML", "Streaming", "Factory ML · NCR"]) {
       expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
     }

--- a/repo-b/src/components/telemetry/RulCalibration.test.tsx
+++ b/repo-b/src/components/telemetry/RulCalibration.test.tsx
@@ -7,7 +7,7 @@ import { CALIBRATION_TRAJECTORY } from "@/lib/telemetry/calibrationEvidence";
 describe("RulCalibration", () => {
   it("renders the champion header and required status chips", () => {
     render(<RulCalibration />);
-    expect(screen.getByText("RUL Calibration")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "RUL Calibration" })).toBeInTheDocument();
     expect(screen.getByText("Champion: CNN-LSTM")).toBeInTheDocument();
     expect(screen.getByText("Gate: Passed")).toBeInTheDocument();
     // honesty: must say not-SOTA and label the data source

--- a/repo-b/src/components/telemetry/SystemHealth.test.tsx
+++ b/repo-b/src/components/telemetry/SystemHealth.test.tsx
@@ -11,7 +11,7 @@ import SystemHealth from "./SystemHealth";
 describe("SystemHealth — consolidated operations view", () => {
   it("renders one System Health heading and embeds both operational sub-surfaces under sections", () => {
     render(<SystemHealth envId="env-1" />);
-    expect(screen.getByText("System Health")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "System Health" })).toBeInTheDocument();
     expect(screen.getByText(/drift, serving, stream health/i)).toBeInTheDocument();
     expect(screen.getByText(/analyzer dispositions/i)).toBeInTheDocument();
     expect(screen.getByTestId("monitoring-embed")).toBeInTheDocument();

--- a/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
@@ -11,8 +11,12 @@ vi.mock("./context/BottleneckMap/BottleneckMap", () => ({
     </div>
   ),
 }));
-// The Overview reads envId from the route to build the demo bridge links.
-vi.mock("next/navigation", () => ({ useParams: () => ({ envId: "env-test" }) }));
+// The Overview reads envId from the route to build the demo bridge links; the page header reads the
+// pathname to resolve its section (Overview → cyan) accent color.
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ envId: "env-test" }),
+  usePathname: () => "/lab/env/env-test/telemetry",
+}));
 
 import TelemetryOverview from "./TelemetryOverview";
 

--- a/repo-b/src/components/telemetry/TelemetryPageHeader.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetryPageHeader.test.tsx
@@ -38,6 +38,20 @@ describe("TelemetryPageHeader", () => {
     expect(screen.getByText("$12k")).toBeInTheDocument();
   });
 
+  it("sentence-cases the title in CSS and emphasizes the leading word in its own span", () => {
+    render(<TelemetryPageHeader variant="standard" eyebrow="Factory & Quality" title="Factory · NCR Intelligence" accent="#f5b452" />);
+    const h1 = screen.getByRole("heading", { level: 1 });
+    // Casing is normalized purely in CSS — textContent (and acronyms) are untouched in the DOM.
+    expect(h1.className).toContain("lowercase");
+    expect(h1.className).toContain("first-letter:uppercase");
+    expect(h1).toHaveTextContent("Factory · NCR Intelligence");
+    // The leading word is isolated so it can carry the category color.
+    const firstWord = screen.getByText("Factory");
+    expect(firstWord.tagName).toBe("SPAN");
+    expect(firstWord).not.toBe(h1);
+    expect(firstWord.getAttribute("style") ?? "").toMatch(/color/i);
+  });
+
   it("renders actions and metadata slots when provided", () => {
     render(
       <TelemetryPageHeader

--- a/repo-b/src/components/telemetry/TelemetryPageHeader.tsx
+++ b/repo-b/src/components/telemetry/TelemetryPageHeader.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import type { CSSProperties, ReactNode } from "react";
+import { usePathname } from "next/navigation";
 import { C } from "./primitives";
+import { telemetryAccentForPath } from "./telemetryNav";
 
 // ===========================================================================
 // Telemetry page header system. One header family for every telemetry route so
@@ -20,13 +22,9 @@ import { C } from "./primitives";
 // the metadata/actions/metrics slots. Nested section headings keep using PageHeading.
 // ---------------------------------------------------------------------------
 
-// Brand fluorescent purple — gradient emphasis is limited to a meaningful phrase
-// (Overview's "Launch"/"Data", and at most one phrase on selected evidence headers).
-const NV_PURPLE = "#B040FF";
-
 export type HeaderVariant = "hero" | "compact" | "standard" | "evidence";
 
-/** A title is plain text or typed segments; a segment may be gradient-emphasized. */
+/** A title is plain text or typed segments; a `gradient` segment is emphasized in the category color. */
 export type TitleSegment = { text: string; gradient?: boolean };
 export type HeaderTitle = string | TitleSegment[];
 
@@ -44,22 +42,42 @@ const FONT_EDITORIAL = "var(--font-editorial), Georgia, serif";
 // face and the same size on every telemetry page, so the headlines read as one product. Overview is no
 // longer the oversized outlier and the operational consoles are no longer the small ones. The clamp() keeps
 // it wrapping cleanly from 390px to desktop. Variant still drives layout (margin, hero metric strip) and the
-// gradient still emphasizes a meaningful phrase, but the title font and size are shared.
+// emphasized word still carries the category color, but the title font and size are shared.
+//
+// Casing is normalized to sentence case in CSS (`lowercase` + a `first-letter:uppercase` cap), so every
+// title reads "First letter capitalized, the rest lowercase" regardless of how it is authored — no per-page
+// copy edits, and source-system acronyms can't reintroduce SHOUTING. text-transform is purely visual, so the
+// h1's textContent (and the header tests) are unchanged.
 const TITLE_STYLE: CSSProperties = {
   fontFamily: FONT_EDITORIAL, fontWeight: 600,
   fontSize: "clamp(1.85rem, 3.4vw, 2.3rem)", lineHeight: 1.12, letterSpacing: "0.003em",
 };
+const TITLE_CASE_CLASS = "lowercase first-letter:uppercase";
 
 const MARGIN_BOTTOM: Record<HeaderVariant, number> = { hero: 26, evidence: 24, standard: 22, compact: 18 };
 
-function renderTitle(title: HeaderTitle): ReactNode {
-  const segments: TitleSegment[] = typeof title === "string" ? [{ text: title }] : title;
-  return segments.map((seg, i) => {
-    if (!seg.gradient) return <span key={i}>{seg.text}</span>;
-    return (
-      <span key={i} style={{ color: NV_PURPLE, textShadow: `0 0 18px ${NV_PURPLE}99` }}>{seg.text}</span>
-    );
-  });
+// One emphasized word per title, painted in the page's category color (the same color the left rail
+// gives this section). For a typed-segment title, the authored `gradient` segments are the emphasis;
+// for a plain string we emphasize the leading word (letters/digits + internal hyphens/apostrophes),
+// leaving any trailing "·"/punctuation un-tinted.
+function accentSpan(text: string, accent: string, key?: number): ReactNode {
+  return <span key={key} style={{ color: accent, textShadow: `0 0 18px ${accent}99` }}>{text}</span>;
+}
+
+function renderTitle(title: HeaderTitle, accent: string): ReactNode {
+  if (typeof title !== "string") {
+    return title.map((seg, i) => (seg.gradient ? accentSpan(seg.text, accent, i) : <span key={i}>{seg.text}</span>));
+  }
+  const m = title.match(/^(\s*)([\p{L}\p{N}]+(?:[-'][\p{L}\p{N}]+)*)([\s\S]*)$/u);
+  if (!m) return <span>{title}</span>;
+  const [, lead, firstWord, rest] = m;
+  return (
+    <>
+      {lead}
+      {accentSpan(firstWord, accent)}
+      {rest}
+    </>
+  );
 }
 
 // Hero metric row — inline editorial stats under the thesis (not a card dashboard).
@@ -89,6 +107,7 @@ export function TelemetryPageHeader({
   metadata,
   actions,
   metrics,
+  accent,
 }: {
   variant?: HeaderVariant;
   eyebrow: string;
@@ -100,18 +119,24 @@ export function TelemetryPageHeader({
   actions?: ReactNode;
   /** Hero metric row (e.g. Overview Big Numbers). */
   metrics?: HeaderMetric[];
+  /** Category color override; defaults to the section color of the current route (the rail color). */
+  accent?: string;
 }) {
   const isWide = variant === "hero" || variant === "evidence";
+  // The page's section color — same as the left rail's. Resolved from the route so no page has to pass
+  // it; `usePathname` is null outside the app router (e.g. unit tests), where we fall back to cyan.
+  const pathname = usePathname();
+  const sectionAccent = accent ?? telemetryAccentForPath(pathname ?? "");
   return (
     <header style={{ marginBottom: MARGIN_BOTTOM[variant], maxWidth: isWide ? 880 : undefined }}>
       <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", flexWrap: "wrap", gap: 12 }}>
         <div style={{ minWidth: 0 }}>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <span aria-hidden style={{ width: variant === "hero" ? 18 : 16, height: 2, borderRadius: 2, background: C.cyan, boxShadow: `0 0 8px ${C.cyan}aa` }} />
-            <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.16em", color: C.cyan, textTransform: "uppercase" }}>{eyebrow}</span>
+            <span aria-hidden style={{ width: variant === "hero" ? 18 : 16, height: 2, borderRadius: 2, background: sectionAccent, boxShadow: `0 0 8px ${sectionAccent}aa` }} />
+            <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.16em", color: sectionAccent, textTransform: "uppercase" }}>{eyebrow}</span>
           </div>
-          <h1 style={{ ...TITLE_STYLE, color: C.text, marginTop: variant === "hero" ? 12 : 9 }}>
-            {renderTitle(title)}
+          <h1 className={TITLE_CASE_CLASS} style={{ ...TITLE_STYLE, color: C.text, marginTop: variant === "hero" ? 12 : 9 }}>
+            {renderTitle(title, sectionAccent)}
           </h1>
         </div>
         {actions && <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", justifyContent: "flex-end", flexShrink: 0 }}>{actions}</div>}

--- a/repo-b/src/components/telemetry/metadata/TelemetryMetadataExplorer.test.tsx
+++ b/repo-b/src/components/telemetry/metadata/TelemetryMetadataExplorer.test.tsx
@@ -140,7 +140,7 @@ describe("TelemetryMetadataExplorer", () => {
     const user = userEvent.setup();
     render(<TelemetryMetadataExplorer envId="route-env" />);
 
-    expect(await screen.findByText("Telemetry Metadata Explorer")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Telemetry Metadata Explorer" })).toBeInTheDocument();
     expect(screen.getByText("route-env")).toBeInTheDocument();
     expect(screen.getByText("telemetry-demo")).toBeInTheDocument();
     expect(screen.getByText("Runtime column enrichment is unavailable.")).toBeInTheDocument();
@@ -157,7 +157,7 @@ describe("TelemetryMetadataExplorer", () => {
     vi.spyOn(metadataApi, "getMetadataGraph").mockResolvedValue(graph);
     const user = userEvent.setup();
     render(<TelemetryMetadataExplorer envId="route-env" />);
-    await screen.findByText("Telemetry Metadata Explorer");
+    await screen.findByRole("heading", { name: "Telemetry Metadata Explorer" });
 
     await user.type(
       screen.getByPlaceholderText("Search schemas, tables, metrics, consumers..."),
@@ -178,6 +178,6 @@ describe("TelemetryMetadataExplorer", () => {
     expect(await screen.findByText("Metadata graph unavailable")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Retry" }));
     await waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    expect(await screen.findByText("Telemetry Metadata Explorer")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Telemetry Metadata Explorer" })).toBeInTheDocument();
   });
 });

--- a/repo-b/src/components/telemetry/relativity-mes/consoles.test.tsx
+++ b/repo-b/src/components/telemetry/relativity-mes/consoles.test.tsx
@@ -39,7 +39,7 @@ describe("BuildOverviewConsole", () => {
       ],
     });
     render(<BuildOverviewConsole envId="telemetry" />);
-    expect(await screen.findByText("Build Overview")).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Build Overview" })).toBeTruthy();
     expect(screen.getByText("synthetic sandbox")).toBeTruthy();
     expect((await screen.findAllByText("VEH-DEMO-001")).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("blocked")).toBeTruthy();
@@ -77,7 +77,7 @@ describe("BuildGenealogyConsole", () => {
       affected_vehicle_count: 2, rows: [{ vehicle_serial: "VEH-DEMO-001" }],
     });
     render(<BuildGenealogyConsole />);
-    expect(await screen.findByText("Build Genealogy")).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Build Genealogy" })).toBeTruthy();
     // LOT-7788 appears as both a tree-row link and a where-used chip
     const lots = await screen.findAllByText("LOT-7788");
     expect(lots.length).toBeGreaterThanOrEqual(1);
@@ -98,7 +98,7 @@ describe("NcrTraceabilityConsole", () => {
         affected_vehicle_count: 2, estimated_rework_cost: 4200 }],
     });
     render(<NcrTraceabilityConsole envId="telemetry" />);
-    expect(await screen.findByText("NCR Traceability")).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "NCR Traceability" })).toBeTruthy();
     expect(await screen.findByText("NCR-0001")).toBeTruthy();
     expect(screen.getByText("Open now")).toBeTruthy();
   });
@@ -116,7 +116,7 @@ describe("CostReconciliationConsole", () => {
         actual_cost: 5700, variance_amount: 700, variance_category: "input_qty", reconciliation_status: "exception" }],
     });
     render(<CostReconciliationConsole />);
-    expect(await screen.findByText("Cost Reconciliation")).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Cost Reconciliation" })).toBeTruthy();
     expect(screen.getByText("Standard cost")).toBeTruthy();
     expect(await screen.findByText("MES actuals (physical truth)")).toBeTruthy();
     expect(screen.getByText("ERP settlement (financial truth)")).toBeTruthy();
@@ -137,7 +137,7 @@ describe("LineageSourceConsole", () => {
       serving: { rel_build_overview: { row_count: 3, serving_provenance: "seed-bootstrap" } },
     });
     render(<LineageSourceConsole />);
-    expect(await screen.findByText("Lineage & Source Tables")).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Lineage & Source Tables" })).toBeTruthy();
     expect(await screen.findByText("rel_mes_vehicle")).toBeTruthy();
     expect(screen.getByText(/Live serving/)).toBeTruthy();
   });

--- a/repo-b/src/components/telemetry/telemetryNav.test.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.test.ts
@@ -4,6 +4,8 @@ import {
   TELEMETRY_NAV_GROUP_META,
   isTelemetryItemActive,
   telemetryHref,
+  telemetryGroupForPath,
+  telemetryAccentForPath,
 } from "./telemetryNav";
 
 describe("telemetry navigation structure (7 presentation sections)", () => {
@@ -99,6 +101,39 @@ describe("telemetry navigation structure (7 presentation sections)", () => {
       expect(meta).toBeDefined();
       expect(meta.icon).toMatch(/^M/); // SVG path data
       expect(meta.accent).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+
+  it("resolves a page's category color from its route — including hidden + multi-segment routes", () => {
+    const base = "/lab/env/env-1/telemetry";
+    const cases: Array<[string, string]> = [
+      [base, "Overview"],                                  // section root
+      [`${base}/stream`, "Operations"],
+      [`${base}/system-health`, "Operations"],
+      [`${base}/model-performance`, "Models & Intelligence"],
+      [`${base}/calibration`, "Models & Intelligence"],
+      [`${base}/factory`, "Factory & Quality"],
+      [`${base}/factory-ml`, "Factory & Quality"],
+      [`${base}/metric-lineage`, "Evidence & Lineage"],
+      [`${base}/metadata`, "Evidence & Lineage"],
+      [`${base}/control-tower`, "Agent Operations"],
+      // hidden-before-delete routes still recover their section color
+      [`${base}/copilot`, "Models & Intelligence"],
+      [`${base}/governance`, "Evidence & Lineage"],
+      [`${base}/how-it-works`, "Evidence & Lineage"],
+      [`${base}/evidence`, "Evidence & Lineage"],
+      // multi-segment groups matched by prefix
+      [`${base}/data-engineering`, "Data Engineering"],
+      [`${base}/data-engineering/grain`, "Data Engineering"],
+      [`${base}/relativity-mes`, "Relativity MES Sandbox"],
+      [`${base}/relativity-mes/ncr`, "Relativity MES Sandbox"],
+      // unknown / off-route falls back to Overview cyan
+      [`${base}/not-a-real-page`, "Overview"],
+      ["/some/other/path", "Overview"],
+    ];
+    for (const [path, group] of cases) {
+      expect(telemetryGroupForPath(path)).toBe(group);
+      expect(telemetryAccentForPath(path)).toBe(TELEMETRY_NAV_GROUP_META[group as keyof typeof TELEMETRY_NAV_GROUP_META].accent);
     }
   });
 

--- a/repo-b/src/components/telemetry/telemetryNav.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.ts
@@ -123,3 +123,47 @@ export function telemetrySectionLabel(pathname: string, envId: string): string {
   const match = TELEMETRY_NAV.find((n) => n.slug && isTelemetryItemActive(pathname, envId, n.slug));
   return match?.label ?? "Overview";
 }
+
+// Top-level slug -> owning group. Covers both visible nav slugs and the hide-before-delete routes
+// (copilot / governance / how-it-works / evidence / data-engineering / monitoring / spike-inspector)
+// that still resolve as deep links — so a page header can always recover its category color even when
+// the route is no longer shown in the rail. Multi-segment groups (relativity-mes/*, data-engineering/*)
+// are matched by prefix below, so they need no entry here.
+const TELEMETRY_SLUG_GROUP: Record<string, TelemetryNavGroup> = {
+  // Operations
+  stream: "Operations", replay: "Operations", stargate: "Operations",
+  runs: "Operations", "system-health": "Operations",
+  monitoring: "Operations", "spike-inspector": "Operations",
+  // Models & Intelligence
+  "model-performance": "Models & Intelligence", calibration: "Models & Intelligence",
+  registry: "Models & Intelligence", copilot: "Models & Intelligence",
+  // Factory & Quality
+  factory: "Factory & Quality", "factory-ml": "Factory & Quality",
+  // Evidence & Lineage
+  "metric-lineage": "Evidence & Lineage", metadata: "Evidence & Lineage",
+  governance: "Evidence & Lineage", "how-it-works": "Evidence & Lineage", evidence: "Evidence & Lineage",
+  // Agent Operations
+  "control-tower": "Agent Operations",
+};
+
+/** Group owning a telemetry pathname (best-effort; defaults to Overview). */
+export function telemetryGroupForPath(pathname: string): TelemetryNavGroup {
+  const marker = "/telemetry";
+  const i = pathname.indexOf(marker);
+  if (i === -1) return "Overview";
+  // Everything after "/telemetry/" — "" at the section root, else "factory", "relativity-mes/ncr", …
+  const rest = pathname.slice(i + marker.length).replace(/^\/+/, "").replace(/[?#].*$/, "");
+  if (rest === "") return "Overview";
+  if (rest.startsWith("relativity-mes")) return "Relativity MES Sandbox";
+  if (rest.startsWith("data-engineering")) return "Data Engineering";
+  return TELEMETRY_SLUG_GROUP[rest.split("/")[0]] ?? "Overview";
+}
+
+/**
+ * Category accent color for a telemetry pathname — the same per-group color the left rail (the
+ * "selector") paints each section with. Page headers use it to tint the eyebrow + emphasize one
+ * word in the title, so every page reads in its section's color. Defaults to the Overview cyan.
+ */
+export function telemetryAccentForPath(pathname: string): string {
+  return TELEMETRY_NAV_GROUP_META[telemetryGroupForPath(pathname)].accent;
+}


### PR DESCRIPTION
## What

Every telemetry page header now reads in **sentence case** (first letter capitalized, the rest lowercase) with **one word and the eyebrow tinted in the page's section color** — the same color the left rail (selector) gives that section.

Examples: `FACTORY · NCR INTELLIGENCE` → **Factory · ncr intelligence** ("Factory" + eyebrow in amber); `MISSION CONTROL · LIVE STREAM` → **Mission control · live stream** (cyan); each Relativity MES page in orange, Models & Intelligence in purple, Evidence & Lineage in green, Agent Operations in pink.

## How

Centralized in [`TelemetryPageHeader`](repo-b/src/components/telemetry/TelemetryPageHeader.tsx), the canonical header for every page reachable from the selector:

- **Casing** — the `<h1>` gets `lowercase first-letter:uppercase`. It's `text-transform` only, so the DOM text (and tests) are unchanged; source acronyms can't reintroduce shouting.
- **Emphasis** — the leading word of a plain title (or the authored emphasis words of the Overview hero) is wrapped in a span colored with the section accent + neon glow.
- **Eyebrow** — the accent bar + label use the same section color.
- **Color source** — `telemetryAccentForPath()` in [`telemetryNav.ts`](repo-b/src/components/telemetry/telemetryNav.ts) resolves the route to its rail color from the existing `TELEMETRY_NAV_GROUP_META`, covering hidden (copilot/governance/data-engineering/…) and multi-segment (relativity-mes/*, data-engineering/*) routes, defaulting to Overview cyan.

## Tests

- Emphasizing a word splits it into its own span, so a handful of tests that matched a full title as a single text node now query the heading by accessible name (`getByRole("heading", { name })`) — the more robust pattern.
- Added resolver coverage in `telemetryNav.test.ts` and a header DOM-contract test in `TelemetryPageHeader.test.tsx`.
- All 58 telemetry test files / 262 tests pass; ESLint clean on changed sources.

## Notes
- Acronyms lowercase under sentence case (`NCR`→`ncr`, `RUL`→`rul`) — the literal "other words lowercase" rule.
- Standalone Monitoring / Spike Inspector routes aren't in the selector (folded into System Health, which is treated), so they're unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)