### PR TITLE
feat(telemetry): continuous prediction provenance drill + MAD reconciliation (#740)

### DIFF
--- a/repo-b/src/components/telemetry/ModelPerformance.tsx
+++ b/repo-b/src/components/telemetry/ModelPerformance.tsx
@@ -8,8 +8,9 @@ import { C, Tag, Panel, Loading, ErrorState, DisclosureFooter, ScrollTable, Sect
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
 import { MetricInspectorDrawer } from "./drawerPrimitives";
 import { SourceRowsTable, DatabricksRunLink, ModelArtifactLink, exportXlsxUrl } from "./drill";
+import { MlProvenanceDrawer, MAD_FROZEN, type MlProvenanceSelection } from "./drill";
 import { ThresholdSweepTab } from "./workbench/ThresholdSweepTab";
-import { FpFnReviewDrawer } from "./workbench/FpFnReviewDrawer";
+import { FpFnReviewDrawer, type ErrorCase } from "./workbench/FpFnReviewDrawer";
 
 // Columns surfaced when drilling into the model rows. Mirrors the server XLSX export
 // (telemetry_export.py "model_runs") so the CSV preview and the .xlsx match.
@@ -103,6 +104,8 @@ export default function ModelPerformance() {
   const [drillOpen, setDrillOpen] = useState(false);
   const [tab, setTab] = useState<"metrics" | "sweep">("metrics");
   const [fpfnOpen, setFpfnOpen] = useState(false);
+  const [provSel, setProvSel] = useState<MlProvenanceSelection | null>(null);
+  const [provOpen, setProvOpen] = useState(false);
 
   useEffect(() => {
     getModelPerformance(TELEMETRY_DEMO_ENV_ID, TELEMETRY_DEMO_BUSINESS_ID)
@@ -118,6 +121,37 @@ export default function ModelPerformance() {
 
   const anomaly = models.filter((m) => m.model_kind === "anomaly");
   const rul = models.filter((m) => m.model_kind === "rul");
+  const champ = anomaly.find((m) => m.model_alias === "champion" || m.promotion_state === "promoted");
+
+  // Build the continuous-drill selection from a failure case + the frozen MAD rule. The exact feature
+  // vector and the per-channel reconciliation caveat arrive with the GCP error_review receipt (S9);
+  // until then the drill shows the rule, the run, and the case facts honestly.
+  function drillCase(c: ErrorCase) {
+    setProvSel({
+      title: `Failure case ${c.id} — ${c.kind}`,
+      signal: [
+        { label: "Case", value: c.kind },
+        { label: "Channel", value: c.channel ?? "—" },
+        { label: "Window", value: c.window ?? "—" },
+        { label: "True label", value: c.true_label ?? "—" },
+      ],
+      featureVector: null,
+      math: [
+        { label: "Rule", value: "MAD: residual = |value − rmean| > k · scale" },
+        { label: "MAD_K", value: MAD_FROZEN.mad_k },
+        { label: "Detector threshold", value: MAD_FROZEN.detector_threshold.toFixed(4) },
+        { label: "Feature pushed", value: c.feature_pushed ?? "—" },
+      ],
+      reconciliationCaveat: null,
+      mlflowRunId: champ?.mlflow_run_id ?? null,
+      modelName: champ?.model_name ?? null,
+      gate: [
+        { label: "Operationally", value: c.acceptable ?? "—" },
+        { label: "Might fix it", value: c.suggested_fix ?? "—" },
+      ],
+    });
+    setProvOpen(true);
+  }
 
   return (
     <>
@@ -200,7 +234,8 @@ export default function ModelPerformance() {
           </div>
         </div>
       </MetricInspectorDrawer>
-      <FpFnReviewDrawer open={fpfnOpen} onClose={() => setFpfnOpen(false)} />
+      <FpFnReviewDrawer open={fpfnOpen} onClose={() => setFpfnOpen(false)} onDrill={drillCase} />
+      <MlProvenanceDrawer open={provOpen} onClose={() => setProvOpen(false)} selection={provSel} />
       <DisclosureFooter />
     </>
   );

--- a/repo-b/src/components/telemetry/drill/MlProvenanceDrawer.test.tsx
+++ b/repo-b/src/components/telemetry/drill/MlProvenanceDrawer.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { MlProvenanceDrawer, type MlProvenanceSelection } from "./MlProvenanceDrawer";
+
+const SEL: MlProvenanceSelection = {
+  title: "Replay anomaly — D-4 @ t=120",
+  signal: [
+    { label: "Verdict", value: "NO_GO (model_pred=1)" },
+    { label: "Channel", value: "D-4" },
+  ],
+  featureVector: { columns: ["t", "residual"], rows: [{ t: 120, residual: 0.5 }], sourceLabel: "gold_replay_feed" },
+  math: [
+    { label: "MAD_K", value: 4 },
+    { label: "Detector threshold", value: "0.1355" },
+  ],
+  reconciliationCaveat: "The serving global-scale fallback threshold does NOT reproduce the champion's D-4 firing.",
+  mlflowRunId: "run-abc",
+  modelName: "tel_anomaly_detector",
+  gate: [{ label: "Promotion gate", value: "honest gate" }],
+  deltaTable: "novendor_1.telemetry.gold_replay_feed",
+};
+
+describe("MlProvenanceDrawer", () => {
+  it("renders the five-rung drill with signal, math, run link, and gate", () => {
+    render(<MlProvenanceDrawer open onClose={() => {}} selection={SEL} />);
+    expect(screen.getByText("NO_GO (model_pred=1)")).toBeInTheDocument();   // rung 1 signal
+    expect(screen.getByText("MAD_K")).toBeInTheDocument();                   // rung 3 math
+    expect(screen.getByText("Promotion gate")).toBeInTheDocument();          // rung 5 gate
+    expect(screen.getByRole("link", { name: /MLflow Run/i })).toBeInTheDocument(); // rung 4 run link
+  });
+
+  it("surfaces the scoring-reconciliation caveat when serving ≠ replay", () => {
+    render(<MlProvenanceDrawer open onClose={() => {}} selection={SEL} />);
+    expect(screen.getByText("scoring reconciliation")).toBeInTheDocument();
+    expect(screen.getByText(/does NOT reproduce/i)).toBeInTheDocument();
+  });
+
+  it("fails closed on the feature-vector rung when no window is attached", () => {
+    render(<MlProvenanceDrawer open onClose={() => {}} selection={{ ...SEL, featureVector: null }} />);
+    expect(screen.getByText(/Feature window not attached/i)).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/drill/MlProvenanceDrawer.tsx
+++ b/repo-b/src/components/telemetry/drill/MlProvenanceDrawer.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { C, MetricRow, Tag } from "../primitives";
+import { MetricInspectorDrawer } from "../drawerPrimitives";
+import { SourceRowsTable } from "./SourceRowsTable";
+import { DatabricksRunLink, DeltaTableLink, LineageLink, ModelArtifactLink } from "./evidenceLinks";
+
+const ACCENT = "#a855f7";
+
+// Frozen anomaly-champion constants, mirrored from backend/app/services/telemetry_serving.py (the serving
+// source of truth). Surfaced so any MAD-based drill shows the exact rule it was scored against. Not a
+// second source of truth — these are the same frozen values the seeded threshold_sweep receipt carries.
+export const MAD_FROZEN = {
+  mad_k: 4.0,
+  global_train_scale: 0.033866801182436346,
+  detector_threshold: 0.13546720472974538,
+};
+
+// The continuous drill payload. The caller assembles it from data it already holds; the drawer does no
+// fetching. Every rung fails closed independently — a missing value renders "—" or the receipt's reason.
+export interface MlProvenanceSelection {
+  title?: string;
+  /** Rung 1 — verdict + score + threshold. */
+  signal: Array<{ label: string; value: ReactNode }>;
+  /** Rung 2 — the exact window rows / feature vector that produced the call. */
+  featureVector?: {
+    columns: string[];
+    rows: Array<Record<string, unknown>>;
+    sourceLabel?: string;
+    nullReason?: string | null;
+  } | null;
+  /** Rung 3 — the mathematical rule (frozen MAD constants, or model card facts). */
+  math: Array<{ label: string; value: ReactNode }>;
+  /** Rung 3 — reconciliation finding when the scoring path diverges (per_channel_caveat). */
+  reconciliationCaveat?: string | null;
+  /** Rung 4 — the experiment run + model artifact. */
+  mlflowRunId?: string | null;
+  modelName?: string | null;
+  /** Rung 5 — the promotion gate decision + the source Delta/BigQuery table + lineage. */
+  gate?: Array<{ label: string; value: ReactNode }>;
+  deltaTable?: string | null;
+  lineageHref?: string | null;
+}
+
+function Rung({ n, label, children }: { n: number; label: string; children: ReactNode }) {
+  return (
+    <div style={{ borderTop: `1px solid ${C.border}`, paddingTop: 12, marginTop: 12 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+        <span aria-hidden style={{ width: 18, height: 18, borderRadius: 999, display: "inline-flex",
+          alignItems: "center", justifyContent: "center", background: `${ACCENT}22`, color: ACCENT,
+          fontFamily: C.mono, fontSize: 10 }}>{n}</span>
+        <span style={{ fontFamily: C.mono, fontSize: 10.5, letterSpacing: "0.1em", textTransform: "uppercase", color: C.faint }}>{label}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// The continuous "anomaly → feature vector → math → run → gate" drill — one drawer, consistent
+// everywhere it is wired, no dead ends. It is the anti-black-box centerpiece.
+export function MlProvenanceDrawer({
+  open, onClose, selection,
+}: { open: boolean; onClose: () => void; selection: MlProvenanceSelection | null }) {
+  const s = selection;
+  return (
+    <MetricInspectorDrawer
+      open={open}
+      onClose={onClose}
+      title={s?.title ?? "Prediction provenance — verdict → feature vector → math → run → gate"}
+      description="Drill any prediction to the exact data, rule, run, and gate behind it. Every rung fails closed with a copyable id when an artifact is missing — no rung is faked."
+      fields={s?.signal ?? [{ label: "Selection", value: "none" }]}
+    >
+      {!s ? null : (
+        <div style={{ marginTop: 4 }}>
+          <Rung n={2} label="Feature vector — the window that produced it">
+            {s.featureVector && !s.featureVector.nullReason && s.featureVector.rows.length > 0 ? (
+              <SourceRowsTable
+                kind="computed-artifact"
+                columns={s.featureVector.columns}
+                rows={s.featureVector.rows}
+                sourceLabel={s.featureVector.sourceLabel ?? "feature window"}
+              />
+            ) : (
+              <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint }}>
+                {s.featureVector?.nullReason ? `Unavailable — ${s.featureVector.nullReason}` : "Feature window not attached to this selection."}
+              </span>
+            )}
+          </Rung>
+
+          <Rung n={3} label="Math — the rule it was scored against">
+            {s.math.map((m) => <MetricRow key={m.label} label={m.label} value={m.value} />)}
+            {s.reconciliationCaveat && (
+              <div style={{ marginTop: 10, background: `${C.amber}14`, border: `1px solid ${C.amber}55`, borderRadius: 8, padding: "10px 12px" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4 }}>
+                  <Tag color={C.amber}>scoring reconciliation</Tag>
+                </div>
+                <span style={{ fontFamily: C.sans, fontSize: 12.5, color: C.dim, lineHeight: 1.55 }}>{s.reconciliationCaveat}</span>
+              </div>
+            )}
+          </Rung>
+
+          <Rung n={4} label="Run — the experiment that produced the model">
+            <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+              <DatabricksRunLink runId={s.mlflowRunId} />
+              <ModelArtifactLink modelName={s.modelName} />
+            </div>
+          </Rung>
+
+          <Rung n={5} label="Gate — the promotion decision + source table">
+            {(s.gate ?? []).map((g) => <MetricRow key={g.label} label={g.label} value={g.value} />)}
+            <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap", marginTop: 8 }}>
+              <DeltaTableLink tableName={s.deltaTable} />
+              <LineageLink href={s.lineageHref ?? undefined} unavailableReason={s.lineageHref ? undefined : "lineage link not attached"} />
+            </div>
+          </Rung>
+        </div>
+      )}
+    </MetricInspectorDrawer>
+  );
+}
+
+export default MlProvenanceDrawer;

--- a/repo-b/src/components/telemetry/drill/index.ts
+++ b/repo-b/src/components/telemetry/drill/index.ts
@@ -13,3 +13,4 @@ export {
   DeltaTableLink,
   LineageLink,
 } from "./evidenceLinks";
+export { MlProvenanceDrawer, MAD_FROZEN, type MlProvenanceSelection } from "./MlProvenanceDrawer";

--- a/repo-b/src/components/telemetry/workbench/ModelWorkbench.tsx
+++ b/repo-b/src/components/telemetry/workbench/ModelWorkbench.tsx
@@ -6,6 +6,7 @@ import { ChampionReviewPanel } from "./ChampionReviewPanel";
 import { ExperimentReplayButton } from "./ExperimentReplayButton";
 import { FeatureSetSelector } from "./FeatureSetSelector";
 import { LifecycleStepper } from "./LifecycleStepper";
+import { WorkbenchDrillButton } from "./WorkbenchDrillButton";
 import { WorkbenchHeadlineCard } from "./WorkbenchHeadlineCard";
 
 // Model Workbench landing — composed inside the existing telemetry shell (Models & Intelligence group).
@@ -25,6 +26,7 @@ export default function ModelWorkbench() {
         <WorkbenchHeadlineCard />
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
           <ExperimentReplayButton />
+          <WorkbenchDrillButton />
         </div>
         <Panel title="ML lifecycle">
           <LifecycleStepper activeSlug="workbench" />

--- a/repo-b/src/components/telemetry/workbench/WorkbenchDrillButton.test.tsx
+++ b/repo-b/src/components/telemetry/workbench/WorkbenchDrillButton.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { WorkbenchDrillButton } from "./WorkbenchDrillButton";
+import { getReplayFeed } from "@/lib/telemetry/api";
+
+vi.mock("@/lib/telemetry/api", () => ({ getReplayFeed: vi.fn() }));
+const mockFeed = getReplayFeed as ReturnType<typeof vi.fn>;
+
+const FEED = {
+  channel: "D-4",
+  spacecraft: "SMAP",
+  fixture_ticks: 3,
+  total_ticks_source: 3,
+  first_model_fire_t: 120,
+  model_fired_ticks: 1,
+  label_anomaly_ticks: 1,
+  feed: [
+    { t: 118, value: 1.0, rmean: 1.0, score: 0, model_pred: 0, is_anomaly: 0 },
+    { t: 119, value: 1.1, rmean: 1.0, score: 0, model_pred: 0, is_anomaly: 0 },
+    { t: 120, value: 2.0, rmean: 1.0, score: 1e12, model_pred: 1, is_anomaly: 1 },
+  ],
+  provenance: {
+    source_table: "novendor_1.telemetry.gold_replay_feed",
+    champion_model: "tel_anomaly_detector",
+    champion_mlflow_run_id: "run-abc",
+    note: "",
+  },
+  scoringDiagnostics: {
+    mad_k: 4.0,
+    global_train_scale: 0.033866801182436346,
+    threshold_residual_units: 0.13546720472974538,
+    threshold_source: "serving global-scale fallback",
+    residual_definition: "abs(value - rmean)",
+    fired_ticks: 1,
+    fired_ticks_above_threshold: 0,
+    max_fired_residual: 1.0,
+    threshold_reproduces_firing: false,
+    per_channel_caveat: "The serving global-scale fallback threshold does NOT reproduce the champion's D-4 firing.",
+    fixture_score_degenerate: true,
+    note: "",
+  },
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("WorkbenchDrillButton", () => {
+  it("drills a real replay anomaly and surfaces the reconciliation caveat", async () => {
+    mockFeed.mockResolvedValue(FEED);
+    render(<WorkbenchDrillButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Drill a live replay anomaly/i }));
+    await waitFor(() => expect(screen.getByText(/does NOT reproduce/i)).toBeInTheDocument());
+    expect(screen.getByText("scoring reconciliation")).toBeInTheDocument();
+    // the fired tick (t=120) anchors the drill — appears across the title/signal/feature rungs
+    expect(screen.getAllByText("120").length).toBeGreaterThan(0);
+    expect(screen.getByText("D-4")).toBeInTheDocument();
+    expect(mockFeed).toHaveBeenCalledTimes(1);
+  });
+});

--- a/repo-b/src/components/telemetry/workbench/WorkbenchDrillButton.tsx
+++ b/repo-b/src/components/telemetry/workbench/WorkbenchDrillButton.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { getReplayFeed, type ReplayFeed, type ReplayTick } from "@/lib/telemetry/api";
+import { TelemetryActionButton } from "../primitives";
+import { MAD_FROZEN, MlProvenanceDrawer, type MlProvenanceSelection } from "../drill";
+
+function residual(t: ReplayTick): number {
+  return Math.abs(t.value - t.rmean);
+}
+
+// Build the continuous drill selection from a real replay anomaly. The reconciliation caveat is the
+// backend's honest per_channel_caveat (for D-4 the global-scale serving threshold does NOT reproduce the
+// champion's firing — surfaced, not hidden). Nothing is fabricated: every field comes from the committed
+// replay fixture + the frozen serving constants.
+function selectionFromReplay(feed: ReplayFeed): MlProvenanceSelection | null {
+  const fired = feed.feed.find((t) => t.model_pred === 1) ?? null;
+  const anchor = fired ?? feed.feed[Math.floor(feed.feed.length / 2)] ?? null;
+  if (!anchor) return null;
+  const idx = feed.feed.indexOf(anchor);
+  const window = feed.feed.slice(Math.max(0, idx - 3), idx + 1).map((t) => ({
+    t: t.t,
+    value: Number(t.value.toFixed(4)),
+    rmean: Number(t.rmean.toFixed(4)),
+    residual: Number(residual(t).toFixed(4)),
+    model_pred: t.model_pred,
+    is_anomaly: t.is_anomaly,
+  }));
+  const diag = feed.scoringDiagnostics ?? null;
+  const r = residual(anchor);
+  const threshold = diag?.threshold_residual_units ?? MAD_FROZEN.detector_threshold;
+  return {
+    title: `Replay anomaly — ${feed.channel} @ t=${anchor.t}`,
+    signal: [
+      { label: "Verdict", value: anchor.model_pred === 1 ? "NO_GO (model_pred=1)" : "GO" },
+      { label: "Channel", value: feed.channel },
+      { label: "Tick", value: anchor.t },
+      { label: "Residual", value: r.toFixed(4) },
+      { label: "Threshold", value: threshold.toFixed(4) },
+    ],
+    featureVector: {
+      columns: ["t", "value", "rmean", "residual", "model_pred", "is_anomaly"],
+      rows: window,
+      sourceLabel: feed.provenance?.source_table ?? "gold_replay_feed",
+    },
+    math: [
+      { label: "Rule", value: "MAD: residual = |value − rmean| > k · scale" },
+      { label: "MAD_K", value: MAD_FROZEN.mad_k },
+      { label: "Global train scale", value: MAD_FROZEN.global_train_scale.toFixed(6) },
+      { label: "Detector threshold", value: threshold.toFixed(4) },
+      { label: "This tick", value: `residual ${r.toFixed(4)} ${r > threshold ? ">" : "≤"} threshold` },
+    ],
+    reconciliationCaveat: diag?.per_channel_caveat ?? null,
+    mlflowRunId: feed.provenance?.champion_mlflow_run_id ?? null,
+    modelName: feed.provenance?.champion_model ?? null,
+    gate: [{ label: "Promotion gate", value: "anomaly honest gate — see Model Registry" }],
+    deltaTable: feed.provenance?.source_table ?? null,
+  };
+}
+
+// "Drill a live replay anomaly" — opens the continuous provenance drill on a real committed replay
+// anomaly, including the honest scoring-reconciliation caveat. This is the demo's anti-black-box moment.
+export function WorkbenchDrillButton() {
+  const [open, setOpen] = useState(false);
+  const [selection, setSelection] = useState<MlProvenanceSelection | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function onClick() {
+    setBusy(true);
+    try {
+      const feed = await getReplayFeed();
+      setSelection(selectionFromReplay(feed));
+    } catch {
+      setSelection(null);
+    } finally {
+      setBusy(false);
+      setOpen(true);
+    }
+  }
+
+  return (
+    <>
+      <TelemetryActionButton variant="secondary" onClick={onClick} disabled={busy}
+        aria-label="Drill a live replay anomaly">
+        {busy ? "Loading…" : "Drill a replay anomaly ›"}
+      </TelemetryActionButton>
+      <MlProvenanceDrawer open={open} onClose={() => setOpen(false)} selection={selection} />
+    </>
+  );
+}
+
+export default WorkbenchDrillButton;


### PR DESCRIPTION
## What
Part I.5 of the **Model Workbench** (ADO #740) — the anti-black-box centerpiece. Closes the Part I demo loop; the 7-minute demo path is now walkable end-to-end on committed/seeded data.

## Changes
- **`MlProvenanceDrawer`** (drill/) — the continuous **5-rung** drill composed from existing primitives: (1) signal verdict/score/threshold, (2) the exact feature window (`SourceRowsTable`, fail-closed), (3) the MAD math with the frozen constants **and the scoring-reconciliation caveat when serving ≠ replay**, (4) experiment run + model artifact links, (5) gate decision + source table + lineage. Caller passes a `MlProvenanceSelection`; the drawer does no fetching; every rung fails closed. Exports `MAD_FROZEN` (mirrors `telemetry_serving.py`).
- **`WorkbenchDrillButton`** — "Drill a replay anomaly ›" on the Workbench landing; reads the real committed replay feed and surfaces the backend's honest `per_channel_caveat` (for D-4 the global-scale serving threshold does **not** reproduce the champion's firing — shown, not hidden). The named MAD reconciliation, demonstrable now.
- **ModelPerformance** — the FP/FN drawer's `onDrill` seam (S3) now opens the drill for any failure case (latent until `error_review` lands in S9).

## Tests / evidence
- 4 new tests (5-rung render + caveat + fail-closed feature rung; real replay drill surfaces caveat). workbench + drill suites **22 passed**; ModelPerformance green; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)