### PR TITLE
feat(telemetry): AI Build & Operations Reference page

### DIFF
--- a/docs/plans/03-implementation-plans/active/0003-telemetry-platform-build.md
+++ b/docs/plans/03-implementation-plans/active/0003-telemetry-platform-build.md
@@ -362,3 +362,23 @@ needs the bindings regenerated** — `pip install grpcio-tools` then
 (output as `stargate_telemetry_pb2.py`). Do not claim full on-wire v3 field production until that regen lands.
 
 **Phase 7 COMPLETE** — T1–T4 landed and committed; the live Confluent sign-off passes.
+
+---
+
+## Reference ticket — AI Build & Operations Reference page (2026-06-27)
+
+Added one document-style telemetry reference page that explains *how the demo was built and how it is
+operated* — the missing "AI / automation / CLI / REST / MCP / CI-CD / DevOps connections" artifact.
+
+- **Route:** `/lab/env/[envId]/telemetry/ai-build-ops` (flat convention; nav label "AI Build & Ops",
+  page title "AI Build & Operations Reference"). Visible in the **Evidence & Lineage** nav group.
+- **Shape:** static — no fetch, no live compute, no new API, no migration. 11 numbered sections (page
+  inventory, AI-skill map, runtime AI, REST endpoint map, MCP map, CLI/DevOps, CI/CD gates, evidence,
+  honest boundaries) rendered from a hand-maintained manifest where every claim-bearing row carries
+  `sourceRefs` citing the real file/route. Engineering-runbook layout, not a card grid.
+- **Files:** `repo-b/src/app/lab/env/[envId]/telemetry/ai-build-ops/page.tsx`;
+  `repo-b/src/components/telemetry/reference/{AiBuildOpsReference.tsx,refPrimitives.tsx,manifest.ts,
+  AiBuildOpsReference.test.tsx}`; nav entry + slug→group in `telemetryNav.ts` (+ test).
+- **Verified:** `npm run typecheck` clean; `npm run lint` clean (new files); focused vitest 13/13;
+  `npm run build` compiles the route (14.8 kB, 295 pages). Manifest sourced from the verified
+  endpoint/MCP/CI inventory so it can't drift silently.

--- a/docs/plans/telemetry-platform/backlog.md
+++ b/docs/plans/telemetry-platform/backlog.md
@@ -44,3 +44,12 @@ can act on it without asking questions.
 - **PCA anomaly model underperformed the baseline (F1 0.42 vs 0.64).** Not a blocker — the baseline
   was promoted honestly. If a stronger anomaly model is wanted later, an LSTM/temporal autoencoder on
   the rolling-feature sequence is the natural next attempt (deferred; not required for the demo).
+
+## AI Build & Operations Reference (shipped 2026-06-27) — follow-ups
+
+- Capture an authenticated desktop+mobile screenshot of `/lab/env/[envId]/telemetry/ai-build-ops` into
+  `docs/plans/telemetry-platform/screenshots/` (this session verified by build + render tests; the route
+  is auth-gated so no headless screenshot was taken).
+- Keep `repo-b/src/components/telemetry/reference/manifest.ts` in step with the code — it is a
+  hand-maintained inventory; if an endpoint/MCP tool/CI job/page changes, update the matching row.
+- Optional: add a focused Playwright route/render check if reference-nav e2e coverage is introduced.

--- a/docs/plans/telemetry-platform/next-session.md
+++ b/docs/plans/telemetry-platform/next-session.md
@@ -1,6 +1,17 @@
 # Next Session - RS Factory Digital Thread PR 3
 
-**Last updated:** 2026-06-25
+**Last updated:** 2026-06-27
+
+> **Shipped (2026-06-27) — AI Build & Operations Reference page (telemetry, static, no migration):**
+> New document-style reference at `/lab/env/[envId]/telemetry/ai-build-ops` (nav "AI Build & Ops" under
+> Evidence & Lineage) answering "how was this demo built and how is it operated" — page-by-page AI
+> inventory, AI-skill map, runtime AI layers, REST endpoint map, MCP tool map, CLI/DevOps, CI/CD gates,
+> evidence checklist, honest boundaries. Pure static manifest (`repo-b/src/components/telemetry/
+> reference/manifest.ts`) where every claim-bearing row cites a real file/route via `sourceRefs`; no
+> fetch, no new API, no DB change. typecheck + lint clean, vitest 13/13, `npm run build` compiles the
+> route. **Follow-up:** keep the manifest in step with the code (it's the only drift risk); an
+> authenticated browser screenshot wasn't captured this session (route is auth-gated) — verified by
+> build + render tests instead.
 
 > **Shipped (2026-06-25) — Residual-vs-threshold chart on Replay (research-gap Ticket 6a, PR #375 → main, prod-verified):**
 > Frontend-only (no migration, no backend deploy — reads the threshold Ticket 2 already deployed). The

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4687,3 +4687,28 @@ The Stargate console gated its entire render on `bridgeBaseUrl()` (reads `NEXT_P
 - **Setting a Vercel env from this Windows shell:** `printf … | vercel env add` and `vercel env add < file` both fail to feed stdin (the CLI prints help / writes empty), and `vercel` resolves to a `.ps1` that `Process.Start` can't launch. The reliable path is the **REST API**: read the token from `C:/Users/paulm/AppData/Roaming/com.vercel.cli/Data/auth.json` (use the Windows `C:/` path in Python, not the Git-Bash `/c/` mount), `projectId`/`orgId` from `.vercel/project.json`, then `POST https://api.vercel.com/v10/projects/{projectId}/env?teamId={orgId}&upsert=true` with `{key,value,type:"plain",target:["production"]}`. NEXT_PUBLIC is inlined at build, so trigger a fresh prod build (merge to main / `vercel deploy --prod`) after setting it — a `redeploy` of the cached build won't pick it up.
 - **The Stargate capture bridge is already deployed on the Railway backend** (`/stargate/*`, `mode:capture`, CORS allows `https://novendor.ai`); wiring the demo is just pointing `NEXT_PUBLIC_STARGATE_BRIDGE_URL` at it — no separate bridge service to deploy. Capture mode = deterministic recorded replay, no Confluent cost.
 - **Databricks deep-links default live:** `resolveWorkspace()` falls back to the committed workspace const when `NEXT_PUBLIC_DATABRICKS_WORKSPACE_URL` is unset, so `deltaTableLink` renders clickable by default; it only fails closed (copyable id + reason) when the workspace resolves empty.
+
+### Telemetry doc-style reference pages: static manifest + two nav edits + the slug-group accent gotcha (2026-06-27)
+
+Adding a *written reference* page to the telemetry section (not a dashboard): mirror `how-it-works`.
+Wrapper is `repo-b/src/app/lab/env/[envId]/telemetry/<slug>/page.tsx` (`async`, `params: Promise<…>`,
+`await params`) rendering a `"use client"` component under `repo-b/src/components/telemetry/<area>/`.
+Reuse the doc primitives in `components/telemetry/primitives.tsx` (`TelemetryPageHeader variant="evidence"`,
+`Panel`, `ScrollTable`, `ResponsiveSwap`+`RowCard` for mobile tables, `InlineCode`, `Tag`,
+`TelemetryStatusBanner`, `DisclosureFooter`) — there is no in-page TOC/`<table>` primitive, so a tiny
+local `refPrimitives.tsx` (TOC + anchored section + a generic `RefTable` that swaps to `RowCard` on
+mobile) is the right amount of new code; keep it on the `C` tokens.
+
+Two **separate** edits in `telemetryNav.ts` for a visible page, and missing the second is a silent bug:
+(1) add the `{ slug, label, icon, group }` to `TELEMETRY_NAV` (the rail); (2) add `slug → group` to the
+`TELEMETRY_SLUG_GROUP` map — the page header resolves its accent color from the **route** via
+`telemetryAccentForPath`, so without (2) the header falls back to Overview cyan even though the rail item
+is green. `telemetryNav.test.ts` hard-asserts the exact sorted slug set ("any OTHER slug change is a
+regression") and the route→color cases, so update both when you add a nav item.
+
+Make a static reference honest by construction: put the data in a `manifest.ts` where every claim-bearing
+row carries `sourceRefs: {label,path,note}[]` rendered as compact path chips, and label real vs
+fixture vs synthetic vs cold with the repo's own vocabulary (`source_kind`, `serving_provenance`,
+`provenance: databricks|local_fallback`, `null_reason`). The only real risk is manifest drift, so cite
+the file/route on every row. Note: `npm run build` is NOT a CI gate (CI runs lint/typecheck/test:unit);
+run it locally to confirm a new route compiles before relying on the Vercel deploy.

--- a/repo-b/src/app/lab/env/[envId]/telemetry/ai-build-ops/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/telemetry/ai-build-ops/page.tsx
@@ -1,0 +1,13 @@
+import AiBuildOpsReference from "@/components/telemetry/reference/AiBuildOpsReference";
+
+// Thin wrapper. The telemetry layout already yields full-bleed and carries the dark palette; forward
+// the env id so any future env-scoped deep links stay scoped to this environment. The reference itself
+// is a static document — no fetch, no live compute.
+export default async function TelemetryAiBuildOpsPage({
+  params,
+}: {
+  params: Promise<{ envId: string }>;
+}) {
+  const { envId } = await params;
+  return <AiBuildOpsReference envId={envId} />;
+}

--- a/repo-b/src/components/telemetry/reference/AiBuildOpsReference.test.tsx
+++ b/repo-b/src/components/telemetry/reference/AiBuildOpsReference.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import AiBuildOpsReference from "./AiBuildOpsReference";
+import { SECTIONS } from "./manifest";
+
+describe("AiBuildOpsReference — telemetry build & operations reference", () => {
+  it("renders the document title", () => {
+    render(<AiBuildOpsReference envId="telemetry-demo" />);
+    expect(
+      screen.getByRole("heading", { name: "AI Build & Operations Reference", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("anchors all eleven numbered sections", () => {
+    const { container } = render(<AiBuildOpsReference envId="telemetry-demo" />);
+    expect(SECTIONS).toHaveLength(11);
+    for (const s of SECTIONS) {
+      expect(container.querySelector(`#${s.id}`)).not.toBeNull();
+    }
+  });
+
+  it("surfaces real, verifiable facts (not vendor copy)", () => {
+    const { container } = render(<AiBuildOpsReference envId="telemetry-demo" />);
+    const text = container.textContent ?? "";
+    // a real MCP tool, a real endpoint, a real CI gate, and an honest-boundary phrase
+    expect(text).toContain("telemetry.get_triggering_prediction");
+    expect(text).toContain("/api/telemetry/summary");
+    expect(text).toContain("frontend-quality");
+    expect(text).toContain("MAD stayed champion");
+  });
+
+  it("renders a table of contents linking each section", () => {
+    render(<AiBuildOpsReference envId="telemetry-demo" />);
+    const toc = screen.getByRole("navigation", { name: "On this page" });
+    for (const s of SECTIONS) {
+      // anchor hrefs in the TOC point at each section id
+      expect(toc.querySelector(`a[href="#${s.id}"]`)).not.toBeNull();
+    }
+  });
+});

--- a/repo-b/src/components/telemetry/reference/AiBuildOpsReference.tsx
+++ b/repo-b/src/components/telemetry/reference/AiBuildOpsReference.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+import { C, DisclosureFooter, InlineCode } from "../primitives";
+import { TelemetryPageHeader } from "../TelemetryPageHeader";
+import { telemetryAccentForPath } from "../telemetryNav";
+import {
+  RefTOC, RefSection, RefProse, RefTable, EvidenceCell, StatusPill, CommandBlock, Callout,
+  type RefCol,
+} from "./refPrimitives";
+import {
+  SECTIONS, KINDS, PAGE_INVENTORY, HIDDEN_ROUTES, CROSS_LINKS, PLANNED_SURFACES,
+  SKILL_FAMILIES, RUNTIME_LAYERS, ENDPOINT_FAMILIES, PLANNED_ENDPOINTS,
+  MCP_TOOLS, MCP_TOOLS_SOURCE, MCP_MUST_NOT, CLI_BLOCKS, RELEASE_FLOW, CI_GATES,
+  EVIDENCE_CHECKLIST, BOUNDARIES, WHY_IT_MATTERS,
+} from "./manifest";
+
+// "AI Build & Operations Reference" — a document-style technical reference (engineering-runbook feel,
+// not a dashboard) explaining how the telemetry demo was built and how it is operated: which parts are
+// deterministic software vs ML vs LLM/agentic, which were produced by AI-assisted engineering, which
+// REST APIs / MCP tools / CLI / CI-CD workflows operate it, and what is real vs fixture vs synthetic
+// vs cold. Honest by construction: nothing here executes; every claim renders from a hand-maintained
+// static manifest whose rows cite the file/route they describe (see ./manifest.ts).
+
+function Bullets({ items }: { items: string[] }) {
+  return (
+    <ul style={{ display: "grid", gap: 8, margin: "0 0 4px", paddingLeft: 18, maxWidth: 880 }}>
+      {items.map((t, i) => (
+        <li key={i} style={{ fontFamily: C.sans, fontSize: 14, color: C.dim, lineHeight: 1.6 }}>{t}</li>
+      ))}
+    </ul>
+  );
+}
+
+function pageCell(route: string, page: string, status: Parameters<typeof StatusPill>[0]["status"]): ReactNode {
+  return (
+    <span style={{ display: "grid", gap: 6 }}>
+      <span style={{ fontFamily: C.sans, fontWeight: 600, color: C.text }}>{page}</span>
+      <InlineCode color={C.faint}>{route}</InlineCode>
+      <span><StatusPill status={status} /></span>
+    </span>
+  );
+}
+
+export default function AiBuildOpsReference({ envId }: { envId: string }) {
+  void envId; // reserved for future env-scoped deep links; the reference itself is static.
+  const accent = telemetryAccentForPath(usePathname() ?? "");
+
+  const inventoryCols: RefCol[] = [
+    { key: "page", header: "Demo page", minWidth: 180 },
+    { key: "sees", header: "What the user sees", minWidth: 200 },
+    { key: "ai", header: "AI / ML connection", minWidth: 200 },
+    { key: "api", header: "API / data source", minWidth: 180 },
+    { key: "tooling", header: "Tooling / DevOps", minWidth: 180 },
+    { key: "evidence", header: "Evidence / audit", minWidth: 180 },
+    { key: "boundary", header: "Honest boundary", minWidth: 220 },
+  ];
+  const inventoryRows = PAGE_INVENTORY.map((r) => ({
+    page: pageCell(r.route, r.page, r.status),
+    sees: r.sees,
+    ai: r.aiConnection,
+    api: <InlineCode color={C.dim}>{r.dataSource}</InlineCode>,
+    tooling: r.tooling,
+    evidence: r.evidence,
+    boundary: (
+      <span style={{ display: "grid", gap: 6 }}>
+        <span>{r.boundary}</span>
+        <EvidenceCell refs={r.sourceRefs} />
+      </span>
+    ),
+  }));
+
+  const skillCols: RefCol[] = [
+    { key: "family", header: "Skill family", minWidth: 170 },
+    { key: "usedFor", header: "Used for", minWidth: 260 },
+    { key: "example", header: "Example in telemetry demo", minWidth: 260 },
+    { key: "evidence", header: "Evidence to inspect", minWidth: 180 },
+  ];
+  const skillRows = SKILL_FAMILIES.map((s) => ({
+    family: s.family, usedFor: s.usedFor, example: s.example, evidence: <EvidenceCell refs={s.sourceRefs} />,
+  }));
+
+  const runtimeCols: RefCol[] = [
+    { key: "layer", header: "Runtime layer", minWidth: 160 },
+    { key: "purpose", header: "Purpose", minWidth: 220 },
+    { key: "examples", header: "Examples", minWidth: 200 },
+    { key: "failure", header: "Failure mode", minWidth: 200 },
+    { key: "evidence", header: "User-visible evidence", minWidth: 200 },
+  ];
+  const runtimeRows = RUNTIME_LAYERS.map((r) => ({
+    layer: r.layer, purpose: r.purpose, examples: r.examples, failure: r.failureMode,
+    evidence: (
+      <span style={{ display: "grid", gap: 6 }}>
+        <span>{r.evidence}</span>
+        <EvidenceCell refs={r.sourceRefs} />
+      </span>
+    ),
+  }));
+
+  const endpointCols: RefCol[] = [
+    { key: "ep", header: "Endpoint", minWidth: 280 },
+    { key: "usedBy", header: "Used by", minWidth: 140 },
+    { key: "purpose", header: "Purpose", minWidth: 220 },
+    { key: "auth", header: "Auth", minWidth: 110 },
+    { key: "evidence", header: "Source", minWidth: 150 },
+  ];
+
+  const mcpCols: RefCol[] = [
+    { key: "name", header: "Tool", minWidth: 250 },
+    { key: "capability", header: "What it can do", minWidth: 240 },
+    { key: "useCase", header: "Telemetry use case", minWidth: 180 },
+    { key: "risk", header: "Risk", minWidth: 90 },
+    { key: "permission", header: "Permission", minWidth: 150 },
+    { key: "audit", header: "Audit", minWidth: 150 },
+  ];
+  const mcpRows = MCP_TOOLS.map((t) => ({
+    name: <InlineCode color={C.text}>{t.name}</InlineCode>,
+    capability: t.capability, useCase: t.useCase, risk: t.risk, permission: t.permission, audit: t.audit,
+  }));
+
+  const ciCols: RefCol[] = [
+    { key: "gate", header: "Gate", minWidth: 170 },
+    { key: "catches", header: "What it catches", minWidth: 240 },
+    { key: "evidence", header: "Command / evidence", minWidth: 220 },
+    { key: "blocks", header: "Blocks release?", minWidth: 110 },
+  ];
+  const ciRows = CI_GATES.map((g) => ({
+    gate: <InlineCode color={C.text}>{g.gate}</InlineCode>,
+    catches: g.catches,
+    evidence: (
+      <span style={{ display: "grid", gap: 6 }}>
+        <span>{g.evidence}</span>
+        <EvidenceCell refs={g.sourceRefs} />
+      </span>
+    ),
+    blocks: g.blocks ? <span style={{ color: C.red }}>Yes</span> : <span style={{ color: C.dim }}>No</span>,
+  }));
+
+  const boundaryCols: RefCol[] = [
+    { key: "area", header: "Claim area", minWidth: 160 },
+    { key: "real", header: "Real today", minWidth: 220 },
+    { key: "sim", header: "Simulated / fixture-backed", minWidth: 200 },
+    { key: "planned", header: "Planned", minWidth: 160 },
+    { key: "ui", header: "How the UI says it", minWidth: 240 },
+  ];
+  const boundaryRows = BOUNDARIES.map((b) => ({
+    area: b.area, real: b.realToday, sim: b.simulated, planned: b.planned,
+    ui: (
+      <span style={{ display: "grid", gap: 6 }}>
+        <span>{b.uiSays}</span>
+        <EvidenceCell refs={b.sourceRefs} />
+      </span>
+    ),
+  }));
+
+  return (
+    <div>
+      <TelemetryPageHeader
+        variant="evidence"
+        eyebrow="Build & Operations"
+        title="AI Build & Operations Reference"
+        description="How the telemetry demo was created, operated, tested, and explained through AI-assisted engineering, REST APIs, MCP tools, CLI workflows, model evidence, and deployment gates. This is a written reference of verified structure — nothing here executes, and every row cites the file or route it describes."
+      />
+
+      <RefProse>
+        The telemetry demo has four different kinds of &ldquo;AI&rdquo; and automation, and they are
+        easy to conflate. This page separates them, then maps each demo surface to the real APIs, tools,
+        and workflows behind it. The goal is to reduce ambiguity: you should leave knowing exactly which
+        parts are deterministic software, which are ML models, which are LLM/RAG/agentic features, and
+        which were produced by AI-assisted coding — and where to click to verify each claim.
+      </RefProse>
+
+      <RefTOC sections={SECTIONS} accent={accent} />
+
+      {/* 1 — What this page documents */}
+      <RefSection {...SECTIONS[0]} accent={accent}>
+        <div style={{ display: "grid", gap: 14, maxWidth: 880 }}>
+          {KINDS.map((k) => (
+            <div key={k.key}>
+              <div style={{ fontFamily: C.sans, fontSize: 14.5, fontWeight: 700, color: C.text, marginBottom: 4 }}>{k.title}</div>
+              <div style={{ fontFamily: C.sans, fontSize: 14, color: C.dim, lineHeight: 1.6 }}>{k.body}</div>
+            </div>
+          ))}
+        </div>
+      </RefSection>
+
+      {/* 2 — Page-by-page inventory */}
+      <RefSection {...SECTIONS[1]} accent={accent}>
+        <RefProse>
+          One row per real telemetry surface. The status pill marks whether a page reads live serving
+          rows (<StatusPill status="real" />), a committed fixture (<StatusPill status="fixture" />),
+          clearly-labeled synthetic data (<StatusPill status="synthetic" />), or infrastructure that is
+          off/cold by default (<StatusPill status="cold" />).
+        </RefProse>
+        <RefTable columns={inventoryCols} rows={inventoryRows} minWidth={1280} />
+        <RefProse style={{ marginTop: 16 }}>
+          <strong style={{ color: C.dim }}>Hidden but resolving.</strong> A few document/console routes
+          are intentionally dropped from the rail (declutter) yet still resolve as deep links:
+        </RefProse>
+        <Bullets items={HIDDEN_ROUTES.map((h) => `${h.label} — ${h.route} — ${h.note}`)} />
+        <RefProse style={{ marginTop: 12 }}>
+          <strong style={{ color: C.dim }}>Cross-links.</strong>{" "}
+          {CROSS_LINKS.map((c) => `${c.label} (${c.route}) — ${c.note}`).join(" ")}
+        </RefProse>
+        <RefProse style={{ marginTop: 12 }}>
+          <strong style={{ color: C.amber }}>Planned / not present yet.</strong> Listed honestly so the
+          inventory above never overclaims:
+        </RefProse>
+        <Bullets items={PLANNED_SURFACES.map((p) => `${p.label} — ${p.note}`)} />
+      </RefSection>
+
+      {/* 3 — AI skills used to build the demo */}
+      <RefSection {...SECTIONS[2]} accent={accent}>
+        <RefProse>
+          This is the AI-assisted <em>engineering</em> system, not a runtime LLM feature. Each family is
+          a governed workflow — planning, code, tests, deploy, safety — that runs through the same PR and
+          CI gates as any other change. Language is grounded: a row is &ldquo;represented by&rdquo; the
+          evidence it cites, not a claim that an agent autonomously did the work unattended.
+        </RefProse>
+        <RefTable columns={skillCols} rows={skillRows} minWidth={960} />
+      </RefSection>
+
+      {/* 4 — Runtime AI connections */}
+      <RefSection {...SECTIONS[3]} accent={accent}>
+        <RefProse>
+          The runtime architecture, layer by layer. Note the distinction the table keeps: LLM answer
+          generation (copilot, gateway), deterministic API responses (serving), traditional ML scoring
+          (/score), and static fixture/historical evidence are separate rows with separate failure modes.
+        </RefProse>
+        <RefTable columns={runtimeCols} rows={runtimeRows} minWidth={1080} />
+      </RefSection>
+
+      {/* 5 — REST API & endpoint map */}
+      <RefSection {...SECTIONS[4]} accent={accent}>
+        <RefProse>
+          Real endpoint families that power the pages above. The frontend reaches them through a
+          catch-all proxy (<InlineCode color={C.dim}>repo-b/src/app/api/telemetry/[...path]/route.ts</InlineCode>)
+          and a typed client (<InlineCode color={C.dim}>repo-b/src/lib/telemetry/api.ts</InlineCode>).
+          Planned endpoints are kept in a separate table below — never blended with the real ones.
+        </RefProse>
+        <div style={{ display: "grid", gap: 18 }}>
+          {ENDPOINT_FAMILIES.map((fam) => (
+            <div key={fam.family}>
+              <div style={{ fontFamily: C.mono, fontSize: 11, letterSpacing: "0.12em", textTransform: "uppercase", color: C.dim, marginBottom: 8 }}>{fam.family}</div>
+              <RefTable
+                columns={endpointCols}
+                minWidth={900}
+                rows={fam.rows.map((e) => ({
+                  ep: <InlineCode color={C.text}>{`${e.method} ${e.path}`}</InlineCode>,
+                  usedBy: e.usedBy, purpose: e.purpose,
+                  auth: <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint }}>{e.auth}</span>,
+                  evidence: <EvidenceCell refs={e.sourceRefs} />,
+                }))}
+              />
+            </div>
+          ))}
+        </div>
+        <RefProse style={{ marginTop: 16 }}>
+          <strong style={{ color: C.amber }}>Not yet implemented / planned.</strong>
+        </RefProse>
+        <Bullets items={PLANNED_ENDPOINTS.map((e) => `${e.path} — ${e.note}`)} />
+      </RefSection>
+
+      {/* 6 — MCP & tool-use map */}
+      <RefSection {...SECTIONS[5]} accent={accent}>
+        <RefProse>
+          MCP is the typed, permissioned tool layer that lets the assistant do operational work without
+          free-form, uncontrolled access. In the telemetry environment it is deliberately small and
+          read-only: four tools, each scope-enforced and audited. Out-of-scope calls are denied with
+          <InlineCode color={C.dim}>tool_not_in_telemetry_scope</InlineCode>.
+        </RefProse>
+        <RefTable columns={mcpCols} rows={mcpRows} minWidth={1080} />
+        <RefProse style={{ marginTop: 12 }}>
+          Source: <EvidenceCell refs={[MCP_TOOLS_SOURCE]} />. Live registry + scope demo:{" "}
+          <InlineCode color={C.dim}>GET /api/telemetry/mcp/tools</InlineCode>,{" "}
+          <InlineCode color={C.dim}>POST /api/telemetry/mcp/check</InlineCode>.
+        </RefProse>
+        <Callout tone="warn">
+          What MCP must not do here: {MCP_MUST_NOT.join(" ")}
+        </Callout>
+      </RefSection>
+
+      {/* 7 — CLI / DevOps operations */}
+      <RefSection {...SECTIONS[6]} accent={accent}>
+        <RefProse>
+          Real commands used to develop, test, and operate the system. No secrets, tokens, or invite
+          codes appear here. Anything illustrative rather than present is labeled in its note.
+        </RefProse>
+        <div style={{ display: "grid", gap: 18, maxWidth: 880 }}>
+          {CLI_BLOCKS.map((b) => (
+            <div key={b.title}>
+              <div style={{ fontFamily: C.sans, fontSize: 14, fontWeight: 700, color: C.text, marginBottom: 8 }}>{b.title}</div>
+              <CommandBlock commands={b.commands} />
+              {b.note && <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.faint, marginTop: 6 }}>{b.note}</div>}
+              <div style={{ marginTop: 6 }}><EvidenceCell refs={b.sourceRefs} /></div>
+            </div>
+          ))}
+        </div>
+      </RefSection>
+
+      {/* 8 — CI/CD & release gates */}
+      <RefSection {...SECTIONS[7]} accent={accent}>
+        <RefProse>The promotion path from code to production:</RefProse>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "6px 4px", alignItems: "center", maxWidth: 880, marginBottom: 16 }}>
+          {RELEASE_FLOW.map((step, i) => (
+            <span key={step} style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+              <span style={{ fontFamily: C.mono, fontSize: 11.5, color: C.dim, background: C.panel, border: `1px solid ${C.border}`, borderRadius: 6, padding: "3px 8px" }}>{step}</span>
+              {i < RELEASE_FLOW.length - 1 && <span aria-hidden style={{ color: accent }}>→</span>}
+            </span>
+          ))}
+        </div>
+        <RefTable columns={ciCols} rows={ciRows} minWidth={840} />
+      </RefSection>
+
+      {/* 9 — Evidence, audit & receipts */}
+      <RefSection {...SECTIONS[8]} accent={accent}>
+        <RefProse>
+          The demo should not say &ldquo;trust us.&rdquo; It should let an interviewer click through the
+          proof: model cards, eval metrics, replay evidence, lineage drawers, audit rows, signed
+          receipts, CI logs, deploy health, and the designed null states when data is missing. The
+          checklist below is the test — every item should be answerable by clicking.
+        </RefProse>
+        <Bullets items={EVIDENCE_CHECKLIST} />
+      </RefSection>
+
+      {/* 10 — Honest boundaries */}
+      <RefSection {...SECTIONS[9]} accent={accent}>
+        <RefProse>
+          What is real, what is simulated or fixture-backed, and what is planned. Cold infrastructure,
+          disabled providers, and fixtures are surfaced here on purpose — this section exists to increase
+          trust, not to market.
+        </RefProse>
+        <RefTable columns={boundaryCols} rows={boundaryRows} minWidth={1080} />
+      </RefSection>
+
+      {/* 11 — Why this matters */}
+      <RefSection {...SECTIONS[10]} accent={accent}>
+        <Bullets items={WHY_IT_MATTERS} />
+      </RefSection>
+
+      <div style={{ marginTop: 24 }}>
+        <DisclosureFooter />
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/telemetry/reference/manifest.ts
+++ b/repo-b/src/components/telemetry/reference/manifest.ts
@@ -1,0 +1,661 @@
+// Static source-of-truth for the "AI Build & Operations Reference" page. This module holds NO live
+// data and triggers NO compute — it is a hand-maintained inventory of the telemetry demo's real
+// surfaces, endpoints, tools, and operational workflows, each row citing the file/route it describes.
+//
+// Discipline (see the reference page's "Manifest contract"): every claim-bearing row carries
+// `sourceRefs` pointing at a real path. A row with status "planned" / "not-present" shows an honest
+// label instead of a citation and is never mixed into a "real" table. If you change behavior in the
+// code, update the matching row here — drift between this file and reality is the only real risk.
+
+export type RowStatus = "real" | "fixture" | "synthetic" | "cold" | "planned" | "not-present";
+
+/** A pointer to the file/route that backs a claim. `path` is repo-relative; `note` scopes it. */
+export type SourceRef = { label: string; path: string; note?: string };
+
+// ── Section 1: the four kinds of "AI" / automation this page separates ──────────────────────────
+export type KindRow = { key: string; title: string; body: string };
+
+export const KINDS: KindRow[] = [
+  {
+    key: "build",
+    title: "1 · Build-time AI assistance",
+    body: "AI-assisted engineering workflows (Claude Code / Codex-style) used to plan, implement, refactor, test, and document the app. This is governed by a dispatcher + active-plan contract, not free-form generation — it produces code, tests, and docs that go through the same PR and CI gates as any other change.",
+  },
+  {
+    key: "runtime",
+    title: "2 · Runtime LLM features",
+    body: "Grounded answers over telemetry evidence: the telemetry copilot explains a NO-GO verdict at the fire tick, the AI gateway serves streamed RAG answers, and the AI dispatch router picks a provider under a typed policy. These refuse out-of-scope questions and fail closed with a null_reason rather than inventing an answer.",
+  },
+  {
+    key: "ml",
+    title: "3 · Traditional ML / data science",
+    body: "Deterministic, inspectable models: a rolling-MAD anomaly champion (beat PCA on operational metrics), a GBM RUL regressor with conformal calibration, PCA/recon-error diagnostics, and factory NCR clustering. The math is numpy/sklearn; results are promoted only when they clear a declared gate.",
+  },
+  {
+    key: "devops",
+    title: "4 · DevOps / platform automation",
+    body: "The operational layer: REST APIs, read-only MCP tools, CLI workflows, GitHub PRs, CI gates, deploy verification, and signed audit receipts. This is ordinary deterministic software — no model is in the loop — and it is what makes the rest auditable.",
+  },
+];
+
+// ── Section 2: page-by-page AI connection inventory ─────────────────────────────────────────────
+export type PageRow = {
+  page: string;
+  route: string; // relative to /lab/env/[envId]/telemetry
+  sees: string;
+  aiConnection: string;
+  dataSource: string;
+  tooling: string;
+  evidence: string;
+  boundary: string;
+  status: RowStatus;
+  sourceRefs: SourceRef[];
+};
+
+const PAGE = (slug: string): SourceRef => ({
+  label: slug === "" ? "telemetry/page.tsx" : `${slug}/page.tsx`,
+  path: `repo-b/src/app/lab/env/[envId]/telemetry/${slug}${slug === "" ? "" : "/"}page.tsx`,
+});
+const TEL_ROUTES: SourceRef = { label: "telemetry.py", path: "backend/app/routes/telemetry.py" };
+
+export const PAGE_INVENTORY: PageRow[] = [
+  {
+    page: "Overview",
+    route: "/telemetry",
+    sees: "Launch-history context + live serving KPIs (runs, predictions, anomalies, promoted models).",
+    aiConnection: "Reads ML outputs; no model runs on the page.",
+    dataSource: "GET /api/telemetry/summary",
+    tooling: "Static serving reads; no live compute.",
+    evidence: "KPIs trace to tel_* serving rows; fail-closed null_reason when empty.",
+    boundary: "Numbers are a deterministic backfill of public datasets, not proprietary fleet data.",
+    status: "real",
+    sourceRefs: [PAGE(""), { ...TEL_ROUTES, note: "GET /summary" }],
+  },
+  {
+    page: "Mission Control",
+    route: "/telemetry/stream",
+    sees: "Live streaming chart with per-channel freshness and ingest lag; a Start control.",
+    aiConnection: "Deterministic threshold / rolling-baseline scoring on the live stream — not the PCA model.",
+    dataSource: "GET /stream/live · /stream/health · POST /stream/control",
+    tooling: "Stream worker reads tel_stream_readings; capture mode is the default (no Confluent cost).",
+    evidence: "Per-channel freshness + ingest-lag p50/p95 shown; source mode reported on control.",
+    boundary: "Default 'capture' mode is deterministic/synthetic; 'iss' is live; both are labeled.",
+    status: "real",
+    sourceRefs: [PAGE("stream"), { ...TEL_ROUTES, note: "GET /stream/live, POST /stream/control" }],
+  },
+  {
+    page: "Replay",
+    route: "/telemetry/replay",
+    sees: "Deterministic replay of a real champion's anomaly scoring over a labeled window.",
+    aiConnection: "Real promoted-champion outputs (MAD), pre-computed; the page does not score live.",
+    dataSource: "GET /api/telemetry/replay",
+    tooling: "Reads a committed fixture; carries scoringDiagnostics (per-channel caveat) + lineage.",
+    evidence: "Provenance block names the source table, champion model, and mlflow run id.",
+    boundary: "Replay = committed fixture (real outputs), not a live /score call. Labeled as such.",
+    status: "fixture",
+    sourceRefs: [
+      PAGE("replay"),
+      { ...TEL_ROUTES, note: "GET /replay" },
+      { label: "replay_fixture.json", path: "backend/app/data/telemetry/replay_fixture.json" },
+    ],
+  },
+  {
+    page: "Stargate Live",
+    route: "/telemetry/stargate",
+    sees: "Kafka-detection → AI-triage → Postgres-serving lineage for a streamed anomaly.",
+    aiConnection: "Agentic triage layer annotates detections; surfaced as lineage, not a single verdict.",
+    dataSource: "GET /stargate/provenance · /stargate/anomalies/tail · /stream/kafka/*",
+    tooling: "Durable Kafka sink is gated off by default; reads fail closed when disabled.",
+    evidence: "Four-layer lineage, each layer with explicit status + null_reason.",
+    boundary: "Durable sink off by default → durable_sink_not_enabled; not a live broker in the demo.",
+    status: "cold",
+    sourceRefs: [PAGE("stargate"), { ...TEL_ROUTES, note: "GET /stargate/provenance, /stream/kafka/*" }],
+  },
+  {
+    page: "Test Runs",
+    route: "/telemetry/runs",
+    sees: "List of test runs and a per-run detail (channels, predictions, anomaly events).",
+    aiConnection: "Displays scored predictions; no model runs on the page.",
+    dataSource: "GET /runs · GET /run/{run_id}",
+    tooling: "Reads backfilled operational history (real champion outputs, real labels).",
+    evidence: "Each run links its predictions + anomaly events; null_reason when a run has no rows.",
+    boundary: "Operated history is a deterministic backfill from public datasets, clearly disclosed.",
+    status: "real",
+    sourceRefs: [PAGE("runs"), { ...TEL_ROUTES, note: "GET /runs, /run/{id}" }],
+  },
+  {
+    page: "System Health",
+    route: "/telemetry/system-health",
+    sees: "Rolling anomaly rate, drift (PSI), conformal budget, and current findings.",
+    aiConnection: "Surfaces ML monitoring + analyzer findings; analyzer is the single source.",
+    dataSource: "GET /monitoring · GET /findings",
+    tooling: "Findings ground in serving reads; fail-closed telemetry_findings_unavailable on error.",
+    evidence: "Provenance block (surface, source, rows_evaluated, fallback_used, last_refresh).",
+    boundary: "Never fabricates findings — returns null_reason instead.",
+    status: "real",
+    sourceRefs: [PAGE("system-health"), { ...TEL_ROUTES, note: "GET /monitoring, /findings" }],
+  },
+  {
+    page: "Model Workbench",
+    route: "/telemetry/workbench",
+    sees: "Guided experiment loop: feature sets, threshold sweep, champion review, prediction drill.",
+    aiConnection: "Inspects ML experiments; the run button replays a committed receipt, never trains live.",
+    dataSource: "Workbench receipts + model-performance / registry reads",
+    tooling: "Replay-not-live by design; live ML compute is off by default.",
+    evidence: "Each panel drills feature vector → residual math → run → artifact → gate.",
+    boundary: "'Replay experiment receipt — no live compute triggered.' Receipts, not live Vertex jobs.",
+    status: "real",
+    sourceRefs: [
+      { label: "workbench/page.tsx", path: "repo-b/src/app/lab/env/[envId]/telemetry/workbench/page.tsx" },
+      { label: "ModelWorkbench.tsx", path: "repo-b/src/components/telemetry/workbench/ModelWorkbench.tsx" },
+    ],
+  },
+  {
+    page: "Model Performance",
+    route: "/telemetry/model-performance",
+    sees: "Promoted-model metrics and the honest 'MAD beat PCA' promotion story.",
+    aiConnection: "Reads exact metrics from tel_model_runs — no hardcoded numbers.",
+    dataSource: "GET /model-performance",
+    tooling: "Display-only; metrics come straight from the run record.",
+    evidence: "Metric values trace to the model-run row; gate decision shown.",
+    boundary: "The fancier model is shown as not promoted, not hidden.",
+    status: "real",
+    sourceRefs: [PAGE("model-performance"), { ...TEL_ROUTES, note: "GET /model-performance" }],
+  },
+  {
+    page: "RUL Calibration",
+    route: "/telemetry/calibration",
+    sees: "Conformal PICP / MPIW reliability for the RUL regressor.",
+    aiConnection: "Calibration evidence for a real GBM model; not a live forecast.",
+    dataSource: "Calibration reads from the RUL model run",
+    tooling: "Display-only conformal intervals + reliability.",
+    evidence: "Coverage vs nominal shown; 'CRPS is an approximation' caveat preserved.",
+    boundary: "Real-time RUL inference stays planned/unavailable.",
+    status: "real",
+    sourceRefs: [PAGE("calibration")],
+  },
+  {
+    page: "Model Registry",
+    route: "/telemetry/registry",
+    sees: "All model runs with metrics, gate decisions, drift history, lifecycle timeline.",
+    aiConnection: "Read-only registry view of ML runs; no mutation.",
+    dataSource: "GET /registry",
+    tooling: "Display-only; no POST/PUT/DELETE on the registry.",
+    evidence: "Real PSI drift history + honest gate jsonb per run.",
+    boundary: "Registry is a read surface; promotion happens offline.",
+    status: "real",
+    sourceRefs: [PAGE("registry"), { ...TEL_ROUTES, note: "GET /registry" }],
+  },
+  {
+    page: "Factory · NCR",
+    route: "/telemetry/factory",
+    sees: "NCR clustering (UMAP/HDBSCAN), Pareto, and a backlog forecast.",
+    aiConnection: "Unsupervised clustering + walk-forward forecast with backtest metrics.",
+    dataSource: "GET /ncr",
+    tooling: "Fails closed (data_not_ingested) when the mirror is unapplied.",
+    evidence: "Cluster provenance is databricks | local_fallback.",
+    boundary: "Falls back to a local computation when Databricks rows are absent — labeled.",
+    status: "real",
+    sourceRefs: [PAGE("factory"), { ...TEL_ROUTES, note: "GET /ncr" }],
+  },
+  {
+    page: "Flight Readiness",
+    route: "/telemetry/factory-ml",
+    sees: "Factory ML readiness with drillable evidence and SHAP attribution.",
+    aiConnection: "Tree-model SHAP (local attribution); deep links to MLflow runs.",
+    dataSource: "Committed factory-ML catalogs + MLflow refs",
+    tooling: "Static JSON catalogs; live Databricks/MLflow deep links when configured.",
+    evidence: "Click-into-evidence drawer across model quality / registry / NCR / readiness.",
+    boundary: "'Global vs local SHAP — tree models only.' No SHAP claims on non-tree models.",
+    status: "real",
+    sourceRefs: [PAGE("factory-ml")],
+  },
+  {
+    page: "Metric Lineage",
+    route: "/telemetry/metric-lineage",
+    sees: "Where a displayed number came from — source → transform → serving.",
+    aiConnection: "None; deterministic lineage of data, not a model.",
+    dataSource: "Reviewed lineage catalog",
+    tooling: "Read-only lineage explorer.",
+    evidence: "Each node names a real source, table, or topic.",
+    boundary: "Lineage is documentation of verified structure, not a live trace.",
+    status: "real",
+    sourceRefs: [PAGE("metric-lineage")],
+  },
+  {
+    page: "Metadata Explorer",
+    route: "/telemetry/metadata",
+    sees: "Allowlisted serving metadata + telemetry lineage graph.",
+    aiConnection: "None; governed metadata surface.",
+    dataSource: "GET /metadata/graph",
+    tooling: "Catalog is validated; fails closed (INVALID_METADATA_CATALOG) on bad input.",
+    evidence: "Graph nodes/edges with grain declarations and status.",
+    boundary: "Only allowlisted metadata is exposed.",
+    status: "real",
+    sourceRefs: [PAGE("metadata"), { ...TEL_ROUTES, note: "GET /metadata/graph" }],
+  },
+  {
+    page: "Agent Control Tower",
+    route: "/telemetry/control-tower",
+    sees: "Go/no-go gates on REVIEW/NO-GO verdicts with signed receipts; Gemma tier state.",
+    aiConnection: "Verdict gating + an LLM provider lifecycle (Gemma) kept cold by default.",
+    dataSource: "POST /control-tower/score-and-gate · GET /decisions · /receipts/{id}/verify · /public-key",
+    tooling: "Ed25519-signed receipts, offline-verifiable; Gemma lifecycle is approval + flag gated.",
+    evidence: "Every gate produces a signed receipt; public key published for verification.",
+    boundary: "Gemma endpoint cold; lifecycle gated by CONTROL_TOWER_GEMMA_LIFECYCLE_ENABLED.",
+    status: "real",
+    sourceRefs: [
+      PAGE("control-tower"),
+      { label: "telemetry_control_tower.py", path: "backend/app/routes/telemetry_control_tower.py" },
+    ],
+  },
+  {
+    page: "Relativity MES Sandbox",
+    route: "/telemetry/relativity-mes (+ genealogy / ncr / cost / lineage)",
+    sees: "A build-to-flight MES/ERP/PLM facsimile: genealogy, NCR traceability, cost, lineage.",
+    aiConnection: "None; a synthetic manufacturing data product, kept visibly separate.",
+    dataSource: "GET /relativity-mes/{overview,genealogy,where-used,ncr,cost,lineage}",
+    tooling: "Reads rel_* serving rows; every response carries source_kind + serving_provenance.",
+    evidence: "source_kind live-rows | unavailable; serving_provenance seed-bootstrap | databricks-gold.",
+    boundary: "Clearly-labeled SYNTHETIC data, not real Relativity production records.",
+    status: "synthetic",
+    sourceRefs: [
+      { label: "relativity-mes/page.tsx", path: "repo-b/src/app/lab/env/[envId]/telemetry/relativity-mes/page.tsx" },
+      { label: "relativity_mes.py", path: "backend/app/routes/relativity_mes.py" },
+    ],
+  },
+];
+
+/** Hidden-but-resolving deep-link routes (shown as a short note, not a "real" inventory row). */
+export const HIDDEN_ROUTES: { label: string; route: string; note: string }[] = [
+  { label: "Test Intelligence (copilot)", route: "/telemetry/copilot", note: "LLM verdict explanation; hidden from rail, route resolves." },
+  { label: "Trust Center (governance)", route: "/telemetry/governance", note: "Governance aggregates; hidden from rail." },
+  { label: "How This Works", route: "/telemetry/how-it-works", note: "System-architecture exhibit; hidden from rail." },
+  { label: "Resume Evidence", route: "/telemetry/evidence", note: "Evidence cards; hidden from rail." },
+  { label: "Data Engineering", route: "/telemetry/data-engineering/*", note: "DE workbench + receipts; group hidden, routes resolve." },
+];
+
+/** Cross-link outside the telemetry section. */
+export const CROSS_LINKS: { label: string; route: string; note: string }[] = [
+  { label: "AI Provider Dispatch (admin)", route: "/lab/system/ai-provider-dispatch", note: "Governed model router admin panel; outside the telemetry env." },
+];
+
+/** Section 2 "planned / not present yet" — never mixed with real rows. */
+export const PLANNED_SURFACES: { label: string; status: RowStatus; note: string }[] = [
+  { label: "Real-time RUL inference", status: "planned", note: "Calibration evidence ships today; live inference stays planned/unavailable." },
+  { label: "LSTM / sequence anomaly model", status: "planned", note: "Appears only as a challenger/diagnostic; not promoted unless it wins on operational metrics." },
+  { label: "Live Vertex training from the UI", status: "planned", note: "No 'train live' button ships; the Workbench replays committed receipts." },
+];
+
+// ── Section 3: AI skills used to build & maintain the demo ───────────────────────────────────────
+export type SkillRow = { family: string; usedFor: string; example: string; sourceRefs: SourceRef[] };
+
+const CLAUDE_MD: SourceRef = { label: "CLAUDE.md", path: "CLAUDE.md", note: "router + intake contract" };
+const TEL_PLAN: SourceRef = {
+  label: "0003-telemetry-platform-build.md",
+  path: "docs/plans/03-implementation-plans/active/0003-telemetry-platform-build.md",
+};
+
+export const SKILL_FAMILIES: SkillRow[] = [
+  {
+    family: "Planning & routing",
+    usedFor: "Classify a request, find/own a plan, decompose tickets, label risk, set acceptance criteria before code.",
+    example: "Telemetry work routes through the dispatcher to an active plan; this page is one such ticket.",
+    sourceRefs: [CLAUDE_MD, TEL_PLAN, { label: "routing-map.md", path: "docs/plans/00-dispatch/routing-map.md" }],
+  },
+  {
+    family: "Code generation & refactoring",
+    usedFor: "Frontend pages/components, FastAPI endpoints, SQL, and guardrail-preserving refactors.",
+    example: "The telemetry pages, serving routes, and shared primitives were built and refactored this way.",
+    sourceRefs: [
+      { label: "components/telemetry/", path: "repo-b/src/components/telemetry/" },
+      { ...TEL_ROUTES },
+    ],
+  },
+  {
+    family: "Data & ML work",
+    usedFor: "Pipeline/notebook inspection, metric validation, model-card summarization, lineage narration.",
+    example: "Honest anomaly/RUL metrics are centralized so the registry and calibration pages agree.",
+    sourceRefs: [
+      { label: "telemetry-platform/", path: "telemetry-platform/", note: "Databricks notebooks + pipeline math" },
+      { label: "telemetry_serving.py", path: "backend/app/services/telemetry_serving.py" },
+    ],
+  },
+  {
+    family: "DevOps & deployment",
+    usedFor: "Branch/worktree hygiene, GitHub PRs, CI inspection, deploy verification, smoke checks.",
+    example: "This change was built in an isolated worktree off origin/main and lands via PR + CI.",
+    sourceRefs: [
+      { label: "ci.yml", path: ".github/workflows/ci.yml" },
+      { label: "deploy_backend.sh", path: "scripts/deploy_backend.sh" },
+    ],
+  },
+  {
+    family: "Runtime AI safety & governance",
+    usedFor: "Tool-use policy, audited tool calls, fail-closed nulls, RAG grounding, approval gates.",
+    example: "Telemetry MCP tools are read-only + scope-enforced; copilot refuses out-of-scope questions.",
+    sourceRefs: [
+      { label: "fail-closed-rules.md", path: "docs/plans/01-shared-standards/ai-runtime/fail-closed-rules.md" },
+      { label: "telemetry_tools.py", path: "backend/app/mcp/tools/telemetry_tools.py" },
+    ],
+  },
+];
+
+// ── Section 4: runtime AI architecture layers ───────────────────────────────────────────────────
+export type RuntimeRow = {
+  layer: string;
+  purpose: string;
+  examples: string;
+  failureMode: string;
+  evidence: string;
+  sourceRefs: SourceRef[];
+};
+
+export const RUNTIME_LAYERS: RuntimeRow[] = [
+  {
+    layer: "Frontend pages (Next.js)",
+    purpose: "Render telemetry surfaces; no secrets, no model logic.",
+    examples: "The pages in Section 2.",
+    failureMode: "Renders a designed EmptyState/ErrorState, never a blank crash.",
+    evidence: "Fail-closed cards with the specific null_reason.",
+    sourceRefs: [{ label: "components/telemetry/", path: "repo-b/src/components/telemetry/" }],
+  },
+  {
+    layer: "Next.js proxy route",
+    purpose: "Forward /api/telemetry/* to the backend; scope metadata by env id.",
+    examples: "catch-all [...path]/route.ts",
+    failureMode: "Auth + env-scope checks before forwarding.",
+    evidence: "Header x-telemetry-route-env-id checked against TELEMETRY_SERVING_ENV_ID.",
+    sourceRefs: [{ label: "[...path]/route.ts", path: "repo-b/src/app/api/telemetry/[...path]/route.ts" }],
+  },
+  {
+    layer: "FastAPI serving",
+    purpose: "Deterministic API responses over tel_* serving rows.",
+    examples: "GET /summary, /monitoring, /registry, /replay.",
+    failureMode: "Returns null_reason (HTTP 200), not a 500, when data is absent.",
+    evidence: "Provenance blocks + null_reason on every data response.",
+    sourceRefs: [{ ...TEL_ROUTES }],
+  },
+  {
+    layer: "Traditional ML scoring",
+    purpose: "Score a window against the promoted champion; return a verdict.",
+    examples: "POST /score → GO / REVIEW / NO_GO.",
+    failureMode: "NOT_AVAILABLE + null_reason when no champion / no data.",
+    evidence: "Verdict carries anomaly_score, threshold, attribution, mlflow_run_id.",
+    sourceRefs: [{ ...TEL_ROUTES, note: "POST /score" }, { label: "telemetry_serving.py", path: "backend/app/services/telemetry_serving.py" }],
+  },
+  {
+    layer: "Telemetry copilot (LLM)",
+    purpose: "Explain a NO-GO verdict from real evidence; refuse out-of-scope questions.",
+    examples: "POST /copilot/explain-verdict · /ask · /draft-report.",
+    failureMode: "Refuses unmatched intents; draft reports require human review.",
+    evidence: "Audit log + governance/usefulness/evals endpoints.",
+    sourceRefs: [{ label: "telemetry_copilot.py", path: "backend/app/routes/telemetry_copilot.py" }],
+  },
+  {
+    layer: "AI gateway (LLM + RAG)",
+    purpose: "Streamed chat answers grounded in an indexed corpus (pgvector).",
+    examples: "POST /api/ai/gateway/ask (SSE: token | citation | tool_call | done).",
+    failureMode: "Health endpoint reports rag_available; no corpus support → no claim.",
+    evidence: "Citations in the stream; call logs + stats endpoints.",
+    sourceRefs: [{ label: "ai_gateway.py", path: "backend/app/services/ai_gateway.py" }],
+  },
+  {
+    layer: "AI provider dispatch",
+    purpose: "Pick a provider/model under a typed risk/privacy policy; execute or fail closed.",
+    examples: "GET /api/ai/dispatch/providers · POST /route (dry-run) · POST /run.",
+    failureMode: "Blocks (403) before any provider call when AI_DISPATCH_ENABLED is off or tenantless.",
+    evidence: "Every run writes a dispatch receipt (provider, model, tokens, latency, null_reason).",
+    sourceRefs: [{ label: "ai_dispatch.py", path: "backend/app/routes/ai_dispatch.py" }, { label: "registry.py", path: "backend/app/services/ai_dispatch/registry.py" }],
+  },
+  {
+    layer: "Audit + receipts",
+    purpose: "Persist every tool call and decision with redaction.",
+    examples: "GET /api/audit/events · signed control-tower receipts.",
+    failureMode: "Receipt-write failure degrades the result honestly (receipt_status).",
+    evidence: "Audit rows + Ed25519-verifiable receipts.",
+    sourceRefs: [{ label: "audit.py", path: "backend/app/services/audit.py" }],
+  },
+];
+
+// ── Section 5: REST API & endpoint map ──────────────────────────────────────────────────────────
+export type EndpointRow = {
+  method: string;
+  path: string;
+  usedBy: string;
+  purpose: string;
+  auth: string;
+  sourceRefs: SourceRef[];
+};
+export type EndpointFamily = { family: string; rows: EndpointRow[] };
+
+export const ENDPOINT_FAMILIES: EndpointFamily[] = [
+  {
+    family: "Core telemetry serving",
+    rows: [
+      { method: "GET", path: "/api/telemetry/summary", usedBy: "Overview", purpose: "Inventory counts + headline KPIs.", auth: "env-scoped", sourceRefs: [{ ...TEL_ROUTES, note: "GET /summary" }] },
+      { method: "GET", path: "/api/telemetry/monitoring", usedBy: "System Health", purpose: "Anomaly rate, PSI, conformal budget.", auth: "env-scoped", sourceRefs: [{ ...TEL_ROUTES, note: "GET /monitoring" }] },
+      { method: "GET", path: "/api/telemetry/registry", usedBy: "Model Registry", purpose: "All model runs + gate + drift.", auth: "env-scoped", sourceRefs: [{ ...TEL_ROUTES, note: "GET /registry" }] },
+      { method: "GET", path: "/api/telemetry/model-performance", usedBy: "Model Performance", purpose: "Promoted-model exact metrics.", auth: "env-scoped", sourceRefs: [{ ...TEL_ROUTES, note: "GET /model-performance" }] },
+      { method: "POST", path: "/api/telemetry/score", usedBy: "Scoring", purpose: "Score a window vs the champion.", auth: "env-scoped", sourceRefs: [{ ...TEL_ROUTES, note: "POST /score" }] },
+      { method: "GET", path: "/api/telemetry/replay", usedBy: "Replay", purpose: "Deterministic champion replay feed.", auth: "public read", sourceRefs: [{ ...TEL_ROUTES, note: "GET /replay" }] },
+      { method: "GET", path: "/api/telemetry/{runs,run/{id},findings,ncr,fused-vector-info,metadata/graph,health}", usedBy: "Runs / Health / Factory / Metadata", purpose: "Remaining serving reads.", auth: "env-scoped", sourceRefs: [{ ...TEL_ROUTES, note: "+7 more endpoints" }] },
+    ],
+  },
+  {
+    family: "Stream & Stargate",
+    rows: [
+      { method: "GET", path: "/api/telemetry/stream/live", usedBy: "Mission Control", purpose: "Ring-buffer rows + freshness.", auth: "env-scoped", sourceRefs: [{ ...TEL_ROUTES, note: "GET /stream/live" }] },
+      { method: "POST", path: "/api/telemetry/stream/control", usedBy: "Mission Control", purpose: "Start/restart the stream worker.", auth: "env-scoped", sourceRefs: [{ ...TEL_ROUTES, note: "POST /stream/control" }] },
+      { method: "GET", path: "/api/telemetry/stargate/provenance", usedBy: "Stargate Live", purpose: "Durable Kafka provenance lookup.", auth: "env-scoped", sourceRefs: [{ ...TEL_ROUTES, note: "GET /stargate/provenance" }] },
+    ],
+  },
+  {
+    family: "Control Tower",
+    rows: [
+      { method: "POST", path: "/api/telemetry/control-tower/score-and-gate", usedBy: "Agent Control Tower", purpose: "Score + open a go/no-go gate.", auth: "operator", sourceRefs: [{ label: "telemetry_control_tower.py", path: "backend/app/routes/telemetry_control_tower.py" }] },
+      { method: "GET", path: "/api/telemetry/control-tower/receipts/{id}/verify", usedBy: "Agent Control Tower", purpose: "Verify a signed receipt.", auth: "public read", sourceRefs: [{ label: "telemetry_control_tower.py", path: "backend/app/routes/telemetry_control_tower.py" }] },
+      { method: "GET", path: "/api/telemetry/control-tower/public-key", usedBy: "Agent Control Tower", purpose: "Ed25519 public key for offline verify.", auth: "public read", sourceRefs: [{ label: "telemetry_control_tower.py", path: "backend/app/routes/telemetry_control_tower.py" }] },
+    ],
+  },
+  {
+    family: "Copilot (LLM)",
+    rows: [
+      { method: "POST", path: "/api/telemetry/copilot/explain-verdict", usedBy: "Test Intelligence", purpose: "Explain a NO-GO at the fire tick.", auth: "env-scoped", sourceRefs: [{ label: "telemetry_copilot.py", path: "backend/app/routes/telemetry_copilot.py" }] },
+      { method: "GET", path: "/api/telemetry/copilot/evals", usedBy: "Test Intelligence", purpose: "Last recorded eval-suite results.", auth: "env-scoped", sourceRefs: [{ label: "telemetry_copilot.py", path: "backend/app/routes/telemetry_copilot.py" }] },
+    ],
+  },
+  {
+    family: "AI dispatch & gateway",
+    rows: [
+      { method: "GET", path: "/api/ai/dispatch/providers", usedBy: "Dispatch admin", purpose: "List providers + availability.", auth: "auth", sourceRefs: [{ label: "ai_dispatch.py", path: "backend/app/routes/ai_dispatch.py" }] },
+      { method: "POST", path: "/api/ai/dispatch/run", usedBy: "Dispatch admin", purpose: "Execute governed dispatch (gated).", auth: "auth + tenant", sourceRefs: [{ label: "ai_dispatch.py", path: "backend/app/routes/ai_dispatch.py" }] },
+      { method: "POST", path: "/api/ai/gateway/ask", usedBy: "Copilot/chat", purpose: "Streamed RAG answer (SSE).", auth: "auth", sourceRefs: [{ label: "ai_gateway.py", path: "backend/app/routes/ai_gateway.py" }] },
+    ],
+  },
+  {
+    family: "MCP & audit",
+    rows: [
+      { method: "GET", path: "/api/telemetry/mcp/tools", usedBy: "Reference / tooling", purpose: "List the registered telemetry MCP tools.", auth: "env-scoped", sourceRefs: [{ ...TEL_ROUTES, note: "GET /mcp/tools" }] },
+      { method: "POST", path: "/api/telemetry/mcp/check", usedBy: "Reference / tooling", purpose: "Demo the scope policy through the audited executor.", auth: "env-scoped", sourceRefs: [{ ...TEL_ROUTES, note: "POST /mcp/check" }] },
+      { method: "GET", path: "/api/audit/events", usedBy: "Audit surfaces", purpose: "List audit events (filterable).", auth: "tenant-scoped", sourceRefs: [{ label: "audit.py", path: "backend/app/routes/audit.py" }] },
+    ],
+  },
+];
+
+export const PLANNED_ENDPOINTS: { method: string; path: string; note: string }[] = [
+  { method: "—", path: "Live Vertex training submit", note: "Offline pipeline writes receipts; no UI-triggered training endpoint ships." },
+  { method: "—", path: "Real-time RUL inference", note: "Planned; calibration evidence ships, live inference does not." },
+];
+
+// ── Section 6: MCP tool map ─────────────────────────────────────────────────────────────────────
+export type McpToolRow = {
+  name: string;
+  capability: string;
+  useCase: string;
+  risk: string;
+  permission: string;
+  audit: string;
+};
+
+export const MCP_TOOLS: McpToolRow[] = [
+  { name: "telemetry.get_triggering_prediction", capability: "Fetch the NO_GO prediction receipt at a fire tick.", useCase: "Explain why a verdict fired.", risk: "low (read)", permission: "read · scope-enforced", audit: "audited via execute_tool" },
+  { name: "telemetry.get_model_run_detail", capability: "Fetch promoted-model metadata (metrics + gate).", useCase: "Show model provenance.", risk: "low (read)", permission: "read · scope-enforced", audit: "audited via execute_tool" },
+  { name: "telemetry.get_anomaly_events_in_window", capability: "List labeled/detected events in a tick window.", useCase: "Compare detections to labels.", risk: "low (read)", permission: "read · scope-enforced", audit: "audited via execute_tool" },
+  { name: "telemetry.preview_score_window", capability: "Score a supplied window WITHOUT writing a receipt.", useCase: "What-if scoring during review.", risk: "low (read)", permission: "read · scope-enforced", audit: "audited via execute_tool" },
+];
+
+export const MCP_TOOLS_SOURCE: SourceRef = { label: "telemetry_tools.py", path: "backend/app/mcp/tools/telemetry_tools.py" };
+
+export const MCP_MUST_NOT: string[] = [
+  "No unscoped production writes — telemetry tools are read-only; out-of-scope calls return tool_not_in_telemetry_scope.",
+  "No destructive DB migrations without explicit human approval.",
+  "No secret exposure — inputs/outputs are redacted before they hit the audit log.",
+  "No fake success receipts — a failed tool call is recorded as failed, not green.",
+  "No unaudited execution — every tool call goes through the audited executor.",
+];
+
+// ── Section 7: CLI / DevOps command blocks ──────────────────────────────────────────────────────
+export type CmdBlock = { title: string; commands: string[]; note?: string; sourceRefs: SourceRef[] };
+
+const PKG: SourceRef = { label: "package.json", path: "repo-b/package.json" };
+
+export const CLI_BLOCKS: CmdBlock[] = [
+  {
+    title: "Local development",
+    commands: [
+      "# Frontend (repo-b)",
+      "cd repo-b && npm run dev",
+      "",
+      "# Business OS backend (FastAPI)",
+      "cd backend && uvicorn app.main:app --reload --port 8000",
+    ],
+    sourceRefs: [PKG, { label: "backend/README.md", path: "backend/README.md" }],
+  },
+  {
+    title: "Testing",
+    commands: [
+      "cd repo-b",
+      "npm run typecheck      # tsc --noEmit",
+      "npm run lint           # next lint",
+      "npm run test:unit      # vitest run",
+      "npm run test:e2e       # playwright (when needed)",
+      "",
+      "# Backend",
+      "cd backend && python3.11 -m pytest tests/test_telemetry_*.py",
+    ],
+    sourceRefs: [PKG],
+  },
+  {
+    title: "Database / schema",
+    commands: [
+      "cd repo-b",
+      "npm run db:apply       # apply schema bundle",
+      "npm run db:verify      # verify applied schema",
+    ],
+    note: "No migration is required for this reference page.",
+    sourceRefs: [PKG],
+  },
+  {
+    title: "Deployment",
+    commands: [
+      "# Backend → Railway (run from backend/)",
+      "scripts/deploy_backend.sh   # railway up --service authentic-sparkle",
+      "curl -s https://<backend>/version   # confirm the live git SHA",
+      "",
+      "# Frontend → Vercel project 'consulting-app' (root repo-b, serves novendor.ai)",
+      "vercel deploy --prod   # from repo root",
+    ],
+    note: "Exact project/deploy details live in CLAUDE.md / docs/tips.md (source of truth) — auto- vs manual-deploy is recorded there, not asserted here. No secrets shown.",
+    sourceRefs: [{ label: "deploy_backend.sh", path: "scripts/deploy_backend.sh" }, CLAUDE_MD],
+  },
+  {
+    title: "Git / PR workflow",
+    commands: [
+      "git worktree add -b feat/<topic> <path> origin/main   # isolated checkout",
+      "gh pr create --fill                                    # open PR; CI gates run",
+      "gh pr merge --squash                                   # after green + review",
+    ],
+    note: "Work lands via PR + CI; branch protection + hooks block direct pushes to main.",
+    sourceRefs: [{ label: "pre-push", path: ".githooks/pre-push" }],
+  },
+];
+
+// ── Section 8: CI/CD & release gates ────────────────────────────────────────────────────────────
+export const RELEASE_FLOW: string[] = [
+  "feature branch", "plan / ticket", "implementation", "tests", "PR", "review", "merge",
+  "Vercel frontend deploy", "Railway backend deploy", "migrations / health checks",
+  "smoke tests", "production verification", "rollback if failed",
+];
+
+export type CiGateRow = { gate: string; catches: string; evidence: string; blocks: boolean; sourceRefs: SourceRef[] };
+
+const CI: SourceRef = { label: "ci.yml", path: ".github/workflows/ci.yml" };
+
+export const CI_GATES: CiGateRow[] = [
+  { gate: "check-mass-deletion", catches: "PRs deleting >100 files.", evidence: "CI job in ci.yml", blocks: true, sourceRefs: [CI, { label: "pre-commit", path: ".githooks/pre-commit" }] },
+  { gate: "backend-lint", catches: "ruff lint + full backend pytest.", evidence: "python -m ruff check; pytest", blocks: true, sourceRefs: [CI] },
+  { gate: "repo-guardrails", catches: "Assistant-runtime + repo guardrail violations.", evidence: "node scripts/check_repo_guardrails.mjs", blocks: true, sourceRefs: [CI] },
+  { gate: "frontend-quality", catches: "lint + typecheck + vitest in repo-b.", evidence: "npm run lint/typecheck/test:unit", blocks: true, sourceRefs: [CI] },
+  { gate: "db-schema-gate", catches: "Schema idempotency + RLS contract.", evidence: "apply twice + verify", blocks: true, sourceRefs: [CI] },
+];
+
+// ── Section 9: evidence / "can I see…?" checklist ────────────────────────────────────────────────
+export const EVIDENCE_CHECKLIST: string[] = [
+  "Can I see the source data? — public datasets + lineage/metadata explorer.",
+  "Can I see the model version? — Model Registry + model-run records.",
+  "Can I see the API response? — every page maps to a real /api/telemetry/* endpoint.",
+  "Can I see the tool call? — MCP scope check + audit events.",
+  "Can I see the audit row? — GET /api/audit/events; signed control-tower receipts.",
+  "Can I see the CI run? — GitHub Actions ci.yml jobs on the PR.",
+  "Can I see what happens when data is missing? — designed fail-closed null_reason states.",
+  "Can I see what is simulated vs live? — source_kind / serving_provenance / capture-mode labels.",
+];
+
+// ── Section 10: honest boundaries ───────────────────────────────────────────────────────────────
+export type BoundaryRow = {
+  area: string;
+  realToday: string;
+  simulated: string;
+  planned: string;
+  uiSays: string;
+  sourceRefs: SourceRef[];
+};
+
+export const BOUNDARIES: BoundaryRow[] = [
+  { area: "Live telemetry stream", realToday: "Stream worker + freshness/lag metrics.", simulated: "Default 'capture' mode is deterministic/synthetic.", planned: "Sustained live ISS/ADS-B ingest.", uiSays: "Source mode reported on every control call.", sourceRefs: [{ ...TEL_ROUTES, note: "stream/*" }] },
+  { area: "Replay evidence", realToday: "Real champion outputs over a labeled window.", simulated: "Served from a committed fixture, not live /score.", planned: "—", uiSays: "'Replay experiment receipt — no live compute triggered.'", sourceRefs: [{ label: "replay_fixture.json", path: "backend/app/data/telemetry/replay_fixture.json" }] },
+  { area: "Anomaly champion", realToday: "Rolling-MAD model, promoted on operational metrics.", simulated: "—", planned: "—", uiSays: "'PCA looked smarter. MAD operated better. MAD stayed champion.'", sourceRefs: [{ label: "telemetry_serving.py", path: "backend/app/services/telemetry_serving.py" }] },
+  { area: "LSTM / forecast model", realToday: "—", simulated: "—", planned: "Challenger/diagnostic only.", uiSays: "Shown as not promoted unless it wins on operational metrics.", sourceRefs: [TEL_PLAN] },
+  { area: "RAG analyst", realToday: "AI gateway with pgvector retrieval.", simulated: "—", planned: "Broader corpus coverage.", uiSays: "Refuses when the corpus lacks support; rag_available in health.", sourceRefs: [{ label: "ai_gateway.py", path: "backend/app/services/ai_gateway.py" }] },
+  { area: "MCP tools", realToday: "4 read-only, scope-enforced telemetry tools.", simulated: "—", planned: "No write tools by design.", uiSays: "Out-of-scope → tool_not_in_telemetry_scope.", sourceRefs: [MCP_TOOLS_SOURCE] },
+  { area: "Deployment infra", realToday: "Vercel frontend (novendor.ai) + Railway backend.", simulated: "—", planned: "—", uiSays: "Exact project names in CLAUDE.md; SHA on /version.", sourceRefs: [CLAUDE_MD, { label: "deploy_backend.sh", path: "scripts/deploy_backend.sh" }] },
+  { area: "GCP / Databricks / Confluent / BQ", realToday: "Training + lineage references where configured.", simulated: "Local fallback when a source is absent.", planned: "Always-on managed pipeline.", uiSays: "provenance: databricks | local_fallback.", sourceRefs: [{ label: "telemetry-platform/", path: "telemetry-platform/" }] },
+  { area: "Gemma provider", realToday: "Registered in the dispatch registry.", simulated: "—", planned: "Endpoint is cold; deploy-on-demand.", uiSays: "Lifecycle gated by CONTROL_TOWER_GEMMA_LIFECYCLE_ENABLED.", sourceRefs: [{ label: "registry.py", path: "backend/app/services/ai_dispatch/registry.py" }] },
+  { area: "Audit receipts", realToday: "Audit events + Ed25519-signed gate receipts.", simulated: "—", planned: "—", uiSays: "Receipts are offline-verifiable via the public key.", sourceRefs: [{ label: "audit.py", path: "backend/app/services/audit.py" }] },
+];
+
+// ── Section 11: why this matters (short, no hype) ───────────────────────────────────────────────
+export const WHY_IT_MATTERS: string[] = [
+  "It shows system thinking, not an isolated model demo.",
+  "It shows how AI-assisted engineering can be governed: plan, PR, CI, review, receipt.",
+  "It connects ML, LLMs, REST APIs, MCP tools, CI/CD, and data lineage in one place.",
+  "It proves the platform can be operated by a team, not a single author.",
+  "It separates demo-scale substrate from the production-scale target honestly.",
+  "It makes failure modes visible — fail-closed nulls, cold infra, fixtures — instead of burying them.",
+];
+
+// Anchored sections, in render order. id drives both the TOC and the in-page anchors.
+export const SECTIONS: { id: string; n: number; title: string }[] = [
+  { id: "documents", n: 1, title: "What this page documents" },
+  { id: "page-inventory", n: 2, title: "Page-by-page AI connection inventory" },
+  { id: "skills", n: 3, title: "AI skills used to build the demo" },
+  { id: "runtime", n: 4, title: "Runtime AI connections" },
+  { id: "rest-api", n: 5, title: "REST API & endpoint map" },
+  { id: "mcp", n: 6, title: "MCP & tool-use map" },
+  { id: "cli", n: 7, title: "CLI / DevOps operations" },
+  { id: "cicd", n: 8, title: "CI/CD & release gates" },
+  { id: "evidence", n: 9, title: "Evidence, audit & receipts" },
+  { id: "boundaries", n: 10, title: "Honest boundaries" },
+  { id: "why", n: 11, title: "Why this matters for a Director of Data & AI demo" },
+];

--- a/repo-b/src/components/telemetry/reference/refPrimitives.tsx
+++ b/repo-b/src/components/telemetry/reference/refPrimitives.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import type { CSSProperties, ReactNode } from "react";
+import { C, InlineCode, ScrollTable, ResponsiveSwap, RowCard, Tag, TelemetryStatusBanner } from "../primitives";
+import type { SourceRef, RowStatus } from "./manifest";
+
+// Boring doc scaffolding for the AI Build & Operations Reference page. No animation, no new palette,
+// no layout framework — everything stays on the telemetry `C` tokens and reuses existing primitives.
+// If any helper here grows past ~80 lines or starts duplicating a primitive, inline it or reuse the
+// primitive instead.
+
+// In-page table of contents. Plain anchor links to each numbered section.
+export function RefTOC({ sections, accent }: {
+  sections: { id: string; n: number; title: string }[]; accent: string;
+}) {
+  return (
+    <nav aria-label="On this page" style={{ background: C.panel, border: `1px solid ${C.border}`, borderRadius: 10, padding: "14px 16px", marginBottom: 26 }}>
+      <div style={{ fontFamily: C.mono, fontSize: 10.5, letterSpacing: "0.14em", color: C.faint, textTransform: "uppercase", marginBottom: 10 }}>On this page</div>
+      <ol style={{ display: "grid", gap: 6, gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))", listStyle: "none", margin: 0, padding: 0 }}>
+        {sections.map((s) => (
+          <li key={s.id}>
+            <a href={`#${s.id}`} style={{ fontFamily: C.sans, fontSize: 13, color: C.dim, textDecoration: "none", display: "flex", gap: 8 }}>
+              <span style={{ fontFamily: C.mono, fontSize: 12, color: accent, minWidth: 16 }}>{s.n}</span>
+              <span>{s.title}</span>
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}
+
+// One numbered section with an anchor id and scroll offset for the TOC jumps.
+export function RefSection({ id, n, title, accent, children }: {
+  id: string; n: number; title: string; accent: string; children: ReactNode;
+}) {
+  return (
+    <section id={id} style={{ scrollMarginTop: 88, marginTop: 38 }}>
+      <h2 style={{ display: "flex", alignItems: "baseline", gap: 10, fontFamily: C.sans, fontSize: 21, fontWeight: 700, letterSpacing: "-0.01em", color: C.text, marginBottom: 6 }}>
+        <span style={{ fontFamily: C.mono, fontSize: 15, color: accent }}>{n}</span>
+        {title}
+      </h2>
+      <div style={{ height: 1, background: C.border, margin: "0 0 16px" }} />
+      {children}
+    </section>
+  );
+}
+
+// Reading-column paragraph (docs measure, not full width).
+export function RefProse({ children, style }: { children: ReactNode; style?: CSSProperties }) {
+  return <p style={{ fontFamily: C.sans, fontSize: 14.5, color: C.dim, lineHeight: 1.65, maxWidth: 820, margin: "0 0 12px", ...style }}>{children}</p>;
+}
+
+// Evidence cell — renders a row's sourceRefs as compact mono path chips (note → title attr).
+export function EvidenceCell({ refs }: { refs: SourceRef[] }) {
+  if (!refs.length) return <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint }}>—</span>;
+  return (
+    <span style={{ display: "inline-flex", flexWrap: "wrap", gap: "4px 8px" }}>
+      {refs.map((r, i) => (
+        <span key={i} title={r.note ? `${r.path} — ${r.note}` : r.path}>
+          <InlineCode color={C.dim}>{r.label}</InlineCode>
+        </span>
+      ))}
+    </span>
+  );
+}
+
+const STATUS_COLOR: Record<RowStatus, string> = {
+  real: C.green, fixture: C.cyan, synthetic: C.amber, cold: C.red, planned: C.faint, "not-present": C.faint,
+};
+export function StatusPill({ status }: { status: RowStatus }) {
+  return <Tag color={STATUS_COLOR[status]}>{status}</Tag>;
+}
+
+// Generic compact reference table: a real <table> on desktop, RowCard list on mobile. The first
+// column is the row title on mobile. Cell values are pre-rendered ReactNodes (the page builds them).
+export type RefCol = { key: string; header: string; minWidth?: number };
+export function RefTable({ columns, rows, minWidth = 820 }: {
+  columns: RefCol[]; rows: Array<Record<string, ReactNode>>; minWidth?: number;
+}) {
+  const headCell: CSSProperties = { fontFamily: C.mono, fontSize: 10, letterSpacing: "0.08em", textTransform: "uppercase", color: C.faint, textAlign: "left", padding: "8px 12px", borderBottom: `1px solid ${C.borderHi}`, verticalAlign: "bottom" };
+  const bodyCell: CSSProperties = { fontFamily: C.sans, fontSize: 12.5, color: C.dim, lineHeight: 1.5, padding: "10px 12px", borderBottom: `1px solid ${C.border}`, verticalAlign: "top" };
+  const desktop = (
+    <ScrollTable minWidth={minWidth}>
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead>
+          <tr>{columns.map((c) => <th key={c.key} style={{ ...headCell, minWidth: c.minWidth }}>{c.header}</th>)}</tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={i}>{columns.map((c, j) => <td key={c.key} style={{ ...bodyCell, color: j === 0 ? C.text : C.dim }}>{r[c.key]}</td>)}</tr>
+          ))}
+        </tbody>
+      </table>
+    </ScrollTable>
+  );
+  const mobile = (
+    <div style={{ display: "grid", gap: 10 }}>
+      {rows.map((r, i) => (
+        <RowCard key={i} title={r[columns[0].key]} fields={columns.slice(1).map((c) => ({ label: c.header, value: r[c.key] }))} />
+      ))}
+    </div>
+  );
+  return <ResponsiveSwap mobile={mobile} desktop={desktop} />;
+}
+
+// Mono command block (read-only; copy by selection). Lines are plain strings.
+export function CommandBlock({ commands }: { commands: string[] }) {
+  return (
+    <pre style={{ fontFamily: C.mono, fontSize: 12, color: C.text, background: C.panelHi, border: `1px solid ${C.border}`, borderRadius: 8, padding: "12px 14px", overflowX: "auto", lineHeight: 1.6, margin: 0 }}>
+      {commands.map((line, i) => (
+        <div key={i} style={{ color: line.trim().startsWith("#") ? C.faint : C.text }}>{line || " "}</div>
+      ))}
+    </pre>
+  );
+}
+
+// Thin callout over the shared status banner (info | warn | error).
+export function Callout({ tone = "info", children }: { tone?: "info" | "warn" | "error"; children: ReactNode }) {
+  return <TelemetryStatusBanner tone={tone}>{children}</TelemetryStatusBanner>;
+}

--- a/repo-b/src/components/telemetry/telemetryNav.test.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.test.ts
@@ -36,6 +36,7 @@ describe("telemetry navigation structure (7 presentation sections)", () => {
     expect(slugs).toEqual(
       [
         "",
+        "ai-build-ops",
         "calibration",
         "control-tower",
         "factory",
@@ -118,6 +119,7 @@ describe("telemetry navigation structure (7 presentation sections)", () => {
       [`${base}/factory-ml`, "Factory & Quality"],
       [`${base}/metric-lineage`, "Evidence & Lineage"],
       [`${base}/metadata`, "Evidence & Lineage"],
+      [`${base}/ai-build-ops`, "Evidence & Lineage"],
       [`${base}/control-tower`, "Agent Operations"],
       // hidden-before-delete routes still recover their section color
       [`${base}/copilot`, "Models & Intelligence"],

--- a/repo-b/src/components/telemetry/telemetryNav.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.ts
@@ -57,6 +57,10 @@ export const TELEMETRY_NAV: TelemetryNavItem[] = [
   // Section 5 — Evidence & Lineage (where did this number come from / why trust it)
   { slug: "metric-lineage", label: "Metric Lineage", icon: "M4 2v12M4 6h6M4 11h5M10 4v4M9 9v3", group: "Evidence & Lineage" },
   { slug: "metadata", label: "Metadata Explorer", icon: "M2 3h5v4H2zM9 3h5v4H9zM5 9h6v4H5zM4.5 7v2M11.5 7v2M7 11H5M11 11h-1", group: "Evidence & Lineage" },
+  // Document-style "how it was built & how it is operated" reference. Visible here (the section that
+  // owns "where it came from / why trust it"); the rail label stays short, the page title carries
+  // the full "AI Build & Operations Reference". Static page — nothing fetches or executes.
+  { slug: "ai-build-ops", label: "AI Build & Ops", icon: "M5 2h6l3 3v9H2V2zM9 2v4h4M4 9h7M4 12h5", group: "Evidence & Lineage" },
   // Hidden-before-delete (presentation declutter): "Trust Center" (governance), "How This Works"
   // (how-it-works), and "Resume Evidence" (evidence) are dropped from the nav. Their /telemetry/<slug>
   // routes still resolve for deep links; only the nav entries are removed. The How-This-Works framing
@@ -143,6 +147,7 @@ const TELEMETRY_SLUG_GROUP: Record<string, TelemetryNavGroup> = {
   factory: "Factory & Quality", "factory-ml": "Factory & Quality",
   // Evidence & Lineage
   "metric-lineage": "Evidence & Lineage", metadata: "Evidence & Lineage",
+  "ai-build-ops": "Evidence & Lineage",
   governance: "Evidence & Lineage", "how-it-works": "Evidence & Lineage", evidence: "Evidence & Lineage",
   // Agent Operations
   "control-tower": "Agent Operations",


### PR DESCRIPTION
## Summary
Adds one **document-style** telemetry reference page that explains *how the demo was built and how it is operated* — the missing "AI / automation / CLI / REST / MCP / CI-CD / DevOps connections" artifact for a Director of Data & AI audience. Engineering-runbook layout, not a dashboard or card grid.

**Route:** `/lab/env/[envId]/telemetry/ai-build-ops` — visible in the **Evidence & Lineage** nav group (rail label "AI Build & Ops"; page title carries the full "AI Build & Operations Reference").

## What it does
Fully **static**: no fetch, no live compute, **no new API, no DB migration**. 11 numbered sections rendered from a hand-maintained manifest:
1. What this page documents (the four kinds of "AI") · 2. Page-by-page AI connection inventory · 3. AI skills used to build it · 4. Runtime AI connections · 5. REST API & endpoint map · 6. MCP & tool-use map · 7. CLI / DevOps · 8. CI/CD & release gates · 9. Evidence, audit & receipts · 10. Honest boundaries · 11. Why this matters.

**Honest by construction:** every claim-bearing manifest row carries `sourceRefs` citing the real file/route; real vs `fixture` vs `synthetic` vs `cold` are labeled with the repo's own vocabulary (`source_kind`, `serving_provenance`, `provenance: databricks|local_fallback`, `null_reason`). Planned/not-present surfaces are kept in separate tables, never blended with real ones. No vendor-pitch copy.

## Files
- New: `repo-b/src/components/telemetry/reference/{AiBuildOpsReference.tsx, refPrimitives.tsx, manifest.ts, AiBuildOpsReference.test.tsx}` + `…/telemetry/ai-build-ops/page.tsx`
- Nav: `telemetryNav.ts` — `TELEMETRY_NAV` entry **and** `TELEMETRY_SLUG_GROUP` mapping (header accent resolves from the route) + `telemetryNav.test.ts` coverage
- Docs: 0003 plan ticket, telemetry `next-session.md`/`backlog.md`, `tips.md` pattern note

## Tests / verification
- `npm run typecheck` — clean
- `npm run lint` — clean for new files (only pre-existing unrelated warnings)
- `npx vitest run …/AiBuildOpsReference.test.tsx …/telemetryNav.test.ts` — **13/13 passed**
- `npm run build` — compiles the new route (`/lab/env/[envId]/telemetry/ai-build-ops`, 14.8 kB; 295 pages generated)

## Honest boundaries / known limitations
- The route is auth-gated, so an authenticated browser screenshot was **not** captured this session — verified via build + render tests instead (follow-up logged in the telemetry backlog).
- Only real drift risk is the static manifest vs the code; mitigated by citing the file/route on every row and a tips.md note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)