### PR TITLE
feat(relativity-mes): dashboards serve from BigQuery (bigquery-gold)

### DIFF
--- a/docs/adr/relativity-mes-sandbox/0004-bigquery-medallion-gcp-fallback.md
+++ b/docs/adr/relativity-mes-sandbox/0004-bigquery-medallion-gcp-fallback.md
@@ -28,8 +28,12 @@ to provision, so the `RESOURCE_EXHAUSTED` failure mode does not exist.
 - Because the BigQuery gold tables genuinely exist, the **Lineage page links to them live** (via
   `relativityMesBigquery.ts`), beside the Databricks links which stay **fail-closed** (Databricks gold
   is not materialized). Honesty rule unchanged: a link is live only when its target exists.
-- `serving_provenance='bigquery-gold'` is reserved for when the Lakebase serving tables are reloaded
-  from the BigQuery gold; `servingLabel()` already renders it ("synthetic BigQuery Gold serving rows").
+- **Serving reloaded from BigQuery (done).** The Lakebase `rel_*` serving tables were genuinely
+  reloaded *from* the BigQuery gold marts (read `gold_*`, transactional DELETE+INSERT per table) and
+  now report `serving_provenance='bigquery-gold'`. Verified in prod: `/overview` → `bigquery-gold`,
+  all five serving marts `bigquery-gold`, invariants intact (VEH-DEMO-001 blocked, `LOT-7788` → 2
+  vehicles). The live dashboards now serve from the GCP/BigQuery medallion; the Lineage page's path
+  text + serving panel reflect it. `servingLabel()` renders "synthetic BigQuery Gold serving rows".
 
 The deterministic generator remains the single source of truth (see ADR 0002), so the BigQuery gold,
 the Databricks gold (when it runs), and the Lakebase serving rows are byte-identical by construction.

--- a/repo-b/src/components/telemetry/relativity-mes/LineageSourceConsole.tsx
+++ b/repo-b/src/components/telemetry/relativity-mes/LineageSourceConsole.tsx
@@ -32,7 +32,16 @@ export default function LineageSourceConsole() {
   const joinKeys: string[] = joinDoc && typeof joinDoc.join_keys === "string"
     ? (() => { try { return JSON.parse(String(joinDoc.join_keys)); } catch { return []; } })() : [];
   const serving = data?.serving ?? {};
-  const dbxLive = Object.values(serving).some((s) => s.serving_provenance === "databricks-gold");
+  const provenance = Object.values(serving).map((s) => s.serving_provenance).find(Boolean) ?? "seed-bootstrap";
+  // dbxLive gates the Databricks panel only (its gold is still not materialized even when serving is BigQuery).
+  const dbxLive = provenance === "databricks-gold";
+  const bqLive = provenance === "bigquery-gold";
+  const goldLive = dbxLive || bqLive;
+  const medallionName = bqLive ? "BigQuery medallion (bronze → silver → gold)"
+    : "Databricks medallion (bronze → silver → gold_rel_*)";
+  const provText = bqLive ? "bigquery-gold (synced from the BigQuery Gold marts)"
+    : dbxLive ? "databricks-gold (synced from Databricks Gold)"
+    : "seed-bootstrap (deterministic gold load; a medallion backfill flips this to bigquery-gold / databricks-gold)";
 
   return (
     <div>
@@ -47,21 +56,19 @@ export default function LineageSourceConsole() {
 
       {data && !data.null_reason && (
         <>
-          <ServingStrip meta={data} note={dbxLive ? "Databricks-gold serving" : "bootstrap serving"} />
+          <ServingStrip meta={data} note={bqLive ? "BigQuery-gold serving" : dbxLive ? "Databricks-gold serving" : "bootstrap serving"} />
 
           <Panel title="Live serving (Postgres/Lakebase) — proof of the real serving path" style={{ marginBottom: 14 }}>
             <StatGrid cols={5}>
               {Object.entries(serving).map(([t, s]) => (
                 <Stat key={t} label={t.replace(/^rel_/, "")} value={s.row_count}
-                  tone={s.serving_provenance === "databricks-gold" ? C.green : REL_ACCENT} />
+                  tone={s.serving_provenance === "bigquery-gold" || s.serving_provenance === "databricks-gold" ? C.green : REL_ACCENT} />
               ))}
             </StatGrid>
             <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, marginTop: 10, lineHeight: 1.6 }}>
-              Path: synthetic source (rel_*) → Databricks medallion (bronze → silver → gold_rel_*) →
+              Path: synthetic source (rel_*) → {medallionName} →
               Postgres/Lakebase serving (rel_*) → FastAPI → this dashboard. Provenance{" "}
-              <span style={{ color: dbxLive ? C.green : REL_ACCENT }}>
-                {dbxLive ? "databricks-gold (synced from Databricks Gold)" : "seed-bootstrap (deterministic gold load; Databricks backfill flips this to databricks-gold)"}
-              </span>.
+              <span style={{ color: goldLive ? C.green : REL_ACCENT }}>{provText}</span>.
             </div>
           </Panel>
 

--- a/repo-b/src/components/telemetry/relativity-mes/consoles.test.tsx
+++ b/repo-b/src/components/telemetry/relativity-mes/consoles.test.tsx
@@ -142,6 +142,20 @@ describe("LineageSourceConsole", () => {
     expect(screen.getByText(/Live serving/)).toBeTruthy();
   });
 
+  it("reflects BigQuery-gold serving in the medallion path when serving is reloaded from BigQuery", async () => {
+    (lib.getLineage as Mock).mockResolvedValue({
+      ...META, serving_provenance: "bigquery-gold",
+      rows: [{ object_name: "rel_mes_vehicle", layer: "source", source_system: "MES", row_count: 3,
+        dashboard_consumers: "[]", ingest_batch_id: "rel-mes-seed-v1", source_system_layer: "rel_*" }],
+      serving: { rel_build_overview: { row_count: 3, serving_provenance: "bigquery-gold" } },
+    });
+    render(<LineageSourceConsole />);
+    expect((await screen.findAllByText(/BigQuery medallion/)).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/bigquery-gold \(synced from the BigQuery Gold marts\)/)).toBeTruthy();
+    // Databricks gold stays fail-closed (its tables aren't materialized even when serving is BigQuery)
+    expect(screen.getAllByText(/Medallion not materialized/).length).toBeGreaterThanOrEqual(1);
+  });
+
   it("renders honest medallion links: BigQuery live, Databricks fail-closed", async () => {
     (lib.getLineage as Mock).mockResolvedValue({
       ...META, // serving_provenance = seed-bootstrap -> Databricks medallion not materialized


### PR DESCRIPTION
Completes the GCP medallion story: the Lakebase `rel_*` serving tables were genuinely **reloaded from the BigQuery gold marts** (transactional DELETE+INSERT per table), and prod now reports `serving_provenance=bigquery-gold` across all five marts — invariants intact (VEH-DEMO-001 blocked, `LOT-7788` → 2 vehicles).

Frontend: the Lineage page's live-serving panel + path text now reflect the active medallion (**BigQuery** when bigquery-gold, Databricks when databricks-gold, else bootstrap); the per-dashboard chip already renders "synthetic BigQuery Gold serving rows" via `servingLabel()`. Databricks gold links stay fail-closed (its tables aren't materialized). 8 console tests pass; typecheck + lint clean.

So the live dashboards now serve from the GCP/BigQuery medallion end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)