### PR TITLE
feat(telemetry): Workbench threshold sweep tab + FP/FN review drawer (#738)

### DIFF
--- a/repo-b/src/components/telemetry/ModelPerformance.tsx
+++ b/repo-b/src/components/telemetry/ModelPerformance.tsx
@@ -4,10 +4,12 @@ import { useEffect, useState } from "react";
 import {
   getModelPerformance, type ModelRun, TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID,
 } from "@/lib/telemetry/api";
-import { C, Tag, Panel, Loading, ErrorState, DisclosureFooter, ScrollTable, TelemetryActionButton } from "./primitives";
+import { C, Tag, Panel, Loading, ErrorState, DisclosureFooter, ScrollTable, SectionTabButton, TelemetryActionButton } from "./primitives";
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
 import { MetricInspectorDrawer } from "./drawerPrimitives";
 import { SourceRowsTable, DatabricksRunLink, ModelArtifactLink, exportXlsxUrl } from "./drill";
+import { ThresholdSweepTab } from "./workbench/ThresholdSweepTab";
+import { FpFnReviewDrawer } from "./workbench/FpFnReviewDrawer";
 
 // Columns surfaced when drilling into the model rows. Mirrors the server XLSX export
 // (telemetry_export.py "model_runs") so the CSV preview and the .xlsx match.
@@ -99,6 +101,8 @@ export default function ModelPerformance() {
   const [nullReason, setNullReason] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [drillOpen, setDrillOpen] = useState(false);
+  const [tab, setTab] = useState<"metrics" | "sweep">("metrics");
+  const [fpfnOpen, setFpfnOpen] = useState(false);
 
   useEffect(() => {
     getModelPerformance(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID)
@@ -118,6 +122,11 @@ export default function ModelPerformance() {
   return (
     <>
       {heading}
+      <div style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap" }}>
+        <SectionTabButton active={tab === "metrics"} onClick={() => setTab("metrics")}>Metrics</SectionTabButton>
+        <SectionTabButton active={tab === "sweep"} onClick={() => setTab("sweep")}>Threshold sweep</SectionTabButton>
+      </div>
+      {tab === "sweep" ? <ThresholdSweepTab /> : (
       <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
         <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
           <Tag color={C.green}>live rows</Tag>
@@ -139,13 +148,18 @@ export default function ModelPerformance() {
             so it was promoted, recorded honestly rather than forcing a fancier model to win.
           </span>
         </Panel>
-        <div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
           <TelemetryActionButton variant="secondary" onClick={() => setDrillOpen(true)}
             aria-label="Inspect the model rows and export">
             Source rows + export ›
           </TelemetryActionButton>
+          <TelemetryActionButton variant="secondary" onClick={() => setFpfnOpen(true)}
+            aria-label="Open the false-positive / false-negative review">
+            Failure review ›
+          </TelemetryActionButton>
         </div>
       </div>
+      )}
       <MetricInspectorDrawer
         open={drillOpen}
         onClose={() => setDrillOpen(false)}
@@ -186,6 +200,7 @@ export default function ModelPerformance() {
           </div>
         </div>
       </MetricInspectorDrawer>
+      <FpFnReviewDrawer open={fpfnOpen} onClose={() => setFpfnOpen(false)} />
       <DisclosureFooter />
     </>
   );

--- a/repo-b/src/components/telemetry/workbench/FpFnReviewDrawer.test.tsx
+++ b/repo-b/src/components/telemetry/workbench/FpFnReviewDrawer.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { FpFnReviewDrawer } from "./FpFnReviewDrawer";
+import { getWorkbenchErrorReview } from "@/lib/telemetry/api";
+
+vi.mock("@/lib/telemetry/api", () => ({ getWorkbenchErrorReview: vi.fn() }));
+const mockReview = getWorkbenchErrorReview as ReturnType<typeof vi.fn>;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("FpFnReviewDrawer", () => {
+  it("does not fetch while closed", () => {
+    render(<FpFnReviewDrawer open={false} onClose={() => {}} />);
+    expect(mockReview).not.toHaveBeenCalled();
+  });
+
+  it("fails closed honestly when the error_review receipt is absent", async () => {
+    mockReview.mockResolvedValue({
+      kind: "error_review", provider: null, null_reason: "gcp_receipt_not_generated_yet",
+      fallback_used: true, payload: null,
+    });
+    render(<FpFnReviewDrawer open onClose={() => {}} />);
+    expect(await screen.findByText("Failure review not generated yet")).toBeInTheDocument();
+  });
+
+  it("renders FP/FN cases and a drill affordance when wired", async () => {
+    const onDrill = vi.fn();
+    mockReview.mockResolvedValue({
+      kind: "error_review", provider: "vertex", null_reason: null, fallback_used: false,
+      payload: {
+        cases: [
+          { id: "fp-1", kind: "false_positive", channel: "D-4", window: "t=120-180",
+            model_saw: "residual spike", true_label: "nominal", feature_pushed: "residual_slope",
+            acceptable: "low-cost false alarm", suggested_fix: "per-channel scale" },
+          { id: "fn-1", kind: "false_negative", channel: "T-1", true_label: "anomaly" },
+        ],
+        highlights: [{ label: "Worst noisy channel", value: "D-4" }],
+      },
+    });
+    render(<FpFnReviewDrawer open onClose={() => {}} onDrill={onDrill} />);
+    expect(await screen.findByText("False positive")).toBeInTheDocument();
+    expect(screen.getByText("False negative")).toBeInTheDocument();
+    expect(screen.getByText("residual_slope")).toBeInTheDocument();
+    expect(screen.getByText("D-4")).toBeInTheDocument();        // highlight value
+    fireEvent.click(screen.getAllByRole("button", { name: /Drill/i })[0]);
+    await waitFor(() => expect(onDrill).toHaveBeenCalledTimes(1));
+  });
+});

--- a/repo-b/src/components/telemetry/workbench/FpFnReviewDrawer.tsx
+++ b/repo-b/src/components/telemetry/workbench/FpFnReviewDrawer.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getWorkbenchErrorReview, type ReceiptEnvelope } from "@/lib/telemetry/api";
+import { C, EmptyState, Loading, Tag, TelemetryActionButton } from "../primitives";
+import { MetricInspectorDrawer } from "../drawerPrimitives";
+
+const ACCENT = "#a855f7";
+
+// One mis-/borderline case. `feature_pushed` = which feature most drove the (wrong) call; `acceptable`
+// = the operational-consequence judgment; `suggested_fix` = the feature that might fix it. All fields
+// come straight from the error_review receipt — no case is fabricated.
+export interface ErrorCase {
+  id: string;
+  kind: "false_positive" | "false_negative" | "borderline";
+  channel?: string;
+  window?: string;
+  model_saw?: string;
+  true_label?: string;
+  feature_pushed?: string;
+  acceptable?: string;
+  suggested_fix?: string;
+}
+interface ErrorReviewPayload {
+  cases: ErrorCase[];
+  highlights?: { label: string; value: string }[];
+  note?: string;
+}
+
+const KIND_LABEL: Record<ErrorCase["kind"], string> = {
+  false_positive: "False positive",
+  false_negative: "False negative",
+  borderline: "Borderline",
+};
+const KIND_COLOR: Record<ErrorCase["kind"], string> = {
+  false_positive: C.amber,
+  false_negative: C.red,
+  borderline: C.dim,
+};
+
+function CaseRow({ c, onDrill }: { c: ErrorCase; onDrill?: (c: ErrorCase) => void }) {
+  const Line = ({ k, v }: { k: string; v?: string }) =>
+    v ? (
+      <div style={{ display: "flex", gap: 8, fontFamily: C.mono, fontSize: 11, lineHeight: 1.5 }}>
+        <span style={{ color: C.faint, minWidth: 118 }}>{k}</span>
+        <span style={{ color: C.text }}>{v}</span>
+      </div>
+    ) : null;
+  return (
+    <div style={{ background: C.panel, border: `1px solid ${C.border}`, borderRadius: 10, padding: 13 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, marginBottom: 8, flexWrap: "wrap" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <Tag color={KIND_COLOR[c.kind]}>{KIND_LABEL[c.kind]}</Tag>
+          <span style={{ fontFamily: C.mono, fontSize: 11, color: C.dim }}>
+            {c.channel ?? "—"}{c.window ? ` · ${c.window}` : ""}
+          </span>
+        </div>
+        {onDrill && (
+          <TelemetryActionButton variant="secondary" onClick={() => onDrill(c)} aria-label={`Drill ${c.id}`}>
+            Drill ›
+          </TelemetryActionButton>
+        )}
+      </div>
+      <Line k="What it saw" v={c.model_saw} />
+      <Line k="True label" v={c.true_label} />
+      <Line k="Feature pushed" v={c.feature_pushed} />
+      <Line k="Operationally" v={c.acceptable} />
+      <Line k="Might fix it" v={c.suggested_fix} />
+    </div>
+  );
+}
+
+// FP / FN review — the credibility centerpiece: show where the model is wrong, not just aggregate metrics.
+// Reads the error_review receipt. Until the GCP run lands it (Part II.4), the drawer fails closed with an
+// honest "not generated yet" state — never invented cases. `onDrill` (wired in S5) opens the prediction
+// provenance drawer for any case.
+export function FpFnReviewDrawer({
+  open, onClose, onDrill,
+}: { open: boolean; onClose: () => void; onDrill?: (c: ErrorCase) => void }) {
+  const [payload, setPayload] = useState<ErrorReviewPayload | null>(null);
+  const [nullReason, setNullReason] = useState<string | null>(null);
+  const [provider, setProvider] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!open || loaded) return;
+    getWorkbenchErrorReview()
+      .then((r: ReceiptEnvelope) => {
+        setProvider(r.provider);
+        setNullReason(r.null_reason);
+        setPayload(r.payload as ErrorReviewPayload | null);
+      })
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoaded(true));
+  }, [open, loaded]);
+
+  const cases = payload?.cases ?? [];
+  const fields = [
+    { label: "Source", value: "error_review receipt" },
+    { label: "Provider", value: provider ?? "—" },
+    { label: "Cases", value: nullReason ? "—" : cases.length },
+  ];
+
+  return (
+    <MetricInspectorDrawer
+      open={open}
+      onClose={onClose}
+      title="Failure review — false positives, false negatives, borderline"
+      description="Where the model is wrong, with the feature that pushed each call and the operational consequence. Every case comes from the error_review receipt; none are fabricated."
+      fields={fields}
+    >
+      <div style={{ marginTop: 14, display: "flex", flexDirection: "column", gap: 10 }}>
+        {error && <EmptyState label="Failure review unavailable" hint="The error_review receipt could not be loaded." nullReason={error} />}
+        {!error && !loaded && <Loading label="Loading failure cases…" />}
+        {!error && loaded && (nullReason || cases.length === 0) && (
+          <EmptyState
+            label="Failure review not generated yet"
+            hint="FP/FN/borderline cases are classified over real predictions in the GCP run (Part II.4). Each case will drill to its exact feature vector and math (S5)."
+            nullReason={nullReason}
+          />
+        )}
+        {!error && loaded && !nullReason && cases.length > 0 && (
+          <>
+            {payload?.highlights && payload.highlights.length > 0 && (
+              <div style={{ display: "flex", gap: 14, flexWrap: "wrap", paddingBottom: 4 }}>
+                {payload.highlights.map((h) => (
+                  <div key={h.label}>
+                    <div style={{ fontFamily: C.mono, fontSize: 9, color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase" }}>{h.label}</div>
+                    <div style={{ fontFamily: C.mono, fontSize: 13, color: ACCENT }}>{h.value}</div>
+                  </div>
+                ))}
+              </div>
+            )}
+            {cases.map((c) => <CaseRow key={c.id} c={c} onDrill={onDrill} />)}
+          </>
+        )}
+      </div>
+    </MetricInspectorDrawer>
+  );
+}
+
+export default FpFnReviewDrawer;

--- a/repo-b/src/components/telemetry/workbench/ThresholdSweepTab.test.tsx
+++ b/repo-b/src/components/telemetry/workbench/ThresholdSweepTab.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ThresholdSweepTab } from "./ThresholdSweepTab";
+import { getWorkbenchThresholdSweep } from "@/lib/telemetry/api";
+
+vi.mock("@/lib/telemetry/api", () => ({ getWorkbenchThresholdSweep: vi.fn() }));
+const mockSweep = getWorkbenchThresholdSweep as ReturnType<typeof vi.fn>;
+
+const OP = { mad_k: 4.0, global_train_scale: 0.033866801182436346, detector_threshold: 0.13546720472974538, source: "frozen" };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("ThresholdSweepTab", () => {
+  it("shows the real operating point and a pending state for the seeded preview", async () => {
+    mockSweep.mockResolvedValue({
+      kind: "threshold_sweep", provider: "local_fixture", null_reason: null, fallback_used: false,
+      payload: { operating_point: OP, sweep: [], confusion_at_operating: null, sweep_pending: true, note: "pending" },
+    });
+    render(<ThresholdSweepTab />);
+    expect(await screen.findByText("Detector threshold")).toBeInTheDocument();
+    expect(screen.getByText("0.1355")).toBeInTheDocument();
+    expect(screen.getByText("Full sweep pending")).toBeInTheDocument();
+  });
+
+  it("renders the confusion matrix when a real sweep is present", async () => {
+    mockSweep.mockResolvedValue({
+      kind: "threshold_sweep", provider: "vertex", null_reason: null, fallback_used: false,
+      payload: {
+        operating_point: OP,
+        sweep: [
+          { threshold: 0.1, precision: 0.2, recall: 0.9 },
+          { threshold: 0.135, precision: 0.5, recall: 0.6 },
+          { threshold: 0.2, precision: 0.8, recall: 0.3 },
+        ],
+        confusion_at_operating: { tp: 12, fp: 4, fn: 8, tn: 200 },
+        sweep_pending: false,
+      },
+    });
+    render(<ThresholdSweepTab />);
+    expect(await screen.findByText("Confusion at the operating threshold")).toBeInTheDocument();
+    expect(screen.getByText("True positives")).toBeInTheDocument();
+    expect(screen.getByText("False negatives")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+  });
+
+  it("fails closed when the sweep receipt is not generated", async () => {
+    mockSweep.mockResolvedValue({
+      kind: "threshold_sweep", provider: null, null_reason: "gcp_receipt_not_generated_yet",
+      fallback_used: true, payload: null,
+    });
+    render(<ThresholdSweepTab />);
+    expect(await screen.findByText("Threshold sweep not generated yet")).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/workbench/ThresholdSweepTab.tsx
+++ b/repo-b/src/components/telemetry/workbench/ThresholdSweepTab.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  CartesianGrid, Line, LineChart, ReferenceDot, ResponsiveContainer, Tooltip, XAxis, YAxis,
+} from "recharts";
+import { getWorkbenchThresholdSweep, type ReceiptEnvelope } from "@/lib/telemetry/api";
+import { C, EmptyState, Loading, MetricCard, StatGrid, Tag } from "../primitives";
+
+const ACCENT = "#a855f7";
+
+interface SweepPoint {
+  threshold: number;
+  precision: number;
+  recall: number;
+  f1_pointwise?: number;
+  tpr?: number;
+  fpr?: number;
+  tp?: number;
+  fp?: number;
+  fn?: number;
+  tn?: number;
+}
+interface Confusion { tp: number; fp: number; fn: number; tn: number; }
+interface OperatingPoint { mad_k: number; global_train_scale: number; detector_threshold: number; source: string; }
+interface SweepPayload {
+  operating_point: OperatingPoint;
+  sweep: SweepPoint[];
+  confusion_at_operating: Confusion | null;
+  metric_basis?: string;
+  sweep_pending?: boolean;
+  note?: string;
+}
+
+function ConfusionGrid({ c }: { c: Confusion }) {
+  const Cell = ({ label, n, tone }: { label: string; n: number; tone: string }) => (
+    <div style={{ background: C.panel, border: `1px solid ${C.border}`, borderRadius: 8, padding: "10px 12px" }}>
+      <div style={{ fontFamily: C.mono, fontSize: 9, color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase" }}>{label}</div>
+      <div style={{ fontFamily: C.mono, fontSize: 18, fontWeight: 700, color: tone }}>{n}</div>
+    </div>
+  );
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+      <Cell label="True positives" n={c.tp} tone={C.green} />
+      <Cell label="False positives" n={c.fp} tone={C.amber} />
+      <Cell label="False negatives" n={c.fn} tone={C.red} />
+      <Cell label="True negatives" n={c.tn} tone={C.dim} />
+    </div>
+  );
+}
+
+export function ThresholdSweepTab() {
+  const [data, setData] = useState<SweepPayload | null>(null);
+  const [nullReason, setNullReason] = useState<string | null>(null);
+  const [provider, setProvider] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getWorkbenchThresholdSweep()
+      .then((r: ReceiptEnvelope) => {
+        setProvider(r.provider);
+        setNullReason(r.null_reason);
+        setData(r.payload as SweepPayload | null);
+      })
+      .catch((e) => setError(String(e)));
+  }, []);
+
+  if (error) return <EmptyState label="Threshold sweep unavailable" hint="The threshold_sweep receipt could not be loaded." nullReason={error} />;
+  if (!data && !nullReason) return <Loading label="Loading threshold sweep…" />;
+  if (nullReason || !data) {
+    return (
+      <EmptyState
+        label="Threshold sweep not generated yet"
+        hint="The MAD_K sweep is computed over the BigQuery labeled SMAP/MSL test split in the GCP run (Part II.4)."
+        nullReason={nullReason}
+      />
+    );
+  }
+
+  const op = data.operating_point;
+  const sweep = data.sweep ?? [];
+  const pending = Boolean(data.sweep_pending) || sweep.length === 0;
+  // PR curve points; operating point marked from the confusion matrix when present.
+  const pr = sweep.map((p) => ({ recall: p.recall, precision: p.precision }));
+  const conf = data.confusion_at_operating;
+  const opPr = conf && conf.tp + conf.fp > 0 && conf.tp + conf.fn > 0
+    ? { recall: conf.tp / (conf.tp + conf.fn), precision: conf.tp / (conf.tp + conf.fp) }
+    : null;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+        <span style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.14em", textTransform: "uppercase", color: ACCENT }}>Threshold sweep</span>
+        <Tag color={provider === "vertex" ? C.green : C.amber}>{provider ?? "local_fixture"}</Tag>
+        <span style={{ fontFamily: C.sans, fontSize: 12, color: C.dim }}>
+          the honest threshold-selection story — a real sweep, not a single magic number
+        </span>
+      </div>
+
+      <StatGrid cols={3}>
+        <MetricCard label="MAD_K (operating)" value={op.mad_k} accent={C.text} />
+        <MetricCard label="Detector threshold" value={op.detector_threshold.toFixed(4)} accent={C.green} sub="residual units · frozen serving" />
+        <MetricCard label="Global train scale" value={op.global_train_scale.toFixed(6)} />
+      </StatGrid>
+
+      {pending ? (
+        <EmptyState
+          label="Full sweep pending"
+          hint={data.note ?? "The operating point above is the real frozen serving threshold; the full MAD_K sweep (PR/ROC + confusion matrix) lands with the GCP run (Part II.4)."}
+        />
+      ) : (
+        <>
+          <div style={{ background: C.panel, border: `1px solid ${C.border}`, borderRadius: 10, padding: 14 }}>
+            <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase", marginBottom: 8 }}>
+              Precision–recall across MAD_K · operating point marked
+            </div>
+            <ResponsiveContainer width="100%" height={220}>
+              <LineChart data={pr} margin={{ top: 8, right: 12, bottom: 18, left: 0 }}>
+                <CartesianGrid stroke={C.border} strokeDasharray="3 3" />
+                <XAxis dataKey="recall" type="number" domain={[0, 1]} stroke={C.faint} tick={{ fontSize: 10, fill: C.faint }}
+                  label={{ value: "recall", position: "insideBottom", offset: -8, fill: C.faint, fontSize: 10 }} />
+                <YAxis type="number" domain={[0, 1]} stroke={C.faint} tick={{ fontSize: 10, fill: C.faint }}
+                  label={{ value: "precision", angle: -90, position: "insideLeft", fill: C.faint, fontSize: 10 }} />
+                <Tooltip contentStyle={{ background: C.panelHi, border: `1px solid ${C.border}`, fontFamily: C.mono, fontSize: 11 }} />
+                <Line type="monotone" dataKey="precision" stroke={ACCENT} dot={false} strokeWidth={2} isAnimationActive={false} />
+                {opPr && <ReferenceDot x={opPr.recall} y={opPr.precision} r={5} fill={C.green} stroke={C.bg} />}
+              </LineChart>
+            </ResponsiveContainer>
+            <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, marginTop: 6 }}>
+              {data.metric_basis ?? "point-wise honest metrics"}
+            </div>
+          </div>
+
+          {conf && (
+            <div>
+              <div style={{ fontFamily: C.mono, fontSize: 10, color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase", marginBottom: 8 }}>
+                Confusion at the operating threshold
+              </div>
+              <ConfusionGrid c={conf} />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default ThresholdSweepTab;


### PR DESCRIPTION
## What
Part I.3 of the **Model Workbench** (ADO #738), threaded onto ModelPerformance.

## Changes
- **`ThresholdSweepTab`** — reads the `threshold_sweep` receipt. Shows the real frozen operating point (`MAD_K=4.0`, `detector_threshold=0.1355`); when a full sweep is present, renders the PR curve (recharts) with the operating point marked + the confusion matrix. The seeded preview shows the operating point with an honest "full sweep pending" state. The honest threshold-selection story — not one magic number.
- **`FpFnReviewDrawer`** — the credibility centerpiece. Reads `error_review`; lists FP / FN / borderline cases (what it saw, true label, feature pushed, operational consequence, suggested fix) + highlights. Fails closed honestly until the GCP run (Part II.4). Optional `onDrill` is the seam the prediction provenance drawer wires into (S5).
- **ModelPerformance** — minimal tab row (Metrics | Threshold sweep) + a "Failure review ›" button. Default tab unchanged.

## Tests / evidence
- 6 new tests (sweep pending/real-confusion/fail-closed; drawer closed-no-fetch / fail-closed / cases+drill). ModelPerformance suite still green. typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)