### PR TITLE
feat(relativity-mes): BigQuery medallion (GCP) + live BQ lineage links

### DIFF
--- a/docs/adr/relativity-mes-sandbox/0004-bigquery-medallion-gcp-fallback.md
+++ b/docs/adr/relativity-mes-sandbox/0004-bigquery-medallion-gcp-fallback.md
@@ -1,0 +1,47 @@
+# ADR 0004 — BigQuery medallion (GCP) as the serverless fallback for Databricks
+
+- Status: Accepted
+- Date: 2026-06-27
+- Deciders: Paul Malmquist
+- Related: [0002](0002-real-serving-architecture-not-fixtures.md),
+  [0003](0003-medallion-and-rel-prefix.md)
+
+## Context
+
+The Databricks medallion (`rel_medallion.py`) is blocked: the workspace serverless **SQL warehouse**
+fails to launch clusters (`RESOURCE_EXHAUSTED: Cannot create the resource`) — an account-level
+serverless capacity/billing condition, not a code defect. We need the medallion + ML to run on GCP
+"in case Databricks can't be made to work." GCP already hosts a working MLOps pattern
+(`novendor-events-prod.mlops_learning_lab` BQ dataset + 3 Vertex models), so this is an extension,
+not greenfield.
+
+## Decision
+
+Replicate the medallion on **BigQuery**, which is **serverless query** — there is no warehouse/cluster
+to provision, so the `RESOURCE_EXHAUSTED` failure mode does not exist.
+
+- `scripts/relativity_mes_seed/bq_medallion.py` builds dataset `novendor-events-prod.relativity_mes`:
+  `bronze_rel_*` (raw synthetic source, loaded from the deterministic generator), `silver_rel_*`
+  (conformed views, synthetic-only contract), `gold_<mart>` (the five gold marts). It validates the
+  demo invariants **in BigQuery** (3 vehicles, suspect lot on exactly two vehicles, an open major NCR,
+  a reconciliation exception) and aborts if any fails.
+- Because the BigQuery gold tables genuinely exist, the **Lineage page links to them live** (via
+  `relativityMesBigquery.ts`), beside the Databricks links which stay **fail-closed** (Databricks gold
+  is not materialized). Honesty rule unchanged: a link is live only when its target exists.
+- `serving_provenance='bigquery-gold'` is reserved for when the Lakebase serving tables are reloaded
+  from the BigQuery gold; `servingLabel()` already renders it ("synthetic BigQuery Gold serving rows").
+
+The deterministic generator remains the single source of truth (see ADR 0002), so the BigQuery gold,
+the Databricks gold (when it runs), and the Lakebase serving rows are byte-identical by construction.
+
+## Alternatives considered
+
+- Wait for the Databricks warehouse to recover — rejected as the only path; capacity is out of our
+  control and the demo needs a working GCP medallion now.
+- Move backend compute to GCP (Cloud Run) — explicitly out of scope; backend stays on Railway.
+
+## Consequences
+
+The medallion + serving story now runs on GCP without any cluster to provision. ML (rel_-specific
+NCR/cost models on Vertex, like the existing `mlops_learning_lab` models) is the natural next step.
+The Databricks medallion code stays committed and runnable for when serverless capacity returns.

--- a/repo-b/src/components/telemetry/relativity-mes/LineageSourceConsole.tsx
+++ b/repo-b/src/components/telemetry/relativity-mes/LineageSourceConsole.tsx
@@ -14,6 +14,9 @@ import { getLineage, useRel, type LineageResp, type Row } from "@/lib/telemetry/
 import {
   REL_GOLD_TABLES, catalogLink, goldTableLink, schemaLink, workspaceLink,
 } from "@/lib/telemetry/relativityMesDatabricks";
+import {
+  BQ_GOLD_TABLES, bqDatasetLink, bqGoldTableLink,
+} from "@/lib/telemetry/relativityMesBigquery";
 import { REL_ACCENT, RelSourceDrill, ServingStrip, SyntheticBanner, useDrill } from "./relMesShared";
 
 const str = (r: Row, k: string) => (r[k] == null ? "—" : String(r[k]));
@@ -59,6 +62,22 @@ export default function LineageSourceConsole() {
               <span style={{ color: dbxLive ? C.green : REL_ACCENT }}>
                 {dbxLive ? "databricks-gold (synced from Databricks Gold)" : "seed-bootstrap (deterministic gold load; Databricks backfill flips this to databricks-gold)"}
               </span>.
+            </div>
+          </Panel>
+
+          <Panel title="BigQuery medallion (GCP) — live" style={{ marginBottom: 14 }}>
+            <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginBottom: 10, lineHeight: 1.5 }}>
+              The medallion is materialized on serverless BigQuery (no warehouse to provision) in{" "}
+              <span style={{ color: C.dim }}>novendor-events-prod.relativity_mes</span> — 23 bronze + 23
+              silver + 5 gold. These links are <span style={{ color: C.green }}>live</span> (the tables exist).
+            </div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 10 }}>
+              <EvidenceLink link={bqDatasetLink()} />
+            </div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              {BQ_GOLD_TABLES.map((t) => (
+                <EvidenceLink key={t} link={bqGoldTableLink(t)} />
+              ))}
             </div>
           </Panel>
 

--- a/repo-b/src/components/telemetry/relativity-mes/consoles.test.tsx
+++ b/repo-b/src/components/telemetry/relativity-mes/consoles.test.tsx
@@ -142,20 +142,27 @@ describe("LineageSourceConsole", () => {
     expect(screen.getByText(/Live serving/)).toBeTruthy();
   });
 
-  it("renders honest Databricks deep links: live catalog, fail-closed gold tables (bootstrap)", async () => {
+  it("renders honest medallion links: BigQuery live, Databricks fail-closed", async () => {
     (lib.getLineage as Mock).mockResolvedValue({
-      ...META, // serving_provenance = seed-bootstrap -> medallion not materialized
+      ...META, // serving_provenance = seed-bootstrap -> Databricks medallion not materialized
       rows: [{ object_name: "rel_mes_vehicle", layer: "source", source_system: "MES", row_count: 3,
         dashboard_consumers: "[]", ingest_batch_id: "rel-mes-seed-v1", source_system_layer: "rel_*" }],
       serving: { rel_build_overview: { row_count: 3, serving_provenance: "seed-bootstrap" } },
     });
     render(<LineageSourceConsole />);
-    expect(await screen.findByText("Databricks medallion & Unity Catalog")).toBeTruthy();
-    // catalog (novendor_1) exists now -> a live anchor to the workspace
-    const catalog = await screen.findByText(/Open catalog novendor_1/);
-    expect(catalog.closest("a")?.getAttribute("href")).toContain("dbc-2504bec5-b5ab");
-    // gold tables not materialized -> fail-closed (disabled + reason), NOT a live link
-    expect(screen.getByText("gold_rel_build_overview").closest("a")).toBeNull();
+    // BigQuery medallion is materialized -> live links
+    expect(await screen.findByText("BigQuery medallion (GCP) — live")).toBeTruthy();
+    const bqDataset = screen.getByText(/Open BigQuery dataset/);
+    expect(bqDataset.closest("a")?.getAttribute("href")).toContain("console.cloud.google.com/bigquery");
+    // a BigQuery gold table is a LIVE anchor to the BQ console
+    const bqGoldAnchor = screen.getAllByRole("link").find(
+      (a) => a.getAttribute("href")?.includes("relativity_mes") && a.textContent?.includes("gold_rel_build_overview"));
+    expect(bqGoldAnchor).toBeTruthy();
+    // Databricks catalog (novendor_1) is live; its gold tables are fail-closed (not materialized)
+    expect(screen.getByText("Databricks medallion & Unity Catalog")).toBeTruthy();
+    expect(screen.getByText(/Open catalog novendor_1/).closest("a")?.getAttribute("href")).toContain("dbc-2504bec5-b5ab");
     expect(screen.getAllByText(/Medallion not materialized/).length).toBeGreaterThanOrEqual(1);
+    // the Databricks gold label (exact text, no trailing ↗) is fail-closed -> not an anchor
+    expect(screen.getByText("gold_rel_build_overview").closest("a")).toBeNull();
   });
 });

--- a/repo-b/src/lib/telemetry/relativityMes.ts
+++ b/repo-b/src/lib/telemetry/relativityMes.ts
@@ -88,8 +88,7 @@ export function useRel<T>(fetcher: () => Promise<T>, deps: unknown[] = []): {
 // Human label for the serving source-kind + provenance (honest chip text).
 export function servingLabel(meta: ServingMeta): string {
   if (meta.source_kind === "unavailable") return "serving unavailable";
-  const prov = meta.serving_provenance === "databricks-gold"
-    ? "synthetic Databricks Gold serving rows"
-    : "synthetic gold serving rows (bootstrap load)";
-  return prov;
+  if (meta.serving_provenance === "bigquery-gold") return "synthetic BigQuery Gold serving rows";
+  if (meta.serving_provenance === "databricks-gold") return "synthetic Databricks Gold serving rows";
+  return "synthetic gold serving rows (bootstrap load)";
 }

--- a/repo-b/src/lib/telemetry/relativityMesBigquery.ts
+++ b/repo-b/src/lib/telemetry/relativityMesBigquery.ts
@@ -1,0 +1,46 @@
+// Live BigQuery / Unity-Catalog-equivalent deep links for the Relativity MES Sandbox lineage page.
+//
+// Unlike the Databricks medallion (warehouse billing-blocked, tables not materialized), the BigQuery
+// medallion IS materialized: `scripts/relativity_mes_seed/bq_medallion.py` built dataset
+// novendor-events-prod.relativity_mes (23 bronze + 23 silver + 5 gold) on serverless BigQuery. So
+// these links are LIVE — they resolve to real tables. Same honesty rule: only emit a live href when
+// the target exists; the gold tables exist, so they do.
+
+import type { ExternalEvidenceLink } from "@/lib/lab/factoryEvidenceLinks";
+
+export const BQ_PROJECT = "novendor-events-prod";
+export const BQ_DATASET = "relativity_mes";
+
+export const BQ_GOLD_TABLES = [
+  "gold_rel_build_overview",
+  "gold_rel_as_built_genealogy",
+  "gold_rel_ncr_traceability",
+  "gold_rel_build_cost_rollup",
+  "gold_rel_mes_erp_reconciliation",
+] as const;
+
+const CONSOLE = "https://console.cloud.google.com/bigquery";
+
+function datasetHref(): string {
+  // BigQuery console workspace deep-link to the dataset.
+  return `${CONSOLE}?project=${BQ_PROJECT}&ws=!1m4!1m3!3m2!1s${BQ_PROJECT}!2s${BQ_DATASET}`;
+}
+
+function tableHref(table: string): string {
+  // Workspace deep-link to a specific table; the FQ name is also copyable as a fallback.
+  return `${CONSOLE}?project=${BQ_PROJECT}&ws=!1m5!1m4!4m3!1s${BQ_PROJECT}!2s${BQ_DATASET}!3s${table}`;
+}
+
+function link(label: string, href: string, copyText: string): ExternalEvidenceLink {
+  return { label, kind: "delta_table", href, copyText };
+}
+
+/** The BigQuery dataset that holds the materialized medallion (live). */
+export function bqDatasetLink(): ExternalEvidenceLink {
+  return link(`Open BigQuery dataset ${BQ_DATASET}`, datasetHref(), `${BQ_PROJECT}.${BQ_DATASET}`);
+}
+
+/** A live gold Delta-equivalent table in BigQuery. */
+export function bqGoldTableLink(table: string): ExternalEvidenceLink {
+  return link(table, tableHref(table), `${BQ_PROJECT}.${BQ_DATASET}.${table}`);
+}

--- a/scripts/relativity_mes_seed/bq_medallion.py
+++ b/scripts/relativity_mes_seed/bq_medallion.py
@@ -1,0 +1,123 @@
+"""Relativity MES Sandbox — BigQuery medallion (GCP-native fallback for the Databricks warehouse).
+
+BigQuery is serverless (no SQL warehouse to provision, so no RESOURCE_EXHAUSTED). This stands up the
+same medallion shape as the Databricks one, in BigQuery dataset `relativity_mes`:
+
+  bronze_rel_*   raw landing of the deterministic synthetic source (loaded from NDJSON)
+  silver_rel_*   conformed views (synthetic-only data contract)
+  gold_<mart>    the five gold marts (loaded; the generator is the gold transform — see ADR 0002)
+
+Then it validates the demo invariants directly in BigQuery (3 vehicles, suspect lot on exactly two
+vehicles, an open major NCR, a reconciliation exception). All data is SYNTHETIC.
+
+Run: CLOUDSDK_PYTHON=<python> python -m scripts.relativity_mes_seed.bq_medallion
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_BQ = shutil.which("bq") or "bq"
+# On Windows bq resolves to bq.CMD, which CreateProcess can't exec directly — go through cmd /c.
+_LAUNCH = (["cmd", "/c", _BQ] if _BQ.lower().endswith((".cmd", ".bat")) else [_BQ])
+
+from .generate import SUSPECT_LOT, build_dataset
+from .emit import SERVING_MAP
+
+PROJECT = "novendor-events-prod"
+DATASET = "relativity_mes"
+LOCATION = "US"
+NS = f"{PROJECT}:{DATASET}"
+FQ = f"{PROJECT}.{DATASET}"
+
+
+def _bq(args: list[str], sql: str | None = None) -> str:
+    env = dict(os.environ)
+    env.setdefault("CLOUDSDK_PYTHON", sys.executable)
+    cmd = [*_LAUNCH, f"--project_id={PROJECT}", *args]
+    res = subprocess.run(cmd, input=sql, capture_output=True, text=True, env=env)
+    if res.returncode != 0:
+        raise RuntimeError(f"bq failed: {' '.join(cmd)}\n{res.stderr.strip()[:600]}")
+    return res.stdout.strip()
+
+
+def _query(sql: str) -> list[dict]:
+    out = _bq(["query", "--use_legacy_sql=false", "--format=json", "--quiet"], sql=sql)
+    return json.loads(out) if out else []
+
+
+def _write_ndjson(rows: list[dict], path: Path) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r, default=str) + "\n")
+
+
+def _load(table: str, rows: list[dict], tmp: Path) -> None:
+    if not rows:
+        print(f"  skip {table} (no rows)")
+        return
+    f = tmp / f"{table}.ndjson"
+    _write_ndjson(rows, f)
+    _bq(["load", "--source_format=NEWLINE_DELIMITED_JSON", "--autodetect", "--replace",
+         f"{DATASET}.{table}", str(f)])
+    print(f"  loaded {table}: {len(rows)} rows")
+
+
+def main() -> int:
+    ds = build_dataset()
+    src, gold = ds["source"], ds["gold"]
+
+    # dataset (idempotent)
+    try:
+        _bq(["mk", "--dataset", f"--location={LOCATION}", NS])
+        print(f"created dataset {NS}")
+    except RuntimeError as e:
+        if "already exists" in str(e).lower():
+            print(f"dataset {NS} exists")
+        else:
+            raise
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        print("bronze: landing synthetic source …")
+        for t, rows in src.items():
+            _load(f"bronze_{t}", rows, tmp)
+
+        print("gold: materializing the five marts …")
+        for mart, serving in SERVING_MAP.items():
+            _load(f"gold_{serving}", gold[mart], tmp)
+
+    print("silver: conforming (views, synthetic-only contract) …")
+    for t in src:
+        _bq(["query", "--use_legacy_sql=false", "--quiet"],
+            sql=f"CREATE OR REPLACE VIEW `{FQ}.silver_{t}` AS "
+                f"SELECT * FROM `{FQ}.bronze_{t}` WHERE synthetic IS TRUE")
+    print(f"  {len(src)} silver views")
+
+    # ---- validate invariants IN BigQuery ----
+    veh = int(_query(f"SELECT count(DISTINCT vehicle_serial) AS n FROM `{FQ}.silver_rel_mes_vehicle`")[0]["n"])
+    sl = int(_query(f"SELECT count(DISTINCT vehicle_serial) AS n FROM `{FQ}.silver_rel_mes_as_built_genealogy` "
+                    f"WHERE lot_no='{SUSPECT_LOT}'")[0]["n"])
+    om = int(_query(f"SELECT count(*) AS n FROM `{FQ}.silver_rel_mes_nonconformance` "
+                    f"WHERE status='open' AND severity='major'")[0]["n"])
+    exc = int(_query(f"SELECT count(*) AS n FROM `{FQ}.gold_rel_mes_erp_reconciliation` "
+                     f"WHERE reconciliation_status='exception'")[0]["n"])
+    print(f"VALIDATE  vehicles={veh}  suspect_lot_vehicles={sl}  open_major_ncr={om}  exceptions={exc}")
+    assert veh == 3, f"expected 3 vehicles, got {veh}"
+    assert sl == 2, f"suspect lot must affect exactly 2 vehicles, got {sl}"
+    assert om >= 1, "expected an open major NCR"
+    assert exc >= 1, "expected a reconciliation exception"
+
+    print(f"\nBigQuery medallion ready: {FQ} "
+          f"({len(src)} bronze + {len(src)} silver + {len(gold)} gold). Serverless — no warehouse.")
+    print(f"Console: https://console.cloud.google.com/bigquery?project={PROJECT}&ws=!1m4!1m3!3m2!1s{PROJECT}!2s{DATASET}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Replicates the Databricks medallion on **serverless BigQuery** as a GCP-native fallback. The Databricks SQL warehouse is `RESOURCE_EXHAUSTED` (account serverless capacity/billing); BigQuery has no warehouse to provision, so that failure mode doesn't exist.

- `scripts/relativity_mes_seed/bq_medallion.py` builds `novendor-events-prod.relativity_mes` (23 bronze + 23 silver views + 5 gold) and **validates the invariants in BigQuery** (vehicles=3, suspect-lot vehicles=2, open-major-NCR=1, exceptions=1). Ran successfully on GCP.
- The BQ gold tables genuinely exist, so the Lineage page now has a **live 'BigQuery medallion (GCP)' panel** with clickable deep links to the dataset + 5 gold tables. The Databricks panel stays fail-closed (its gold isn't materialized) — same honesty rule.
- 7 console tests pass; typecheck + lint clean.

Net: the medallion + serving story now runs on GCP without any cluster to provision. ML on Vertex (rel_-specific NCR/cost models, like the existing mlops_learning_lab models) is the natural next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)