### PR TITLE
feat(relativity-mes): Build Analytics — simulation-analysis surface, Batch A (#752)

### DIFF
--- a/backend/app/routes/relativity_mes.py
+++ b/backend/app/routes/relativity_mes.py
@@ -48,6 +48,13 @@ def lineage(env_id: str = Query(...), business_id: UUID = Query(...)):
     return svc.lineage(env_id=env_id, business_id=business_id)
 
 
+@router.get("/analytics")
+def analytics(env_id: str = Query(...), business_id: UUID = Query(...),
+              vehicle_serial: str | None = Query(None)):
+    """Build Analytics simulation-analysis blocks. vehicle_serial refilters readiness+bridge only."""
+    return svc.analytics(env_id=env_id, business_id=business_id, vehicle_serial=vehicle_serial)
+
+
 @router.get("/source/{table}")
 def source(table: str, env_id: str = Query(...), business_id: UUID = Query(...),
            key: str | None = Query(None), value: str | None = Query(None),

--- a/backend/app/services/relativity_mes.py
+++ b/backend/app/services/relativity_mes.py
@@ -33,6 +33,10 @@ SOURCE_TABLES = {
 _COL_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
 _MISSING = (psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn, psycopg.errors.InsufficientPrivilege)
 
+# |variance %| at/above which a work order is an MES↔ERP reconciliation exception. Single source of
+# truth (the generator's gold writer uses the same 25); covered by a boundary test so it cannot drift.
+RECON_EXCEPTION_PCT = 25.0
+
 
 def _kind(rows: list) -> str:
     return "live-rows" if rows else "unavailable"
@@ -196,6 +200,276 @@ def _cost_kpis(rollup: list[dict], recon: list[dict]) -> dict:
         "labor_variance": s(rollup, "labor_actual_cost"),
         "ncr_rework_cost": s(rollup, "ncr_rework_cost"),
         "unreconciled_rows": len([r for r in recon if r.get("reconciliation_status") == "exception"]),
+    }
+
+
+# ── Build Analytics (Phase 10) — simulation-analysis blocks over the rel_* serving marts ──────────
+# Display-only, fail-closed PER BLOCK. Every number traces to a serving row; concentration/ratio stats
+# are computed, not asserted. Multi-seed stability + scenario manifest + data-quality are receipt-backed
+# (Batch B) and fail closed in the response until their committed receipts land.
+
+def _f(v) -> float:
+    try:
+        return float(v) if v is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _fetch(cur, table: str, env_id: str, business_id: UUID, order_col: str) -> list[dict]:
+    cur.execute(f"SELECT * FROM {table} WHERE env_id = %s AND business_id = %s ORDER BY {order_col}",
+                (env_id, str(business_id)))
+    return [dict(r) for r in cur.fetchall()]
+
+
+def _readiness_block(ov: list[dict], ncrs: list[dict], vehicle_serial: str | None) -> dict:
+    rows = []
+    for v in ov:
+        if vehicle_serial and v.get("vehicle_serial") != vehicle_serial:
+            continue
+        state = v.get("readiness_state")
+        if state == "blocked":
+            driver = "open major NCR" if v.get("open_ncr_count") else "blocked"
+        elif state == "at_risk":
+            driver = f"variance {round(_f(v.get('variance_pct')), 1)}%"
+        else:
+            driver = "on track"
+        if v.get("affected_by_suspect_lot"):
+            driver += " · suspect lot"
+        rows.append({"vehicle_serial": v.get("vehicle_serial"), "readiness_state": state,
+                     "open_ncr_count": int(_f(v.get("open_ncr_count"))),
+                     "variance_pct": round(_f(v.get("variance_pct")), 2),
+                     "suspect_lot_flag": bool(v.get("affected_by_suspect_lot")), "driver": driver})
+    return {"rows": rows, "null_reason": None if rows else "serving_not_loaded"}
+
+
+def _asymmetry_block(ov: list[dict], ncrs: list[dict], geneal: list[dict]) -> dict:
+    """Why one suspect-lot vehicle is blocked and another is not — derived from rows, not prose."""
+    exposed = sorted({g.get("vehicle_serial") for g in geneal
+                      if g.get("child_type") == "lot" and g.get("lot_no")
+                      and any(o.get("vehicle_serial") == g.get("vehicle_serial") and o.get("affected_by_suspect_lot") for o in ov)})
+    if len(exposed) < 2:
+        return {"rows": [], "shared_exposure": exposed, "null_reason": "no_shared_exposure"}
+    rows = []
+    for vs in exposed:
+        ov_row = next((o for o in ov if o.get("vehicle_serial") == vs), {})
+        v_ncrs = [n for n in ncrs if n.get("vehicle_serial") == vs]
+        open_major = [n for n in v_ncrs if n.get("status") == "open" and n.get("severity") == "major"]
+        lot_wo = next((g.get("work_order_no") for g in geneal
+                       if g.get("vehicle_serial") == vs and g.get("child_type") == "lot"), None)
+        rows.append({
+            "vehicle_serial": vs, "readiness_state": ov_row.get("readiness_state"),
+            "open_ncr_count": int(_f(ov_row.get("open_ncr_count"))),
+            "open_major_ncr": len(open_major), "lot_install_wo": lot_wo,
+            "note": ("open major NCR on the lot install" if open_major
+                     else "lot installed; no open major NCR on it"),
+        })
+    return {"rows": rows, "shared_exposure": exposed, "null_reason": None}
+
+
+def _blast_block(ov: list[dict], ncrs: list[dict], recon: list[dict], geneal: list[dict]) -> dict:
+    lot_edges = [g for g in geneal if g.get("child_type") == "lot" and g.get("lot_no")]
+    if not lot_edges:
+        return {"rows_present": False, "null_reason": "no_suspect_lot", "lot_id": None,
+                "part_number": None, "vehicles": [], "ncrs": [], "work_orders": [], "edges": []}
+    # the suspect lot = the lot with the widest where-used (exposure)
+    by_lot: dict[str, set] = {}
+    for g in lot_edges:
+        by_lot.setdefault(g["lot_no"], set()).add(g.get("vehicle_serial"))
+    lot_id = max(by_lot, key=lambda k: len(by_lot[k]))
+    part_number = next((g.get("part_no") for g in lot_edges if g.get("lot_no") == lot_id), None)
+    veh_serials = sorted(v for v in by_lot[lot_id] if v)
+    vehicles = [{"vehicle_serial": vs,
+                 "readiness_state": next((o.get("readiness_state") for o in ov if o.get("vehicle_serial") == vs), None)}
+                for vs in veh_serials]
+    lot_ncrs = [n for n in ncrs if n.get("lot_no") == lot_id]
+    ncr_rows = [{"ncr_id": n.get("ncr_id"), "severity": n.get("severity"), "status": n.get("status"),
+                 "rework_cost": round(_f(n.get("estimated_rework_cost")), 2)} for n in lot_ncrs]
+    wo_ids = {n.get("work_order_no") for n in lot_ncrs if n.get("work_order_no")}
+    wos = [{"work_order_id": r.get("work_order_no"), "variance_pct": round(_f(r.get("variance_pct")), 2),
+            "actual_cost": round(_f(r.get("actual_cost")), 2), "standard_cost": round(_f(r.get("standard_cost")), 2)}
+           for r in recon if r.get("work_order_no") in wo_ids]
+    edges = ([{"from": lot_id, "to": vs, "label": "where-used"} for vs in veh_serials]
+             + [{"from": lot_id, "to": n["ncr_id"], "label": n.get("severity")} for n in ncr_rows]
+             + [{"from": n["ncr_id"], "to": w["work_order_id"], "label": f"{w['variance_pct']}%"}
+                for n, w in zip(ncr_rows, wos)])
+    return {"rows_present": True, "null_reason": None, "lot_id": lot_id, "part_number": part_number,
+            "vehicles": vehicles, "ncrs": ncr_rows, "work_orders": wos, "edges": edges}
+
+
+def _bridge_block(ov: list[dict], rollup: list[dict], vehicle_serial: str | None) -> dict:
+    rows = []
+    for v in ov:
+        vs = v.get("vehicle_serial")
+        if vehicle_serial and vs != vehicle_serial:
+            continue
+        vr = [r for r in rollup if r.get("vehicle_serial") == vs]
+        material = round(sum(_f(r.get("material_actual_cost")) for r in vr), 2)
+        labor_oh = round(sum(_f(r.get("labor_actual_cost")) + _f(r.get("overhead_cost")) for r in vr), 2)
+        rework = round(sum(_f(r.get("ncr_rework_cost")) for r in vr), 2)
+        actual = round(_f(v.get("actual_cost")), 2)
+        # analytics-only reconciliation residual: what 'actual' does NOT explain via the components.
+        residual = round(actual - (material + labor_oh + rework), 2)
+        rows.append({"vehicle_serial": vs, "planned_cost": round(_f(v.get("planned_cost")), 2),
+                     "material": material, "labor_overhead": labor_oh, "rework": rework,
+                     "residual": residual, "actual_cost": actual})
+    explained = sum(r["material"] + r["labor_overhead"] + r["rework"] for r in rows)
+    actual_tot = sum(r["actual_cost"] for r in rows)
+    reconciled_pct = round(explained / actual_tot * 100, 2) if actual_tot else None
+    return {"rows": rows, "reconciled_pct": reconciled_pct,
+            "residual_total": round(actual_tot - explained, 2),
+            "null_reason": None if rows else "serving_not_loaded"}
+
+
+def _pareto_block(ncrs: list[dict]) -> dict:
+    if not ncrs:
+        return {"rows": [], "concentration_pct": None, "null_reason": "serving_not_loaded"}
+    agg: dict[str, dict] = {}
+    for n in ncrs:
+        label = n.get("cluster_label") or f"{n.get('defect_code')}·{n.get('work_center')}"
+        a = agg.setdefault(label, {"cluster_label": label, "ncr_count": 0, "rework_cost": 0.0})
+        a["ncr_count"] += 1
+        a["rework_cost"] += _f(n.get("estimated_rework_cost"))
+    ranked = sorted(agg.values(), key=lambda x: x["rework_cost"], reverse=True)
+    total = sum(a["rework_cost"] for a in ranked) or 0.0
+    cum = 0.0
+    for a in ranked:
+        a["rework_cost"] = round(a["rework_cost"], 2)
+        cum += a["rework_cost"]
+        a["cumulative_rework_pct"] = round(cum / total * 100, 2) if total else 0.0
+    concentration = round(ranked[0]["rework_cost"] / total * 100, 2) if total else None
+    return {"rows": ranked, "concentration_pct": concentration, "n_ncrs": len(ncrs), "null_reason": None}
+
+
+def _workcenter_block(ops: list[dict], wos: list[dict]) -> dict:
+    if not ops:
+        return {"rows": [], "null_reason": "serving_not_loaded"}
+    sub_by_wo = {w.get("work_order_no"): w.get("subassembly") for w in wos}
+    agg: dict[tuple, dict] = {}
+    for o in ops:
+        wc = o.get("work_center") or "unknown"
+        sub = sub_by_wo.get(o.get("work_order_no")) or "unknown"
+        a = agg.setdefault((wc, sub), {"work_center": wc, "subassembly": sub,
+                                       "actual_minutes": 0.0, "std_minutes": 0.0, "op_count": 0})
+        a["actual_minutes"] += _f(o.get("actual_minutes"))
+        a["std_minutes"] += _f(o.get("std_minutes"))
+        a["op_count"] += 1
+    rows = []
+    for a in agg.values():
+        a["actual_minutes"] = round(a["actual_minutes"], 1)
+        a["std_minutes"] = round(a["std_minutes"], 1)
+        a["actual_std_ratio"] = round(a["actual_minutes"] / a["std_minutes"], 3) if a["std_minutes"] else None
+        a["low_n"] = a["op_count"] < 5
+        rows.append(a)
+    rows.sort(key=lambda x: x["actual_minutes"], reverse=True)
+    return {"rows": rows, "null_reason": None}
+
+
+def _recon_block(recon: list[dict]) -> dict:
+    if not recon:
+        return {"rows": [], "threshold_sensitivity": [], "null_reason": "serving_not_loaded"}
+    rows = []
+    for r in recon:
+        vp = _f(r.get("variance_pct"))
+        rows.append({"work_order_id": r.get("work_order_no"), "vehicle_serial": r.get("vehicle_serial"),
+                     "standard_cost": round(_f(r.get("standard_cost")), 2),
+                     "actual_cost": round(_f(r.get("actual_cost")), 2),
+                     "variance_pct": round(vp, 2), "variance_category": r.get("variance_category"),
+                     "reconciliation_status": r.get("reconciliation_status"),
+                     "is_exception": abs(vp) >= RECON_EXCEPTION_PCT})
+    # threshold sensitivity: how many WOs are exceptions as the band moves — shows the fixed band's grip.
+    sweep = [{"k": k, "exception_count": sum(1 for r in recon if abs(_f(r.get("variance_pct"))) >= k)}
+             for k in (15, 20, 25, 30, 40, 50, 65)]
+    return {"rows": rows, "threshold_sensitivity": sweep, "exception_threshold_pct": RECON_EXCEPTION_PCT,
+            "null_reason": None}
+
+
+def _disconfirmation_block(recon: list[dict], ncrs: list[dict], ov: list[dict], geneal: list[dict]) -> dict:
+    """Look for what the scenario did NOT plant — the 'not replaying seeds' rebuttal. Honest 0 is fine."""
+    ncr_wos = {n.get("work_order_no") for n in ncrs if n.get("work_order_no")}
+    findings = []
+    # 1) WO over threshold with no linked NCR
+    for r in recon:
+        if abs(_f(r.get("variance_pct"))) >= RECON_EXCEPTION_PCT and r.get("work_order_no") not in ncr_wos:
+            findings.append({"kind": "exception_without_ncr", "ref": r.get("work_order_no"),
+                             "detail": f"variance {round(_f(r.get('variance_pct')),1)}% but no linked NCR"})
+    # 2) NCR with rework $ but its WO is not a cost exception
+    recon_excep_wo = {r.get("work_order_no") for r in recon if abs(_f(r.get("variance_pct"))) >= RECON_EXCEPTION_PCT}
+    for n in ncrs:
+        if _f(n.get("estimated_rework_cost")) > 0 and n.get("work_order_no") not in recon_excep_wo:
+            findings.append({"kind": "rework_without_variance", "ref": n.get("ncr_id"),
+                             "detail": "rework cost recorded but its work order is within tolerance"})
+    # 3) suspect-lot exposed vehicle that is not blocked
+    exposed = {g.get("vehicle_serial") for g in geneal if g.get("child_type") == "lot"}
+    for o in ov:
+        if o.get("vehicle_serial") in exposed and o.get("readiness_state") != "blocked":
+            findings.append({"kind": "exposed_not_blocked", "ref": o.get("vehicle_serial"),
+                             "detail": f"contains a suspect lot but readiness={o.get('readiness_state')}"})
+    return {"findings": findings, "checks_run": 3, "null_reason": None}
+
+
+def _analytics_kpis(ov: list[dict], rollup: list[dict], recon: list[dict], ncrs: list[dict],
+                    ops: list[dict]) -> dict:
+    total_variance = round(sum(_f(r.get("variance_amount")) for r in recon), 2)
+    actual_tot = sum(_f(r.get("total_actual_cost")) for r in rollup) or 0.0
+    rework_tot = sum(_f(r.get("ncr_rework_cost")) for r in rollup)
+    excep = len([r for r in recon if str(r.get("reconciliation_status")) == "exception"])
+    suspect_vehicles = len([o for o in ov if o.get("affected_by_suspect_lot")])
+    wc_minutes: dict[str, float] = {}
+    for o in ops:
+        wc_minutes[o.get("work_center") or "unknown"] = wc_minutes.get(o.get("work_center") or "unknown", 0.0) + _f(o.get("actual_minutes"))
+    busiest = max(wc_minutes, key=wc_minutes.get) if wc_minutes else None
+    rework_by_cluster: dict[str, float] = {}
+    for n in ncrs:
+        label = n.get("cluster_label") or "unknown"
+        rework_by_cluster[label] = rework_by_cluster.get(label, 0.0) + _f(n.get("estimated_rework_cost"))
+    ncr_rework_tot = sum(rework_by_cluster.values()) or 0.0
+    concentration = round(max(rework_by_cluster.values()) / ncr_rework_tot * 100, 2) if ncr_rework_tot else None
+    return {
+        "total_variance": total_variance,
+        "rework_share_pct": round(rework_tot / actual_tot * 100, 2) if actual_tot else None,
+        "recon_exception_count": excep,
+        "suspect_lot_vehicle_count": suspect_vehicles,
+        "busiest_work_center": busiest,
+        "defect_concentration_pct": concentration,
+    }
+
+
+def analytics(*, env_id: str, business_id: UUID, vehicle_serial: str | None = None) -> dict:
+    """Build Analytics — live simulation-analysis blocks over the rel_* serving marts.
+
+    Per-block null_reason (one empty supporting mart degrades that block, not the page). Page-level
+    null_reason only if a CORE mart (rel_build_overview or rel_build_cost_rollup) is empty. vehicle_serial
+    refilters readiness + bridge only; the program-wide blocks (blast/pareto/workcenter/recon/
+    disconfirmation/asymmetry) stay global.
+    """
+    try:
+        with get_cursor() as cur:
+            resolve_tenant_id(cur, business_id)
+            ov = _fetch(cur, "rel_build_overview", env_id, business_id, "vehicle_serial")
+            rollup = _fetch(cur, "rel_build_cost_rollup", env_id, business_id, "work_order_no")
+            recon = _fetch(cur, "rel_mes_erp_reconciliation", env_id, business_id, "work_order_no")
+            ncrs = _fetch(cur, "rel_ncr_traceability", env_id, business_id, "ncr_id")
+            geneal = _fetch(cur, "rel_as_built_genealogy", env_id, business_id, "vehicle_serial")
+            ops = _fetch(cur, "rel_mes_operation_execution", env_id, business_id, "exec_id")
+            wos = _fetch(cur, "rel_mes_work_order", env_id, business_id, "work_order_no")
+    except _MISSING:
+        return _empty("serving_table_missing", kpis=None, blocks={})
+    if not ov or not rollup:
+        return _empty("serving_not_loaded", kpis=None, blocks={})
+    return {
+        "source_kind": "live-rows", "serving_provenance": _provenance(ov), "as_of": _as_of(ov),
+        "null_reason": None,
+        "kpis": _analytics_kpis(ov, rollup, recon, ncrs, ops),
+        "blocks": {
+            "readiness": _readiness_block(ov, ncrs, vehicle_serial),
+            "asymmetry": _asymmetry_block(ov, ncrs, geneal),
+            "blast": _blast_block(ov, ncrs, recon, geneal),
+            "bridge": _bridge_block(ov, rollup, vehicle_serial),
+            "pareto": _pareto_block(ncrs),
+            "workcenter": _workcenter_block(ops, wos),
+            "recon": _recon_block(recon),
+            "disconfirmation": _disconfirmation_block(recon, ncrs, ov, geneal),
+        },
     }
 
 

--- a/backend/tests/test_relativity_mes.py
+++ b/backend/tests/test_relativity_mes.py
@@ -130,3 +130,125 @@ def test_route_overview_wired(client, fake_cursor):
     body = resp.json()
     assert body["source_kind"] == "live-rows"
     assert body["rows"][0]["vehicle_serial"] == "VEH-DEMO-001"
+
+
+# ── Build Analytics (Phase 10 hardening) ──────────────────────────────────────
+
+def _analytics_scenario(fc):
+    """Push a small realistic scenario: 3 vehicles; suspect lot on 001 & 002; one cost exception WO
+    (WO-003-AVI) with NO linked NCR (a non-authored finding); VEH-DEMO-002 exposed but on_track."""
+    _resolve(fc)
+    fc.push_result([  # rel_build_overview
+        {"vehicle_serial": "VEH-DEMO-001", "readiness_state": "blocked", "affected_by_suspect_lot": True,
+         "open_ncr_count": 1, "planned_cost": 10000, "actual_cost": 16000, "variance_pct": 60,
+         "variance_amount": 6000, "serving_provenance": "seed-bootstrap", "as_of": "2026-06-26"},
+        {"vehicle_serial": "VEH-DEMO-002", "readiness_state": "on_track", "affected_by_suspect_lot": True,
+         "open_ncr_count": 0, "planned_cost": 10000, "actual_cost": 10500, "variance_pct": 5,
+         "variance_amount": 500, "serving_provenance": "seed-bootstrap", "as_of": "2026-06-26"},
+        {"vehicle_serial": "VEH-DEMO-003", "readiness_state": "at_risk", "affected_by_suspect_lot": False,
+         "open_ncr_count": 0, "planned_cost": 8000, "actual_cost": 11000, "variance_pct": 37.5,
+         "variance_amount": 3000, "serving_provenance": "seed-bootstrap", "as_of": "2026-06-26"},
+    ])
+    fc.push_result([  # rel_build_cost_rollup
+        {"vehicle_serial": "VEH-DEMO-001", "work_order_no": "WO-001-TPS", "material_actual_cost": 6000,
+         "labor_actual_cost": 4000, "overhead_cost": 1800, "ncr_rework_cost": 4200, "total_actual_cost": 16000},
+        {"vehicle_serial": "VEH-DEMO-002", "work_order_no": "WO-002-STR", "material_actual_cost": 4000,
+         "labor_actual_cost": 4000, "overhead_cost": 1800, "ncr_rework_cost": 0, "total_actual_cost": 10500},
+    ])
+    fc.push_result([  # rel_mes_erp_reconciliation
+        {"vehicle_serial": "VEH-DEMO-001", "work_order_no": "WO-001-TPS", "standard_cost": 9400,
+         "actual_cost": 16000, "variance_pct": 70, "variance_amount": 6600, "variance_category": "over",
+         "reconciliation_status": "exception"},
+        {"vehicle_serial": "VEH-DEMO-002", "work_order_no": "WO-002-STR", "standard_cost": 10000,
+         "actual_cost": 10500, "variance_pct": 5, "variance_amount": 500, "variance_category": "in_band",
+         "reconciliation_status": "reconciled"},
+        {"vehicle_serial": "VEH-DEMO-003", "work_order_no": "WO-003-AVI", "standard_cost": 8000,
+         "actual_cost": 11000, "variance_pct": 37.5, "variance_amount": 3000, "variance_category": "over",
+         "reconciliation_status": "exception"},
+    ])
+    fc.push_result([  # rel_ncr_traceability
+        {"ncr_id": "NCR-0001", "vehicle_serial": "VEH-DEMO-001", "lot_no": "LOT-7788",
+         "work_order_no": "WO-001-TPS", "work_center": "WC-NDE", "defect_code": "witness-mark",
+         "severity": "major", "status": "open", "age_days": 6, "estimated_rework_cost": 4200,
+         "cluster_label": "witness-mark·WC-NDE"},
+        {"ncr_id": "NCR-0002", "vehicle_serial": "VEH-DEMO-002", "lot_no": None,
+         "work_order_no": "WO-002-STR", "work_center": "WC-WELD", "defect_code": "weld-undercut",
+         "severity": "major", "status": "closed", "age_days": 6, "estimated_rework_cost": 2650,
+         "cluster_label": "weld-undercut·WC-WELD"},
+    ])
+    fc.push_result([  # rel_as_built_genealogy
+        {"vehicle_serial": "VEH-DEMO-001", "child_type": "lot", "lot_no": "LOT-7788",
+         "part_no": "PN-TPS-SEAL", "work_order_no": "WO-001-TPS"},
+        {"vehicle_serial": "VEH-DEMO-002", "child_type": "lot", "lot_no": "LOT-7788",
+         "part_no": "PN-TPS-SEAL", "work_order_no": "WO-002-TPS"},
+    ])
+    fc.push_result(  # rel_mes_operation_execution (6 on WC-NDE, 2 on WC-WELD → low_n)
+        [{"work_center": "WC-NDE", "work_order_no": "WO-001-TPS", "actual_minutes": 30, "std_minutes": 25} for _ in range(6)]
+        + [{"work_center": "WC-WELD", "work_order_no": "WO-002-STR", "actual_minutes": 40, "std_minutes": 30} for _ in range(2)]
+    )
+    fc.push_result([  # rel_mes_work_order
+        {"work_order_no": "WO-001-TPS", "subassembly": "TPS"},
+        {"work_order_no": "WO-002-STR", "subassembly": "STR"},
+    ])
+
+
+def test_analytics_blocks_and_kpis(fake_cursor):
+    _analytics_scenario(fake_cursor)
+    out = svc.analytics(env_id=ENV, business_id=BIZ)
+    assert out["null_reason"] is None and out["source_kind"] == "live-rows"
+    k = out["kpis"]
+    assert k["recon_exception_count"] == 2
+    assert k["suspect_lot_vehicle_count"] == 2
+    assert k["busiest_work_center"] == "WC-NDE"
+    assert k["defect_concentration_pct"] == round(4200 / 6850 * 100, 2)  # emergent, computed
+    b = out["blocks"]
+    # bridge residual is analytics-only: 001 reconciles to 0, 002 leaves 700 unexplained
+    by_v = {r["vehicle_serial"]: r for r in b["bridge"]["rows"]}
+    assert by_v["VEH-DEMO-001"]["residual"] == 0.0
+    assert by_v["VEH-DEMO-002"]["residual"] == 700.0
+    # pareto sorted + concentration computed (no Lorenz)
+    assert b["pareto"]["rows"][0]["rework_cost"] == 4200.0
+    assert b["pareto"]["concentration_pct"] == round(4200 / 6850 * 100, 2)
+    # workcenter low-n flag on the 2-op cell
+    assert any(r["low_n"] for r in b["workcenter"]["rows"])
+    # recon threshold sensitivity present
+    assert any(s["k"] == 25 for s in b["recon"]["threshold_sensitivity"])
+
+
+def test_analytics_asymmetry_explains_001_vs_002(fake_cursor):
+    _analytics_scenario(fake_cursor)
+    out = svc.analytics(env_id=ENV, business_id=BIZ)
+    asym = out["blocks"]["asymmetry"]
+    assert asym["shared_exposure"] == ["VEH-DEMO-001", "VEH-DEMO-002"]
+    by_v = {r["vehicle_serial"]: r for r in asym["rows"]}
+    assert by_v["VEH-DEMO-001"]["open_major_ncr"] == 1
+    assert by_v["VEH-DEMO-002"]["open_major_ncr"] == 0
+
+
+def test_analytics_surfaces_non_authored_findings(fake_cursor):
+    # The hard "not replaying seeds" criterion: at least one finding NOT in the planted story.
+    _analytics_scenario(fake_cursor)
+    out = svc.analytics(env_id=ENV, business_id=BIZ)
+    kinds = {f["kind"] for f in out["blocks"]["disconfirmation"]["findings"]}
+    assert "exception_without_ncr" in kinds          # WO-003-AVI: 37.5% exception, no linked NCR
+    assert "exposed_not_blocked" in kinds            # VEH-DEMO-002: has the lot but on_track
+
+
+def test_analytics_page_fail_closed_when_core_mart_empty(fake_cursor):
+    _resolve(fake_cursor)
+    fake_cursor.push_result([])  # rel_build_overview empty -> page-level fail closed
+    out = svc.analytics(env_id=ENV, business_id=BIZ)
+    assert out["null_reason"] == "serving_not_loaded"
+    assert out["kpis"] is None and out["blocks"] == {}
+
+
+def test_recon_exception_threshold_boundary():
+    # RECON_EXCEPTION_PCT is the single source of truth; assert the >= boundary so it can't drift.
+    assert svc.RECON_EXCEPTION_PCT == 25.0
+    block = svc._recon_block([
+        {"work_order_no": "A", "variance_pct": 25.0},   # exactly at threshold -> exception
+        {"work_order_no": "B", "variance_pct": 24.99},  # just under -> not
+    ])
+    by_wo = {r["work_order_id"]: r for r in block["rows"]}
+    assert by_wo["A"]["is_exception"] is True
+    assert by_wo["B"]["is_exception"] is False

--- a/repo-b/src/app/lab/env/[envId]/telemetry/relativity-mes/analytics/page.tsx
+++ b/repo-b/src/app/lab/env/[envId]/telemetry/relativity-mes/analytics/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from "react";
+import BuildAnalyticsConsole from "@/components/telemetry/relativity-mes/BuildAnalyticsConsole";
+
+export default function RelativityMesAnalyticsPage() {
+  return (
+    <Suspense>
+      <BuildAnalyticsConsole />
+    </Suspense>
+  );
+}

--- a/repo-b/src/components/telemetry/relativity-mes/BuildAnalyticsConsole.tsx
+++ b/repo-b/src/components/telemetry/relativity-mes/BuildAnalyticsConsole.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+// Build Analytics — a SIMULATION-ANALYSIS surface over the rel_* serving marts, not a dashboard with
+// caveats. Six base visuals + three simulation-analysis panels. Every claim is labeled generated vs
+// emergent; small-n facts are shown structurally (no Lorenz/Gini, no clustering of 7 NCRs). Multi-seed
+// stability + chaos survivability are receipt-backed (Batch B) and fail closed here.
+
+import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import {
+  ScatterChart, Scatter, XAxis, YAxis, ZAxis, CartesianGrid, Tooltip, ReferenceLine,
+} from "recharts";
+import {
+  C, EmptyState, ErrorState, Loading, Panel, ScrollTable, SelectField, SplitGrid, Stat, StatGrid, Tag,
+} from "../primitives";
+import { TelemetryPageHeader } from "../TelemetryPageHeader";
+import { TelemetryChartFrame } from "../chartPrimitives";
+import { getAnalytics, useRel, type AnalyticsResp, type Row } from "@/lib/telemetry/relativityMes";
+import { REL_ACCENT, RelSourceDrill, ServingStrip, SyntheticBanner, useDrill } from "./relMesShared";
+
+const n = (v: unknown) => Number(v ?? 0);
+const str = (r: Row, k: string) => (r[k] == null ? "—" : String(r[k]));
+const money = (v: unknown) => `$${Math.round(n(v)).toLocaleString()}`;
+
+// ── provenance chip — the central honesty fix ────────────────────────────────
+type Prov = "generated" | "emergent" | "identity" | "low-n" | "data-quality";
+const PROV: Record<Prov, { color: string; label: string }> = {
+  generated: { color: C.amber, label: "generated scenario input" },
+  emergent: { color: C.green, label: "emergent from simulation" },
+  identity: { color: C.dim, label: "derived accounting identity" },
+  "low-n": { color: C.faint, label: "low-n directional only" },
+  "data-quality": { color: REL_ACCENT, label: "data-quality" },
+};
+function Chip({ kind }: { kind: Prov }) {
+  const p = PROV[kind];
+  return <Tag color={p.color}>{p.label}</Tag>;
+}
+function Caption({ children }: { children: React.ReactNode }) {
+  return <div style={{ fontFamily: C.sans, fontSize: 12, color: C.dim, lineHeight: 1.5, marginTop: 8 }}>{children}</div>;
+}
+
+type Mode = "current" | "stability" | "chaos";
+
+export default function BuildAnalyticsConsole() {
+  const params = useSearchParams();
+  const [vehicle, setVehicle] = useState(params?.get("vehicle") || "");
+  const [mode, setMode] = useState<Mode>("current");
+  const [drill, setDrill] = useDrill();
+  const { data, loading, error } = useRel<AnalyticsResp>(() => getAnalytics(vehicle || undefined), [vehicle]);
+
+  const k = data?.kpis ?? null;
+  const b = data?.blocks ?? {};
+  const readiness = b.readiness?.rows ?? [];
+  const vehicles = readiness.map((r) => String(r.vehicle_serial)).sort();
+
+  return (
+    <div>
+      <TelemetryPageHeader variant="standard" eyebrow="Relativity MES Sandbox" title="Build Analytics"
+        description="A simulation-analysis surface: what the synthetic seed planted, what fell out of the simulated rows, and which findings survive re-randomization. Read from the rel_* serving marts; every number traces to a row."
+        actions={<Tag color={REL_ACCENT}>synthetic</Tag>} />
+      <SyntheticBanner />
+
+      {/* Limitation banner + the blunt page copy */}
+      <div style={{ border: `1px solid ${C.border}`, background: C.panel, borderRadius: 10, padding: "11px 13px", marginBottom: 14 }}>
+        <div style={{ fontFamily: C.sans, fontSize: 12.5, color: C.dim, lineHeight: 1.55 }}>
+          Synthetic, single-snapshot MES scenario — useful for lineage, reconciliation, and drill-through;
+          <b style={{ color: C.text }}> not</b> evidence of trend, throughput, or statistical stability until multi-seed simulation is enabled.
+        </div>
+        <div style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, marginTop: 7, lineHeight: 1.5 }}>
+          This page does not claim the synthetic seed discovered the suspect lot. It shows which parts of the
+          scenario were planted, which facts fell out of the simulated rows, and which findings survive
+          re-randomization. · <b>Current seed is a story. Multi-seed stability is the analysis.</b>
+        </div>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 14, flexWrap: "wrap" }}>
+        <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint }}>SCENARIO MODE</span>
+        <SelectField value={mode} onChange={(v) => setMode(v as Mode)} ariaLabel="Scenario mode">
+          <option value="current">Current seed (the story)</option>
+          <option value="stability">Multi-seed stability (the analysis)</option>
+          <option value="chaos">Chaos survivability</option>
+        </SelectField>
+        <span style={{ fontFamily: C.mono, fontSize: 11, color: C.faint }}>VEHICLE</span>
+        <SelectField value={vehicle} onChange={setVehicle} ariaLabel="Select vehicle">
+          <option value="">All vehicles</option>
+          {vehicles.map((v) => <option key={v} value={v}>{v}</option>)}
+        </SelectField>
+      </div>
+
+      {loading && <Loading label="Loading analytics serving marts…" />}
+      {error && <ErrorState message={error} />}
+      {data && data.null_reason && <EmptyState label="No analytics data" hint="core serving marts returned no rows." nullReason={data.null_reason} />}
+
+      {data && !data.null_reason && (
+        <>
+          <ServingStrip meta={data} note={`${readiness.length} vehicles`} />
+
+          {/* KPI band */}
+          <StatGrid cols={4} style={{ marginBottom: 14 }}>
+            <Stat label="Total variance" value={money(k?.total_variance)} tone={C.amber} />
+            <Stat label="Rework share" value={k?.rework_share_pct == null ? "—" : `${n(k.rework_share_pct).toFixed(1)}%`} />
+            <Stat label="Recon exceptions" value={n(k?.recon_exception_count)} tone={n(k?.recon_exception_count) ? C.red : C.green} />
+            <Stat label="Suspect-lot vehicles" value={n(k?.suspect_lot_vehicle_count)} tone={C.amber} />
+            <Stat label="Busiest work center" value={k?.busiest_work_center ?? "—"} />
+            <Stat label="Defect concentration" value={k?.defect_concentration_pct == null ? "—" : `${n(k.defect_concentration_pct).toFixed(1)}%`} />
+          </StatGrid>
+
+          {mode === "stability" && (
+            <Panel title="Multi-seed stability" style={{ marginBottom: 14 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}><Chip kind="emergent" /></div>
+              <EmptyState label="Multi-seed stability not generated yet"
+                hint="The N-seed study (seed_stability.json) lands in Batch B; it shows median + P10–P90 for the fragile metrics so the exact percentages aren't read as stable."
+                nullReason="study_receipt_not_generated_yet" />
+            </Panel>
+          )}
+          {mode === "chaos" && (
+            <Panel title="Chaos survivability" style={{ marginBottom: 14 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}><Chip kind="data-quality" /></div>
+              <EmptyState label="Chaos survivability not generated yet"
+                hint="The data-quality chaos study (data_quality.json) lands in Batch B: graph join coverage, NCR linkage rate, dangling work orders under injected mess."
+                nullReason="chaos_receipt_not_generated_yet" />
+            </Panel>
+          )}
+
+          {/* 1. Readiness board + asymmetry */}
+          <Panel title="Build readiness" style={{ marginBottom: 14 }}>
+            <div style={{ display: "flex", gap: 8, marginBottom: 10, flexWrap: "wrap" }}>
+              <Chip kind="emergent" />
+            </div>
+            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+              {readiness.map((r) => {
+                const state = str(r, "readiness_state");
+                const tone = state === "blocked" ? C.red : state === "at_risk" ? C.amber : C.green;
+                return (
+                  <div key={str(r, "vehicle_serial")} style={{ flex: "1 1 200px", background: C.panel, border: `1px solid ${tone}55`, borderRadius: 10, padding: 12 }}>
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
+                      <span style={{ fontFamily: C.mono, fontSize: 12, color: C.text }}>{str(r, "vehicle_serial")}</span>
+                      <Tag color={tone}>{state}</Tag>
+                    </div>
+                    <div style={{ fontFamily: C.sans, fontSize: 12, color: C.dim, marginTop: 6 }}>{str(r, "driver")}</div>
+                  </div>
+                );
+              })}
+            </div>
+            {b.asymmetry && b.asymmetry.rows.length > 0 && (
+              <div style={{ marginTop: 12, borderTop: `1px solid ${C.border}`, paddingTop: 10 }}>
+                <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.faint, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 6 }}>
+                  Why {b.asymmetry.shared_exposure.join(" vs ")} differ — both contain the suspect lot
+                </div>
+                {b.asymmetry.rows.map((r) => (
+                  <div key={str(r, "vehicle_serial")} style={{ fontFamily: C.mono, fontSize: 11.5, color: C.text, padding: "4px 0" }}>
+                    <span style={{ color: C.dim }}>{str(r, "vehicle_serial")}</span> · {str(r, "readiness_state")} · {str(r, "note")}
+                  </div>
+                ))}
+                <Caption>Shared exposure is generated (the lot was planted on both); the blocked-state asymmetry is emergent from each vehicle&apos;s open-NCR + critical-WO state.</Caption>
+              </div>
+            )}
+          </Panel>
+
+          {/* 2. Blast radius (custom SVG-ish columns) */}
+          {b.blast?.rows_present && (
+            <Panel title="Suspect-lot blast radius" style={{ marginBottom: 14 }}>
+              <div style={{ display: "flex", gap: 8, marginBottom: 10, flexWrap: "wrap" }}>
+                <Chip kind="generated" /><Chip kind="emergent" />
+              </div>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 10 }}>
+                <BlastCol title="Lot (exposure)" prov="generated">
+                  <Node label={`${b.blast.lot_id}`} sub={b.blast.part_number ?? ""} tone={C.amber}
+                    onClick={() => setDrill({ table: "rel_mes_lot", filterKey: "lot_no", filterValue: String(b.blast?.lot_id), title: `${b.blast?.lot_id} — lot source` })} />
+                </BlastCol>
+                <BlastCol title="Vehicles (where-used)" prov="generated">
+                  {b.blast.vehicles.map((v) => (
+                    <Node key={str(v, "vehicle_serial")} label={str(v, "vehicle_serial")} sub={str(v, "readiness_state")}
+                      tone={str(v, "readiness_state") === "blocked" ? C.red : C.dim}
+                      onClick={() => setDrill({ table: "rel_mes_vehicle", filterKey: "vehicle_serial", filterValue: str(v, "vehicle_serial"), title: `${str(v, "vehicle_serial")} — vehicle source` })} />
+                  ))}
+                </BlastCol>
+                <BlastCol title="NCRs (attribution)" prov="emergent">
+                  {b.blast.ncrs.map((nc) => (
+                    <Node key={str(nc, "ncr_id")} label={str(nc, "ncr_id")} sub={`${str(nc, "severity")} · ${money(nc.rework_cost)}`}
+                      tone={str(nc, "status") === "open" ? C.red : C.dim}
+                      onClick={() => setDrill({ table: "rel_mes_nonconformance", filterKey: "ncr_id", filterValue: str(nc, "ncr_id"), title: `${str(nc, "ncr_id")} — NCR source` })} />
+                  ))}
+                </BlastCol>
+                <BlastCol title="Work orders (blocked-state)" prov="emergent">
+                  {b.blast.work_orders.map((w) => (
+                    <Node key={str(w, "work_order_id")} label={str(w, "work_order_id")} sub={`${n(w.variance_pct).toFixed(0)}% var`}
+                      tone={C.amber}
+                      onClick={() => setDrill({ table: "rel_mes_work_order", filterKey: "work_order_no", filterValue: str(w, "work_order_id"), title: `${str(w, "work_order_id")} — work order source` })} />
+                  ))}
+                </BlastCol>
+              </div>
+              <Caption>Exposure (lot → 2 vehicles) was planted; the blocked-state (only one vehicle, via its open major NCR and over-threshold WO) is emergent.</Caption>
+            </Panel>
+          )}
+
+          {/* 3. Cost-overrun bridge with residual */}
+          {b.bridge && b.bridge.rows.length > 0 && (
+            <Panel title="Cost-overrun bridge" style={{ marginBottom: 14 }} right={
+              <Tag color={(b.bridge.residual_total ?? 0) === 0 ? C.dim : C.amber}>
+                {b.bridge.reconciled_pct == null ? "—" : `reconciled ${b.bridge.reconciled_pct}%`} · residual {money(b.bridge.residual_total)}
+              </Tag>
+            }>
+              <div style={{ display: "flex", gap: 8, marginBottom: 10 }}><Chip kind="identity" /></div>
+              {b.bridge.rows.map((r) => (
+                <div key={str(r, "vehicle_serial")} style={{ marginBottom: 10 }}>
+                  <div style={{ fontFamily: C.mono, fontSize: 11, color: C.text, marginBottom: 4 }}>
+                    {str(r, "vehicle_serial")} — planned {money(r.planned_cost)} → actual {money(r.actual_cost)}
+                  </div>
+                  <div style={{ display: "flex", height: 18, borderRadius: 4, overflow: "hidden", border: `1px solid ${C.border}` }}>
+                    {([["material", C.cyan], ["labor_overhead", C.green], ["rework", C.amber], ["residual", C.red]] as const).map(([key, col]) => {
+                      const val = n(r[key]); const tot = n(r.actual_cost) || 1;
+                      if (val <= 0) return null;
+                      return <span key={key} title={`${key}: ${money(val)}`} style={{ width: `${Math.min(100, val / tot * 100)}%`, background: col, opacity: 0.8 }} />;
+                    })}
+                  </div>
+                </div>
+              ))}
+              <Caption>
+                Decomposed as material + labor/overhead + rework (+ unallocated residual). Residual is an
+                analytics-only reconciliation line; today the synthetic generator allocates all variance
+                (residual ≈ 0) — real ERP/MES data expects a non-zero residual.
+              </Caption>
+            </Panel>
+          )}
+
+          {/* 4. Defect concentration — sorted bar (NOT Lorenz) */}
+          {b.pareto && b.pareto.rows.length > 0 && (
+            <Panel title="Defect concentration" style={{ marginBottom: 14 }}>
+              <div style={{ display: "flex", gap: 8, marginBottom: 8, flexWrap: "wrap" }}><Chip kind="low-n" /></div>
+              {(() => {
+                const max = Math.max(1, ...b.pareto.rows.map((r) => n(r.rework_cost)));
+                return b.pareto.rows.map((r) => (
+                  <button key={str(r, "cluster_label")} type="button"
+                    onClick={() => setDrill({ table: "rel_mes_nonconformance", filterKey: "defect_code", filterValue: str(r, "cluster_label").split("·")[0], title: `${str(r, "cluster_label")} — NCR rows` })}
+                    style={{ display: "grid", gridTemplateColumns: "minmax(150px,1.4fr) 2fr minmax(90px,auto)", gap: 10, alignItems: "center", width: "100%", background: "transparent", border: "none", cursor: "pointer", textAlign: "left", padding: "3px 0" }}>
+                    <span style={{ fontFamily: C.mono, fontSize: 11, color: C.text }}>{str(r, "cluster_label")}</span>
+                    <span style={{ position: "relative", height: 14, background: C.panelHi, borderRadius: 4 }}>
+                      <span style={{ position: "absolute", inset: 0, width: `${n(r.rework_cost) / max * 100}%`, background: REL_ACCENT, opacity: 0.8, borderRadius: 4 }} />
+                    </span>
+                    <span style={{ fontFamily: C.mono, fontSize: 11, color: C.amber, textAlign: "right" }}>{money(r.rework_cost)}</span>
+                  </button>
+                ));
+              })()}
+              <Caption>
+                Largest NCR group = {b.pareto.concentration_pct == null ? "—" : `${b.pareto.concentration_pct}%`} of observed rework
+                in this seed (n={b.pareto.n_ncrs ?? b.pareto.rows.length} — a ranking, not a distribution; no Lorenz/Gini at this n).
+              </Caption>
+            </Panel>
+          )}
+
+          {/* 5. Work-center heatmap (custom grid) */}
+          {b.workcenter && b.workcenter.rows.length > 0 && (
+            <Panel title="Work-center load & variance" style={{ marginBottom: 14 }}>
+              <div style={{ display: "flex", gap: 8, marginBottom: 8 }}><Chip kind="emergent" /></div>
+              <ScrollTable minWidth={520}>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+                  {(() => {
+                    const max = Math.max(1, ...b.workcenter.rows.map((r) => n(r.actual_minutes)));
+                    return b.workcenter.rows.map((r) => {
+                      const lowN = Boolean(r.low_n);
+                      const intensity = n(r.actual_minutes) / max;
+                      const ratio = r.actual_std_ratio == null ? null : n(r.actual_std_ratio);
+                      return (
+                        <button key={`${str(r, "work_center")}-${str(r, "subassembly")}`} type="button"
+                          onClick={() => setDrill({ table: "rel_mes_operation_execution", filterKey: "work_center", filterValue: str(r, "work_center"), title: `${str(r, "work_center")} — operations` })}
+                          style={{ width: 130, textAlign: "left", borderRadius: 8, padding: 10, cursor: "pointer",
+                            background: `rgba(255,158,100,${0.08 + intensity * 0.3})`, opacity: lowN ? 0.55 : 1,
+                            border: `1px solid ${ratio && ratio > 1.1 ? C.amber : C.border}` }}>
+                          <div style={{ fontFamily: C.mono, fontSize: 10.5, color: C.text }}>{str(r, "work_center")}</div>
+                          <div style={{ fontFamily: C.mono, fontSize: 9.5, color: C.faint }}>{str(r, "subassembly")}</div>
+                          <div style={{ fontFamily: C.mono, fontSize: 12, color: C.text, marginTop: 4 }}>{n(r.actual_minutes).toFixed(0)}m</div>
+                          <div style={{ fontFamily: C.mono, fontSize: 9.5, color: ratio && ratio > 1.1 ? C.amber : C.dim }}>
+                            {ratio == null ? "—" : `${ratio.toFixed(2)}×std`}{lowN ? " · n<5" : ""}
+                          </div>
+                        </button>
+                      );
+                    });
+                  })()}
+                </div>
+              </ScrollTable>
+              <Caption>Color = actual minutes (load); border = over-standard. Cells with fewer than 5 operations are dimmed (low-n directional). Standard minutes are synthetic.</Caption>
+            </Panel>
+          )}
+
+          {/* 6. MES↔ERP reconciliation scatter */}
+          {b.recon && b.recon.rows.length > 0 && (
+            <TelemetryChartFrame title="MES↔ERP reconciliation" ariaLabel="Reconciliation scatter"
+              caption={`Most work orders reconcile within ±${b.recon.exception_threshold_pct ?? 25}%; exceptions pop out. Threshold sensitivity: ${b.recon.threshold_sensitivity.map((s) => `${s.k}%→${s.exception_count}`).join(" · ")} (the count barely moves — the band is not what's discriminating).`}>
+              <div style={{ display: "flex", gap: 8, marginBottom: 8 }}><Chip kind="emergent" /></div>
+              <ScatterChart width={460} height={260} margin={{ top: 8, right: 16, bottom: 18, left: 0 }}>
+                <CartesianGrid stroke={C.border} strokeDasharray="3 3" />
+                <XAxis type="number" dataKey="standard_cost" name="standard" stroke={C.faint} tick={{ fontSize: 9, fill: C.faint }} />
+                <YAxis type="number" dataKey="actual_cost" name="actual" stroke={C.faint} tick={{ fontSize: 9, fill: C.faint }} />
+                <ZAxis range={[40, 40]} />
+                <Tooltip contentStyle={{ background: C.panelHi, border: `1px solid ${C.border}`, fontFamily: C.mono, fontSize: 11 }} />
+                <ReferenceLine stroke={C.dim} strokeDasharray="4 4" segment={[{ x: 0, y: 0 }, { x: 20000, y: 20000 }]} />
+                <Scatter name="reconciled" data={b.recon.rows.filter((r) => !r.is_exception)} fill={C.green} isAnimationActive={false} />
+                <Scatter name="exception" data={b.recon.rows.filter((r) => r.is_exception)} fill={C.red} isAnimationActive={false} />
+              </ScatterChart>
+            </TelemetryChartFrame>
+          )}
+
+          {/* 8. Disconfirmation — the "not replaying seeds" panel */}
+          {b.disconfirmation && (
+            <Panel title="Disconfirmation — what the scenario did not plant" style={{ marginTop: 14 }}>
+              <div style={{ display: "flex", gap: 8, marginBottom: 8 }}><Chip kind="emergent" /></div>
+              {b.disconfirmation.findings.length === 0 ? (
+                <div style={{ fontFamily: C.mono, fontSize: 11.5, color: C.green }}>
+                  0 unexpected exceptions found on this seed ({b.disconfirmation.checks_run} checks run) — clean.
+                </div>
+              ) : (
+                b.disconfirmation.findings.map((f, i) => (
+                  <div key={`${str(f, "kind")}-${i}`} style={{ fontFamily: C.mono, fontSize: 11.5, color: C.text, padding: "4px 0", borderBottom: `1px solid ${C.border}` }}>
+                    <Tag color={C.amber}>{str(f, "kind")}</Tag> <span style={{ color: C.dim }}>{str(f, "ref")}</span> — {str(f, "detail")}
+                  </div>
+                ))
+              )}
+              <Caption>These checks look for facts the generator did not author (e.g. a cost exception with no linked NCR, an exposed-but-unblocked vehicle) — the test that this is analysis, not a replay of the seed.</Caption>
+            </Panel>
+          )}
+        </>
+      )}
+
+      <RelSourceDrill target={drill} onClose={() => setDrill(null)} />
+    </div>
+  );
+}
+
+function BlastCol({ title, prov, children }: { title: string; prov: Prov; children: React.ReactNode }) {
+  return (
+    <div>
+      <div style={{ fontFamily: C.mono, fontSize: 9.5, color: C.faint, textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 6 }}>{title}</div>
+      <div style={{ marginBottom: 6 }}><Chip kind={prov} /></div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>{children}</div>
+    </div>
+  );
+}
+
+function Node({ label, sub, tone, onClick }: { label: string; sub: string; tone: string; onClick: () => void }) {
+  return (
+    <button type="button" onClick={onClick} style={{ textAlign: "left", background: C.panel, border: `1px solid ${tone}55`, borderRadius: 8, padding: "8px 10px", cursor: "pointer" }}>
+      <div style={{ fontFamily: C.mono, fontSize: 11, color: C.text }}>{label}</div>
+      {sub && <div style={{ fontFamily: C.mono, fontSize: 9.5, color: C.dim }}>{sub}</div>}
+    </button>
+  );
+}

--- a/repo-b/src/components/telemetry/relativity-mes/consoles.test.tsx
+++ b/repo-b/src/components/telemetry/relativity-mes/consoles.test.tsx
@@ -7,6 +7,7 @@ import BuildGenealogyConsole from "./BuildGenealogyConsole";
 import NcrTraceabilityConsole from "./NcrTraceabilityConsole";
 import CostReconciliationConsole from "./CostReconciliationConsole";
 import LineageSourceConsole from "./LineageSourceConsole";
+import BuildAnalyticsConsole from "./BuildAnalyticsConsole";
 
 // Keep useRel + servingLabel real; mock only the network fetchers so the consoles render over canned
 // serving payloads (the dashboards read APIs, never local data).
@@ -16,6 +17,7 @@ vi.mock("@/lib/telemetry/relativityMes", async (importOriginal) => {
     ...actual,
     getOverview: vi.fn(), getGenealogy: vi.fn(), getWhereUsed: vi.fn(),
     getNcr: vi.fn(), getCost: vi.fn(), getLineage: vi.fn(), getSourceRows: vi.fn(),
+    getAnalytics: vi.fn(),
   };
 });
 
@@ -178,5 +180,69 @@ describe("LineageSourceConsole", () => {
     expect(screen.getAllByText(/Medallion not materialized/).length).toBeGreaterThanOrEqual(1);
     // the Databricks gold label (exact text, no trailing ↗) is fail-closed -> not an anchor
     expect(screen.getByText("gold_rel_build_overview").closest("a")).toBeNull();
+  });
+});
+
+describe("BuildAnalyticsConsole", () => {
+  const ANALYTICS = {
+    ...META,
+    kpis: {
+      total_variance: 9600, rework_share_pct: 25.8, recon_exception_count: 2,
+      suspect_lot_vehicle_count: 2, busiest_work_center: "WC-NDE", defect_concentration_pct: 61.3,
+    },
+    blocks: {
+      readiness: { rows: [
+        { vehicle_serial: "VEH-DEMO-001", readiness_state: "blocked", driver: "open major NCR · suspect lot" },
+        { vehicle_serial: "VEH-DEMO-002", readiness_state: "on_track", driver: "on track · suspect lot" },
+      ], null_reason: null },
+      asymmetry: { shared_exposure: ["VEH-DEMO-001", "VEH-DEMO-002"], rows: [
+        { vehicle_serial: "VEH-DEMO-001", readiness_state: "blocked", open_major_ncr: 1, note: "open major NCR on the lot install" },
+        { vehicle_serial: "VEH-DEMO-002", readiness_state: "on_track", open_major_ncr: 0, note: "lot installed; no open major NCR on it" },
+      ], null_reason: null },
+      blast: { rows_present: true, lot_id: "LOT-7788", part_number: "PN-TPS-SEAL",
+        vehicles: [{ vehicle_serial: "VEH-DEMO-001", readiness_state: "blocked" }],
+        ncrs: [{ ncr_id: "NCR-0001", severity: "major", status: "open", rework_cost: 4200 }],
+        work_orders: [{ work_order_id: "WO-001-TPS", variance_pct: 70, actual_cost: 16000, standard_cost: 9400 }],
+        edges: [], null_reason: null },
+      bridge: { reconciled_pct: 95.6, residual_total: 700, rows: [
+        { vehicle_serial: "VEH-DEMO-001", planned_cost: 10000, material: 6000, labor_overhead: 5800, rework: 4200, residual: 0, actual_cost: 16000 },
+      ], null_reason: null },
+      pareto: { concentration_pct: 61.3, n_ncrs: 7, rows: [
+        { cluster_label: "witness-mark·WC-NDE", ncr_count: 1, rework_cost: 4200, cumulative_rework_pct: 61.3 },
+        { cluster_label: "weld-undercut·WC-WELD", ncr_count: 1, rework_cost: 2650, cumulative_rework_pct: 100 },
+      ], null_reason: null },
+      workcenter: { rows: [
+        { work_center: "WC-NDE", subassembly: "TPS", actual_minutes: 180, std_minutes: 150, actual_std_ratio: 1.2, op_count: 6, low_n: false },
+        { work_center: "WC-WELD", subassembly: "STR", actual_minutes: 80, std_minutes: 60, actual_std_ratio: 1.33, op_count: 2, low_n: true },
+      ], null_reason: null },
+      recon: { exception_threshold_pct: 25, threshold_sensitivity: [{ k: 25, exception_count: 2 }, { k: 50, exception_count: 1 }], rows: [
+        { work_order_id: "WO-001-TPS", standard_cost: 9400, actual_cost: 16000, variance_pct: 70, is_exception: true },
+      ], null_reason: null },
+      disconfirmation: { checks_run: 3, findings: [
+        { kind: "exception_without_ncr", ref: "WO-003-AVI", detail: "variance 37.5% but no linked NCR" },
+      ], null_reason: null },
+    },
+  };
+
+  it("renders the simulation-analysis surface with provenance chips + page copy", async () => {
+    (lib.getAnalytics as Mock).mockResolvedValue(ANALYTICS);
+    render(<BuildAnalyticsConsole />);
+    expect(await screen.findByRole("heading", { name: "Build Analytics" })).toBeTruthy();
+    expect(screen.getByText(/Current seed is a story\. Multi-seed stability is the analysis\./)).toBeTruthy();
+    expect(screen.getAllByText("generated scenario input").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("emergent from simulation").length).toBeGreaterThan(0);
+    expect(screen.getByText("low-n directional only")).toBeTruthy();
+    // asymmetry + disconfirmation (non-authored finding) are the credibility panels
+    expect(screen.getByText(/Why VEH-DEMO-001 vs VEH-DEMO-002 differ/)).toBeTruthy();
+    expect(screen.getByText("exception_without_ncr")).toBeTruthy();
+  });
+
+  it("fails closed at the page level when core marts are empty", async () => {
+    (lib.getAnalytics as Mock).mockResolvedValue({
+      source_kind: "unavailable", serving_provenance: null, as_of: null,
+      null_reason: "serving_not_loaded", kpis: null, blocks: {},
+    });
+    render(<BuildAnalyticsConsole />);
+    expect(await screen.findByText("No analytics data")).toBeTruthy();
   });
 });

--- a/repo-b/src/components/telemetry/telemetryNav.test.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.test.ts
@@ -56,6 +56,7 @@ describe("telemetry navigation structure (7 presentation sections)", () => {
         "relativity-mes/ncr",
         "relativity-mes/cost",
         "relativity-mes/lineage",
+        "relativity-mes/analytics",
       ].sort(),
     );
     // The hidden slugs must NOT appear in the nav (but their page routes still exist on disk).

--- a/repo-b/src/components/telemetry/telemetryNav.ts
+++ b/repo-b/src/components/telemetry/telemetryNav.ts
@@ -77,6 +77,7 @@ export const TELEMETRY_NAV: TelemetryNavItem[] = [
   { slug: "relativity-mes/ncr", label: "NCR Traceability", icon: "M8 2l6 11H2zM8 6v3M8 11h.01", group: "Relativity MES Sandbox" },
   { slug: "relativity-mes/cost", label: "Cost Reconciliation", icon: "M3 13V8l3-2 4 3 3-4v8zM2 14h12", group: "Relativity MES Sandbox" },
   { slug: "relativity-mes/lineage", label: "Lineage & Source Tables", icon: "M4 2v12M4 6h6M4 11h5M10 4v4M9 9v3", group: "Relativity MES Sandbox" },
+  { slug: "relativity-mes/analytics", label: "Build Analytics", icon: "M2 13l3-4 3 2 3-6 3 3M2 13h12", group: "Relativity MES Sandbox" },
 ];
 
 export const TELEMETRY_NAV_GROUPS: TelemetryNavGroup[] = [

--- a/repo-b/src/lib/telemetry/relativityMes.ts
+++ b/repo-b/src/lib/telemetry/relativityMes.ts
@@ -41,6 +41,37 @@ export interface SourceRowsResp extends ServingMeta {
   table: string; columns: string[]; rows: Row[]; row_count: number;
 }
 
+// Build Analytics — simulation-analysis blocks (Phase 10 hardening). Each block carries its own
+// null_reason so one empty supporting mart degrades that block, not the page.
+export interface AnalyticsKpis {
+  total_variance: number | null;
+  rework_share_pct: number | null;
+  recon_exception_count: number | null;
+  suspect_lot_vehicle_count: number | null;
+  busiest_work_center: string | null;
+  defect_concentration_pct: number | null;
+}
+export interface AnalyticsBlocks {
+  readiness?: { rows: Row[]; null_reason: string | null };
+  asymmetry?: { rows: Row[]; shared_exposure: string[]; null_reason: string | null };
+  blast?: {
+    rows_present: boolean; lot_id: string | null; part_number: string | null;
+    vehicles: Row[]; ncrs: Row[]; work_orders: Row[]; edges: Row[]; null_reason: string | null;
+  };
+  bridge?: { rows: Row[]; reconciled_pct: number | null; residual_total: number; null_reason: string | null };
+  pareto?: { rows: Row[]; concentration_pct: number | null; n_ncrs?: number; null_reason: string | null };
+  workcenter?: { rows: Row[]; null_reason: string | null };
+  recon?: {
+    rows: Row[]; threshold_sensitivity: { k: number; exception_count: number }[];
+    exception_threshold_pct?: number; null_reason: string | null;
+  };
+  disconfirmation?: { findings: Row[]; checks_run: number; null_reason: string | null };
+}
+export interface AnalyticsResp extends ServingMeta {
+  kpis: AnalyticsKpis | null;
+  blocks: AnalyticsBlocks;
+}
+
 export const getOverview = () =>
   apiFetch<OverviewResp>(`${base}/overview`, { params: tenant() });
 
@@ -58,6 +89,9 @@ export const getCost = (vehicleSerial?: string) =>
   apiFetch<CostResp>(`${base}/cost`, { params: { ...tenant(), vehicle_serial: vehicleSerial } });
 
 export const getLineage = () => apiFetch<LineageResp>(`${base}/lineage`, { params: tenant() });
+
+export const getAnalytics = (vehicleSerial?: string) =>
+  apiFetch<AnalyticsResp>(`${base}/analytics`, { params: { ...tenant(), vehicle_serial: vehicleSerial } });
 
 export const getSourceRows = (table: string, key?: string, value?: string) =>
   apiFetch<SourceRowsResp>(`${base}/source/${encodeURIComponent(table)}`, {


### PR DESCRIPTION
## What
Batch A of the **Build Analytics** MES console — reframed from "synthetic scenario visualization" to a **simulation-analysis surface**. Every claim is labeled **generated-vs-emergent**; small-n facts are shown structurally (no Lorenz/Gini, no clustering of 7 NCRs). Greenfield 6th console + one read-only endpoint over the existing `rel_*` serving marts. **No generator change, no determinism risk, additive.**

## Backend — `GET /api/telemetry/relativity-mes/analytics`
Fail-closed **per block** (page-level `null_reason` only if a core mart is empty). Blocks: `readiness`, **`asymmetry`** (why VEH-DEMO-001 is blocked but 002 isn't — both carry the suspect lot), `blast` (exposure→attribution→blocked-state, separated, not one causal handwave), `bridge` (with an **analytics-only unallocated residual** + reconciled%), `pareto` (sorted, computed concentration), `workcenter` (per-cell `op_count` + `low_n`), `recon` (+ **threshold sensitivity** across K), **`disconfirmation`** (surfaces facts NOT in the scenario: exception-without-NCR, exposed-but-not-blocked), `kpis`. `RECON_EXCEPTION_PCT` is one constant with a boundary test.

## Frontend
`AnalyticsResp` + `getAnalytics`; nav entry; page route; `BuildAnalyticsConsole` with provenance chips, the limitation banner + verbatim copy (*"Current seed is a story. Multi-seed stability is the analysis."*), a **scenario-mode selector** (Current seed live; Multi-seed/Chaos fail-closed until Batch B), and all nine surfaces with source-drill (recharts scatter for recon; custom layout for blast/heatmap/bridge/pareto).

## Tests
Backend `test_relativity_mes` **15 passed** — incl. the hard **"surfaces a non-authored finding"** criterion (`test_analytics_surfaces_non_authored_findings`) and the RECON boundary. Frontend consoles + nav **21 passed**. typecheck + lint clean.

Batch B (next): seed-parametric generator + residual cost row + scenario_manifest/seed_stability/data_quality receipts + the Multi-Seed Stability & Chaos panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)