### PR TITLE
feat(telemetry): Workbench champion review + Replay experiment receipt button (#739)

### DIFF
--- a/repo-b/src/components/telemetry/workbench/ChampionReviewPanel.test.tsx
+++ b/repo-b/src/components/telemetry/workbench/ChampionReviewPanel.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ChampionReviewPanel } from "./ChampionReviewPanel";
+import { getModelPerformance, getWorkbenchPromotionReview } from "@/lib/telemetry/api";
+
+vi.mock("@/lib/telemetry/api", () => ({
+  getModelPerformance: vi.fn(),
+  getWorkbenchPromotionReview: vi.fn(),
+  TELEMETRY_DEMO_ENV_ID: "telemetry-demo",
+  TELEMETRY_DEMO_BUSINESS_ID: "7e1eb000-0000-4000-a000-000000000001",
+}));
+const mockModels = getModelPerformance as ReturnType<typeof vi.fn>;
+const mockReview = getWorkbenchPromotionReview as ReturnType<typeof vi.fn>;
+
+const MODELS = [
+  { model_name: "tel_anomaly_mad", model_kind: "anomaly", model_version: "3", model_alias: "champion",
+    mlflow_run_id: "r1", experiment_id: "e1", promotion_state: "promoted",
+    metrics: { alarm_precision: 0.33, event_recall: 0.77, f1_pointwise: 0.31, precision: 0.33 }, gate: {} },
+  { model_name: "tel_anomaly_pca", model_kind: "anomaly", model_version: "2", model_alias: null,
+    mlflow_run_id: "r2", experiment_id: "e1", promotion_state: "baseline",
+    metrics: { alarm_precision: 0.20, event_recall: 0.28, f1_pointwise: 0.42, precision: 0.87 }, gate: {} },
+];
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("ChampionReviewPanel", () => {
+  it("renders the canonical narrative and champion/challenger from live rows", async () => {
+    mockModels.mockResolvedValue({ models: MODELS, null_reason: null });
+    mockReview.mockResolvedValue({ kind: "promotion_review", provider: null, null_reason: "gcp_receipt_not_generated_yet", fallback_used: true, payload: null });
+    render(<ChampionReviewPanel />);
+    expect(await screen.findByText("MAD stayed champion.")).toBeInTheDocument();
+    expect(screen.getByText("PCA looked smarter.")).toBeInTheDocument();
+    expect(screen.getByText("tel_anomaly_mad")).toBeInTheDocument();
+    expect(screen.getByText("tel_anomaly_pca")).toBeInTheDocument();
+    expect(screen.getByText("champion")).toBeInTheDocument();
+    expect(screen.getByText("challenger")).toBeInTheDocument();
+  });
+
+  it("renders the gate table when the promotion_review receipt has landed", async () => {
+    mockModels.mockResolvedValue({ models: MODELS, null_reason: null });
+    mockReview.mockResolvedValue({
+      kind: "promotion_review", provider: "vertex", null_reason: null, fallback_used: false,
+      payload: {
+        decision: "model_not_promoted", reason_rejected: "challenger improved recall but degraded alarm precision",
+        gates: [{ name: "alarm_precision", champion: 0.33, challenger: 0.20, verdict: "fail" }],
+      },
+    });
+    render(<ChampionReviewPanel />);
+    expect(await screen.findByText("alarm_precision")).toBeInTheDocument();
+    expect(screen.getByText(/degraded alarm precision/i)).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/workbench/ChampionReviewPanel.tsx
+++ b/repo-b/src/components/telemetry/workbench/ChampionReviewPanel.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  getModelPerformance, getWorkbenchPromotionReview, type ModelRun, type ReceiptEnvelope,
+  TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID,
+} from "@/lib/telemetry/api";
+import { C, EmptyState, Loading, Tag } from "../primitives";
+
+const ACCENT = "#a855f7";
+const FONT_EDITORIAL = "var(--font-editorial), Georgia, serif";
+
+// promotion_review payload (Part II.5). Optional — enriches the panel with the structured gate decision.
+interface GateCheck { name: string; champion?: number | string; challenger?: number | string; verdict?: string; }
+interface PromotionReviewPayload {
+  champion?: string;
+  challenger?: string;
+  decision?: string;
+  reason_rejected?: string;
+  gates?: GateCheck[];
+}
+
+function metric(m: ModelRun, k: string): string {
+  const v = (m.metrics || {})[k];
+  return v == null ? "—" : Number(v).toFixed(4);
+}
+
+function ModelCard({ m, role }: { m: ModelRun; role: "champion" | "challenger" }) {
+  const isChamp = role === "champion";
+  return (
+    <div style={{ background: C.panel, border: `1px solid ${isChamp ? ACCENT : C.border}`, borderRadius: 10, padding: 14 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, marginBottom: 10 }}>
+        <span style={{ fontFamily: C.mono, fontSize: 12.5, color: C.text }}>{m.model_name}</span>
+        {isChamp ? <Tag color={C.green}>champion</Tag> : <Tag color={C.faint}>challenger</Tag>}
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px 12px" }}>
+        {[
+          ["Alarm precision", "alarm_precision"],
+          ["Event recall", "event_recall"],
+          ["F1 (point-wise)", "f1_pointwise"],
+          ["Precision", "precision"],
+        ].map(([label, key]) => (
+          <div key={key} style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <span style={{ fontFamily: C.mono, fontSize: 9, color: C.faint, letterSpacing: "0.06em", textTransform: "uppercase" }}>{label}</span>
+            <span style={{ fontFamily: C.mono, fontSize: 14, color: C.text }}>{metric(m, key)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function GateTable({ review }: { review: PromotionReviewPayload }) {
+  return (
+    <div style={{ background: C.panel, border: `1px solid ${C.border}`, borderRadius: 10, padding: 14 }}>
+      <div style={{ display: "grid", gridTemplateColumns: "1.4fr 0.8fr 0.8fr 0.8fr", gap: 8, fontFamily: C.mono, fontSize: 10, color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase", paddingBottom: 8, borderBottom: `1px solid ${C.border}` }}>
+        <span>Gate</span><span>Champion</span><span>Challenger</span><span>Verdict</span>
+      </div>
+      {(review.gates ?? []).map((g) => (
+        <div key={g.name} style={{ display: "grid", gridTemplateColumns: "1.4fr 0.8fr 0.8fr 0.8fr", gap: 8, alignItems: "center", fontFamily: C.mono, fontSize: 11.5, color: C.text, padding: "8px 0", borderBottom: `1px solid ${C.border}` }}>
+          <span>{g.name}</span>
+          <span>{g.champion ?? "—"}</span>
+          <span style={{ color: C.dim }}>{g.challenger ?? "—"}</span>
+          <span><Tag color={g.verdict === "pass" ? C.green : g.verdict === "fail" ? C.red : C.faint}>{g.verdict ?? "—"}</Tag></span>
+        </div>
+      ))}
+      {review.reason_rejected && (
+        <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.dim, lineHeight: 1.5, marginTop: 10 }}>
+          <span style={{ color: C.faint, fontFamily: C.mono, fontSize: 10, textTransform: "uppercase", letterSpacing: "0.08em" }}>Why not promoted — </span>
+          {review.reason_rejected}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Champion review — the theatrical-but-honest story: PCA looked smarter, MAD operated better, MAD stayed
+// champion. Champion/challenger facts come from the live registry (tel_model_runs). The gate-by-gate
+// decision enriches the panel when the promotion_review receipt has landed (Part II.5).
+export function ChampionReviewPanel() {
+  const [models, setModels] = useState<ModelRun[] | null>(null);
+  const [review, setReview] = useState<PromotionReviewPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getModelPerformance(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID)
+      .then((d) => setModels(d.models))
+      .catch((e) => setError(String(e)));
+    getWorkbenchPromotionReview()
+      .then((r: ReceiptEnvelope) => { if (!r.null_reason) setReview(r.payload as PromotionReviewPayload); })
+      .catch(() => { /* receipt is optional enrichment */ });
+  }, []);
+
+  if (error) return <EmptyState label="Champion review unavailable" hint="The registry-backed model API could not be loaded." nullReason={error} />;
+  if (!models) return <Loading label="Loading champion review…" />;
+
+  const anomaly = models.filter((m) => m.model_kind === "anomaly");
+  const champ = anomaly.find((m) => m.model_alias === "champion" || m.promotion_state === "promoted");
+  const challenger = anomaly.find((m) => m !== champ);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "6px 10px", fontFamily: FONT_EDITORIAL, fontSize: 19, lineHeight: 1.4 }}>
+        <span style={{ color: C.dim }}>PCA looked smarter.</span>
+        <span style={{ color: C.text }}>MAD operated better.</span>
+        <span style={{ color: ACCENT }}>MAD stayed champion.</span>
+      </div>
+      <span style={{ fontFamily: C.sans, fontSize: 13, color: C.dim, lineHeight: 1.6, maxWidth: 780 }}>
+        The promotion gate cared about operational false alarms, not headline accuracy. A model can look
+        sharper on one metric and still be rejected if it degrades alarm precision — that is the gate
+        doing its job, recorded honestly rather than forcing a fancier model to win.
+      </span>
+
+      {champ && (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 12 }}>
+          <ModelCard m={champ} role="champion" />
+          {challenger && <ModelCard m={challenger} role="challenger" />}
+        </div>
+      )}
+
+      {review?.gates && review.gates.length > 0 ? (
+        <GateTable review={review} />
+      ) : (
+        <span style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint }}>
+          Live registry rows shown. The gate-by-gate promotion receipt (challenger improved X, failed Y)
+          lands with the GCP run (Part II.5).
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default ChampionReviewPanel;

--- a/repo-b/src/components/telemetry/workbench/ExperimentReplayButton.test.tsx
+++ b/repo-b/src/components/telemetry/workbench/ExperimentReplayButton.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ExperimentReplayButton } from "./ExperimentReplayButton";
+import { getWorkbenchExperiments } from "@/lib/telemetry/api";
+
+vi.mock("@/lib/telemetry/api", () => ({ getWorkbenchExperiments: vi.fn() }));
+const mockExp = getWorkbenchExperiments as ReturnType<typeof vi.fn>;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("ExperimentReplayButton", () => {
+  it("is labeled Replay (never train) and does not fetch until opened", () => {
+    render(<ExperimentReplayButton />);
+    expect(screen.getByRole("button", { name: /Replay experiment receipt/i })).toBeInTheDocument();
+    expect(screen.queryByText(/Train model live/i)).not.toBeInTheDocument();
+    expect(mockExp).not.toHaveBeenCalled();
+  });
+
+  it("opens the receipt and fails closed when none has been generated", async () => {
+    mockExp.mockResolvedValue({
+      kind: "experiment_runs", provider: null, null_reason: "gcp_receipt_not_generated_yet",
+      fallback_used: true, payload: null,
+    });
+    render(<ExperimentReplayButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Replay experiment receipt/i }));
+    expect(await screen.findByText("No experiment receipt to replay yet")).toBeInTheDocument();
+    // "no live compute triggered" appears in both the drawer title and the Mode field — assert ≥1.
+    expect(screen.getAllByText(/no live compute triggered/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders a committed run receipt when present", async () => {
+    mockExp.mockResolvedValue({
+      kind: "experiment_runs", provider: "vertex", null_reason: null, fallback_used: false,
+      payload: { latest_run: {
+        run_id: "vertex/anomaly-mad-temporal-v003", dataset: "bq gold_smap_msl_windows",
+        feature_set: "temporal_v2", result: "did not displace champion",
+        reason: "recall improved, alarm precision degraded", artifacts: ["threshold_sweep.json"],
+      } },
+    });
+    render(<ExperimentReplayButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Replay experiment receipt/i }));
+    expect(await screen.findByText("did not displace champion")).toBeInTheDocument();
+    expect(screen.getByText("threshold_sweep.json")).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/workbench/ExperimentReplayButton.tsx
+++ b/repo-b/src/components/telemetry/workbench/ExperimentReplayButton.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getWorkbenchExperiments, type ReceiptEnvelope } from "@/lib/telemetry/api";
+import { C, EmptyState, Loading, Tag, TelemetryActionButton } from "../primitives";
+import { MetricInspectorDrawer } from "../drawerPrimitives";
+
+// One replayed experiment receipt. Every field is committed by the GCP MLOps pipeline (Part II) — the
+// button NEVER triggers live compute.
+interface RunReceipt {
+  run_id?: string;
+  dataset?: string;
+  feature_set?: string;
+  training_window?: string;
+  validation?: string;
+  params?: string;
+  result?: string;
+  reason?: string;
+  artifacts?: string[];
+}
+interface ExperimentsPayload { latest_run?: RunReceipt }
+
+function Row({ k, v }: { k: string; v?: string }) {
+  if (!v) return null;
+  return (
+    <div style={{ display: "flex", gap: 10, fontFamily: C.mono, fontSize: 11.5, lineHeight: 1.6 }}>
+      <span style={{ color: C.faint, minWidth: 120 }}>{k}</span>
+      <span style={{ color: C.text }}>{v}</span>
+    </div>
+  );
+}
+
+function RunReceiptView({ run }: { run: RunReceipt }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <Row k="Dataset" v={run.dataset} />
+      <Row k="Feature set" v={run.feature_set} />
+      <Row k="Training window" v={run.training_window} />
+      <Row k="Validation" v={run.validation} />
+      <Row k="Params" v={run.params} />
+      <Row k="Result" v={run.result} />
+      <Row k="Reason" v={run.reason} />
+      {run.artifacts && run.artifacts.length > 0 && (
+        <div style={{ marginTop: 8 }}>
+          <span style={{ fontFamily: C.mono, fontSize: 9, color: C.faint, letterSpacing: "0.08em", textTransform: "uppercase" }}>Artifacts</span>
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginTop: 5 }}>
+            {run.artifacts.map((a) => <Tag key={a} color={C.dim}>{a}</Tag>)}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// The honest "run" button — labeled Replay, never "Train model live". Opens the latest committed
+// experiment receipt; fails closed when none has been generated yet.
+export function ExperimentReplayButton() {
+  const [open, setOpen] = useState(false);
+  const [run, setRun] = useState<RunReceipt | null>(null);
+  const [nullReason, setNullReason] = useState<string | null>(null);
+  const [provider, setProvider] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || loaded) return;
+    getWorkbenchExperiments()
+      .then((r: ReceiptEnvelope) => {
+        setProvider(r.provider);
+        setNullReason(r.null_reason);
+        setRun((r.payload as ExperimentsPayload | null)?.latest_run ?? null);
+      })
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoaded(true));
+  }, [open, loaded]);
+
+  const fields = [
+    { label: "Mode", value: "replay — no live compute triggered" },
+    { label: "Provider", value: provider ?? "—" },
+    { label: "Run ID", value: run?.run_id ?? "—" },
+  ];
+
+  return (
+    <>
+      <TelemetryActionButton variant="primary" onClick={() => setOpen(true)} aria-label="Replay experiment receipt">
+        Replay experiment receipt
+      </TelemetryActionButton>
+      <MetricInspectorDrawer
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Replay experiment receipt — no live compute triggered"
+        description="The Workbench replays a committed receipt produced offline by the GCP MLOps pipeline. Clicking this never starts a training job."
+        fields={fields}
+      >
+        <div style={{ marginTop: 14 }}>
+          {error && <EmptyState label="Receipt unavailable" hint="The experiment_runs receipt could not be loaded." nullReason={error} />}
+          {!error && !loaded && <Loading label="Opening receipt…" />}
+          {!error && loaded && (nullReason || !run) && (
+            <EmptyState
+              label="No experiment receipt to replay yet"
+              hint="The first experiment run is produced offline by the GCP MLOps pipeline (Part II) and committed verbatim."
+              nullReason={nullReason}
+            />
+          )}
+          {!error && loaded && !nullReason && run && <RunReceiptView run={run} />}
+        </div>
+      </MetricInspectorDrawer>
+    </>
+  );
+}
+
+export default ExperimentReplayButton;

--- a/repo-b/src/components/telemetry/workbench/ModelWorkbench.tsx
+++ b/repo-b/src/components/telemetry/workbench/ModelWorkbench.tsx
@@ -2,6 +2,8 @@
 
 import { TelemetryPageHeader } from "../TelemetryPageHeader";
 import { C, DisclosureFooter, Panel } from "../primitives";
+import { ChampionReviewPanel } from "./ChampionReviewPanel";
+import { ExperimentReplayButton } from "./ExperimentReplayButton";
 import { FeatureSetSelector } from "./FeatureSetSelector";
 import { LifecycleStepper } from "./LifecycleStepper";
 import { WorkbenchHeadlineCard } from "./WorkbenchHeadlineCard";
@@ -21,11 +23,17 @@ export default function ModelWorkbench() {
       />
       <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
         <WorkbenchHeadlineCard />
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <ExperimentReplayButton />
+        </div>
         <Panel title="ML lifecycle">
           <LifecycleStepper activeSlug="workbench" />
         </Panel>
         <Panel title="Feature sets — baseline → temporal → diagnostic">
           <FeatureSetSelector />
+        </Panel>
+        <Panel title="Champion review — why MAD stayed champion">
+          <ChampionReviewPanel />
         </Panel>
         <Panel pad={14}>
           <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, lineHeight: 1.6 }}>


### PR DESCRIPTION
## What
Part I.4 of the **Model Workbench** (ADO #739), on the landing surface.

## Changes
- **`ChampionReviewPanel`** — "PCA looked smarter. MAD operated better. MAD stayed champion." Champion/challenger facts from the live registry (`tel_model_runs`); the gate-by-gate decision (challenger improved X, failed Y) enriches the panel when the `promotion_review` receipt lands (Part II.5), else an honest pending note.
- **`ExperimentReplayButton`** — the honest run action: **"Replay experiment receipt — no live compute triggered"**, never "Train model live". Opens the latest committed run receipt (dataset / feature set / params / result / reason / artifacts); fails closed when none exists yet.
- Mounted both on `ModelWorkbench` (replay button under the headline card; champion review after the feature selector).

## Tests / evidence
- 5 new tests (narrative + live champion/challenger + gate-table; replay label-not-train + closed-no-fetch + fail-closed + committed-receipt). Full workbench suite **18 passed**; typecheck + lint clean.

## Honesty notes
- Acceptance copy preserved verbatim. Champion facts are real live rows; nothing fabricated; replay never triggers compute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)