### PR TITLE
fix(telemetry): left-align RUL Calibration like the other pages

### DIFF
--- a/repo-b/src/components/telemetry/RulCalibration.tsx
+++ b/repo-b/src/components/telemetry/RulCalibration.tsx
@@ -108,7 +108,9 @@ export default function RulCalibration() {
   const [drillOpen, setDrillOpen] = useState(false);
 
   return (
-    <div style={{ maxWidth: 1320, margin: "0 auto" }}>
+    // Full-bleed left-aligned like every other telemetry page (no centered max-width wrapper) so the
+    // left margin matches the rest of the workbench; the shell's main padding owns the gutter.
+    <div>
       <TelemetryPageHeader
         variant="standard"
         eyebrow="Telemetry · Calibration"


### PR DESCRIPTION
RUL Calibration was the only telemetry page wrapping its content in a centered max-width column (`maxWidth: 1320, margin: "0 auto"`). On wide screens that centered the column, so its left margin didn't line up with the rest of the workbench (e.g. Mission Control, which is full-bleed).

Dropped the centered wrapper so the page is full-bleed left-aligned like every other telemetry page — the shell's `main` padding owns the gutter. One-file change; RulCalibration test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)