### PR TITLE
fix(telemetry): only the most-specific nav route stays highlighted

### DIFF
--- a/repo-b/src/components/telemetry/telemetryNav.test.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.test.ts
@@ -97,6 +97,18 @@ describe("telemetry navigation structure (7 presentation sections)", () => {
     ).toBe(true);
   });
 
+  it("highlights only the most specific route — an index route does not stay active on a child", () => {
+    const child = "/lab/env/env-1/telemetry/relativity-mes/ncr";
+    // On a child route, only the child is active; the index ("Build Overview") is NOT.
+    expect(isTelemetryItemActive(child, "env-1", "relativity-mes/ncr")).toBe(true);
+    expect(isTelemetryItemActive(child, "env-1", "relativity-mes")).toBe(false);
+    // The index route is active on its own page.
+    expect(isTelemetryItemActive("/lab/env/env-1/telemetry/relativity-mes", "env-1", "relativity-mes")).toBe(true);
+    // Overview (empty slug) stays exact-only and never matches a child path.
+    expect(isTelemetryItemActive("/lab/env/env-1/telemetry", "env-1", "")).toBe(true);
+    expect(isTelemetryItemActive(child, "env-1", "")).toBe(false);
+  });
+
   it("provides icon + accent metadata for every displayed nav group (collapsible icon rail)", () => {
     for (const group of TELEMETRY_NAV_GROUPS) {
       const meta = TELEMETRY_NAV_GROUP_META[group];

--- a/repo-b/src/components/telemetry/telemetryNav.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.ts
@@ -118,9 +118,19 @@ export function telemetryHref(envId: string, slug: string): string {
 
 export function isTelemetryItemActive(pathname: string, envId: string, slug: string): boolean {
   const base = `/lab/env/${envId}/telemetry`;
-  if (!slug) return pathname === base;
-  const href = `${base}/${slug}`;
-  return pathname === href || pathname.startsWith(`${href}/`);
+  // A slug matches the path when it is the exact route or an ancestor segment of it.
+  const matches = (s: string): boolean => {
+    const href = s ? `${base}/${s}` : base;
+    return pathname === href || (s !== "" && pathname.startsWith(`${href}/`));
+  };
+  if (!matches(slug)) return false;
+  // Only the MOST specific (longest) matching slug is active, so an index route like "relativity-mes"
+  // ("Build Overview") does not stay highlighted while a child route ("relativity-mes/ncr") is open.
+  // Candidates are the declared nav slugs plus this slug (so deep-link-only routes still resolve).
+  const best = [...TELEMETRY_NAV.map((n) => n.slug), slug]
+    .filter(matches)
+    .reduce((a, b) => (b.length > a.length ? b : a), "");
+  return slug === best;
 }
 
 /** Label of the section owning the current pathname (for the mobile header). */


### PR DESCRIPTION
**Bug:** in the Relativity MES Sandbox group, "Build Overview" (index slug `relativity-mes`) stayed highlighted while a child page (`relativity-mes/ncr`, etc.) was open — two items lit at once — because the index slug matched child paths via `startsWith`.

**Fix:** `isTelemetryItemActive` now activates only the **longest** matching slug, so an index route is active only on its own page; children win on their own paths. Overview (empty slug) stays exact-only; deep-link-only routes still resolve. Regression test added.

Green: vitest (nav + sidebar, 18), tsc, lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)