### PR TITLE
feat(telemetry): gpt-5 copilot + typewriter reveal + model badge

### DIFF
--- a/backend/app/services/telemetry_copilot_policy.py
+++ b/backend/app/services/telemetry_copilot_policy.py
@@ -17,8 +17,6 @@ import hashlib
 import json
 import re
 
-from app.config import OPENAI_CHAT_MODEL
-
 COPILOT_MODEL = "gpt-5"
 
 # ── null_reason vocabulary (superset of the serving-layer reasons) ─────────────

--- a/backend/app/services/telemetry_copilot_policy.py
+++ b/backend/app/services/telemetry_copilot_policy.py
@@ -19,7 +19,7 @@ import re
 
 from app.config import OPENAI_CHAT_MODEL
 
-COPILOT_MODEL = OPENAI_CHAT_MODEL
+COPILOT_MODEL = "gpt-5"
 
 # ── null_reason vocabulary (superset of the serving-layer reasons) ─────────────
 NULL_UNSUPPORTED = "unsupported_question"
@@ -182,7 +182,10 @@ SYSTEM_PROMPT_TEXT = (
     "5. Finish with one complete sentence that starts with 'Human review:' and names what a human "
     "should inspect next (e.g. the channel around the flagged window vs. nominal runs). Never leave "
     "it empty. This is assistant-generated draft analysis, not a final disposition.\n"
-    "6. Be terse: 3 to 6 sentences, under 120 words. No preamble, no restating the question, no JSON.\n"
+    "6. Structure the output as TWO paragraphs separated by a blank line.\n"
+    "   First paragraph — technical briefing (3 to 5 sentences, under 100 words): model name, score vs. threshold, flagged window, and the human-review sentence.\n"
+    "   Second paragraph — start with the exact label 'Plain language:' on its own line, then 1-2 sentences any non-engineer can understand: describe what the system noticed in everyday terms (no acronyms, no raw numbers), and state clearly that a human must confirm before any action is taken.\n"
+    "   No preamble, no restating the question, no JSON.\n"
     "7. Public NASA analog data — never imply proprietary or real-vehicle telemetry."
 )
 

--- a/repo-b/src/components/telemetry/Copilot.module.css
+++ b/repo-b/src/components/telemetry/Copilot.module.css
@@ -1,0 +1,9 @@
+@keyframes caretBlink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+.caret {
+  animation: caretBlink 0.8s step-end infinite;
+  user-select: none;
+}

--- a/repo-b/src/components/telemetry/Copilot.tsx
+++ b/repo-b/src/components/telemetry/Copilot.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   askCopilot, explainVerdict, getGovernance, draftReport, recordDisposition,
   type CopilotResponse, type EvidenceItem, type ToolTraceItem, type GovernanceSummary,
   type DraftReportResponse, type DispositionResult,
 } from "@/lib/telemetry/copilot-api";
 import { C, Tag, Panel, Loading } from "./primitives";
+import styles from "./Copilot.module.css";
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
 
 export interface ReportContext { runKey: string; fireTick: number; channel?: string }
@@ -112,17 +113,45 @@ export function GovernanceStrip({ r }: { r: CopilotResponse }) {
   );
 }
 
-// ── Answer block (renders the markdown-ish prose simply) ───────────────────────
-function AnswerBody({ r }: { r: CopilotResponse }) {
+// ── Typewriter reveal ──────────────────────────────────────────────────────────
+// setTimeout-chain (not setInterval) so React 18 Strict Mode double-invocation
+// can't kill the animation: cleanup cancels only the pending next tick, not a
+// mid-run interval, so the second mount starts fresh and animates cleanly.
+// Lives at CopilotResult level so the timer survives sibling state updates.
+function useTypewriter(full: string | null, charsPerTick = 3, intervalMs = 18): [string, boolean] {
+  const [displayed, setDisplayed] = useState("");
+  const cancelRef = useRef(false);
+  useEffect(() => {
+    if (!full) { setDisplayed(""); return; }
+    cancelRef.current = false;
+    setDisplayed("");
+    let i = 0;
+    const tick = () => {
+      if (cancelRef.current) return;
+      i = Math.min(i + charsPerTick, full.length);
+      setDisplayed(full.slice(0, i));
+      if (i < full.length) setTimeout(tick, intervalMs);
+    };
+    const id = setTimeout(tick, intervalMs);
+    return () => { cancelRef.current = true; clearTimeout(id); };
+  }, [full, charsPerTick, intervalMs]);
+  const done = full != null && displayed.length >= full.length;
+  return [displayed, !done];
+}
+
+// ── Answer block ───────────────────────────────────────────────────────────────
+function AnswerBody({ r, displayed, typing }: { r: CopilotResponse; displayed: string; typing: boolean }) {
   const col = r.is_refusal ? C.amber : C.text;
   return (
     <div>
       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
         <Tag color={sourceColor(r.answer_source)}>{r.is_refusal ? "refused" : r.answer_source}</Tag>
+        {r.model && <Tag color={C.dim}>{r.model}</Tag>}
         {!r.is_refusal && <span style={{ fontFamily: C.mono, fontSize: 10, color: C.faint }}>assistant-generated draft — human review required</span>}
       </div>
       <p style={{ fontFamily: C.sans, fontSize: 13.5, color: col, lineHeight: 1.6, whiteSpace: "pre-wrap", margin: 0 }}>
-        {r.answer}
+        {displayed}
+        {typing && <span className={styles.caret}>▋</span>}
       </p>
     </div>
   );
@@ -193,6 +222,8 @@ export function CopilotResult({ r, reportContext }: { r: CopilotResponse; report
   const [drafting, setDrafting] = useState(false);
   const [evidenceOpened, setEvidenceOpened] = useState(0);
   const canDraft = !!reportContext && !r.is_refusal && r.evidence.length > 0;
+  // Typewriter lives here so the interval survives re-renders of this component's own state.
+  const [displayed, typing] = useTypewriter(r.answer ?? null);
 
   const onDraft = () => {
     if (!reportContext) return;
@@ -206,7 +237,7 @@ export function CopilotResult({ r, reportContext }: { r: CopilotResponse; report
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-      <Panel title="Answer"><AnswerBody r={r} /></Panel>
+      <Panel title="Answer"><AnswerBody r={r} displayed={displayed} typing={typing} /></Panel>
       {r.evidence.length > 0 && (
         <Panel title={`Evidence (${r.evidence.length})`}>
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))", gap: 10 }}>


### PR DESCRIPTION
## Summary

- **gpt-5 model**: `COPILOT_MODEL` switched from `gpt-5-mini` to `gpt-5` (already triggers reasoning-model path — `developer` role + `reasoning_effort=minimal`)
- **Two-paragraph prompt**: system prompt now requires a technical briefing paragraph followed by a `Plain language:` section for non-engineers
- **Typewriter reveal**: `setTimeout`-chain hook (`~167 chars/sec`) reveals the AI answer character-by-character with a blinking ▋ cursor; Strict Mode-safe via `cancelRef`; lives at `CopilotResult` level so sibling state can't remount it
- **Model badge**: `r.model` shown as a `Tag` next to `LIVE_LLM` — confirms `gpt-5` is live
- **`Copilot.module.css`**: `caretBlink` keyframe extracted from inline `<style>` tag

## Test plan

- [x] Frontend: `Copilot.test.tsx` — 6/6 pass
- [x] Backend: `test_copilot_telemetry.py` — 37/37 pass
- [ ] Manual: reload the Replay page → GROUNDED AI EXPLANATION types out with cursor; `gpt-5` badge visible; `Plain language:` paragraph appears below technical briefing

🤖 Generated with [Claude Code](https://claude.com/claude-code)