### PR TITLE
fix(telemetry): header accent for telemetry-named envs + .vercelignore collision guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,9 @@ jobs:
       - name: Assistant runtime validation
         run: node scripts/validate_assistant_runtime.mjs
 
+      - name: .vercelignore collision guard
+        run: node scripts/check_vercelignore_collisions.mjs
+
   frontend-quality:
     name: Frontend Lint + Typecheck + Unit
     runs-on: ubuntu-latest

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,25 +1,32 @@
 # Vercel builds only the frontend (Root Directory = repo-b). Exclude everything else from the
 # deploy upload — especially large ML/data artifacts that exceed Vercel's 100 MB file limit
 # (e.g. the 1 GB NASA IMS bearing archive under telemetry-platform/databricks/data/).
-telemetry-platform/
-backend/
-mcp-servers/
-notebooks/
-orchestration/
-verification/
-supabase/
-novendor-crm/
-excel-addin/
-ops/
-audit/
-compliance/
-eval_loop/
-artifacts/
-applications/
-Hone_work/
-reference/
-demo_docs/
-design_handoff_accounting_command_desk/
+#
+# IMPORTANT: every directory pattern below is **anchored with a leading `/`** so it excludes ONLY the
+# repo-root directory of that name. An UNANCHORED pattern (e.g. `audit/`) uses gitignore semantics and
+# matches a folder of that name at ANY depth — which silently drops real frontend folders like
+# `repo-b/src/app/lab/audit/` from the deploy upload. That class of bug fails ONLY at `vercel deploy`
+# (local `npm run build` and CI both pass — CI doesn't run `next build`), so it is enforced by
+# `scripts/check_vercelignore_collisions.mjs` in the repo-guardrails CI job. Keep these anchored.
+/telemetry-platform/
+/backend/
+/mcp-servers/
+/notebooks/
+/orchestration/
+/verification/
+/supabase/
+/novendor-crm/
+/excel-addin/
+/ops/
+/audit/
+/compliance/
+/eval_loop/
+/artifacts/
+/applications/
+/Hone_work/
+/reference/
+/demo_docs/
+/design_handoff_accounting_command_desk/
 *.pptx
 *.webp
 *.zip

--- a/repo-b/src/components/telemetry/buildops/manifest.ts
+++ b/repo-b/src/components/telemetry/buildops/manifest.ts
@@ -598,6 +598,7 @@ export const CI_GATES: CiGateRow[] = [
   { gate: "repo-guardrails", catches: "Assistant-runtime + repo guardrail violations.", evidence: "node scripts/check_repo_guardrails.mjs", blocks: true, sourceRefs: [CI] },
   { gate: "frontend-quality", catches: "lint + typecheck + vitest in repo-b.", evidence: "npm run lint/typecheck/test:unit", blocks: true, sourceRefs: [CI] },
   { gate: "db-schema-gate", catches: "Schema idempotency + RLS contract.", evidence: "apply twice + verify", blocks: true, sourceRefs: [CI] },
+  { gate: "vercelignore-collision-guard", catches: "A frontend folder silently dropped from the Vercel deploy upload by an unanchored .vercelignore pattern — a class of bug local `npm run build` and CI both miss (neither runs `next build`). Added after this exact failure: this very page's component folder was excluded; the deploy 500'd with 'Module not found' while local build + CI were green. Fixed in PR #462 (commit 57c459c5) + the .vercelignore anchored repo-wide.", evidence: "node scripts/check_vercelignore_collisions.mjs (repo-guardrails)", blocks: true, sourceRefs: [{ label: "check_vercelignore_collisions.mjs", path: "scripts/check_vercelignore_collisions.mjs" }, { label: ".vercelignore", path: ".vercelignore" }, CI] },
 ];
 
 // ── Section 9: evidence / "can I see…?" checklist ────────────────────────────────────────────────

--- a/repo-b/src/components/telemetry/telemetryArchitectureData.test.ts
+++ b/repo-b/src/components/telemetry/telemetryArchitectureData.test.ts
@@ -10,7 +10,9 @@ import { TELEMETRY_NAV } from "./telemetryNav";
 // intentionally hidden from the nav but still resolve (PR 2.1 hide-before-delete: Trust Center,
 // How This Works, Resume Evidence). Their page.tsx still exist, so an arch node pointing at them is
 // a real deep-link, not a dead one.
-const HIDDEN_BUT_RESOLVING = ["governance", "how-it-works", "evidence", "copilot"];
+// `monitoring` + `spike-inspector` were consolidated out of the nav (System Health was removed in
+// ecd47f50) but their page.tsx still resolve, so an arch node deep-linking to them is real, not dead.
+const HIDDEN_BUT_RESOLVING = ["governance", "how-it-works", "evidence", "copilot", "monitoring", "spike-inspector"];
 const VALID_SLUGS = new Set<string>([...TELEMETRY_NAV.map((n) => n.slug), ...HIDDEN_BUT_RESOLVING]);
 const ALL_NODES: ArchNode[] = ARCH_VIEWS.flatMap((v) => v.nodes);
 

--- a/repo-b/src/components/telemetry/telemetryArchitectureData.ts
+++ b/repo-b/src/components/telemetry/telemetryArchitectureData.ts
@@ -184,7 +184,7 @@ const MASTER_NODES: ArchNode[] = [
   // Lane B — operational serving
   n("B_db", 8, 1, "cylinder", "live", "Supabase / Postgres\noperational serving", 0, "The operational serving system of record.", "The always-on database of record. Everything the live app shows comes from here.", "sb"),
   n("B_api", 9, 1, "rect", "live", "FastAPI services", 0, "Does not import Spark or the full MLflow training stack.", "The web-service layer. Deliberately lightweight — it never runs the heavy training engine.", "api"),
-  n("B_ui", 10, 1, "screen", "live", "Monitoring · Registry\nSystem Health", 0, "", "Operational dashboards: monitoring, model registry, system health.", null, { slug: "system-health" }),
+  n("B_ui", 10, 1, "screen", "live", "Monitoring · Registry\nSystem Health", 0, "", "Operational dashboards: monitoring, model registry, system health.", null, { slug: "monitoring" }),
 
   // Lane C — ISS live streaming
   n("C_iss", 1, 2, "cloud", "optional", "ISS Lightstreamer\n(live)", -30, "Optional; fails closed when unavailable.", "A live feed of real telemetry from the International Space Station. Nice to have — if it drops, the system keeps working.", "iss"),
@@ -192,7 +192,7 @@ const MASTER_NODES: ArchNode[] = [
   n("C_open", 2, 2, "cloud", "optional", "OpenSky ADS-B\nfallback", -34, "", "A backup live feed (aircraft positions) used if the ISS feed is down.", null),
   n("C_ing", 2, 2, "rect", "live", "telemetry_stream_ingest", 30, "", "Takes each incoming reading and stores it.", "api"),
   n("C_bz", 3, 2, "cylinder", "live", "tel_stream_readings\n_bronze", 0, "", "Raw streamed readings, as they arrive.", "sb", { slug: "stream" }),
-  n("C_sv", 4, 2, "cylinder", "live", "tel_stream_readings\ntel_stream_minute_agg", 0, "", "Cleaned readings plus per-minute summaries.", "sb", { slug: "system-health" }),
+  n("C_sv", 4, 2, "cylinder", "live", "tel_stream_readings\ntel_stream_minute_agg", 0, "", "Cleaned readings plus per-minute summaries.", "sb", { slug: "monitoring" }),
   n("C_ev", 8, 2, "cylinder", "live", "tel_anomaly_events\ntel_dq_assertions", 0, "", "Flagged anomalies and data-quality checks.", "sb"),
   n("C_api", 9, 2, "rect", "live", "/stream/live\n/stream/health", 0, "", "Endpoints the live-stream dashboards poll.", "api"),
   n("C_ui", 10, 2, "screen", "live", "Mission Control Stream\nSystem Health", 0, "", "The live Mission Control stream and system-health screens.", null, { slug: "stream" }),
@@ -326,7 +326,7 @@ const STREAM_NODES: ArchNode[] = [
   d("s_bz", 3, 1, "cylinder", "live", "tel_stream_readings\n_bronze", "Raw streamed readings, as received.", "sb", { slug: "stream" }),
   d("s_etl", 4, 1, "rect", "live", "telemetry_stream_etl", "Cleans the readings and rolls them up.", "api"),
   d("s_rd", 5, 0.4, "cylinder", "live", "tel_stream_readings", "The cleaned per-reading table.", "sb"),
-  d("s_agg", 5, 1.6, "cylinder", "live", "tel_stream_minute_agg", "Per-minute summaries.", "sb", { slug: "system-health" }),
+  d("s_agg", 5, 1.6, "cylinder", "live", "tel_stream_minute_agg", "Per-minute summaries.", "sb", { slug: "monitoring" }),
   d("s_state", 6, 1, "cylinder", "live", "tel_anomaly_events · dq_assertions\netl_watermarks · pipeline_status", "Anomalies, data-quality checks, and pipeline bookkeeping.", "sb", { width: 214 }),
   d("s_api", 7, 1, "rect", "live", "/api/telemetry/stream\n/live · /health", "Endpoints the live dashboards poll.", "api"),
   d("s_ui", 8, 1, "screen", "live", "Mission Control Stream\nSystem Health", "The live ISS stream and health screens.", null, { slug: "stream" }),

--- a/repo-b/src/components/telemetry/telemetryNav.test.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.test.ts
@@ -151,6 +151,28 @@ describe("telemetry navigation structure (7 presentation sections)", () => {
     }
   });
 
+  it("resolves the category color when the ENV ID itself contains 'telemetry' (real prod env)", () => {
+    // Regression: the prod telemetry env id is "telemetry-demo". A naive indexOf("/telemetry") matched
+    // inside "/telemetry-demo" so every page fell back to the Overview cyan accent. The section must be
+    // matched as a whole path segment, not a substring.
+    const base = "/lab/env/telemetry-demo/telemetry";
+    const cases: Array<[string, string]> = [
+      [base, "Overview"],
+      [`${base}/ai-build-ops`, "Evidence & Lineage"],
+      [`${base}/metadata`, "Evidence & Lineage"],
+      [`${base}/model-performance`, "Models & Intelligence"],
+      [`${base}/factory-ml`, "Factory & Quality"],
+      [`${base}/control-tower`, "Agent Operations"],
+      [`${base}/relativity-mes/ncr`, "Relativity MES Sandbox"],
+    ];
+    for (const [path, group] of cases) {
+      expect(telemetryGroupForPath(path)).toBe(group);
+      expect(telemetryAccentForPath(path)).toBe(TELEMETRY_NAV_GROUP_META[group as keyof typeof TELEMETRY_NAV_GROUP_META].accent);
+    }
+    // The specific failing value before the fix: green Evidence & Lineage, not Overview cyan.
+    expect(telemetryAccentForPath(`${base}/ai-build-ops`)).toBe("#6ee7a0");
+  });
+
   it("no longer surfaces any Data Engineering nav items (group hidden; routes still resolve)", () => {
     expect(TELEMETRY_NAV.filter((n) => n.group === "Data Engineering")).toHaveLength(0);
     // The nested route still builds/recognizes for deep links even though it is not in the nav.

--- a/repo-b/src/components/telemetry/telemetryNav.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.ts
@@ -160,11 +160,15 @@ const TELEMETRY_SLUG_GROUP: Record<string, TelemetryNavGroup> = {
 
 /** Group owning a telemetry pathname (best-effort; defaults to Overview). */
 export function telemetryGroupForPath(pathname: string): TelemetryNavGroup {
+  // Match "/telemetry" only as a whole path segment (followed by "/" or end-of-path), NOT as a bare
+  // substring — otherwise an env id that contains "telemetry" (e.g. /lab/env/telemetry-demo/…) matches
+  // inside the env id, `rest` becomes "-demo/telemetry/…", and every page falls back to the Overview
+  // accent. The `(?=\/|$)` lookahead skips "/telemetry-demo" and lands on the real section root.
   const marker = "/telemetry";
-  const i = pathname.indexOf(marker);
-  if (i === -1) return "Overview";
+  const m = pathname.match(/\/telemetry(?=\/|$)/);
+  if (!m || m.index === undefined) return "Overview";
   // Everything after "/telemetry/" — "" at the section root, else "factory", "relativity-mes/ncr", …
-  const rest = pathname.slice(i + marker.length).replace(/^\/+/, "").replace(/[?#].*$/, "");
+  const rest = pathname.slice(m.index + marker.length).replace(/^\/+/, "").replace(/[?#].*$/, "");
   if (rest === "") return "Overview";
   if (rest.startsWith("relativity-mes")) return "Relativity MES Sandbox";
   if (rest.startsWith("data-engineering")) return "Data Engineering";

--- a/scripts/check_vercelignore_collisions.mjs
+++ b/scripts/check_vercelignore_collisions.mjs
@@ -1,0 +1,95 @@
+// Guard against the ".vercelignore unanchored folder" deploy trap.
+//
+// .vercelignore uses gitignore semantics: an UNANCHORED directory pattern like `audit/` (no leading
+// `/`) matches a folder of that name at ANY depth. So a real shippable frontend folder such as
+// `repo-b/src/app/lab/audit/` gets silently dropped from the Vercel deploy upload. If a page/route in
+// that folder is imported elsewhere, the production build fails with `Module not found`; if it is just
+// a route segment, the route silently 404s in prod. Either way:
+//   - local `npm run build` PASSES (the files are present locally), and
+//   - CI PASSES (the frontend job runs lint/typecheck/vitest, NOT `next build`),
+// so the failure surfaces only at `vercel deploy`. This guard closes that gap.
+//
+// Rule: no UNANCHORED bare-directory pattern in .vercelignore may match a directory name that also
+// exists anywhere under repo-b/src (the shippable frontend). Fix a violation by EITHER anchoring the
+// pattern (`/name/` — excludes only the repo-root dir) OR renaming the colliding frontend folder.
+//
+// Exit 0 = clean, exit 1 = collision(s) found.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const VERCELIGNORE = path.join(ROOT, ".vercelignore");
+const FRONTEND_SRC = path.join(ROOT, "repo-b", "src");
+
+/** Parse .vercelignore into the set of UNANCHORED bare-directory-name patterns. */
+function parseUnanchoredDirPatterns(text) {
+  const out = [];
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue; // blank / comment
+    if (line.startsWith("/") || line.startsWith("!")) continue; // anchored or negated — safe
+    if (line.includes("*") || line.includes("?")) continue; // glob (e.g. *.zip) — not a dir-name match
+    const name = line.replace(/\/$/, ""); // drop trailing slash
+    if (!name || name.includes("/")) continue; // must be a bare single segment
+    out.push(name);
+  }
+  return out;
+}
+
+/** Collect the set of directory names that exist anywhere under repo-b/src. */
+async function collectDirNames(dir, acc = new Map()) {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return acc;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === "node_modules" || entry.name === ".next") continue;
+    const full = path.join(dir, entry.name);
+    const rel = path.relative(ROOT, full).split(path.sep).join("/");
+    if (!acc.has(entry.name)) acc.set(entry.name, []);
+    acc.get(entry.name).push(rel);
+    await collectDirNames(full, acc);
+  }
+  return acc;
+}
+
+async function main() {
+  const text = await fs.readFile(VERCELIGNORE, "utf8");
+  const patterns = parseUnanchoredDirPatterns(text);
+  const dirNames = await collectDirNames(FRONTEND_SRC);
+
+  const violations = [];
+  for (const name of patterns) {
+    const hits = dirNames.get(name);
+    if (hits && hits.length) violations.push({ name, hits });
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `[vercelignore-guard] OK — no unanchored .vercelignore pattern collides with repo-b/src ` +
+        `(${patterns.length} bare-dir pattern(s) checked).`,
+    );
+    return;
+  }
+
+  console.error("[vercelignore-guard] FAIL — unanchored .vercelignore pattern(s) drop shippable frontend folders:\n");
+  for (const v of violations) {
+    console.error(`  pattern "${v.name}/" (unanchored) excludes these from the Vercel deploy upload:`);
+    for (const h of v.hits) console.error(`    - ${h}`);
+  }
+  console.error(
+    "\nFix: anchor the pattern to the repo root (`/" + violations[0].name + "/`) so it only excludes the\n" +
+      "top-level directory, OR rename the colliding frontend folder. This is invisible to `npm run build`\n" +
+      "and CI (neither runs `next build`); it only breaks at `vercel deploy`.",
+  );
+  process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error("[vercelignore-guard] error:", err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Surfaced by an **authenticated production click-through** of the new AI Build & Operations Reference page (`/lab/env/telemetry-demo/telemetry/ai-build-ops`). Three fixes:

## 1. Header accent bug (`telemetryGroupForPath`)
The page title / eyebrow / TOC rendered in **Overview cyan** instead of the **green Evidence & Lineage** accent. Root cause: `pathname.indexOf("/telemetry")` matched inside the prod env id `telemetry-demo` (`/lab/env/**telemetry**-demo/...`), so `rest` became `-demo/...` → unknown slug → Overview fallback. Fixed by matching `/telemetry` as a **whole path segment** (`/\/telemetry(?=\/|$)/`).

This affected **every telemetry page header** on any env whose id contains "telemetry" (i.e. the real prod env). Unit tests used env id `env-1`, so they never caught it — added regression cases on a `telemetry-demo` base.

## 2. `.vercelignore` over-exclusion (restores missing prod routes)
Bare directory patterns use gitignore semantics and matched **nested `repo-b/src` route folders**, silently dropping them from the Vercel deploy upload. These routes were **not shipping to production**:
- `audit/` → `repo-b/src/app/lab/audit`, `.../credit/audit`, `.../pds/audit`, `api/v1/audit`, …
- `compliance/` → `repo-b/src/app/app/compliance`, `.../legal/compliance`
- `notebooks/` → `repo-b/src/app/lab/env/[envId]/supply-chain/notebooks`
- `artifacts/` → `repo-b/src/app/happyco/artifacts`, `api/happyco/artifacts`

Anchored every directory pattern to the repo root (`/name/`) so it excludes only the top-level dir (the original intent — the comment is about top-level non-frontend dirs). **This restores those routes to prod.** ⚠️ Reviewer note: if any of those routes were *intentionally* hidden from prod, say so and I'll exclude them explicitly instead.

## 3. Regression guard (CI)
New `scripts/check_vercelignore_collisions.mjs` fails when an unanchored `.vercelignore` dir pattern collides with a `repo-b/src` folder; wired into the **repo-guardrails** CI job. This class of bug is invisible to `npm run build` and CI (neither runs `next build`) — it only breaks at `vercel deploy`, exactly how it bit #459/#462.

Also records the deploy-guardrail incident as a CI-gate row on the reference page itself (`manifest.ts`), citing PR #462 / commit `57c459c5`.

## Verification
- `npm run typecheck` clean (fresh `.next`); `npm run lint` clean for touched files
- `npx vitest run telemetryNav.test.ts buildops/AiBuildOpsReference.test.tsx` — 15/15 (incl. new accent regression on a telemetry-named env)
- Guard: passes on the anchored `.vercelignore` (0 collisions); fails with a clear message when an unanchored colliding pattern is re-introduced
- Post-merge: re-deploy + re-capture authenticated screenshots showing the **green** accent

🤖 Generated with [Claude Code](https://claude.com/claude-code)