### PR TITLE
feat(telemetry): real BigQuery gold + MAD_K threshold sweep + parity (#742)

### DIFF
--- a/backend/app/data/telemetry/parity_receipt.json
+++ b/backend/app/data/telemetry/parity_receipt.json
@@ -1,0 +1,34 @@
+{
+  "provider": "gcp",
+  "source_bigquery_table": "novendor-events-prod.telemetry.gold_smap_msl_windows",
+  "vertex_experiment": null,
+  "vertex_run_id": null,
+  "vertex_model_id": null,
+  "gcs_artifact_uri": null,
+  "created_at": "2026-06-27T00:00:00Z",
+  "code_version": "gcp-migration@08a0d352",
+  "data_manifest_sha": "d26cb66bb7817b67",
+  "rows_evaluated": 509555,
+  "null_reason": null,
+  "payload": {
+    "claim": "GCP-side rolling-MAD reproduces the deployed champion's honest metrics from public data, with no Databricks dependency.",
+    "operating_k": 4.0,
+    "gcp_metrics": {
+      "f1_pointwise": 0.312953,
+      "event_recall": 0.769231,
+      "affiliation_f1": 0.474634
+    },
+    "champion_metrics": {
+      "f1_pointwise": 0.312953,
+      "event_recall": 0.769231,
+      "affiliation_f1": 0.474634
+    },
+    "deltas": {
+      "f1_pointwise": 0.0,
+      "event_recall": 0.0,
+      "affiliation_f1": 0.0
+    },
+    "match": true,
+    "test_channels": 81
+  }
+}

--- a/backend/app/data/telemetry/threshold_sweep.json
+++ b/backend/app/data/telemetry/threshold_sweep.json
@@ -1,27 +1,244 @@
 {
-  "provider": "local_fixture",
-  "source_bigquery_table": null,
+  "provider": "gcp",
+  "source_bigquery_table": "novendor-events-prod.telemetry.gold_smap_msl_windows",
   "vertex_experiment": null,
   "vertex_run_id": null,
   "vertex_model_id": null,
   "gcs_artifact_uri": null,
   "created_at": "2026-06-27T00:00:00Z",
-  "code_version": "local_fixture@0d502954",
-  "data_manifest_sha": null,
-  "rows_evaluated": null,
+  "code_version": "gcp-migration@08a0d352",
+  "data_manifest_sha": "d26cb66bb7817b67",
+  "rows_evaluated": 509555,
   "null_reason": null,
   "payload": {
     "operating_point": {
       "mad_k": 4.0,
-      "global_train_scale": 0.033866801182436346,
-      "detector_threshold": 0.13546720472974538,
-      "source": "frozen serving constants (backend/app/services/telemetry_serving.py)"
+      "global_train_scale": 0.033866801182424466,
+      "detector_threshold": 0.13546720472969787,
+      "source": "rolling-MAD over BigQuery gold_smap_msl_windows (public SMAP/MSL test split)"
     },
-    "sweep": [],
-    "confusion_at_operating": null,
-    "curves": {"pr": [], "roc": []},
+    "sweep": [
+      {
+        "threshold": 2.0,
+        "precision": 0.264653,
+        "recall": 0.362455,
+        "f1_pointwise": 0.305928,
+        "event_recall": 0.971154,
+        "alarm_precision": 0.264653,
+        "affiliation_f1": 0.434318,
+        "tpr": 0.362455,
+        "fpr": 0.143583,
+        "tp": 23046,
+        "fp": 64034,
+        "fn": 40537,
+        "tn": 381938
+      },
+      {
+        "threshold": 2.5,
+        "precision": 0.284714,
+        "recall": 0.338314,
+        "f1_pointwise": 0.309208,
+        "event_recall": 0.932692,
+        "alarm_precision": 0.284714,
+        "affiliation_f1": 0.453997,
+        "tpr": 0.338314,
+        "fpr": 0.121178,
+        "tp": 21511,
+        "fp": 54042,
+        "fn": 42072,
+        "tn": 391930
+      },
+      {
+        "threshold": 3.0,
+        "precision": 0.302593,
+        "recall": 0.320054,
+        "f1_pointwise": 0.311079,
+        "event_recall": 0.894231,
+        "alarm_precision": 0.302593,
+        "affiliation_f1": 0.469342,
+        "tpr": 0.320054,
+        "fpr": 0.105168,
+        "tp": 20350,
+        "fp": 46902,
+        "fn": 43233,
+        "tn": 399070
+      },
+      {
+        "threshold": 3.5,
+        "precision": 0.318217,
+        "recall": 0.309234,
+        "f1_pointwise": 0.313661,
+        "event_recall": 0.807692,
+        "alarm_precision": 0.318217,
+        "affiliation_f1": 0.472736,
+        "tpr": 0.309234,
+        "fpr": 0.094459,
+        "tp": 19662,
+        "fp": 42126,
+        "fn": 43921,
+        "tn": 403846
+      },
+      {
+        "threshold": 4.0,
+        "precision": 0.3279,
+        "recall": 0.29931,
+        "f1_pointwise": 0.312953,
+        "event_recall": 0.769231,
+        "alarm_precision": 0.3279,
+        "affiliation_f1": 0.474634,
+        "tpr": 0.29931,
+        "fpr": 0.087467,
+        "tp": 19031,
+        "fp": 39008,
+        "fn": 44552,
+        "tn": 406964
+      },
+      {
+        "threshold": 4.5,
+        "precision": 0.341676,
+        "recall": 0.290722,
+        "f1_pointwise": 0.314146,
+        "event_recall": 0.721154,
+        "alarm_precision": 0.341676,
+        "affiliation_f1": 0.477843,
+        "tpr": 0.290722,
+        "fpr": 0.079862,
+        "tp": 18485,
+        "fp": 35616,
+        "fn": 45098,
+        "tn": 410356
+      },
+      {
+        "threshold": 5.0,
+        "precision": 0.346955,
+        "recall": 0.281884,
+        "f1_pointwise": 0.311052,
+        "event_recall": 0.701923,
+        "alarm_precision": 0.346955,
+        "affiliation_f1": 0.477779,
+        "tpr": 0.281884,
+        "fpr": 0.075644,
+        "tp": 17923,
+        "fp": 33735,
+        "fn": 45660,
+        "tn": 412237
+      },
+      {
+        "threshold": 5.5,
+        "precision": 0.350487,
+        "recall": 0.275608,
+        "f1_pointwise": 0.30857,
+        "event_recall": 0.692308,
+        "alarm_precision": 0.350487,
+        "affiliation_f1": 0.478567,
+        "tpr": 0.275608,
+        "fpr": 0.072818,
+        "tp": 17524,
+        "fp": 32475,
+        "fn": 46059,
+        "tn": 413497
+      },
+      {
+        "threshold": 6.0,
+        "precision": 0.356193,
+        "recall": 0.269978,
+        "f1_pointwise": 0.30715,
+        "event_recall": 0.663462,
+        "alarm_precision": 0.356193,
+        "affiliation_f1": 0.475768,
+        "tpr": 0.269978,
+        "fpr": 0.069572,
+        "tp": 17166,
+        "fp": 31027,
+        "fn": 46417,
+        "tn": 414945
+      }
+    ],
+    "confusion_at_operating": {
+      "tp": 19031,
+      "fp": 39008,
+      "fn": 44552,
+      "tn": 406964
+    },
+    "curves": {
+      "pr": [
+        {
+          "recall": 0.362455,
+          "precision": 0.264653
+        },
+        {
+          "recall": 0.338314,
+          "precision": 0.284714
+        },
+        {
+          "recall": 0.320054,
+          "precision": 0.302593
+        },
+        {
+          "recall": 0.309234,
+          "precision": 0.318217
+        },
+        {
+          "recall": 0.29931,
+          "precision": 0.3279
+        },
+        {
+          "recall": 0.290722,
+          "precision": 0.341676
+        },
+        {
+          "recall": 0.281884,
+          "precision": 0.346955
+        },
+        {
+          "recall": 0.275608,
+          "precision": 0.350487
+        },
+        {
+          "recall": 0.269978,
+          "precision": 0.356193
+        }
+      ],
+      "roc": [
+        {
+          "fpr": 0.143583,
+          "tpr": 0.362455
+        },
+        {
+          "fpr": 0.121178,
+          "tpr": 0.338314
+        },
+        {
+          "fpr": 0.105168,
+          "tpr": 0.320054
+        },
+        {
+          "fpr": 0.094459,
+          "tpr": 0.309234
+        },
+        {
+          "fpr": 0.087467,
+          "tpr": 0.29931
+        },
+        {
+          "fpr": 0.079862,
+          "tpr": 0.290722
+        },
+        {
+          "fpr": 0.075644,
+          "tpr": 0.281884
+        },
+        {
+          "fpr": 0.072818,
+          "tpr": 0.275608
+        },
+        {
+          "fpr": 0.069572,
+          "tpr": 0.269978
+        }
+      ]
+    },
     "metric_basis": "point-wise honest (telemetry-platform/pipeline/metrics.honest_anomaly_metrics)",
-    "sweep_pending": true,
-    "note": "The operating point is the real frozen serving threshold. The full MAD_K sweep + confusion matrix + PR/ROC curves are computed over the BigQuery labeled SMAP/MSL test split in the GCP run (Part II.4) and will replace this preview."
+    "sweep_pending": false
   }
 }

--- a/backend/app/routes/telemetry.py
+++ b/backend/app/routes/telemetry.py
@@ -225,6 +225,15 @@ def workbench_promotion_review():
         raise _to_http(exc)
 
 
+@router.get("/workbench/parity", response_model=ReceiptEnvelope)
+def workbench_parity():
+    """GCP-side reproduction of the champion's honest metrics vs the deployed champion (parity receipt)."""
+    try:
+        return ReceiptEnvelope(**receipts.load_receipt("parity"))
+    except Exception as exc:  # noqa: BLE001
+        raise _to_http(exc)
+
+
 @router.get("/summary")
 def summary(env_id: str = Query(...), business_id: UUID = Query(...)):
     """Single KPI + serving-inventory contract for the Overview (counts + headline metrics)."""

--- a/backend/app/services/telemetry_receipts.py
+++ b/backend/app/services/telemetry_receipts.py
@@ -27,6 +27,7 @@ RECEIPT_FILES: dict[str, str] = {
     "threshold_sweep": "threshold_sweep.json",
     "error_review": "error_review.json",
     "promotion_review": "promotion_review.json",
+    "parity": "parity_receipt.json",
 }
 
 # Strict provenance header every receipt carries. Missing keys normalize to None — never fabricated.

--- a/backend/tests/test_telemetry_receipts.py
+++ b/backend/tests/test_telemetry_receipts.py
@@ -25,15 +25,28 @@ def test_seeded_feature_manifest_loads():
     assert all(fs["included"] is False for fs in out["payload"]["feature_sets"][1:])
 
 
-def test_seeded_threshold_sweep_operating_point_is_real():
+def test_threshold_sweep_is_real_gcp_sweep():
+    # S7 replaced the seed with the real GCP/BigQuery-backed sweep.
     out = rcpt.load_receipt("threshold_sweep")
     assert out["null_reason"] is None
-    assert out["provider"] == "local_fixture"
+    assert out["provider"] == "gcp"
+    assert out["source_bigquery_table"] == "novendor-events-prod.telemetry.gold_smap_msl_windows"
     op = out["payload"]["operating_point"]
     assert op["mad_k"] == 4.0
-    assert op["detector_threshold"] == pytest.approx(0.13546720472974538)
-    assert out["payload"]["sweep"] == []             # full sweep pending the GCP run (Part II.4)
-    assert out["payload"]["sweep_pending"] is True
+    assert op["detector_threshold"] == pytest.approx(0.13546720472974538, rel=1e-6)
+    assert out["payload"]["sweep_pending"] is False
+    assert len(out["payload"]["sweep"]) >= 5         # a real multi-K sweep
+    # operating point reproduces the deployed champion's honest f1
+    op_row = next(s for s in out["payload"]["sweep"] if s["threshold"] == 4.0)
+    assert op_row["f1_pointwise"] == pytest.approx(0.312953, abs=1e-4)
+
+
+def test_parity_receipt_reproduces_champion():
+    out = rcpt.load_receipt("parity")
+    assert out["null_reason"] is None
+    assert out["provider"] == "gcp"
+    assert out["payload"]["match"] is True
+    assert out["payload"]["deltas"]["f1_pointwise"] == pytest.approx(0.0, abs=1e-4)
 
 
 # ── service: fail-closed paths ────────────────────────────────────────────────

--- a/repo-b/src/components/telemetry/workbench/ThresholdSweepTab.tsx
+++ b/repo-b/src/components/telemetry/workbench/ThresholdSweepTab.tsx
@@ -6,6 +6,7 @@ import {
 } from "recharts";
 import { getWorkbenchThresholdSweep, type ReceiptEnvelope } from "@/lib/telemetry/api";
 import { C, EmptyState, Loading, MetricCard, StatGrid, Tag } from "../primitives";
+import { FeatureTableLink } from "../drill";
 
 const ACCENT = "#a855f7";
 
@@ -53,12 +54,14 @@ export function ThresholdSweepTab() {
   const [data, setData] = useState<SweepPayload | null>(null);
   const [nullReason, setNullReason] = useState<string | null>(null);
   const [provider, setProvider] = useState<string | null>(null);
+  const [sourceTable, setSourceTable] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     getWorkbenchThresholdSweep()
       .then((r: ReceiptEnvelope) => {
         setProvider(r.provider);
+        setSourceTable(r.source_bigquery_table);
         setNullReason(r.null_reason);
         setData(r.payload as SweepPayload | null);
       })
@@ -95,6 +98,7 @@ export function ThresholdSweepTab() {
         <span style={{ fontFamily: C.sans, fontSize: 12, color: C.dim }}>
           the honest threshold-selection story — a real sweep, not a single magic number
         </span>
+        {sourceTable && <FeatureTableLink provider={provider} table={sourceTable} />}
       </div>
 
       <StatGrid cols={3}>

--- a/repo-b/src/lib/telemetry/cloudLinks.test.ts
+++ b/repo-b/src/lib/telemetry/cloudLinks.test.ts
@@ -37,4 +37,12 @@ describe("cloudLinks — provider-aware deep links", () => {
     expect(l.href).toContain("vertex-ai/models");
     expect(l.href).toContain("9988");
   });
+
+  it("gcp provider (BigQuery-backed, no Vertex run) routes the table to BigQuery and fails the run closed", () => {
+    const table = cloudTableLink({ provider: "gcp", table: "novendor-events-prod.telemetry.gold_smap_msl_windows" });
+    expect(table.href).toContain("bigquery");
+    expect(table.href).toContain("gold_smap_msl_windows");
+    const run = cloudRunLink({ provider: "gcp", runId: null });
+    expect(run.href).toBeNull(); // no Vertex run produced a gcp-computed receipt
+  });
 });

--- a/repo-b/src/lib/telemetry/cloudLinks.ts
+++ b/repo-b/src/lib/telemetry/cloudLinks.ts
@@ -23,6 +23,12 @@ const GCP_PROJECT =
 const GCP_LOCATION =
   (typeof process !== "undefined" && process.env.NEXT_PUBLIC_TELEMETRY_GCP_LOCATION) || "us-east4";
 
+// GCP family — a Vertex run, a BigQuery-backed artifact, or a generic GCP-computed receipt all route to
+// the GCP console. (Run/model deep links still require a real id; otherwise they fail closed.)
+function isGcp(p: LinkProvider): boolean {
+  return p === "vertex" || p === "gcp" || p === "bigquery";
+}
+
 function fixtureOnly(label: string, copyText?: string | null): ExternalEvidenceLink {
   return {
     label,
@@ -38,7 +44,7 @@ export function cloudRunLink(opts: {
   provider?: LinkProvider; runId?: string | null; experimentId?: string | null;
 }): ExternalEvidenceLink {
   const { provider, runId, experimentId } = opts;
-  if (provider === "vertex") {
+  if (isGcp(provider)) {
     const label = "Open Vertex run";
     if (!runId) return { label, kind: "mlflow_run", href: null, unavailableReason: "No Vertex run id on this object.", copyText: null };
     const exp = experimentId ?? "";
@@ -56,7 +62,7 @@ export function cloudModelLink(opts: {
   provider?: LinkProvider; modelId?: string | null; modelName?: string | null;
 }): ExternalEvidenceLink {
   const { provider, modelId, modelName } = opts;
-  if (provider === "vertex") {
+  if (isGcp(provider)) {
     const label = "Open Vertex model";
     if (!modelId) return { label, kind: "registered_model", href: null, unavailableReason: "No Vertex model id on this object.", copyText: null };
     return {
@@ -73,7 +79,7 @@ export function cloudModelLink(opts: {
 // ── Feature / source table ─────────────────────────────────────────────────────
 export function cloudTableLink(opts: { provider?: LinkProvider; table?: string | null }): ExternalEvidenceLink {
   const { provider, table } = opts;
-  if (provider === "vertex") {
+  if (isGcp(provider)) {
     const label = "Open BigQuery table";
     if (!table) return { label, kind: "delta_table", href: null, unavailableReason: "No source table on this object.", copyText: null };
     // table is "project.dataset.table" or "dataset.table".

--- a/telemetry-platform/gcp/build_gold_and_sweep.py
+++ b/telemetry-platform/gcp/build_gold_and_sweep.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""S7 — BigQuery gold + real MAD_K threshold sweep + parity (Databricks-free).
+
+Reproduces the FROZEN rolling-MAD champion from the public SMAP/MSL data (no Databricks), materializes
+the test-split gold windows in BigQuery, sweeps MAD_K over the labeled test split using the canonical
+pipeline.metrics, and exports two committed receipts:
+
+  - threshold_sweep.json  — real PR/ROC + confusion across MAD_K, operating point at K=4.0.
+  - parity_receipt.json   — the honest metrics at K=4.0 vs the deployed champion (must match), proving
+                            the GCP-side computation reproduces the champion WITHOUT Databricks.
+
+Run:
+    python telemetry-platform/gcp/build_gold_and_sweep.py --data-dir <.../smap_msl> \
+        --project novendor-events-prod --dataset telemetry --location us-east4
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]  # telemetry-platform/
+sys.path.insert(0, str(ROOT))
+from pipeline import metrics as pm  # noqa: E402  (canonical metric definitions)
+
+RECEIPT_DIR = ROOT.parent / "backend" / "app" / "data" / "telemetry"
+BASELINE_K = 4.0
+GOLD_TABLE = "gold_smap_msl_windows"
+SWEEP_KS = [2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0]
+
+
+def trailing_rmean(values: np.ndarray, window: int = 50) -> np.ndarray:
+    n = len(values)
+    csum = np.concatenate([[0.0], np.cumsum(values, dtype=np.float64)])
+    out = np.empty(n, dtype=np.float64)
+    for i in range(n):
+        lo = max(0, i - window + 1)
+        out[i] = (csum[i + 1] - csum[lo]) / (i + 1 - lo)
+    return out
+
+
+def load_sequences(labels_csv: Path) -> dict:
+    seqs = {}
+    with labels_csv.open(newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            seqs[row["chan_id"]] = json.loads(row["anomaly_sequences"])
+    return seqs
+
+
+def channel_values(npy: Path) -> np.ndarray:
+    arr = np.load(npy)
+    return (arr[:, 0] if arr.ndim == 2 else arr.ravel()).astype(np.float64)
+
+
+def git_sha() -> str:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], cwd=str(ROOT)).decode().strip()
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def build_channels(data_dir: Path):
+    """Return (train scale map, global scale, per-test-channel records, gold rows)."""
+    seqs = load_sequences(data_dir / "labeled_anomalies.csv")
+    train_resid = {}
+    for npy in sorted((data_dir / "arrays" / "train").glob("*.npy")):
+        v = channel_values(npy)
+        train_resid[npy.stem] = np.abs(v - trailing_rmean(v))
+    global_scale = float(np.median(np.concatenate(list(train_resid.values())))) or 1.0
+    scale = {c: (float(np.median(r)) or global_scale) for c, r in train_resid.items()}
+    scale = {c: (s if s > 0 else global_scale) for c, s in scale.items()}
+
+    test_chans = []
+    gold_rows = []
+    for npy in sorted((data_dir / "arrays" / "test").glob("*.npy")):
+        chan = npy.stem
+        v = channel_values(npy)
+        rmean = trailing_rmean(v)
+        resid = np.abs(v - rmean)
+        s = scale.get(chan, global_scale)
+        y = np.zeros(len(v), dtype=int)
+        for seq in seqs.get(chan, []):
+            a, b = int(seq[0]), min(int(seq[1]), len(v) - 1)
+            if a <= b:
+                y[a:b + 1] = 1
+        test_chans.append({"chan": chan, "resid": resid, "scale": s, "y": y})
+        for t in range(len(v)):
+            gold_rows.append({
+                "chan_id": chan, "split": "test", "t": int(t),
+                "value": float(v[t]), "value_rmean50": float(rmean[t]),
+                "residual": float(resid[t]), "train_scale": float(s),
+                "is_anomaly": int(y[t]),
+            })
+    return scale, global_scale, test_chans, gold_rows
+
+
+def sweep(test_chans) -> list:
+    out = []
+    for k in SWEEP_KS:
+        channels = []
+        tp = fp = fn = tn = 0
+        for ch in test_chans:
+            pred = (ch["resid"] > k * ch["scale"]).astype(int)
+            y = ch["y"]
+            channels.append((y, pred))
+            tp += int(((pred == 1) & (y == 1)).sum())
+            fp += int(((pred == 1) & (y == 0)).sum())
+            fn += int(((pred == 0) & (y == 1)).sum())
+            tn += int(((pred == 0) & (y == 0)).sum())
+        m = pm.honest_anomaly_metrics(channels)
+        recall = tp / (tp + fn) if (tp + fn) else 0.0
+        precision = tp / (tp + fp) if (tp + fp) else 0.0
+        fpr = fp / (fp + tn) if (fp + tn) else 0.0
+        out.append({
+            "threshold": round(k, 3),
+            "precision": round(precision, 6), "recall": round(recall, 6),
+            "f1_pointwise": round(m["f1_pointwise"], 6),
+            "event_recall": round(m["event_recall"], 6),
+            "alarm_precision": round(m["alarm_precision"], 6),
+            "affiliation_f1": round(m["affiliation_f1"], 6),
+            "tpr": round(recall, 6), "fpr": round(fpr, 6),
+            "tp": tp, "fp": fp, "fn": fn, "tn": tn,
+        })
+    return out
+
+
+def load_bigquery(gold_rows, project, dataset, location) -> dict:
+    from google.cloud import bigquery
+    client = bigquery.Client(project=project)
+    ds_id = f"{project}.{dataset}"
+    ds = bigquery.Dataset(ds_id)
+    ds.location = location
+    client.create_dataset(ds, exists_ok=True)
+    table_id = f"{ds_id}.{GOLD_TABLE}"
+    # Write NDJSON to a temp file and load (avoids a pyarrow dependency).
+    tmp = ROOT / "gcp" / "_gold_load.ndjson"
+    with tmp.open("w", encoding="utf-8") as f:
+        for r in gold_rows:
+            f.write(json.dumps(r) + "\n")
+    job_config = bigquery.LoadJobConfig(
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+        source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
+        autodetect=True,
+    )
+    with tmp.open("rb") as f:
+        job = client.load_table_from_file(f, table_id, job_config=job_config, location=location)
+    job.result()
+    tmp.unlink(missing_ok=True)
+    t = client.get_table(table_id)
+    return {"table": table_id, "rows": int(t.num_rows)}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data-dir", required=True)
+    ap.add_argument("--project", default="novendor-events-prod")
+    ap.add_argument("--dataset", default="telemetry")
+    ap.add_argument("--location", default="us-east4")
+    ap.add_argument("--skip-bq", action="store_true", help="compute receipts without loading BigQuery")
+    args = ap.parse_args()
+
+    data_dir = Path(args.data_dir)
+    manifest = ROOT / "databricks" / "data" / "manifest_smap_msl.json"
+    manifest_sha = hashlib.sha256(manifest.read_bytes()).hexdigest()[:16]
+
+    scale, global_scale, test_chans, gold_rows = build_channels(data_dir)
+    rows_evaluated = sum(len(ch["y"]) for ch in test_chans)
+    sw = sweep(test_chans)
+    op = next(s for s in sw if abs(s["threshold"] - BASELINE_K) < 1e-9)
+
+    bq = {"table": None, "rows": 0}
+    if not args.skip_bq:
+        bq = load_bigquery(gold_rows, args.project, args.dataset, args.location)
+
+    source_table = bq["table"] or f"{args.project}.{args.dataset}.{GOLD_TABLE}"
+    created = "2026-06-27T00:00:00Z"
+    code_version = f"gcp-migration@{git_sha()}"
+
+    detector_threshold = BASELINE_K * global_scale
+    threshold_sweep = {
+        "provider": "gcp",
+        "source_bigquery_table": source_table,
+        "vertex_experiment": None, "vertex_run_id": None, "vertex_model_id": None,
+        "gcs_artifact_uri": None,
+        "created_at": created, "code_version": code_version, "data_manifest_sha": manifest_sha,
+        "rows_evaluated": rows_evaluated, "null_reason": None,
+        "payload": {
+            "operating_point": {
+                "mad_k": BASELINE_K, "global_train_scale": global_scale,
+                "detector_threshold": detector_threshold,
+                "source": f"rolling-MAD over BigQuery {GOLD_TABLE} (public SMAP/MSL test split)",
+            },
+            "sweep": sw,
+            "confusion_at_operating": {"tp": op["tp"], "fp": op["fp"], "fn": op["fn"], "tn": op["tn"]},
+            "curves": {
+                "pr": [{"recall": s["recall"], "precision": s["precision"]} for s in sw],
+                "roc": [{"fpr": s["fpr"], "tpr": s["tpr"]} for s in sw],
+            },
+            "metric_basis": "point-wise honest (telemetry-platform/pipeline/metrics.honest_anomaly_metrics)",
+            "sweep_pending": False,
+        },
+    }
+
+    # Parity vs the deployed champion (Databricks-trained) honest metrics — must match.
+    CHAMP = {"f1_pointwise": 0.312953, "event_recall": 0.769231, "affiliation_f1": 0.474634}
+    parity = {
+        "provider": "gcp",
+        "source_bigquery_table": source_table,
+        "vertex_experiment": None, "vertex_run_id": None, "vertex_model_id": None, "gcs_artifact_uri": None,
+        "created_at": created, "code_version": code_version, "data_manifest_sha": manifest_sha,
+        "rows_evaluated": rows_evaluated, "null_reason": None,
+        "payload": {
+            "claim": "GCP-side rolling-MAD reproduces the deployed champion's honest metrics from public data, with no Databricks dependency.",
+            "operating_k": BASELINE_K,
+            "gcp_metrics": {"f1_pointwise": op["f1_pointwise"], "event_recall": op["event_recall"], "affiliation_f1": op["affiliation_f1"]},
+            "champion_metrics": CHAMP,
+            "deltas": {k: round(op[k] - CHAMP[k], 6) for k in CHAMP},
+            "match": all(abs(op[k] - CHAMP[k]) <= 1e-4 for k in CHAMP),
+            "test_channels": len(test_chans),
+        },
+    }
+
+    (RECEIPT_DIR / "threshold_sweep.json").write_text(json.dumps(threshold_sweep, indent=2) + "\n", encoding="utf-8")
+    (RECEIPT_DIR / "parity_receipt.json").write_text(json.dumps(parity, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps({
+        "bigquery": bq, "rows_evaluated": rows_evaluated, "operating_point": op,
+        "parity_match": parity["payload"]["match"], "deltas": parity["payload"]["deltas"],
+        "receipts": ["threshold_sweep.json", "parity_receipt.json"],
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/telemetry-platform/gcp/download_raw.py
+++ b/telemetry-platform/gcp/download_raw.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Download the public NASA telemetry data (Databricks-free) from a committed manifest.
+
+The same public SMAP/MSL (and C-MAPSS) data the Databricks bronze stage used, fetched directly from
+its public sources so the GCP pipeline never depends on Databricks. Idempotent + SHA-verified.
+
+Usage:
+    python telemetry-platform/gcp/download_raw.py --dataset smap_msl --out <dir>
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]  # telemetry-platform/
+MANIFESTS = {
+    "smap_msl": ROOT / "databricks" / "data" / "manifest_smap_msl.json",
+    "cmapss": ROOT / "databricks" / "data" / "manifest_cmapss.json",
+}
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def download(dataset: str, out: Path) -> dict:
+    manifest = MANIFESTS[dataset]
+    recs = json.loads(manifest.read_text(encoding="utf-8"))["records"]
+    ok = skipped = failed = 0
+    t0 = time.time()
+    for r in recs:
+        dest = out / r["dest"].replace("\\", "/")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if dest.exists() and r.get("sha256") and sha256(dest) == r["sha256"]:
+            skipped += 1
+            continue
+        try:
+            req = urllib.request.Request(r["url"], headers={"User-Agent": "telemetry-gcp-migration/1.0"})
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                dest.write_bytes(resp.read())
+            if r.get("sha256") and sha256(dest) != r["sha256"]:
+                failed += 1
+                continue
+            ok += 1
+        except Exception:  # noqa: BLE001
+            failed += 1
+    return {"dataset": dataset, "fetched": ok, "cached": skipped, "failed": failed,
+            "seconds": round(time.time() - t0, 1), "out": str(out),
+            "manifest_sha": sha256(manifest)}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", default="smap_msl", choices=list(MANIFESTS))
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+    res = download(args.dataset, Path(args.out))
+    print(json.dumps(res, indent=2))
+    return 0 if res["failed"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What
Part II.2 — the **first real GCP-backed artifact**, fully Databricks-free. Reproduces the frozen rolling-MAD champion from the public SMAP/MSL data, materializes the gold windows in **BigQuery**, sweeps `MAD_K` with the canonical `pipeline.metrics`, and exports two real receipts.

## Real run (this PR's committed receipts came from it)
- **BigQuery:** `novendor-events-prod.telemetry.gold_smap_msl_windows` — **509,555 rows** (us-east4).
- **Threshold sweep** `K=2.0→6.0`: precision 0.265→0.356, event-recall 0.97→0.66, F1 peaks ~K=4.0–4.5. ThresholdSweepTab now renders the **real** PR curve + confusion (the seed is replaced).
- **Parity: exact.** At K=4.0 the GCP-side honest metrics reproduce the deployed champion — `f1_pointwise 0.312953`, `event_recall 0.769231`, `affiliation_f1 0.474634`, **deltas all 0.0**. Zero Databricks dependency.

## Changes
- `telemetry-platform/gcp/{download_raw,build_gold_and_sweep}.py` — Databricks-free pipeline.
- `threshold_sweep.json` (real, provider=gcp, `source_bigquery_table` set) + new `parity_receipt.json`.
- Backend: +parity receipt kind + `GET /api/telemetry/workbench/parity`.
- Frontend: `cloudLinks` treats gcp/vertex/bigquery as the GCP family; ThresholdSweepTab surfaces the BigQuery source link.

## Tests
- Backend receipts **11 passed** (real sweep + parity asserted). cloudLinks +gcp case. typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)