### PR TITLE
feat(telemetry): Model Workbench receipt contract — fail-closed /workbench reads (#736)

### DIFF
--- a/backend/app/data/telemetry/feature_manifest.json
+++ b/backend/app/data/telemetry/feature_manifest.json
@@ -1,0 +1,71 @@
+{
+  "provider": "local_fixture",
+  "source_bigquery_table": null,
+  "vertex_experiment": null,
+  "vertex_run_id": null,
+  "vertex_model_id": null,
+  "gcs_artifact_uri": null,
+  "created_at": "2026-06-27T00:00:00Z",
+  "code_version": "local_fixture@0d502954",
+  "data_manifest_sha": null,
+  "rows_evaluated": null,
+  "null_reason": null,
+  "payload": {
+    "feature_sets": [
+      {
+        "id": "baseline",
+        "label": "A — Baseline",
+        "purpose": "Transparent starting point — the promoted MAD champion's real inputs.",
+        "model_family": "rolling-MAD",
+        "included": true,
+        "features": [
+          {"name": "value", "calc": "raw channel reading", "leakage_risk": "none"},
+          {"name": "rolling_mean_50", "calc": "trailing mean over 50 ticks (no look-ahead)", "leakage_risk": "none"},
+          {"name": "residual", "calc": "abs(value - rolling_mean_50)", "leakage_risk": "none"},
+          {"name": "global_train_scale", "calc": "median abs residual across SMAP/MSL train channels (frozen)", "leakage_risk": "none"},
+          {"name": "channel_id", "calc": "categorical channel identifier", "leakage_risk": "none"}
+        ],
+        "leakage_notes": "Trailing windows only; train scale frozen from the train split. No test labels touch features."
+      },
+      {
+        "id": "temporal",
+        "label": "B — Temporal context",
+        "purpose": "Catch drift before static redlines trip.",
+        "model_family": "MAD / PCA",
+        "included": false,
+        "features": [
+          {"name": "rolling_mean_10", "calc": "trailing mean over 10 ticks", "leakage_risk": "none"},
+          {"name": "rolling_mean_50", "calc": "trailing mean over 50 ticks", "leakage_risk": "none"},
+          {"name": "rolling_mean_100", "calc": "trailing mean over 100 ticks", "leakage_risk": "none"},
+          {"name": "rolling_std_10", "calc": "trailing std over 10 ticks", "leakage_risk": "none"},
+          {"name": "rolling_std_50", "calc": "trailing std over 50 ticks", "leakage_risk": "none"},
+          {"name": "residual_zscore", "calc": "residual / trailing residual std", "leakage_risk": "none"},
+          {"name": "residual_slope", "calc": "OLS slope of residual over a short trailing window", "leakage_risk": "none"},
+          {"name": "residual_acceleration", "calc": "second difference of residual", "leakage_risk": "none"},
+          {"name": "time_since_last_spike", "calc": "ticks since last residual above the warning band", "leakage_risk": "none"},
+          {"name": "duration_above_warning_band", "calc": "consecutive ticks above the warning band", "leakage_risk": "none"}
+        ],
+        "leakage_notes": "All windows are trailing. Engineered in the GCP gold step (Part II) — not yet computed; this is the planned contract, not measured output."
+      },
+      {
+        "id": "diagnostic",
+        "label": "C — Rich diagnostic state",
+        "purpose": "More robust and more explainable.",
+        "model_family": "PCA / autoencoder",
+        "included": false,
+        "features": [
+          {"name": "channel_normalized_residual", "calc": "residual / per-channel train scale", "leakage_risk": "none"},
+          {"name": "per_channel_train_scale", "calc": "median abs residual per channel (train only)", "leakage_risk": "none"},
+          {"name": "regime_bucket", "calc": "discretized operating regime", "leakage_risk": "low"},
+          {"name": "recent_volatility_regime", "calc": "trailing volatility band", "leakage_risk": "none"},
+          {"name": "cross_channel_aggregate", "calc": "aggregate across correlated channels (if present)", "leakage_risk": "medium"},
+          {"name": "pca_recon_error", "calc": "PCA-256 reconstruction error", "leakage_risk": "none"},
+          {"name": "ae_recon_error", "calc": "autoencoder reconstruction error", "leakage_risk": "none"},
+          {"name": "top_contributing_feature_group", "calc": "argmax reconstruction-error contributor", "leakage_risk": "none"}
+        ],
+        "leakage_notes": "PCA/AE fit on train only; cross-channel aggregate flagged medium pending a look-ahead audit. Engineered in Part II."
+      }
+    ],
+    "note": "Feature-set contract for the Workbench selector. A is the promoted champion's real inputs; B/C are the planned feature-tightening candidates engineered in the GCP gold step (Part II). Measured ablation results arrive as separate receipts (experiment_runs / threshold_sweep / error_review)."
+  }
+}

--- a/backend/app/data/telemetry/threshold_sweep.json
+++ b/backend/app/data/telemetry/threshold_sweep.json
@@ -1,0 +1,27 @@
+{
+  "provider": "local_fixture",
+  "source_bigquery_table": null,
+  "vertex_experiment": null,
+  "vertex_run_id": null,
+  "vertex_model_id": null,
+  "gcs_artifact_uri": null,
+  "created_at": "2026-06-27T00:00:00Z",
+  "code_version": "local_fixture@0d502954",
+  "data_manifest_sha": null,
+  "rows_evaluated": null,
+  "null_reason": null,
+  "payload": {
+    "operating_point": {
+      "mad_k": 4.0,
+      "global_train_scale": 0.033866801182436346,
+      "detector_threshold": 0.13546720472974538,
+      "source": "frozen serving constants (backend/app/services/telemetry_serving.py)"
+    },
+    "sweep": [],
+    "confusion_at_operating": null,
+    "curves": {"pr": [], "roc": []},
+    "metric_basis": "point-wise honest (telemetry-platform/pipeline/metrics.honest_anomaly_metrics)",
+    "sweep_pending": true,
+    "note": "The operating point is the real frozen serving threshold. The full MAD_K sweep + confusion matrix + PR/ROC curves are computed over the BigQuery labeled SMAP/MSL test split in the GCP run (Part II.4) and will replace this preview."
+  }
+}

--- a/backend/app/routes/telemetry.py
+++ b/backend/app/routes/telemetry.py
@@ -29,10 +29,12 @@ from app.mcp.tools.telemetry_tools import (
 )
 from app.observability.logger import emit_log
 from app.schemas.telemetry import (
-    MonitoringResponse, RunDetailOut, ScoreRequest, ScoreResponse, StreamSourceRequest, TestRunOut,
+    MonitoringResponse, ReceiptEnvelope, RunDetailOut, ScoreRequest, ScoreResponse,
+    StreamSourceRequest, TestRunOut,
 )
 from app.schemas.telemetry_metadata import TelemetryMetadataGraph
 from app.services import telemetry_analyzer
+from app.services import telemetry_receipts as receipts
 from app.services import telemetry_serving as svc
 
 router = APIRouter(prefix="/api/telemetry", tags=["telemetry"])
@@ -168,6 +170,57 @@ def model_performance(env_id: str = Query(...), business_id: UUID = Query(...)):
     """Promoted-model metadata + exact metrics from tel_model_runs (no hardcoded numbers)."""
     try:
         return svc.model_performance(env_id=env_id, business_id=business_id)
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+# ── Model Workbench receipts (Part I.1) — receipt-driven, DB-free, fail-closed ─────────────────────
+# The Workbench REPLAYS committed receipts produced offline by the GCP MLOps pipeline (Part II); it
+# never triggers live compute. An absent receipt returns null_reason at HTTP 200 — never a 500, never a
+# fabricated value. No env/business params: these are demo artifacts (the /replay precedent), not
+# tenant-scoped DB reads.
+
+@router.get("/workbench/experiments", response_model=ReceiptEnvelope)
+def workbench_experiments():
+    """MLflow/Vertex experiment runs + HPO board (experiment_runs receipt)."""
+    try:
+        return ReceiptEnvelope(**receipts.load_receipt("experiment_runs"))
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/workbench/feature-manifest", response_model=ReceiptEnvelope)
+def workbench_feature_manifest():
+    """Feature-set contract A/B/C with leakage notes (feature_manifest receipt)."""
+    try:
+        return ReceiptEnvelope(**receipts.load_receipt("feature_manifest"))
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/workbench/threshold-sweep", response_model=ReceiptEnvelope)
+def workbench_threshold_sweep():
+    """MAD_K sweep PR/ROC + confusion + operating point (threshold_sweep receipt)."""
+    try:
+        return ReceiptEnvelope(**receipts.load_receipt("threshold_sweep"))
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/workbench/error-review", response_model=ReceiptEnvelope)
+def workbench_error_review():
+    """FP/FN/borderline cases with feature attribution (error_review receipt)."""
+    try:
+        return ReceiptEnvelope(**receipts.load_receipt("error_review"))
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
+@router.get("/workbench/promotion-review", response_model=ReceiptEnvelope)
+def workbench_promotion_review():
+    """Gate-by-gate promotion decision vs prior champion (promotion_review receipt)."""
+    try:
+        return ReceiptEnvelope(**receipts.load_receipt("promotion_review"))
     except Exception as exc:  # noqa: BLE001
         raise _to_http(exc)
 

--- a/backend/app/schemas/telemetry.py
+++ b/backend/app/schemas/telemetry.py
@@ -6,6 +6,7 @@ null_reason field wherever a value can be unavailable (fail-closed contract).
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -125,3 +126,25 @@ class MonitoringResponse(BaseModel):
 
 class StreamSourceRequest(BaseModel):
     source: str                                # iss | capture | adsb
+
+
+# ── /workbench/* receipts (Model Workbench, receipt-driven) ────────────────────
+
+class ReceiptEnvelope(BaseModel):
+    """One committed Model Workbench receipt: a strict provenance header + heterogeneous payload, served
+    fail-closed. ``payload`` is None and ``null_reason`` is set when the real GCP artifact has not been
+    generated yet — the Workbench replays receipts, it never triggers live compute."""
+    kind: str
+    provider: str | None = None                # databricks | vertex | local_fixture | None
+    source_bigquery_table: str | None = None
+    vertex_experiment: str | None = None
+    vertex_run_id: str | None = None
+    vertex_model_id: str | None = None
+    gcs_artifact_uri: str | None = None
+    created_at: str | None = None
+    code_version: str | None = None
+    data_manifest_sha: str | None = None
+    rows_evaluated: int | None = None
+    payload: Any = None
+    fallback_used: bool = False
+    null_reason: str | None = None             # e.g. gcp_receipt_not_generated_yet

--- a/backend/app/services/telemetry_receipts.py
+++ b/backend/app/services/telemetry_receipts.py
@@ -1,0 +1,93 @@
+"""Model Workbench receipt loader (Part I.1) — read-only, fail-closed, serving-light.
+
+The Workbench *replays* committed receipt artifacts; it NEVER triggers live compute. Each receipt is a
+committed JSON file under ``app/data/telemetry/`` carrying a strict provenance header plus a payload
+body. Real receipts are produced offline by the GCP MLOps pipeline (Part II) and committed verbatim.
+Until a real receipt lands, the loader fails closed with ``null_reason='gcp_receipt_not_generated_yet'``
+— it never fabricates values and never imports heavy ML deps (no pyspark / mlflow / sklearn / aiplatform).
+
+Receipt file shape on disk:
+
+    { <header fields...>, "null_reason": <str|null>, "payload": <object|array|null> }
+
+The header fields are normalized (missing → ``None``) so every response carries the full contract.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_RECEIPT_DIR = Path(__file__).resolve().parent.parent / "data" / "telemetry"
+
+# kind -> committed filename. These five are the Model Workbench receipt contract (Part I.1).
+RECEIPT_FILES: dict[str, str] = {
+    "experiment_runs": "experiment_runs.json",
+    "feature_manifest": "feature_manifest.json",
+    "threshold_sweep": "threshold_sweep.json",
+    "error_review": "error_review.json",
+    "promotion_review": "promotion_review.json",
+}
+
+# Strict provenance header every receipt carries. Missing keys normalize to None — never fabricated.
+_HEADER_FIELDS = (
+    "provider",               # databricks | vertex | local_fixture | None
+    "source_bigquery_table",
+    "vertex_experiment",
+    "vertex_run_id",
+    "vertex_model_id",
+    "gcs_artifact_uri",
+    "created_at",
+    "code_version",
+    "data_manifest_sha",
+    "rows_evaluated",
+)
+
+_NOT_GENERATED = "gcp_receipt_not_generated_yet"
+
+
+def _empty_header() -> dict[str, Any]:
+    return {k: None for k in _HEADER_FIELDS}
+
+
+def _fail_closed(kind: str, reason: str) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        **_empty_header(),
+        "payload": None,
+        "fallback_used": True,
+        "null_reason": reason,
+    }
+
+
+def load_receipt(kind: str, *, base_dir: Path | None = None) -> dict[str, Any]:
+    """Load one committed receipt, fail-closed.
+
+    Raises ``ValueError`` on an unknown kind (programmer error). Otherwise NEVER raises: an absent or
+    unreadable file returns a ``null_reason`` envelope so the route stays at HTTP 200 and the UI shows
+    the honest "receipt not generated yet" state instead of a fabricated value or a 500.
+    """
+    if kind not in RECEIPT_FILES:
+        raise ValueError(f"unknown receipt kind: {kind!r}")
+    directory = base_dir or _RECEIPT_DIR
+    path = directory / RECEIPT_FILES[kind]
+    if not path.exists():
+        return _fail_closed(kind, _NOT_GENERATED)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return _fail_closed(kind, "receipt_unreadable")
+    if not isinstance(raw, dict):
+        return _fail_closed(kind, "receipt_malformed")
+
+    header = _empty_header()
+    for k in _HEADER_FIELDS:
+        if raw.get(k) is not None:
+            header[k] = raw[k]
+    return {
+        "kind": kind,
+        **header,
+        "payload": raw.get("payload"),
+        "fallback_used": False,
+        "null_reason": raw.get("null_reason"),
+    }

--- a/backend/tests/test_telemetry_receipts.py
+++ b/backend/tests/test_telemetry_receipts.py
@@ -1,0 +1,108 @@
+"""Tests for the Model Workbench receipt loader (Part I.1) — receipt-driven, fail-closed.
+
+Covers: the two committed honest seed receipts load with real local_fixture values and no Vertex
+provenance; absent/malformed receipts fail closed with a null_reason (never a 500, never fabricated);
+an unknown kind is a programmer error (raises); and the five /workbench/* routes return HTTP 200 with
+the correct envelope in both the present and the not-yet-generated states.
+"""
+import pytest
+
+from app.services import telemetry_receipts as rcpt
+
+
+# ── service: committed seed receipts (real, local_fixture, no Vertex claim) ────
+
+def test_seeded_feature_manifest_loads():
+    out = rcpt.load_receipt("feature_manifest")
+    assert out["null_reason"] is None
+    assert out["fallback_used"] is False
+    assert out["provider"] == "local_fixture"
+    assert out["vertex_run_id"] is None              # a preview may NOT claim Vertex provenance
+    ids = [fs["id"] for fs in out["payload"]["feature_sets"]]
+    assert ids == ["baseline", "temporal", "diagnostic"]
+    base = out["payload"]["feature_sets"][0]
+    assert base["included"] is True                   # A is the real promoted champion's inputs
+    assert all(fs["included"] is False for fs in out["payload"]["feature_sets"][1:])
+
+
+def test_seeded_threshold_sweep_operating_point_is_real():
+    out = rcpt.load_receipt("threshold_sweep")
+    assert out["null_reason"] is None
+    assert out["provider"] == "local_fixture"
+    op = out["payload"]["operating_point"]
+    assert op["mad_k"] == 4.0
+    assert op["detector_threshold"] == pytest.approx(0.13546720472974538)
+    assert out["payload"]["sweep"] == []             # full sweep pending the GCP run (Part II.4)
+    assert out["payload"]["sweep_pending"] is True
+
+
+# ── service: fail-closed paths ────────────────────────────────────────────────
+
+def test_absent_receipt_fails_closed(tmp_path):
+    out = rcpt.load_receipt("experiment_runs", base_dir=tmp_path)
+    assert out["payload"] is None
+    assert out["fallback_used"] is True
+    assert out["null_reason"] == "gcp_receipt_not_generated_yet"
+    # the header is still fully present (normalized to None), never omitted
+    assert "vertex_run_id" in out and out["vertex_run_id"] is None
+    assert out["provider"] is None
+
+
+def test_malformed_receipt_fails_closed(tmp_path):
+    (tmp_path / "promotion_review.json").write_text("{not valid json", encoding="utf-8")
+    out = rcpt.load_receipt("promotion_review", base_dir=tmp_path)
+    assert out["null_reason"] == "receipt_unreadable"
+    assert out["fallback_used"] is True
+    assert out["payload"] is None
+
+
+def test_non_object_receipt_fails_closed(tmp_path):
+    (tmp_path / "experiment_runs.json").write_text("[1, 2, 3]", encoding="utf-8")
+    out = rcpt.load_receipt("experiment_runs", base_dir=tmp_path)
+    assert out["null_reason"] == "receipt_malformed"
+    assert out["fallback_used"] is True
+
+
+def test_unknown_kind_raises():
+    with pytest.raises(ValueError):
+        rcpt.load_receipt("not_a_receipt")
+
+
+# ── route-level: HTTP 200 + null_reason (never 500), read-only ────────────────
+
+def test_workbench_experiments_route_fails_closed(client):
+    # experiment_runs.json is intentionally absent in the repo until the GCP run (Part II).
+    r = client.get("/api/telemetry/workbench/experiments")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["kind"] == "experiment_runs"
+    assert body["payload"] is None
+    assert body["null_reason"] == "gcp_receipt_not_generated_yet"
+    assert body["fallback_used"] is True
+
+
+def test_workbench_feature_manifest_route_real(client):
+    r = client.get("/api/telemetry/workbench/feature-manifest")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["provider"] == "local_fixture"
+    assert body["null_reason"] is None
+    assert body["payload"]["feature_sets"][0]["id"] == "baseline"
+    assert body["vertex_run_id"] is None
+
+
+def test_workbench_threshold_sweep_route_real(client):
+    r = client.get("/api/telemetry/workbench/threshold-sweep")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["payload"]["operating_point"]["mad_k"] == 4.0
+
+
+def test_workbench_routes_are_read_only(client):
+    for path in ("experiments", "feature-manifest", "threshold-sweep",
+                 "error-review", "promotion-review"):
+        url = f"/api/telemetry/workbench/{path}"
+        assert client.get(url).status_code == 200
+        assert client.post(url, json={}).status_code in (404, 405)
+        assert client.put(url, json={}).status_code in (404, 405)
+        assert client.delete(url).status_code in (404, 405)

--- a/repo-b/src/lib/telemetry/api.ts
+++ b/repo-b/src/lib/telemetry/api.ts
@@ -275,6 +275,38 @@ export const getRuns = (env: string, biz: string) =>
 export const getSummary = (env: string, biz: string) =>
   apiFetch<TelemetrySummary>("/api/telemetry/summary", { params: params(env, biz) });
 
+// ── Model Workbench receipts (Part I.1) — receipt-driven, DB-free, fail-closed ──────────────────
+// The Workbench REPLAYS committed receipts produced offline by the GCP MLOps pipeline (Part II); no
+// live compute. `payload` is null and `null_reason` is set ("gcp_receipt_not_generated_yet") until the
+// real artifact lands. A `local_fixture` provider with no vertex_* refs is an honest seeded preview.
+export interface ReceiptEnvelope<P = unknown> {
+  kind: string;
+  provider: string | null;               // databricks | vertex | local_fixture | null
+  source_bigquery_table: string | null;
+  vertex_experiment: string | null;
+  vertex_run_id: string | null;
+  vertex_model_id: string | null;
+  gcs_artifact_uri: string | null;
+  created_at: string | null;
+  code_version: string | null;
+  data_manifest_sha: string | null;
+  rows_evaluated: number | null;
+  payload: P | null;
+  fallback_used: boolean;
+  null_reason: string | null;
+}
+
+export const getWorkbenchExperiments = () =>
+  apiFetch<ReceiptEnvelope>("/api/telemetry/workbench/experiments");
+export const getWorkbenchFeatureManifest = () =>
+  apiFetch<ReceiptEnvelope>("/api/telemetry/workbench/feature-manifest");
+export const getWorkbenchThresholdSweep = () =>
+  apiFetch<ReceiptEnvelope>("/api/telemetry/workbench/threshold-sweep");
+export const getWorkbenchErrorReview = () =>
+  apiFetch<ReceiptEnvelope>("/api/telemetry/workbench/error-review");
+export const getWorkbenchPromotionReview = () =>
+  apiFetch<ReceiptEnvelope>("/api/telemetry/workbench/promotion-review");
+
 export interface FusedVectorInfo {
   available: boolean;
   null_reason?: string;


### PR DESCRIPTION
## What
Part I.1 of the **Model Workbench** (ADO #736, under Feature #513 / Epic #497). Establishes the receipt-driven contract the Workbench replays — it **never triggers live compute**. Real receipts are produced offline by the GCP MLOps pipeline (Part II) and committed verbatim.

## Changes
- **`telemetry_receipts.load_receipt`** — read-only, serving-light (no pyspark/mlflow/sklearn/aiplatform), fail-closed. Absent/unreadable/malformed → `null_reason` at **HTTP 200**, never a 500 or a fabricated value.
- **5 routes** `GET /api/telemetry/workbench/{experiments,feature-manifest,threshold-sweep,error-review,promotion-review}` (`ReceiptEnvelope` response_model), DB-free like `/replay`.
- **`ReceiptEnvelope`** schema — strict provenance header + heterogeneous payload + `fallback_used`/`null_reason`.
- **Two honest `local_fixture` seeds:** `feature_manifest` (A/B/C feature-set contract — A is the real promoted champion inputs, B/C planned) and `threshold_sweep` (real frozen operating point `MAD_K=4.0`, `detector_threshold=0.13546720472974538`; full sweep pending Part II). Neither claims Vertex provenance. `experiment_runs`/`error_review`/`promotion_review` left absent to exercise the fail-closed path.
- **Frontend** `api.ts`: `ReceiptEnvelope` + 5 getters.

## Tests / evidence
- 10 new tests in `test_telemetry_receipts.py` (seeded-loads, absent/malformed/non-object fail-closed, unknown-kind raises, route 200 + read-only).
- Full telemetry suite: **191 passed, 1 skipped**. `repo-b` typecheck: clean.

## Honesty notes
- Seeds copy values only from existing serving constants; `provider: local_fixture`, no `vertex_*` claim.
- Serving stays light (no heavy imports). No new write tools; routes are read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)