### PR TITLE
fix(agent-builder): restore tenant context under the headerless telemetry demo login

### DIFF
--- a/backend/app/routes/agent_builder.py
+++ b/backend/app/routes/agent_builder.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import psycopg
 from fastapi import APIRouter, HTTPException, Query, Request
 
-from app.auth.platform import require_tenant_context
+from app.auth.platform import require_authenticated_request
+from app.config import TELEMETRY_STREAM_BUSINESS_ID, TELEMETRY_STREAM_ENV_ID
 from app.schemas.agent_builder import (
     DryRunRequest,
     PublishRequest,
@@ -18,14 +19,50 @@ from app.services import agent_builder_evals as eval_service
 
 router = APIRouter(prefix="/api/agent-builder", tags=["agent-builder"])
 
+# A headerless reviewer/demo session (the scoped telemetry login, which carries no DB
+# membership and therefore no x-bm-business-id header) may scope ONLY to this single,
+# known-public demo tenant — supplied via query params. Any other (env_id, business_id)
+# pair from params is rejected, so params are never a general tenant-injection path.
+_DEMO_SCOPE_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
+    {(TELEMETRY_STREAM_ENV_ID, TELEMETRY_STREAM_BUSINESS_ID)}
+)
+
 
 def _scope(request: Request, *, mutate: bool = False) -> tuple[str, str, str]:
-    auth = require_tenant_context(request)
-    if not auth.env_id:
-        raise HTTPException(status_code=403, detail="Environment context required")
-    if mutate and "write" not in auth.permissions and "admin" not in auth.roles:
-        raise HTTPException(status_code=403, detail="Operator or admin role required")
-    return auth.env_id, str(auth.business_id), auth.actor
+    """Resolve (env_id, business_id, actor) with explicit precedence.
+
+    1. A real, header-derived platform-session tenant always wins; params are ignored,
+       so a real tenant can never be redirected to (or downgraded into) the demo scope.
+    2. A headerless-but-authenticated demo session falls back to query params, accepted
+       ONLY for the allowlisted telemetry-demo pair — otherwise it fails closed (403),
+       exactly as before.
+
+    The mutate gate (operator/admin) is enforced for real tenants. For the allowlisted
+    demo scope only, Agent Builder persistence is permitted (workflow drafts, validation
+    records, dry-run/run-step rows, run events, receipts — all in the ai_agent_* audit/
+    config tables, scoped to env_id='telemetry-demo'). This grant does NOT enable MCP
+    write tools (still disabled in describe_tools and rejected by validate_graph), any
+    production data write, deploy/PR action, or any non-demo-tenant mutation.
+    """
+    auth = require_authenticated_request(request)
+
+    if auth.business_id:
+        # Real, header-derived tenant — authoritative. Params are ignored.
+        if not auth.env_id:
+            raise HTTPException(status_code=403, detail="Environment context required")
+        if mutate and "write" not in auth.permissions and "admin" not in auth.roles:
+            raise HTTPException(status_code=403, detail="Operator or admin role required")
+        return auth.env_id, str(auth.business_id), auth.actor
+
+    # Headerless demo/reviewer session — fall back to allowlisted param scope.
+    env_id = request.query_params.get("env_id") or ""
+    business_id = request.query_params.get("business_id") or ""
+    if (env_id, business_id) not in _DEMO_SCOPE_ALLOWLIST:
+        raise HTTPException(
+            status_code=403,
+            detail="Tenant context required: this request carries no business_id",
+        )
+    return env_id, business_id, auth.actor or "telemetry-demo"
 
 
 def _to_http(exc: Exception) -> HTTPException:

--- a/backend/tests/test_agent_builder.py
+++ b/backend/tests/test_agent_builder.py
@@ -587,6 +587,131 @@ def _platform_headers(role: str = "member") -> dict[str, str]:
     }
 
 
+# The scoped telemetry reviewer login: authenticated, but its session carries no DB
+# membership and therefore NO x-bm-business-id / x-bm-env-id header. This is the exact
+# shape that previously 403'd the whole Agent Builder.
+def _demo_headers() -> dict[str, str]:
+    return {
+        "x-bm-auth-provider": "platform-session",
+        "x-bm-user-id": "reviewer-1",
+        "x-bm-actor": "user:test:reviewer-1",
+        # deliberately no x-bm-business-id / x-bm-env-id
+    }
+
+
+_DEMO_ENV, _DEMO_BIZ = next(iter(agent_builder_route._DEMO_SCOPE_ALLOWLIST))
+
+
+def _demo_scope_params() -> dict[str, str]:
+    return {"env_id": _DEMO_ENV, "business_id": _DEMO_BIZ}
+
+
+def test_agent_builder_api_demo_scope_resolves_palette_without_business_id_header(client):
+    # The headerless reviewer session, scoped via allowlisted query params, must load the
+    # palette — this is the regression test for the original "Tenant context required" bug.
+    response = client.get(
+        "/api/agent-builder/palette",
+        headers=_demo_headers(),
+        params=_demo_scope_params(),
+    )
+    assert response.status_code == 200
+    assert len(response.json()["nodes"]) == 10
+
+
+def test_agent_builder_api_rejects_non_allowlisted_param_scope(client):
+    # Params are NOT a general tenant-injection path: any pair other than the demo tenant
+    # fails closed even for an authenticated-but-tenantless session.
+    response = client.get(
+        "/api/agent-builder/palette",
+        headers=_demo_headers(),
+        params={"env_id": "some-other-env", "business_id": str(uuid4())},
+    )
+    assert response.status_code == 403
+
+
+def test_agent_builder_api_header_tenant_overrides_spoofed_params(client, monkeypatch):
+    # A real, header-derived tenant must win: spoofed demo params cannot redirect a real
+    # session's reads to the demo scope.
+    captured: dict[str, str] = {}
+
+    def _capture(**kwargs):
+        captured["env_id"] = kwargs["env_id"]
+        captured["business_id"] = kwargs["business_id"]
+        return []
+
+    monkeypatch.setattr(agent_builder_route.service, "list_workflows", _capture)
+    response = client.get(
+        "/api/agent-builder/workflows",
+        headers=_platform_headers("member"),
+        params=_demo_scope_params(),  # attempt to spoof the demo scope
+    )
+    assert response.status_code == 200
+    assert captured["env_id"] == ENV
+    assert captured["business_id"] == BIZ
+
+
+def test_agent_builder_api_demo_scope_can_persist_drafts_and_dry_runs(client, monkeypatch):
+    # Decision 1: the allowlisted demo scope is granted Agent Builder persistence so
+    # Save / Validate / Dry Run work under the reviewer login (no write tools, demo tenant
+    # only). Without the demo grant the headerless 'viewer' session would 403 on mutate.
+    monkeypatch.setattr(
+        agent_builder_route.service,
+        "create_workflow",
+        lambda **kwargs: {"id": "wf-demo", "version_number": 1, "env_id": kwargs["env_id"]},
+    )
+    monkeypatch.setattr(
+        agent_builder_route.service,
+        "dry_run",
+        lambda **kwargs: {"id": "run-demo", "status": "succeeded", "steps": [], "receipts": []},
+    )
+    created = client.post(
+        "/api/agent-builder/workflows",
+        headers=_demo_headers(),
+        params=_demo_scope_params(),
+        json={"name": "Agent", "graph": valid_minimal_graph().model_dump(mode="json")},
+    )
+    assert created.status_code == 200
+    assert created.json()["env_id"] == _DEMO_ENV
+    run = client.post(
+        "/api/agent-builder/workflows/wf-demo/dry-run",
+        headers=_demo_headers(),
+        params=_demo_scope_params(),
+        json={"input": {"run_key": "run-1"}},
+    )
+    assert run.status_code == 200
+    assert run.json()["status"] == "succeeded"
+
+
+def test_agent_builder_demo_scope_does_not_unlock_write_capable_mcp_tools():
+    # The demo persistence grant must NOT open MCP writes. A graph pinning a write-capable
+    # tool is rejected by validation and the tool is reported disabled — independent of the
+    # caller's scope (validation is scope-agnostic; the route never executes a failing graph).
+    write_tool = registry.get("business.create")
+    assert write_tool is not None and write_tool.permission == "write"
+    candidate = graph(
+        [
+            node("trigger", "manual_trigger", 0),
+            node(
+                "tool",
+                "mcp_tool",
+                100,
+                {
+                    "tool_name": write_tool.name,
+                    "tool_schema_digest": agent_builder.tool_schema_digest(write_tool),
+                    "bindings": {},
+                },
+            ),
+            node("output", "output", 200),
+        ],
+        [edge("trigger", "tool"), edge("tool", "output")],
+    )
+    result = agent_builder.validate_graph(candidate)
+    assert result["status"] == "fail"
+    assert any(issue["code"] == "WRITE_TOOL_FORBIDDEN" for issue in result["issues"])
+    described = next(tool for tool in agent_builder.describe_tools() if tool["name"] == write_tool.name)
+    assert described["enabled"] is False
+
+
 def test_agent_builder_api_enforces_viewer_vs_operator_mutations(client, monkeypatch):
     payload = {"name": "Agent", "graph": valid_minimal_graph().model_dump(mode="json")}
     monkeypatch.setattr(

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4796,3 +4796,28 @@ reusing on any synthetic/demo analytics surface:
   rewrites `repo-b/db/schema/10037`/`10038` in place from the generator; applying to Lakebase needs a
   short-lived Databricks cred (see the Lakebase-owner-DDL memory). Generator changes that alter rows are
   a backend-deploy + serving-refresh, not just a code merge.
+- **Two telemetry tenancy patterns — don't mix them up.** The telemetry demo is reached via the scoped
+  reviewer login (`telemetry`), whose session has NO DB membership and therefore NO `x-bm-business-id`
+  header. Most telemetry routes (`/api/telemetry/*`, control-tower) read `env_id`/`business_id` from
+  **request params**, and the frontend passes the hardcoded `TELEMETRY_DEMO_ENV_ID`/`_BUSINESS_ID`
+  constants (`repo-b/src/lib/telemetry/api.ts`) — so they work under the reviewer login. The Agent
+  Builder backend was instead written to **header-based** tenancy (`require_tenant_context`), which 403s
+  ("Tenant context required: this request carries no business_id") for the headerless reviewer session →
+  the whole builder went dead (empty palette, because `refresh()` used `Promise.all`). Fix pattern:
+  resolve scope with precedence — header-derived `auth.business_id` wins when present (real tenant, never
+  overridable by params); else fall back to query params **allowlisted to the one telemetry-demo pair**
+  (`_DEMO_SCOPE_ALLOWLIST` in `backend/app/routes/agent_builder.py`, sourced from `config.TELEMETRY_STREAM_*`).
+  Read scope from `request.query_params` for ALL methods so typed Pydantic POST bodies stay untouched.
+  Never accept arbitrary param scope — that's an open tenant-injection hole.
+- **A headerless `platform-session` request is still authenticated.** `mcp_provider.authenticate` treats
+  `x-bm-auth-provider: platform-session` (or any `x-bm-user-id`) as authenticated even with no
+  `x-bm-business-id`; default `membership_role` is `viewer` → `permissions=["read"]`. So a tenantless
+  demo session passes `require_authenticated_request` but fails any `write`/`admin` mutate gate. To make
+  a demo interactive (Save/Validate/Dry-Run), grant the mutate skip for the allowlisted demo scope ONLY
+  — it persists to the `ai_agent_*` audit/config tables under `env_id='telemetry-demo'`, and does NOT
+  unlock MCP write tools (still disabled in `describe_tools` / rejected by `validate_graph`).
+- **Test the context pipe, not just mocked handlers.** The Agent Builder break was pure
+  context-propagation, yet the heavy component test mocks the whole api module and never noticed. Add a
+  thin test that un-mocks `fetch` and asserts the real `agentBuilder-api` + `apiFetch` put
+  `env_id`/`business_id` on the request URL (`repo-b/src/lib/telemetry/agentBuilder-api.test.ts`).
+  Backend coverage: `cd backend && python -m pytest tests/test_agent_builder.py -q`.

--- a/repo-b/src/components/telemetry/AgentBuilder.tsx
+++ b/repo-b/src/components/telemetry/AgentBuilder.tsx
@@ -458,22 +458,39 @@ export default function AgentBuilder({ tab, onOpenBuilder }: { tab: ControlTower
 
   const refresh = useCallback(async () => {
     setError(null);
+    // Bootstrap each surface independently: a failure in one call (e.g. tenant context
+    // unresolved, or schema not migrated) must not blank the whole builder. Whatever
+    // resolves still renders; only the parts that genuinely failed surface a banner.
+    const [paletteResult, toolResult, workflowResult, runResult] = await Promise.allSettled([
+      getPalette(),
+      getMcpTools(),
+      getWorkflows(),
+      getRuns(),
+    ]);
+    if (paletteResult.status === "fulfilled") setPalette(paletteResult.value.nodes);
+    if (toolResult.status === "fulfilled") setTools(toolResult.value.tools);
+    let firstWorkflowId: string | null = null;
+    if (workflowResult.status === "fulfilled") {
+      setWorkflows(workflowResult.value.workflows);
+      firstWorkflowId = workflowResult.value.workflows[0]?.id ?? null;
+    }
+    if (runResult.status === "fulfilled") setRuns(runResult.value.runs);
+
+    const failures = [paletteResult, toolResult, workflowResult, runResult].filter(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (failures.length) {
+      const detail = failures[0].reason;
+      const detailMessage = detail instanceof Error ? detail.message : String(detail);
+      setError(
+        "Context required — select an environment or reload from a valid telemetry environment. " +
+          `Read-only demo templates and palette remain available where they loaded. (${detailMessage})`,
+      );
+    }
     try {
-      const [paletteResult, toolResult, workflowResult, runResult] = await Promise.all([
-        getPalette(),
-        getMcpTools(),
-        getWorkflows(),
-        getRuns(),
-      ]);
-      setPalette(paletteResult.nodes);
-      setTools(toolResult.tools);
-      setWorkflows(workflowResult.workflows);
-      setRuns(runResult.runs);
-      if (!workflow && workflowResult.workflows[0]) {
-        await loadWorkflow(workflowResult.workflows[0].id);
+      if (!workflow && firstWorkflowId) {
+        await loadWorkflow(firstWorkflowId);
       }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
     }

--- a/repo-b/src/lib/telemetry/agentBuilder-api.test.ts
+++ b/repo-b/src/lib/telemetry/agentBuilder-api.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID } from "./api";
+import { dryRunWorkflow, getPalette } from "./agentBuilder-api";
+
+// This bug was a tenant-context-propagation break: the Agent Builder API stopped sending
+// env_id/business_id, so the headerless reviewer login 403'd. Test the pipe directly —
+// the real agentBuilder-api + real apiFetch must put the demo scope on the request URL for
+// both a GET and a POST. Mock only the network boundary (global fetch).
+
+function captureFetch() {
+  const calls: string[] = [];
+  const mock = vi.fn(async (input: RequestInfo | URL) => {
+    calls.push(typeof input === "string" ? input : input.toString());
+    return new Response(JSON.stringify({ schema_version: "agent-graph/v1", nodes: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  vi.stubGlobal("fetch", mock);
+  return calls;
+}
+
+describe("agentBuilder-api scope propagation", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("appends the demo scope to a GET request URL", async () => {
+    const calls = captureFetch();
+    await getPalette();
+    expect(calls).toHaveLength(1);
+    const url = new URL(calls[0]);
+    expect(url.pathname).toBe("/api/agent-builder/palette");
+    expect(url.searchParams.get("env_id")).toBe(TELEMETRY_DEMO_ENV_ID);
+    expect(url.searchParams.get("business_id")).toBe(TELEMETRY_DEMO_BUSINESS_ID);
+  });
+
+  it("appends the demo scope to a POST request URL", async () => {
+    const calls = captureFetch();
+    await dryRunWorkflow("wf-1", { run_key: "FD001-test-001" });
+    expect(calls).toHaveLength(1);
+    const url = new URL(calls[0]);
+    expect(url.pathname).toBe("/api/agent-builder/workflows/wf-1/dry-run");
+    expect(url.searchParams.get("env_id")).toBe(TELEMETRY_DEMO_ENV_ID);
+    expect(url.searchParams.get("business_id")).toBe(TELEMETRY_DEMO_BUSINESS_ID);
+  });
+});

--- a/repo-b/src/lib/telemetry/agentBuilder-api.ts
+++ b/repo-b/src/lib/telemetry/agentBuilder-api.ts
@@ -1,8 +1,17 @@
 "use client";
 
 import { apiFetch } from "@/lib/api";
+import { TELEMETRY_DEMO_BUSINESS_ID, TELEMETRY_DEMO_ENV_ID } from "./api";
 
 const BASE = "/api/agent-builder";
+
+// The Agent Builder backend resolves tenant context from session headers when present,
+// and otherwise falls back to allowlisted query params (the headerless telemetry reviewer
+// login). Mirror the Control Tower pattern: always send the demo scope as query params so
+// the page works under the reviewer login. For a real platform session the backend ignores
+// these params and uses the header-derived tenant. Sent on every method (the backend reads
+// scope from query params for GET/POST/PATCH alike, so typed POST bodies stay untouched).
+const scope = { env_id: TELEMETRY_DEMO_ENV_ID, business_id: TELEMETRY_DEMO_BUSINESS_ID };
 
 export type AgentNodeType =
   | "manual_trigger"
@@ -199,19 +208,24 @@ export interface AgentEvalRun {
 }
 
 const post = <T>(path: string, body: Record<string, unknown> = {}) =>
-  apiFetch<T>(`${BASE}${path}`, { method: "POST", body: JSON.stringify(body), timeoutMs: 120_000 });
+  apiFetch<T>(`${BASE}${path}`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    params: scope,
+    timeoutMs: 120_000,
+  });
 
 export const getPalette = () =>
-  apiFetch<{ schema_version: string; nodes: PaletteNode[] }>(`${BASE}/palette`);
+  apiFetch<{ schema_version: string; nodes: PaletteNode[] }>(`${BASE}/palette`, { params: scope });
 
 export const getMcpTools = () =>
-  apiFetch<{ tools: McpTool[] }>(`${BASE}/mcp-tools`);
+  apiFetch<{ tools: McpTool[] }>(`${BASE}/mcp-tools`, { params: scope });
 
 export const getWorkflows = () =>
-  apiFetch<{ workflows: WorkflowSummary[] }>(`${BASE}/workflows`, { timeoutMs: 60_000 });
+  apiFetch<{ workflows: WorkflowSummary[] }>(`${BASE}/workflows`, { params: scope, timeoutMs: 60_000 });
 
 export const getWorkflow = (workflowId: string) =>
-  apiFetch<WorkflowDetail>(`${BASE}/workflows/${workflowId}`);
+  apiFetch<WorkflowDetail>(`${BASE}/workflows/${workflowId}`, { params: scope });
 
 export const createWorkflow = (body: {
   name: string;
@@ -227,6 +241,7 @@ export const saveWorkflowDraft = (
   apiFetch<WorkflowDetail>(`${BASE}/workflows/${workflowId}/draft`, {
     method: "PATCH",
     body: JSON.stringify(body),
+    params: scope,
   });
 
 export const validateWorkflow = (workflowId: string) =>
@@ -236,19 +251,19 @@ export const dryRunWorkflow = (workflowId: string, input: Record<string, unknown
   post<AgentRun>(`/workflows/${workflowId}/dry-run`, { input });
 
 export const getRuns = () =>
-  apiFetch<{ runs: AgentRun[] }>(`${BASE}/runs`);
+  apiFetch<{ runs: AgentRun[] }>(`${BASE}/runs`, { params: scope });
 
 export const getRun = (runId: string) =>
-  apiFetch<AgentRun>(`${BASE}/runs/${runId}`);
+  apiFetch<AgentRun>(`${BASE}/runs/${runId}`, { params: scope });
 
 export const getWorkflowEvals = (workflowId: string) =>
-  apiFetch<AgentEvalRun>(`${BASE}/workflows/${workflowId}/evals`);
+  apiFetch<AgentEvalRun>(`${BASE}/workflows/${workflowId}/evals`, { params: scope });
 
 export const runWorkflowEvals = (workflowId: string) =>
   post<AgentEvalRun>(`/workflows/${workflowId}/evals/run`);
 
 export const getEvalRun = (evalRunId: string) =>
-  apiFetch<AgentEvalRun>(`${BASE}/eval-runs/${evalRunId}`);
+  apiFetch<AgentEvalRun>(`${BASE}/eval-runs/${evalRunId}`, { params: scope });
 
 export const stageWorkflow = (workflowId: string) =>
   post<WorkflowDetail>(`/workflows/${workflowId}/publish`, { status: "staged" });


### PR DESCRIPTION
## Summary

The telemetry **Agent Builder** tab rendered but was unusable — empty node palette, "No node selected", and a blocking banner: `Could not load: Tenant context required: this request carries no business_id`. The entire already-built builder (10 typed nodes, 16 templates, validation, dry-run with receipts, evals, tool registry) was gated behind a single 403.

## Root cause

Agent Builder's backend used **header-based** tenancy (`_scope()` → `require_tenant_context` → `x-bm-business-id`). The scoped telemetry reviewer login (`telemetry`) has no DB membership, so the proxy sets no `x-bm-business-id` header → every `/api/agent-builder/*` call 403'd. `refresh()` used `Promise.all`, so one failure blanked the whole surface. Every **working** telemetry surface (Run Console / Control Tower) instead scopes via **request params** using the `TELEMETRY_DEMO_*` constants.

## Fix

- **Backend** (`backend/app/routes/agent_builder.py`): `_scope()` now resolves `(env_id, business_id, actor)` with explicit precedence:
  1. A real header-derived tenant always wins — params ignored, never overridable (closes real-tenant downgrade).
  2. Else fall back to query params **allowlisted to the single telemetry-demo pair** (`_DEMO_SCOPE_ALLOWLIST`, sourced from `config.TELEMETRY_STREAM_*`) — closes param tenant-injection. Read from `query_params` for all methods so typed POST bodies stay untouched.
  - The allowlisted demo scope is granted **Agent Builder persistence** (Save/Validate/Dry-Run) into the `ai_agent_*` audit/config tables under `env_id='telemetry-demo'` only. It does **NOT** enable MCP write tools (still disabled / rejected by `validate_graph`), production writes, deploy/PR actions, or any non-demo-tenant mutation.
- **Frontend** (`repo-b/src/lib/telemetry/agentBuilder-api.ts`): sends the demo scope as query params on every call (mirrors `controlTower-api.ts`).
- **Degradation** (`AgentBuilder.tsx`): `refresh()` now uses `Promise.allSettled` + a structured banner, so a partial failure renders what loaded instead of blanking the palette.

## Tests

Backend (`backend/tests/test_agent_builder.py`, 33 pass):
- demo-scope param path resolves the palette **without** a `business_id` header (the regression test)
- non-allowlisted param scope → 403 (no tenant injection)
- header tenant overrides spoofed demo params (no real-tenant downgrade)
- demo scope can persist drafts + dry-runs
- write-capable MCP tool stays blocked under the demo grant

Frontend (`repo-b/src/lib/telemetry/agentBuilder-api.test.ts`, new): un-mocks `fetch` and asserts the real `agentBuilder-api` + `apiFetch` put `env_id`/`business_id` on a GET and a POST URL — tests the context pipe directly.

- Backend: `33 passed`; auth/tenant suite `130 passed, 8 skipped`, no regressions.
- Frontend: `9 passed` (2 new + 7 existing AgentBuilder).

## Notes

- **No migration** — `10035_agent_builder_mvp.sql` / `10036_agent_builder_evals.sql` already define every table.
- No production write path, no auth/tenant-isolation bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)