### PR TITLE
chore(repo): R0.1 — ignore _scratch/ working-tree scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,9 @@ scripts/.winston_managed_agent_state.json
 # Local scratch: daily dumps, outreach drafts, article scratch
 outputs/
 deal-opportunities-*.md
+# Loose working-tree scratch swept out of the repo root during cleanup passes
+# (relativity demo notes, productionize drafts, test reports, etc.). Local-only.
+_scratch/
 
 # Binary files and outputs
 *.pdf


### PR DESCRIPTION
First slice of the **Repo Hygiene R0** pass (structure/scratch/reference hygiene — not a code or CSS refactor).

## What this does
- Adds `_scratch/` to `.gitignore` so swept-out working-tree scratch never lands as source.

## Context
Phase 0 (done locally, not in this PR): a plaintext **Confluent Cloud** API key (`api-key-*.txt`, never committed, already gitignored) was deleted from disk — **needs rotation in Confluent Cloud** — and 9 untracked root scratch files (relativity demo notes, productionize drafts, a test report, demo images) were moved into a local `_scratch/` folder. This PR just ignores that folder.

## Scope guarantee
Gitignore-only. No code, no behavior, no doc content changes.

## Verification
- `git diff --stat` → `.gitignore | 3 +++`
- `git check-ignore -v _scratch/` → matches the new rule
- Typecheck/lint N/A (no code touched)

Follow-ups (separate PRs): R0.2 root-doc organization, R0.3 docs/ top-level grouping, R0.4 dead-reference reconciliation. Code-quality/style work (4,466 inline styles, oversized backend files) is deferred to a separate **R1** plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)