### PR TITLE
docs(ml): plain-language teaching comments across all live ML code, tied to the visuals

### DIFF
--- a/backend/app/services/ai_dispatch/providers/gemma_vertex_provider.py
+++ b/backend/app/services/ai_dispatch/providers/gemma_vertex_provider.py
@@ -1,5 +1,30 @@
 """Gemma-on-Vertex adapter — real Vertex AI endpoint call; fail-closed without config.
 
+WHAT THIS FILE DOES (in plain language)
+    This is the backend "translator" that lets the app actually talk to the private Gemma model
+    running on Google Cloud. Given a request, it builds the right web call to the deployed model,
+    signs in with ambient Google credentials, sends the text, and reads the answer back out.
+    If anything about the setup is missing or broken, it refuses safely instead of guessing.
+
+WHERE YOU SEE THIS
+    The Control Tower page uses this adapter to route SENSITIVE (ITAR-ish) triage to the private
+    Gemma tier — so that sensitive text is handled by our own model on our own cloud and never
+    sent to a public AI API.
+
+INPUTS -> OUTPUT
+    INPUT:  an AIRequest (the text to process) + which model name to report.
+    OUTPUT: a ProviderCompletion (the generated text + token usage), OR a typed failure that the
+            dispatch supervisor turns into UNAVAILABLE / DEGRADED.
+
+HOW TO READ IT
+    * Vertex AI endpoint = the deployed, callable Gemma model on Google Cloud.
+    * ":predict" = the standard URL suffix you POST to in order to get a prediction from it.
+    * ADC (Application Default Credentials) = ambient Google auth picked up from the environment;
+      no pasted API keys. We trade it for a short-lived token to authorize each call.
+    * fail-closed = if config is missing or auth fails, raise ProviderUnavailable rather than
+      return a fake answer. -> the supervisor maps that to UNAVAILABLE, and the Control Tower
+      shows its honest fail-closed state instead of a guessed result.
+
 Replaces the PR 1 stub. Calls a deployed Vertex AI endpoint (Model Garden Gemma) via the
 endpoint ``:predict`` contract, authenticating with Application Default Credentials (ADC).
 
@@ -33,6 +58,8 @@ _SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 _VERTEX_TIMEOUT_S = 60.0
 
 
+# Get a temporary Google sign-in token from the ambient credentials (ADC) so we can authorize a
+# call to the endpoint. -> if no credentials are available, this raises and the caller fails closed.
 def _vertex_access_token() -> str:
     """Mint a short-lived OAuth token via Application Default Credentials. Monkeypatched in tests."""
     import google.auth
@@ -45,6 +72,9 @@ def _vertex_access_token() -> str:
     return creds.token
 
 
+# Send the text to the deployed model and return its raw JSON answer. Any HTTP error (e.g. the
+# endpoint is down or unauthorized) becomes a typed ProviderCallError -> the supervisor maps that
+# to DEGRADED rather than a guessed answer.
 def _vertex_predict(
     url: str, token: str, payload: dict[str, Any], timeout: float = _VERTEX_TIMEOUT_S
 ) -> dict[str, Any]:
@@ -62,6 +92,8 @@ def _vertex_predict(
     return resp.json()
 
 
+# Different serving containers wrap the generated text differently, so this digs the actual
+# answer string out of whichever common response shape Vertex returned (and "" if none found).
 def _extract_text(data: dict[str, Any]) -> str:
     """Pull generated text out of common Vertex prediction response shapes."""
     preds = data.get("predictions")
@@ -83,6 +115,8 @@ def _extract_text(data: dict[str, Any]) -> str:
     return ""
 
 
+# Pull token counts (how much input/output the model processed) out of the response, when the
+# endpoint reports them. -> feeds the usage/cost numbers the dispatch receipts record.
 def _extract_usage(data: dict[str, Any]) -> Usage:
     meta = data.get("metadata") or data.get("usageMetadata") or {}
     if not isinstance(meta, dict):
@@ -93,9 +127,13 @@ def _extract_usage(data: dict[str, Any]) -> Usage:
     )
 
 
+# The provider object the dispatch registry calls. Its one job: turn an AIRequest into a real
+# answer from the private Gemma endpoint, or fail closed.
 class GemmaVertexProvider:
     name = ProviderName.GEMMA_GCP
 
+    # The whole call, end to end: check config, get a token, build the URL, send the text, parse
+    # the answer. Never raises out the top — it raises only the typed fail-closed errors above.
     def complete(self, req: AIRequest, model: str) -> ProviderCompletion:
         from app.config import (
             GEMMA_VERTEX_DEDICATED_DNS,
@@ -104,9 +142,13 @@ class GemmaVertexProvider:
             GEMMA_VERTEX_PROJECT_ID,
         )
 
+        # Fail-closed gate #1: if the endpoint isn't fully wired (project/region/endpoint id all
+        # set by deploy.py), refuse. -> Control Tower shows the fail-closed "not configured" state.
         if not (GEMMA_VERTEX_PROJECT_ID and GEMMA_VERTEX_LOCATION and GEMMA_VERTEX_ENDPOINT_ID):
             raise ProviderUnavailable("GEMMA_VERTEX_* is not fully configured")
 
+        # Fail-closed gate #2: if we can't get Google credentials (no ADC in the environment),
+        # refuse rather than attempt an unauthenticated call.
         try:
             token = _vertex_access_token()
         except Exception as exc:  # noqa: BLE001 — missing/invalid ADC ⇒ fail closed
@@ -125,9 +167,13 @@ class GemmaVertexProvider:
             if GEMMA_VERTEX_DEDICATED_DNS
             else f"{GEMMA_VERTEX_LOCATION}-aiplatform.googleapis.com"
         )
+        # Final call URL = host + the endpoint's resource path + ":predict". The payload wraps the
+        # request text and an output-length cap in the shape Vertex serving expects.
         url = f"https://{host}/v1/{resource}:predict"
         payload = {"instances": [{"prompt": req.task, "max_tokens": req.max_tokens}]}
 
+        # Send it. A clean transport/timeout failure becomes a typed ProviderCallError so the
+        # supervisor reports DEGRADED — again, never a fabricated answer.
         try:
             data = _vertex_predict(url, token, payload)
         except ProviderCallError:
@@ -135,6 +181,7 @@ class GemmaVertexProvider:
         except Exception as exc:  # noqa: BLE001 — transport/timeout ⇒ typed call error
             raise ProviderCallError(f"vertex request failed: {exc}") from exc
 
+        # Success: hand back the parsed answer text + token usage for the dispatch layer to record.
         return ProviderCompletion(
             text=_extract_text(data),
             model=model or "gemma",

--- a/backend/app/services/market_regime_engine.py
+++ b/backend/app/services/market_regime_engine.py
@@ -3,6 +3,43 @@
 Computes a composite market regime label (risk_on / risk_off / transitional / stress)
 from four asset-class signal pillars: equities, rates, credit, crypto.
 
+===== TEACHING NOTES (plain language) =====
+WHAT THIS FILE DOES:
+  This is the LIVE backend that answers "what mood is the market in right now?" for
+  the app (it sits behind the /api/market/regime endpoint). It is a scorecard, not
+  machine learning: it reads a handful of real market numbers, turns each into a
+  0-to-1 "health score," blends them into one overall score, and maps that to a
+  plain label. Like the notebooks' classifier, the rules and thresholds are
+  hand-chosen and fully transparent — nothing is "trained."
+
+  The four "pillars" are the four corners of the market it watches:
+    - equities (stocks: S&P 500 vs. its trend, the VIX fear gauge, momentum)
+    - rates    (government bond yields and the 2s10s yield-curve spread)
+    - credit   (how much extra interest risky borrowers pay = credit spreads)
+    - crypto   (Bitcoin's recent return and dominance)
+  Each pillar is scored 0.0-1.0, where 0 = bearish/stress and 1 = bullish/risk-on.
+
+WHERE YOU SEE THIS:
+  Drives the market-regime surface in the UI: the headline regime label (e.g.
+  "Risk-On") and the composite gauge (the 0-1 needle), plus the per-pillar
+  breakdown and the cross-vertical "what this means for REPE / Credit / PDS" notes.
+
+INPUTS -> OUTPUT:
+  Reads fact_market_timeseries (latest market metrics) -> writes a snapshot row to
+  public.market_regime_snapshot and returns a RegimeSnapshot object holding the
+  label, confidence, per-pillar breakdown, and implications.
+
+HOW TO READ THE NUMBERS:
+  - pillar score : 0-1 health of one asset class (1 = calm/bullish, 0 = stressed).
+  - composite    : the single blended 0-1 score = weighted average of the four
+                   pillars (equities 0.30, rates 0.25, credit 0.25, crypto 0.20).
+                   This is the gauge needle.
+  - regime label : the composite bucketed into a 4-tier name (see thresholds below).
+  - confidence   : how DECISIVE the call is = how far the composite sits from the
+                   nearest tier boundary, scaled 0-100. A score sitting right on a
+                   threshold is a coin-flip (low confidence); one deep inside a tier
+                   is a confident call. It is NOT a probability of being right.
+
 Data sources:
 - fact_market_timeseries (existing table, additive reads only)
 - public.market_regime_snapshot (new table, additive writes only)
@@ -57,7 +94,14 @@ def _clamp(v: float, lo: float = 0.0, hi: float = 1.0) -> float:
 
 
 def _regime_from_composite(composite: float) -> tuple[str, float]:
-    """Return (regime_label, confidence_pct) from composite score 0–1."""
+    """Return (regime_label, confidence_pct) from composite score 0–1.
+
+    Plain language: take the single blended 0-1 score and (1) bucket it into a
+    named tier, and (2) measure how decisive that call is. Confidence here is just
+    "how far from the nearest tier boundary is the score?" — a score parked right on
+    a threshold is a near coin-flip (low confidence); one sitting deep in the middle
+    of a tier is a confident call. It is NOT the odds of being correct.
+    """
     thresholds = [
         (0.65, "risk_on"),
         (0.50, "transitional"),
@@ -147,14 +191,22 @@ def _compute_equities_score(cur) -> AssetClassSignal:
         rsi = data.get(("SPX", "rsi_14"))
         ret20 = data.get(("SPX", "return_20d"))
 
+        # Each block below turns one raw market reading into a 0-1 health score.
+        # The pattern is always the same: pick a "bad" level and a "good" level,
+        # then scale linearly between them and clamp to [0,1]. The score is then
+        # averaged with the others to get this pillar's overall score.
         if spx_close and spx_ma200:
+            # Stock price relative to its own 200-day average. Above the average
+            # (ratio > 1) = uptrend = bullish. Map 0.85x -> 0 (well below trend)
+            # and 1.15x -> 1 (well above trend).
             ratio = spx_close / spx_ma200
             s = _clamp((ratio - 0.85) / 0.30)  # 0.85 → 0, 1.15 → 1
             scores.append(s)
             signals.append({"name": "SPX vs MA200", "value": round(ratio, 4), "score": round(s, 3)})
 
         if vix:
-            # VIX 12 → 1.0 (calm), VIX 40 → 0.0 (panic)
+            # VIX is the stock-market "fear gauge." Low = calm, high = panic, so it
+            # scores INVERSELY: VIX 12 → 1.0 (calm/bullish), VIX 40 → 0.0 (panic).
             s = _clamp((40.0 - vix) / 28.0)
             scores.append(s)
             signals.append({"name": "VIX level", "value": round(vix, 2), "score": round(s, 3)})
@@ -173,10 +225,12 @@ def _compute_equities_score(cur) -> AssetClassSignal:
     except Exception:
         pass
 
+    # Pillar score = simple average of whatever signals we managed to read. If no
+    # data came back at all, fall back to a neutral 0.5 rather than a false extreme.
     composite = sum(scores) / len(scores) if scores else 0.5
     return AssetClassSignal(
         score=round(_clamp(composite), 4),
-        weight=0.30,
+        weight=0.30,  # equities carry the most weight in the final blend.
         signals=signals,
     )
 
@@ -217,6 +271,9 @@ def _compute_rates_score(cur) -> AssetClassSignal:
         us10y_ma = data.get(("US10Y", "ma_252"))
 
         if us2y and us10y:
+            # 2s10s spread = the 10-year yield minus the 2-year yield. Normally
+            # long-term yields are higher (positive spread = healthy). When it goes
+            # negative the curve is "inverted" — a classic recession warning.
             spread = us10y - us2y
             # 2s10s: +1.5 = normal/bullish, -0.5 = deeply inverted/stress
             s = _clamp((spread + 0.5) / 2.0)
@@ -282,7 +339,10 @@ def _compute_credit_score(cur) -> AssetClassSignal:
             spread = float(r["value"])
             ticker = r["ticker"]
             if ticker == "HYG_SPREAD":
-                # HY spreads: 300bps = risk-on (1.0), 800bps = stress (0.0)
+                # A credit spread is the extra interest risky borrowers pay over safe
+                # government bonds — a direct read on how nervous lenders are. Tight
+                # (low) = confident/risk-on; wide (high) = fear/stress. Scores
+                # inversely: HY 300bps = risk-on (1.0), 800bps = stress (0.0).
                 s = _clamp((800.0 - spread) / 500.0)
                 scores.append(s)
                 signals.append({
@@ -347,6 +407,8 @@ def _compute_crypto_score(cur) -> AssetClassSignal:
         btc_dom = data.get(("BTC_DOMINANCE", "pct"))
 
         if btc_ret is not None:
+            # Bitcoin's last-30-days return as a risk-appetite proxy: a strong rally
+            # signals risk-on, a deep drop signals risk-off. -30% → 0, +30% → 1.
             s = _clamp((btc_ret + 0.30) / 0.60)  # -30% → 0, +30% → 1
             scores.append(s)
             signals.append({
@@ -387,17 +449,21 @@ def compute_regime_snapshot(tenant_id: UUID | None = None) -> RegimeSnapshot:
     Returns the persisted RegimeSnapshot.
     """
     with get_cursor() as cur:
+        # Score each of the four pillars independently (each returns a 0-1 score).
         eq = _compute_equities_score(cur)
         ra = _compute_rates_score(cur)
         cr = _compute_credit_score(cur)
         cy = _compute_crypto_score(cur)
 
+        # Blend the pillars into ONE number: a weighted average where equities count
+        # most (0.30) and crypto least (0.20). This composite is the gauge needle.
         composite = (
             eq.score * eq.weight
             + ra.score * ra.weight
             + cr.score * cr.weight
             + cy.score * cy.weight
         )
+        # Bucket the composite into a named regime and measure how decisive it is.
         regime_label, confidence = _regime_from_composite(composite)
 
         signal_breakdown = {

--- a/backend/app/services/telemetry_receipts.py
+++ b/backend/app/services/telemetry_receipts.py
@@ -1,5 +1,34 @@
 """Model Workbench receipt loader (Part I.1) — read-only, fail-closed, serving-light.
 
+WHAT THIS FILE DOES (in plain language)
+    Reads pre-computed "receipts" off disk and hands them to the UI. A "receipt" here = a
+    committed, provenance-stamped JSON record of what an OFFLINE machine-learning run already
+    produced (a training run, a threshold sweep, a data-quality study, etc.). The app does NOT
+    re-run any ML to show these numbers — it just replays the saved record. If the receipt for a
+    given panel hasn't been generated yet, this loader returns an honest "not generated yet" state
+    instead of inventing a number.
+
+WHERE YOU SEE THIS
+    * Model Workbench page panels (experiment runs, threshold sweep, parity, promotion review,
+      drift, embeddings, SHAP).
+    * Relativity MES Build Analytics page — the Multi-Seed Stability and Chaos/Data-Quality
+      panels (the mes_* receipts below).
+    A missing receipt here is exactly why one of those panels shows "receipt not generated yet".
+
+INPUTS -> OUTPUT
+    INPUT:  a receipt "kind" (one of RECEIPT_FILES below) -> names which committed file to read.
+    OUTPUT: a dict with the full provenance header + the payload, OR a fail-closed envelope whose
+            null_reason explains why there's no data (file absent / unreadable / malformed).
+
+HOW TO READ IT
+    * receipt = a committed, signed-by-provenance snapshot of a past offline run's results, so the
+      UI can show real history without recomputing anything live.
+    * provenance header = the strict "where did this come from" block on every receipt (which
+      provider produced it, the Vertex run id, when, the data fingerprint, etc. — see
+      _HEADER_FIELDS). It's what makes the displayed numbers auditable/trustworthy.
+    * fail-closed = on any problem, return null_reason (HTTP stays 200) rather than a fake value
+      or a 500. The loader also imports zero heavy ML libraries, so it's cheap and safe to call.
+
 The Workbench *replays* committed receipt artifacts; it NEVER triggers live compute. Each receipt is a
 committed JSON file under ``app/data/telemetry/`` carrying a strict provenance header plus a payload
 body. Real receipts are produced offline by the GCP MLOps pipeline (Part II) and committed verbatim.
@@ -20,6 +49,9 @@ from typing import Any
 
 _RECEIPT_DIR = Path(__file__).resolve().parent.parent / "data" / "telemetry"
 
+# The catalog of valid receipts: each "kind" the UI can ask for maps to the committed file that
+# holds it. Asking for any kind not in this map is treated as a programmer error (see load_receipt).
+# The first block feeds Model Workbench panels; the mes_* block feeds MES Build Analytics panels.
 # kind -> committed filename. These five are the Model Workbench receipt contract (Part I.1).
 RECEIPT_FILES: dict[str, str] = {
     "experiment_runs": "experiment_runs.json",
@@ -38,6 +70,9 @@ RECEIPT_FILES: dict[str, str] = {
     "mes_data_quality": "mes_data_quality.json",
 }
 
+# The "where did this come from" block stamped on every receipt — this is what makes a displayed
+# number auditable. Each field answers one trust question (who produced it, which run, when, against
+# what data fingerprint). If a field is absent it's set to None, never guessed.
 # Strict provenance header every receipt carries. Missing keys normalize to None — never fabricated.
 _HEADER_FIELDS = (
     "provider",               # databricks | vertex | local_fixture | None
@@ -55,10 +90,13 @@ _HEADER_FIELDS = (
 _NOT_GENERATED = "gcp_receipt_not_generated_yet"
 
 
+# A blank provenance header (all fields None) — the starting point we fill in from a real receipt.
 def _empty_header() -> dict[str, Any]:
     return {k: None for k in _HEADER_FIELDS}
 
 
+# Build the honest "no data" envelope. fallback_used=True + a null_reason tell the UI to show the
+# explained empty state. -> this is the shape a panel receives when its receipt isn't generated yet.
 def _fail_closed(kind: str, reason: str) -> dict[str, Any]:
     return {
         "kind": kind,
@@ -76,19 +114,27 @@ def load_receipt(kind: str, *, base_dir: Path | None = None) -> dict[str, Any]:
     unreadable file returns a ``null_reason`` envelope so the route stays at HTTP 200 and the UI shows
     the honest "receipt not generated yet" state instead of a fabricated value or a 500.
     """
+    # An unknown kind means the caller asked for something not in our catalog — that's a bug, so
+    # raise loudly. (Everything below this point fails SOFT, never raising.)
     if kind not in RECEIPT_FILES:
         raise ValueError(f"unknown receipt kind: {kind!r}")
     directory = base_dir or _RECEIPT_DIR
     path = directory / RECEIPT_FILES[kind]
+    # No file on disk = the offline run hasn't produced this receipt yet -> panel shows
+    # "not generated yet" rather than a number.
     if not path.exists():
         return _fail_closed(kind, _NOT_GENERATED)
+    # File exists but won't parse as JSON / can't be read -> honest "unreadable" empty state.
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (ValueError, OSError):
         return _fail_closed(kind, "receipt_unreadable")
+    # File parsed but isn't the expected object shape -> honest "malformed" empty state.
     if not isinstance(raw, dict):
         return _fail_closed(kind, "receipt_malformed")
 
+    # Good receipt: copy through only the provenance fields that are actually present (absent ones
+    # stay None) so the response always carries the complete, auditable header contract.
     header = _empty_header()
     for k in _HEADER_FIELDS:
         if raw.get(k) is not None:

--- a/scripts/gemma_vertex_stage/deploy.py
+++ b/scripts/gemma_vertex_stage/deploy.py
@@ -1,5 +1,36 @@
 """Deploy the smallest Gemma to a Vertex endpoint (stage), cheapest GPU, and save state.
 
+WHAT THIS FILE DOES (in plain language)
+    Stands up a private copy of Google's open "Gemma" language model on Google Cloud's
+    managed ML platform ("Vertex AI"), so sensitive text can be triaged WITHOUT sending it to
+    any public AI API. It picks the smallest Gemma and the cheapest GPU, deploys it, looks up
+    the model's private web address, and saves everything needed to call it later.
+
+    Vocabulary you'll meet here:
+      * Vertex AI  = Google Cloud's managed ML platform (where the model runs).
+      * endpoint   = a deployed, callable model — you POST text to it and get text back.
+      * Model Garden = Google's catalog of ready-to-deploy open models (Gemma lives here).
+      * L4 GPU     = the graphics chip that runs the model; ~$1/hr WHILE WARM. That's why we
+                     deploy on demand and tear down right after — see teardown.py.
+
+WHERE YOU SEE THIS
+    This is an operator/provisioning script, not a page. The endpoint it creates is what the
+    backend "Gemma on Vertex" adapter (gemma_vertex_provider.py) calls, which is in turn what
+    the Control Tower page uses to route SENSITIVE triage to the private model tier.
+
+INPUTS -> OUTPUT
+    INPUTS:  Google credentials (via GOOGLE_APPLICATION_CREDENTIALS) + the GVS_* env overrides
+             below (which model / region / machine / GPU to use).
+    OUTPUT:  a live Vertex endpoint, plus ~/.gemma-stage-state.json holding
+             project/location/endpoint_id/dedicated_dns, plus printed `export` lines that wire
+             the dispatch adapter to this endpoint.
+
+HOW TO READ IT
+    * "dedicated DNS" = the endpoint's own private web address (Model Garden endpoints reject
+      the shared Google domain, so we must fetch and use their dedicated address).
+    * The two-attempt retry exists because Google's very first deploy in a fresh project can
+      return a transient 500 while it provisions service agents — one retry usually clears it.
+
 Usage:
     GOOGLE_APPLICATION_CREDENTIALS=~/.gcp-stage-sa.json \\
       python -m scripts.gemma_vertex_stage.deploy
@@ -24,13 +55,20 @@ from pathlib import Path
 STATE = Path(os.path.expanduser("~/.gemma-stage-state.json"))
 
 
+# Look up the endpoint's private web address ("dedicated DNS"). Model Garden endpoints can only
+# be called at this address, not the shared Google domain, so we read it back from Vertex and
+# save it. -> this value becomes GEMMA_VERTEX_DEDICATED_DNS, which the backend adapter uses to
+# reach the model; without it, calls to a Model Garden endpoint fail.
 def _fetch_dedicated_dns(project: str, location: str, endpoint_id: str) -> str:
     import google.auth
     import httpx
     from google.auth.transport.requests import Request
 
+    # Application Default Credentials (ADC): ambient Google auth from the environment — no pasted
+    # keys. We exchange them for a short-lived token to authorize the lookup call below.
     creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
     creds.refresh(Request())
+    # Ask Vertex for the endpoint's details; the dedicated address is one field in the response.
     r = httpx.get(
         f"https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/{endpoint_id}",
         headers={"Authorization": "Bearer " + creds.token},
@@ -39,7 +77,10 @@ def _fetch_dedicated_dns(project: str, location: str, endpoint_id: str) -> str:
     return r.json().get("dedicatedEndpointDns", "") if r.status_code == 200 else ""
 
 
+# Deploy Gemma, fetch its private address, save state, and print the env lines to wire it up.
 def main() -> int:
+    # Read the deployment choices (which model / region / machine / GPU), falling back to the
+    # cheapest sensible stage defaults when an override isn't set.
     project = os.environ.get("GVS_PROJECT", "novendor-events-prod")
     location = os.environ.get("GVS_LOCATION", "us-central1")
     model_id = os.environ.get("GVS_MODEL", "google/gemma3@gemma-3-1b-it")
@@ -50,13 +91,19 @@ def main() -> int:
     from google.api_core.exceptions import InternalServerError
     from vertexai.preview import model_garden
 
+    # Point the Vertex client at the target project/region, then grab the Gemma model from
+    # Google's Model Garden catalog so we can deploy it.
     vertexai.init(project=project, location=location)
     print(f"[deploy] {model_id} on {machine} + 1x {accel} in {project}/{location} ...", flush=True)
     model = model_garden.OpenModel(model_id)
 
+    # Deploy the model onto a warm GPU and get back a callable endpoint. The retry handles the
+    # one-time transient 500 Google can throw the very first time a project deploys anything.
     endpoint = None
     for attempt in (1, 2):  # first Vertex use can 500 (service-agent provisioning) — retry once
         try:
+            # accept_eula=True agrees to Gemma's license; this call is what actually spins up the
+            # (billable) GPU-backed endpoint.
             endpoint = model.deploy(
                 accept_eula=True,
                 machine_type=machine,
@@ -73,6 +120,8 @@ def main() -> int:
             time.sleep(10)
 
     assert endpoint is not None
+    # Pull the short numeric endpoint id out of its full resource path, look up its private
+    # address, and save both to disk so run.py and teardown.py can find this exact endpoint.
     ep_id = endpoint.resource_name.rsplit("/", 1)[-1]
     dns = _fetch_dedicated_dns(project, location, ep_id)
     state = {"project": project, "location": location, "endpoint_id": ep_id, "dedicated_dns": dns}
@@ -81,6 +130,8 @@ def main() -> int:
     print(f"\n[deploy] DONE endpoint_id={ep_id}")
     print(f"[deploy] dedicated_dns={dns or '(none — regular endpoint)'}")
     print(f"[deploy] state saved to {STATE}\n")
+    # Print copy-paste env lines so an operator can point the backend Gemma adapter at this
+    # endpoint. -> set these and the Control Tower can route sensitive triage to this private tier.
     print("# export these to wire the dispatch adapter (STAGE ONLY):")
     print(f"export GEMMA_VERTEX_PROJECT_ID={project}")
     print(f"export GEMMA_VERTEX_LOCATION={location}")

--- a/scripts/gemma_vertex_stage/run.py
+++ b/scripts/gemma_vertex_stage/run.py
@@ -1,5 +1,29 @@
 """Exercise the governed dispatch path against the stage Gemma endpoint, and print evidence.
 
+WHAT THIS FILE DOES (in plain language)
+    Proves the deployed Gemma endpoint actually works AND that the safety rules around it hold.
+    It sends one real request through the same routing code the live app uses, prints what
+    happened, and captures the "receipt" (a record of the call) WITHOUT writing it to the real
+    production audit log. Then it checks the guardrails: a broken endpoint should fail safely,
+    and Gemma should stay BLOCKED for high-risk, code, and sensitive-privacy requests.
+
+WHERE YOU SEE THIS
+    Operator verification script. The routing it exercises is the same logic the Control Tower
+    page relies on when it decides whether to send triage to the private Gemma tier.
+
+INPUTS -> OUTPUT
+    INPUTS:  ~/.gemma-stage-state.json (written by deploy.py) + Google credentials.
+    OUTPUT:  printed evidence lines (provider availability, the routing decision, run status,
+             receipt summary, and the four guardrail checks). No production data is written.
+
+HOW TO READ IT
+    * dispatch  = the governed router that picks WHICH model handles a request and records a
+      receipt proving what it did.
+    * fail-closed = if something isn't fully/correctly configured, the system returns UNAVAILABLE
+      rather than guessing. -> the "bad endpoint" check below confirms this.
+    * "receipt" here = a redacted record of the call (decision + model used + tags), deliberately
+      WITHOUT the raw answer, so logs never leak sensitive content.
+
 Usage:
     GOOGLE_APPLICATION_CREDENTIALS=~/.gcp-stage-sa.json \\
       python -m scripts.gemma_vertex_stage.run
@@ -20,7 +44,10 @@ ROOT = Path(__file__).resolve().parents[2]
 STATE = Path(os.path.expanduser("~/.gemma-stage-state.json"))
 
 
+# Wire the backend to the deployed endpoint, send one real request, capture its receipt, then
+# run the four guardrail checks and print evidence of each.
 def main() -> int:
+    # No state file means deploy.py never ran (or was torn down) — nothing to test against.
     if not STATE.exists():
         print(f"no state file at {STATE} — run deploy.py first", file=sys.stderr)
         return 2
@@ -33,6 +60,8 @@ def main() -> int:
     os.environ["GEMMA_VERTEX_ENDPOINT_ID"] = st["endpoint_id"]
     if st.get("dedicated_dns"):
         os.environ["GEMMA_VERTEX_DEDICATED_DNS"] = st["dedicated_dns"]
+    # Turn execution on for this run, and feed harmless placeholder DB/Supabase values so the
+    # backend modules import cleanly — this script never touches a real database.
     os.environ["AI_DISPATCH_ENABLED"] = "true"
     os.environ.setdefault("DATABASE_URL", "postgresql://placeholder:placeholder@localhost:5432/placeholder")
     os.environ.setdefault("SUPABASE_URL", "https://placeholder.supabase.co")
@@ -45,22 +74,32 @@ def main() -> int:
     from app.services.ai_dispatch.supervisor import run_dispatch
 
     print(f"=== STAGE endpoint {st['endpoint_id']} ({st['project']}/{st['location']}) ===")
+    # Check 1: is the Gemma provider registered and usable at all?
     print("[providers] gemma available:", provider_registry.available(ProviderName.GEMMA_GCP))
 
+    # Check 2: a low-risk summarize request should ROUTE to Gemma. select_provider only decides
+    # the route (no model call yet); we print which provider it picked.
     req = AIRequest(task="Summarize: loader retried 3x then OOM.", mode=TaskMode.SUMMARIZATION, risk_level=RiskLevel.LOW)
     d = select_provider(req)
     print(f"[route] summarization/low -> {d.status.value} / {d.selected_provider.value if d.selected_provider else None}")
 
+    # Check 3: actually run the request. We swap in a fake recorder that CAPTURES the receipt in
+    # memory instead of writing to the production audit log, so this test leaves prod untouched.
     captured: dict = {}
     receipts_mod.record_decision = lambda **kw: (captured.update(kw) or "stage-receipt-id")  # capture, no prod write
     r = run_dispatch(req)
     print(f"[run] -> status={r.status.value} provider={r.provider.value if r.provider else None} latency_ms={r.latency_ms}")
     print(f"[run] answer (first 160): {(r.answer or '')[:160]!r}")
     if captured:
+        # Confirm the receipt records the decision but does NOT contain the raw answer text —
+        # this is the privacy guarantee that lets us log every call safely.
         print(f"[receipt] decision_type={captured.get('decision_type')} model_used={captured.get('model_used')} tags={captured.get('tags')}")
         no_answer = (r.answer or "X") not in json.dumps(captured.get("output_summary") or {})
         print(f"[receipt] raw answer NOT in output_summary: {no_answer}")
 
+    # Check 4 (fail-closed): point the config at a bogus endpoint id, run again, and confirm the
+    # system returns a safe UNAVAILABLE/null_reason instead of guessing. Then restore the real id.
+    # -> in the live app this same path is what makes the Control Tower show its fail-closed state.
     import app.config as cfg
     good = cfg.GEMMA_VERTEX_ENDPOINT_ID
     cfg.GEMMA_VERTEX_ENDPOINT_ID = "0000000000000000000"
@@ -68,6 +107,8 @@ def main() -> int:
     print(f"[fail-closed] bad endpoint -> {rbad.status.value}/{rbad.null_reason.value if rbad.null_reason else None}")
     cfg.GEMMA_VERTEX_ENDPOINT_ID = good
 
+    # Check 5 (policy guardrails): Gemma must stay BLOCKED for high-risk, code, and sensitive
+    # requests. These are decisions only (no model call); we just confirm each one is refused.
     hi = select_provider(AIRequest(task="x", mode=TaskMode.SUMMARIZATION, risk_level=RiskLevel.HIGH))
     code = select_provider(AIRequest(task="x", mode=TaskMode.CODE, risk_level=RiskLevel.LOW, forced_provider=ProviderName.GEMMA_GCP))
     sens = select_provider(AIRequest(task="x", mode=TaskMode.SUMMARIZATION, risk_level=RiskLevel.LOW, privacy=Privacy.SENSITIVE))

--- a/scripts/gemma_vertex_stage/teardown.py
+++ b/scripts/gemma_vertex_stage/teardown.py
@@ -1,5 +1,27 @@
 """Tear down the stage Gemma endpoint + model to stop GPU billing.
 
+WHAT THIS FILE DOES (in plain language)
+    Shuts the Gemma deployment back down so we STOP paying for the GPU. The L4 GPU costs about
+    $1/hour while warm, so the model is kept "cold" (not deployed) by default and only warmed up
+    when needed. This script does the cooling-down: it undeploys the model, deletes the endpoint
+    and model, and clears the saved state file.
+
+WHERE YOU SEE THIS
+    Operator/cost-control script (the cleanup half of deploy.py). No page.
+
+INPUTS -> OUTPUT
+    INPUTS:  ~/.gemma-stage-state.json (written by deploy.py), or GVS_ENDPOINT_ID to force a
+             teardown without that file. Plus Google credentials.
+    OUTPUT:  the GPU-backed model is removed and billing stops; the state file is deleted.
+
+HOW TO READ IT
+    * "undeploy" = take the model off its GPU (this is what actually stops the meter); "delete"
+      then removes the now-idle endpoint and model records.
+    * "Idempotent" = safe to run twice — if a resource is already gone, the error is ignored and
+      the script still finishes cleanly.
+    * cold vs warm GPU: cold = nothing deployed, $0/hr (this script's end state); warm = deployed
+      and billing. Re-warming later is cheap because the endpoint/config can be recreated.
+
 Usage:
     GOOGLE_APPLICATION_CREDENTIALS=~/.gcp-stage-sa.json \\
       python -m scripts.gemma_vertex_stage.teardown
@@ -16,7 +38,11 @@ from pathlib import Path
 STATE = Path(os.path.expanduser("~/.gemma-stage-state.json"))
 
 
+# Find which endpoint to remove (from the saved state, or a forced env id), then undeploy and
+# delete it so GPU billing stops.
 def main() -> int:
+    # If deploy.py never ran there's no saved endpoint. We still allow a forced teardown via
+    # GVS_ENDPOINT_ID (e.g. cleaning up a leftover endpoint by hand); otherwise there's nothing to do.
     if not STATE.exists():
         print(f"[teardown] no state file at {STATE}; nothing to do (set GVS_ENDPOINT_ID to force).")
         endpoint_id = os.environ.get("GVS_ENDPOINT_ID", "")
@@ -31,6 +57,9 @@ def main() -> int:
     from google.cloud import aiplatform
 
     aiplatform.init(project=project, location=location)
+    # Step 1: undeploy then delete the endpoint. undeploy_all is the line that actually stops the
+    # GPU meter; delete removes the now-idle endpoint. A failure here usually means it's already
+    # gone, which is fine (idempotent) — we log and continue.
     try:
         ep = aiplatform.Endpoint(endpoint_id)
         print("[teardown] undeploying all models (stops GPU billing)...", flush=True)
@@ -41,6 +70,7 @@ def main() -> int:
     except Exception as exc:  # noqa: BLE001 — already gone is fine
         print(f"[teardown] endpoint cleanup: {exc}")
 
+    # Step 2: delete the uploaded model record(s) by their display name, so no stray model lingers.
     try:
         for m in aiplatform.Model.list(filter='display_name="ai-dispatch-stage-gemma"'):
             print(f"[teardown] deleting model {m.resource_name}", flush=True)
@@ -48,6 +78,8 @@ def main() -> int:
     except Exception as exc:  # noqa: BLE001
         print(f"[teardown] model cleanup: {exc}")
 
+    # Step 3: remove the saved state file so the next deploy starts clean and run.py knows there's
+    # no live endpoint anymore.
     try:
         STATE.unlink()
     except Exception:

--- a/scripts/ml_demo_materialize.py
+++ b/scripts/ml_demo_materialize.py
@@ -4,6 +4,43 @@
 Writes BigQuery tables (observations / predictions / eval) and exports model
 cards to GCS so the lab's GCP detail links resolve to real resources.
 
+===== TEACHING NOTES (plain language) =====
+WHAT THIS FILE DOES:
+  This is a one-shot publishing script for the ML Algorithm Decision Lab — a
+  teaching playground where a user can compare different ML algorithms side by side.
+  "Materialize" here just means: take the lab's datasets and the model results and
+  write them out to real cloud storage (BigQuery tables + model-card files in GCS)
+  so the lab's "view this in GCP" links point at actual, browsable resources instead
+  of dead links. This script doesn't train anything itself — it persists what the
+  lab produces so the cloud-detail panels have something real to show.
+
+  How the lab itself works (context for what's being materialized): the lab trains
+  several SMALL, SYNTHETIC models on demand using a fixed random seed. "Synthetic"
+  means the data is generated, not real-world; "fixed seed" means everyone gets the
+  exact same numbers every run, so the comparison is reproducible and fair. The
+  point is to TEACH algorithm trade-offs (accuracy vs. speed vs. interpretability),
+  not to make real predictions. The lab also has a "Reality Mode" that throws
+  curveballs at the trained models (shifted/noisier data) to expose where each one
+  is fragile — a deliberate "watch it break" teaching moment.
+
+WHERE YOU SEE THIS:
+  Feeds the MLAlgorithmLab pages in the UI:
+    - AlgorithmComparisonMatrix : the grid comparing algorithms head-to-head
+    - AlgorithmDetailPanel      : the drill-in view for one algorithm (incl. the
+                                  GCP resource links this script makes resolvable)
+    - HonestMetricsPanel        : the "no cherry-picking" metrics view, including
+                                  how models hold up under Reality Mode curveballs
+
+INPUTS -> OUTPUT:
+  Input: the lab's generated datasets + model evaluation results (and GCP env config
+  for where to write). Output: BigQuery tables (observations / predictions / eval)
+  and GCS model-card exports. Prints a JSON summary of what it did.
+
+HOW TO READ THE OUTPUT:
+  The printed JSON's "status" tells you the result: "skipped" (with a reason) means
+  the GCP config wasn't present, so it wrote nothing and exits cleanly (fail-soft) —
+  this is normal in environments without cloud credentials, not an error.
+
 Usage:
     python scripts/ml_demo_materialize.py --dry-run     # show the plan only
     python scripts/ml_demo_materialize.py               # write to BigQuery/GCS
@@ -36,8 +73,12 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true", help="print the plan, write nothing")
     args = parser.parse_args()
 
+    # Do the actual write (or, with --dry-run, just describe the plan and touch
+    # nothing). The returned dict is echoed as JSON so a human or CI can see exactly
+    # which tables/files were written or why it was skipped.
     result = materialize(dry_run=args.dry_run)
     print(json.dumps(result, indent=2))
+    # "skipped" is the fail-soft path: config missing -> nothing written, exit 0.
     if result.get("status") == "skipped":
         print(f"\n[skipped] {result.get('reason')}", file=sys.stderr)
     return 0

--- a/skills/historyrhymes/notebooks/02_build_features.py
+++ b/skills/historyrhymes/notebooks/02_build_features.py
@@ -2,6 +2,36 @@
 
 Reads from signals_raw, writes to signals_featured.
 
+===== TEACHING NOTES (plain language) =====
+WHAT THIS FILE DOES:
+  This is the "feature engineering" step. Raw market numbers (an inflation index,
+  a VIX level, a credit spread) are hard to compare because they live on totally
+  different scales. This step turns each raw number into a few standardized,
+  comparable descriptions of "how unusual is today vs. recent history":
+    - z-score : how many standard deviations today's value is from its own recent
+                average. 0 = perfectly normal, +2 = unusually high, -2 = unusually
+                low. This is the key "is this weird?" measure.
+    - delta   : the simple change in a value over the last week / last month
+                (today minus a-week-ago). Tells you direction and speed of movement.
+    - percentile : where today ranks among the last 2 years of its own values
+                (0.95 = higher than 95% of recent days = near a 2-year extreme).
+
+WHERE YOU SEE THIS:
+  Nowhere directly. These engineered features are the *inputs* that feed the next
+  two steps. The regime classifier (03) and the analog scorer (04) both read these
+  z-scores. So this file quietly shapes every regime label and "most similar past
+  period" the History Rhymes UI shows.
+
+INPUTS -> OUTPUT:
+  Reads the signals_raw table (one raw value per signal per day) ->
+  writes the signals_featured table (the same rows, now enriched with
+  zscore_1y, zscore_2y, delta_1w, delta_1m, percentile_2y, plus freshness flags).
+
+HOW TO READ THE NUMBERS:
+  z = (today's value - recent average) / recent standard deviation.
+  A standard deviation is the "typical wobble" of the signal; dividing by it puts
+  every signal on the same ruler so they can be compared and combined later.
+
 Fixes applied:
   - RANGE BETWEEN INTERVAL for date-based windows (handles gaps in monthly data)
   - CPI YoY computed from index before z-scoring
@@ -22,6 +52,11 @@ from databricks_client import DatabricksClient
 
 
 # Step 1: Compute CPI YoY from the raw CPI index
+# The raw inflation feed is a price *index* (a level like 312.4) which means
+# nothing on its own. What people actually care about is the year-over-year
+# inflation *rate*: today's index divided by the index 12 months ago, minus 1.
+# This block computes that rate and stores it back as a new 'cpi_yoy' signal so
+# the later steps z-score the inflation *rate*, not the meaningless raw level.
 CPI_YOY_SQL = """
 MERGE INTO novendor_1.historyrhymes.signals_raw AS tgt
 USING (
@@ -45,8 +80,14 @@ WHEN MATCHED THEN UPDATE SET tgt.value = src.value, tgt.source = src.source, tgt
 WHEN NOT MATCHED THEN INSERT (as_of_date, signal_name, asset_scope, value, source) VALUES (src.as_of_date, src.signal_name, src.asset_scope, src.value, src.source)
 """
 
-# Step 2: Compute features with date-based windows
+# Step 2: Compute the engineered features for every signal.
+# For each signal we walk a "rolling window" of its own recent history (1 year and
+# 2 years) and compute the average and the standard deviation over that window.
+# A z-score is then (today - rolling average) / rolling standard deviation: the
+# core "how unusual is today" number every downstream step relies on.
 # Uses RANGE BETWEEN INTERVAL which handles gaps in monthly/weekly data correctly
+# (it measures the window by calendar days, not by row count, so missing days
+# don't quietly shrink the window).
 FEATURE_SQL = """
 MERGE INTO novendor_1.historyrhymes.signals_featured AS tgt
 USING (
@@ -89,10 +130,16 @@ USING (
         signal_name,
         asset_scope,
         value,
+        -- z-score = (today - 1yr average) / 1yr standard deviation. The guard
+        -- (std > 0.0001) avoids dividing by zero for flat signals; if the signal
+        -- never wobbled, we call it "normal" (z = 0) instead of blowing up.
         CASE WHEN std_1y > 0.0001 THEN (value - mean_1y) / std_1y ELSE 0 END AS zscore_1y,
         CASE WHEN std_2y > 0.0001 THEN (value - mean_2y) / std_2y ELSE 0 END AS zscore_2y,
+        -- deltas = plain change vs. roughly a week / a month ago (direction & speed).
         value - value_1w_ago AS delta_1w,
         value - value_1m_ago AS delta_1m,
+        -- percentile = today's rank within the last 2 years of this signal
+        -- (0.95 means today is higher than 95% of the last two years' values).
         pct_rank_2y AS percentile_2y,
         TIMESTAMPDIFF(HOUR, loaded_at, current_timestamp()) AS freshness_hours,
         CASE WHEN TIMESTAMPDIFF(HOUR, loaded_at, current_timestamp()) > 24 THEN true ELSE false END AS is_stale

--- a/skills/historyrhymes/notebooks/03_classify_regime.py
+++ b/skills/historyrhymes/notebooks/03_classify_regime.py
@@ -3,6 +3,40 @@
 Reads latest row per signal from signals_featured, applies rule set,
 writes one row per day to market_state_daily.
 
+===== TEACHING NOTES (plain language) =====
+WHAT THIS FILE DOES:
+  This step reads today's standardized signals (the z-scores built in step 02)
+  and decides which "regime" the market is in. A regime is just a short name for
+  the prevailing market mood, e.g. late-cycle, stress, disinflation, risk-on, or
+  range-bound (no clear pattern).
+
+  IMPORTANT: this is a RULES-BASED classifier, not machine learning. Nothing here
+  is "trained." There are no learned weights. It is a hand-written set of explicit
+  if/then rules ("IF the yield curve is inverted AND inflation is high AND credit
+  spreads are widening THEN call it late-cycle"). A human picked these rules and
+  thresholds; the computer just checks them. That makes it fully transparent and
+  auditable, which is the point at this phase.
+
+WHERE YOU SEE THIS:
+  The regime_label this writes drives the regime surfaces in the History Rhymes UI
+  (the headline "the market is in a ___ regime" plus the per-dimension state chips
+  like inflation=sticky, credit=widening, volatility=elevated).
+
+INPUTS -> OUTPUT:
+  Reads the latest day of signals_featured (z-scores per signal) ->
+  writes one row to market_state_daily holding the regime_label, a confidence
+  number, and a state label for each dimension (inflation/growth/liquidity/
+  volatility/credit) plus a top risk flag.
+
+HOW TO READ THE NUMBERS:
+  - regime  : the named market mood the rules matched (or range_bound if none did).
+  - z-score : reused from step 02 — how many standard deviations a signal is from
+              normal. The rules compare these z-scores to fixed thresholds.
+  - confidence : NOT a probability. It is simply the fraction of the 7 watched
+              signals that point the "risk/stress" direction (agreeing signals / 7).
+              0.85 means 6 of 7 signals lean the same way (a decisive, coherent
+              picture); 0.40 means signals disagree (a murky, mixed picture).
+
 Fixes applied:
   - VIX used directly for volatility_state (not BTC proxy)
   - CPI uses cpi_yoy (derived YoY rate, not raw index)
@@ -30,6 +64,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from databricks_client import DatabricksClient
 
 
+# The whole classification is one SQL statement built in stages:
+#   1. latest   : grab the most recent z-score for every signal.
+#   2. pivoted  : reshape those rows into one wide row with a named column per
+#                 signal (yc_z, cpi_z, spread_z, ...) so the rules can read them.
+#   3. classified : apply the hand-written if/then rules to pick a regime label,
+#                 a confidence fraction, and per-dimension state chips.
+# It then MERGEs that single result row into market_state_daily for today.
 CLASSIFY_SQL = """
 WITH latest AS (
     SELECT signal_name, value, zscore_1y, delta_1w
@@ -55,20 +96,35 @@ classified AS (
     SELECT
         current_date() AS as_of_date,
         'global' AS scope,
-        -- Regime classification
+        -- Regime classification: the hand-written rule ladder. The FIRST matching
+        -- rule wins (top to bottom), so order encodes priority. Each line reads in
+        -- plain English as a combination of conditions on the standardized signals.
         CASE
+            -- Late cycle: yield curve inverted (short rates above long rates, a
+            -- classic late-cycle warning), inflation unusually high (z > 1), and
+            -- credit spreads already widening.
             WHEN yc_value < 0 AND cpi_z > 1.0 AND spread_z > 0.5
                 THEN 'late_cycle_tightening'
+            -- Stress: fear gauge spiking (VIX very high), credit spreads blowing
+            -- out, AND jobless claims rising together — a genuine risk-off break.
             WHEN (vix_z > 1.5 OR vix_value > 30) AND spread_z > 1.5 AND claims_z > 1.0
                 THEN 'stress_transition'
+            -- Disinflation recovery: inflation falling below normal and credit
+            -- conditions easing (spreads below their average).
             WHEN cpi_z < -0.5 AND spread_z < 0
                 THEN 'disinflation_recovery'
+            -- Risk-on expansion: growth proxy up, spreads tight, claims low, calm
+            -- volatility — everything pointing the healthy/bullish direction.
             WHEN housing_z > 0 AND spread_z < -0.5 AND claims_z < 0 AND vix_z < 0
                 THEN 'risk_on_expansion'
+            -- No clean pattern matched: signals are mixed -> range_bound.
             ELSE 'range_bound'
         END AS regime_label,
-        -- Confidence: count signals supporting the dominant pattern
-        -- Each signal that agrees adds 1/7 to confidence
+        -- Confidence: NOT a probability. It is just a head-count of how many of
+        -- the 7 watched signals lean the "risk/stress" direction, divided by 7.
+        -- Each agreeing signal adds 1/7 (~0.143). A high value means the signals
+        -- tell one coherent story; a low value means they disagree (a murky call).
+        -- This number drives how decisive the regime call looks in the UI.
         (
             CASE WHEN yc_value < 0 THEN 1 ELSE 0 END +
             CASE WHEN cpi_z > 0.5 THEN 1 ELSE 0 END +
@@ -78,7 +134,11 @@ classified AS (
             CASE WHEN vix_z > 0 THEN 1 ELSE 0 END +
             CASE WHEN btc_z < 0 THEN 1 ELSE 0 END
         ) / 7.0 AS regime_confidence,
-        -- Per-dimension state labels
+        -- Per-dimension state labels: each market dimension gets its own plain
+        -- word (sticky/falling, expanding/contracting, etc.) based on where its
+        -- z-score sits. These become the colored state chips shown beside the
+        -- headline regime label in the UI, so a reader can see *why* the regime
+        -- was called, dimension by dimension.
         CASE
             WHEN cpi_z > 1.0 THEN 'sticky'
             WHEN cpi_z > 0 THEN 'elevated'
@@ -105,7 +165,9 @@ classified AS (
             WHEN spread_z > 0.3 THEN 'widening'
             ELSE 'tight'
         END AS credit_state,
-        -- Top risk flag
+        -- Top risk flag: a single short headline naming the most pressing danger
+        -- right now (or NULL if nothing stands out). Surfaced as the "watch this"
+        -- callout in the UI.
         CASE
             WHEN spread_delta > 0 AND claims_delta > 0 THEN 'credit+labor deterioration'
             WHEN spread_z > 1.5 THEN 'credit stress'

--- a/skills/historyrhymes/notebooks/04_score_analogs.py
+++ b/skills/historyrhymes/notebooks/04_score_analogs.py
@@ -2,6 +2,43 @@
 
 Returns top-3 matches (not just top-1) with proper NULL handling.
 
+===== TEACHING NOTES (plain language) =====
+WHAT THIS FILE DOES:
+  This is the "history rhymes" step: it asks "which famous past market episode
+  looks most like today?" It represents today as a short list of z-scores (one
+  per signal — think of it as today's "fingerprint") and compares that fingerprint
+  to a stored fingerprint for each historical episode (2008 GFC, 2020 COVID crash,
+  the 2022 crypto contagion, etc.). It returns the top-3 closest matches.
+
+  How "closeness" is measured: Euclidean distance — the ordinary straight-line
+  distance between two fingerprints. For each signal it takes the difference,
+  squares it, sums them up, and takes the square root (the same Pythagoras formula
+  you'd use for distance on a map, just in more than 2 dimensions). SMALLER
+  distance = more alike. Distance is then flipped into a 0-1 similarity score where
+  higher = more similar, which is friendlier to read.
+
+  PHASE-1 CAVEAT: this is a deliberately simple proxy. The reference fingerprints
+  are hardcoded below, and distance ignores the *order* things happened in. A later
+  phase swaps in proper vector search (pgvector) and path-shape matching (DTW). So
+  treat these analogs as a useful sketch, not a precise verdict.
+
+WHERE YOU SEE THIS:
+  The top-3 results are the "most similar past periods" shown to the user in the
+  History Rhymes UI, along with bull/base/bear scenario odds and a trap flag for
+  when the underlying signals disagree too much to trust the match.
+
+INPUTS -> OUTPUT:
+  Reads today's z-scores (signals_featured) and today's regime (market_state_daily)
+  -> writes one row to history_rhymes_daily with the #1 analog, its score, the
+  #2 and #3 analogs, scenario probabilities, and a trap flag/reason.
+
+HOW TO READ THE NUMBERS:
+  - Euclidean distance : straight-line distance between today's z-score vector and
+                an episode's z-score vector. Smaller = more alike.
+  - analog_score : that distance flipped to a 0-1 similarity (higher = more similar).
+  - bull/base/bear : rough scenario odds blended from regime confidence + analog fit.
+  - trap_flag : true when signals disagree (low agreement) — "don't over-trust this."
+
 Fixes applied:
   - Top 3 analogs returned, not just 1
   - NULL dimensions excluded from both numerator and denominator
@@ -39,6 +76,8 @@ current_regime AS (
     WHERE as_of_date = (SELECT MAX(as_of_date) FROM novendor_1.historyrhymes.market_state_daily)
     LIMIT 1
 ),
+-- Today's "fingerprint": one z-score per signal, laid out as a single wide row.
+-- This is the point we measure every historical episode's distance from.
 current_vector AS (
     SELECT
         MAX(CASE WHEN signal_name = 'yield_curve_10y2y' THEN zscore_1y END) AS yc_z,
@@ -50,7 +89,11 @@ current_vector AS (
         MAX(CASE WHEN signal_name = 'btc_price_usd' THEN zscore_1y END) AS btc_z
     FROM current_state
 ),
--- Episode reference vectors (Phase 1: hardcoded; Phase 2: read from Supabase episode_signals)
+-- The stored "fingerprints" for each historical episode: the same seven z-scores
+-- (yield curve, inflation, spreads, claims, housing, vix, btc) that we use for
+-- today, hand-set to characterize each episode. NULL means "this signal didn't
+-- exist or isn't relevant for that era" (e.g. there was no Bitcoin in the 1970s).
+-- Phase 1: hardcoded here; Phase 2: read from Supabase episode_signals.
 episode_refs AS (
     SELECT * FROM (VALUES
         ('2022 Luna/3AC/FTX Crypto Contagion', -0.8, 2.1, 1.2, -0.3, -0.5, 1.8, -1.8, 'deflationary_deleveraging'),
@@ -63,12 +106,17 @@ episode_refs AS (
         ('2016 Brexit Shock', 0.5, 0.0, 0.2, -0.1, 0.1, 0.8, NULL, 'crisis')
     ) AS t(name, yc_z, cpi_z, spread_z, claims_z, housing_z, vix_z, btc_z, regime_type)
 ),
+-- Compare today against EVERY episode (CROSS JOIN = pair today with each one)
+-- and compute the straight-line (Euclidean) distance between the two fingerprints.
 distances AS (
     SELECT
         e.name,
         e.regime_type,
-        -- Euclidean distance excluding NULL dimensions from BOTH sides
-        -- dim_count tracks how many dimensions are compared
+        -- Euclidean distance = sqrt( sum of (today - episode)^2 across signals ).
+        -- We only compare a signal if BOTH sides have a value; a NULL on either
+        -- side contributes 0 (it's skipped) so missing data can't fake closeness.
+        -- dim_count (below) records how many signals actually got compared, so we
+        -- can fairly normalize the distance afterward.
         SQRT(
             COALESCE(CASE WHEN c.yc_z IS NOT NULL AND e.yc_z IS NOT NULL THEN POW(c.yc_z - e.yc_z, 2) END, 0) +
             COALESCE(CASE WHEN c.cpi_z IS NOT NULL AND e.cpi_z IS NOT NULL THEN POW(c.cpi_z - e.cpi_z, 2) END, 0) +
@@ -106,7 +154,13 @@ scored AS (
         raw_dist,
         dim_count,
         categorical_match,
-        -- Normalize distance by dimension count, then convert to similarity
+        -- Turn raw distance into a 0-1 similarity score (higher = more alike).
+        -- First normalize by how many signals were compared (so episodes matched
+        -- on more signals aren't unfairly penalized), then blend three pieces:
+        --   60% structural similarity (the normalized distance, inverted),
+        --   30% a rough "path" proxy, and
+        --   10% a categorical bonus for matching the same regime type.
+        -- This blended number is the analog_score the UI shows next to each match.
         CASE WHEN dim_count > 0
             THEN 0.6 * GREATEST(0, 1 - (raw_dist / SQRT(dim_count)) / 3.0)  -- structural similarity
                + 0.3 * GREATEST(0, 1 - raw_dist / (dim_count * 1.5))         -- path proxy
@@ -122,8 +176,11 @@ scored AS (
             END DESC
         ) AS rank
     FROM distances
-    WHERE dim_count >= 3  -- Require at least 3 overlapping dimensions
+    -- Require at least 3 signals in common before we trust a comparison; matching
+    -- on only one or two signals is too thin to call anything an "analog."
+    WHERE dim_count >= 3
 ),
+-- Keep the three closest episodes (rank 1 = best match = most similar to today).
 top3 AS (
     SELECT * FROM scored WHERE rank <= 3
 )
@@ -135,7 +192,10 @@ USING (
         'global' AS scope,
         (SELECT name FROM top3 WHERE rank = 1) AS top_analog_name,
         (SELECT ROUND(analog_score, 4) FROM top3 WHERE rank = 1) AS top_analog_score,
-        -- Scenario probs: blend regime confidence with analog score
+        -- Scenario probs (bull/base/bear): rough odds for how the next stretch could
+        -- go, nudged by today's regime and how strongly today resembles the analog.
+        -- These are illustrative, not forecasts — base is pinned near 0.50 and the
+        -- tails flex a little around it. Blend regime confidence with analog score.
         ROUND(CASE
             WHEN cr.regime_label LIKE '%tightening%' THEN 0.12 + (1 - COALESCE((SELECT analog_score FROM top3 WHERE rank = 1), 0.5)) * 0.12
             ELSE 0.22 + COALESCE((SELECT analog_score FROM top3 WHERE rank = 1), 0.5) * 0.08
@@ -146,6 +206,9 @@ USING (
             ELSE 0.18 + (1 - COALESCE((SELECT analog_score FROM top3 WHERE rank = 1), 0.5)) * 0.10
         END, 4) AS bear_prob,
         ROUND(cr.regime_confidence, 4) AS confidence_score,
+        -- Trap flag: when the underlying signals barely agree (agreement < 0.4),
+        -- raise a "don't over-trust this match" warning rather than presenting a
+        -- shaky analog as if it were solid. The UI shows this as a caution badge.
         CASE WHEN cr.signal_agreement_score < 0.4 THEN true ELSE false END AS trap_flag,
         CASE WHEN cr.signal_agreement_score < 0.4 THEN 'Low signal agreement — mixed regime' ELSE NULL END AS trap_reason,
         (SELECT name || ' (score=' || ROUND(analog_score, 2) || ')' FROM top3 WHERE rank = 1) AS key_similarity_1,

--- a/skills/historyrhymes/notebooks/run_pipeline.py
+++ b/skills/historyrhymes/notebooks/run_pipeline.py
@@ -3,6 +3,36 @@
 This is the daily batch job. Each step is idempotent (MERGE/ON CONFLICT).
 The warehouse is started once at the top and stopped once at the end.
 
+===== TEACHING NOTES (plain language) =====
+WHAT THIS FILE DOES:
+  This is the daily ORCHESTRATOR — the conductor that runs the four analysis steps
+  in the right order and checks each one's work before moving on. It does no math
+  itself; it just calls the other notebooks in sequence:
+    01 load     -> pull the raw market signals into signals_raw
+    02 features -> turn raw values into z-scores/deltas/percentiles (the comparable
+                   "how unusual is today" numbers)
+    03 classify -> apply the rule set to label today's regime (market mood)
+    04 score    -> find the top-3 historical episodes most like today
+    05 export   -> push the results out to Supabase for the UI to read
+  "Idempotent" means running it twice on the same day is safe: each step overwrites
+  today's row instead of piling up duplicates.
+
+WHERE YOU SEE THIS:
+  Indirectly everywhere in History Rhymes — this is the job that refreshes all the
+  data the UI displays. If a regime label or analog looks stale, this is the run
+  that should have updated it.
+
+INPUTS -> OUTPUT:
+  Input: yesterday's tables + today's fresh signals. Output: today's row written to
+  every History Rhymes table, plus a pass/warn/fail summary printed per step.
+
+HOW TO READ THE OUTPUT:
+  After each step it runs validate_row_count() — a sanity check that the step
+  actually wrote at least one row for today. OK = step produced data; WARNING = the
+  step ran but its table has 0 rows for today (likely an upstream gap); FAILED = the
+  step threw an error. The warehouse (the compute that runs the SQL) is started once
+  up front and stopped once at the end to avoid wasteful start/stop cost.
+
 Fixes applied:
   - Single warehouse lifecycle (no start/stop thrashing)
   - Shared DatabricksClient passed to each step
@@ -22,6 +52,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from databricks_client import DatabricksClient
 
+# The ordered recipe: (module to import, human label, table to sanity-check after).
+# Order matters — each step consumes the table the previous step wrote. The third
+# tuple element is the table validate_row_count() checks; None means "no check."
 STEPS = [
     ("01_load_signals", "Load raw signals", "novendor_1.historyrhymes.signals_raw"),
     ("02_build_features", "Build features", "novendor_1.historyrhymes.signals_featured"),
@@ -32,7 +65,12 @@ STEPS = [
 
 
 def validate_row_count(client: DatabricksClient, table: str, min_rows: int = 1) -> bool:
-    """Check that a table has at least min_rows rows for today."""
+    """Check that a table has at least min_rows rows for today.
+
+    Plain language: confirm the step we just ran actually produced output for the
+    latest date. Returns True if the table has data for its newest as_of_date,
+    False if it's empty — which the orchestrator surfaces as a WARNING.
+    """
     result = client.execute_sql(f"""
         SELECT COUNT(*) FROM {table}
         WHERE as_of_date = (SELECT MAX(as_of_date) FROM {table})

--- a/skills/rs-factory-ml/notebooks/02_silver_features.py
+++ b/skills/rs-factory-ml/notebooks/02_silver_features.py
@@ -10,6 +10,42 @@
 # MAGIC salted variant spreads every key across 16 subkeys and recombines
 # MAGIC exact partials; both wall-times are MEASURED and logged to MLflow —
 # MAGIC the artifact reports whatever the data showed, it never presumes.
+# MAGIC
+# MAGIC ## ===== TEACHING NOTES (plain language) =====
+# MAGIC
+# MAGIC **WHAT THIS FILE DOES (the "silver" stage):** A 3D-printed part is built up
+# MAGIC layer by layer. As it prints, sensors record signals (flow, pressure,
+# MAGIC temperature, vibration). This notebook turns those raw signals into
+# MAGIC *shape statistics* that describe how each signal behaves across the build:
+# MAGIC how jumpy it is (std), whether it is trending up or down (slope), how big
+# MAGIC its swings are (peak-to-peak), and how much all of that has drifted since
+# MAGIC the start of the print. "Silver" is the middle tier of the bronze→silver→gold
+# MAGIC convention: bronze = raw, silver = cleaned/engineered, gold = ready to serve.
+# MAGIC
+# MAGIC **WHY IT MATTERS:** these engineered numbers are the *features* — the inputs
+# MAGIC the models in notebook 04 learn from. A model can only be as smart as the
+# MAGIC features you hand it. The per-layer-window numbers built here also become the
+# MAGIC z-scores that color the **LayerHeatmap** panel on the Factory ML console
+# MAGIC (gold table built in notebook 03, exported to /labs/factory-ml/).
+# MAGIC
+# MAGIC **INPUTS -> OUTPUT:**
+# MAGIC - in:  `bronze_fact_process_feature_window` (raw per-layer-window shape stats),
+# MAGIC        `bronze_raw_iot_telemetry_samples` (raw waveform samples),
+# MAGIC        `bronze_raw_test_runs`, `bronze_raw_test_limit_violations`
+# MAGIC - out: `silver_layer_features` (rolling shape stats along the layer axis),
+# MAGIC        `silver_print_aggregates` (one row per print run — the model-ready rollup),
+# MAGIC        `silver_run_waveform_stats` (waveform summary via the salted join)
+# MAGIC
+# MAGIC **HOW TO READ THE NUMBERS:**
+# MAGIC - *std* = standard deviation = how spread-out / jumpy a signal is.
+# MAGIC - *slope* = trend direction (rising or falling) across the window.
+# MAGIC - *peak_to_peak* = max minus min = the size of the biggest swing.
+# MAGIC - *rolling_* = the same stat smoothed over the last few layers (a 4-layer
+# MAGIC   moving window), so a single noisy layer doesn't dominate.
+# MAGIC - *drift_from_first* = how far a layer has wandered from where the print started.
+# MAGIC - *salting* = a performance trick for a "skewed" join (one key has far more
+# MAGIC   rows than the rest). You split each hot key into 16 sub-keys so the work
+# MAGIC   spreads evenly, then recombine the partial sums into the exact same answer.
 
 # COMMAND ----------
 
@@ -38,6 +74,15 @@ spark.sql(f"USE {Q}")
 # COMMAND ----------
 
 # silver_layer_features — rolling shape statistics along the layer axis.
+# Each row is one (run, sensor channel, layer-window). We start from the raw
+# per-window shape stats (std/slope/peak_to_peak) and add SMOOTHED versions and
+# DRIFT versions using SQL window functions:
+#   - w4   = the current layer plus the 3 before it (a 4-layer moving window),
+#            used to smooth out single-layer noise (rolling_std_4, etc.).
+#   - wall = everything from the first layer up to here, used to measure how far
+#            a signal has drifted from where the print began (*_drift_from_first).
+# These per-window numbers are exactly what becomes the LayerHeatmap z-scores in
+# notebook 03, and they roll up into the model features just below.
 spark.sql(f"""
 CREATE OR REPLACE TABLE {Q}.silver_layer_features
 COMMENT 'Per (run, channel, layer-window) rolling shape features over bronze_fact_process_feature_window'
@@ -69,9 +114,17 @@ print("silver_layer_features:", spark.table(f"{Q}.silver_layer_features").count(
 
 # silver_print_aggregates — one row per run: per-channel aggregates of the
 # layer features plus late-vs-early drift and limit-violation counts.
+# This is the model-ready table: it collapses the many per-layer rows of a print
+# into a single fixed-width row of features per print run, which is the shape a
+# tabular model needs (one row = one thing you want to predict about). For each
+# sensor channel we compute summary numbers; we also compare the END of the print
+# to the START (late_minus_early) because a process going bad often drifts late.
 per_channel_exprs = []
 for ch in CHANNELS:
     c = ch.replace("-", "_")
+    # Build one set of summary columns per sensor channel. The CASE WHEN trick
+    # is a "pivot": it isolates rows for one channel before aggregating, so each
+    # channel gets its own _std_mean, _slope_mean, etc. column on the print row.
     per_channel_exprs += [
         f"AVG(CASE WHEN channel = '{ch}' THEN std END) AS {c}_std_mean",
         f"MAX(CASE WHEN channel = '{ch}' THEN rolling_std_4 END) AS {c}_rolling_std_max",
@@ -112,15 +165,23 @@ print("silver_print_aggregates:", spark.table(f"{Q}.silver_print_aggregates").co
 
 # COMMAND ----------
 
-# The salting demonstration. Raw telemetry samples exist only for the
-# full-rate run subset, so the samples side concentrates on a fraction of the
-# key space. Serverless compute does not allow freezing AQE
-# (spark.sql.adaptive.enabled is locked), so both variants run under identical
-# engine settings and the timings report whatever the engine showed — the
-# point is the technique and the exact-recombination math, not a rigged race.
+# The salting demonstration (a data-engineering technique, not a model step).
+# Problem being illustrated: when one join key has hugely more rows than the
+# others ("skew"), the worker handling that key becomes a bottleneck while the
+# rest sit idle. Fix: SALT the keys — hash each row into one of 16 buckets so the
+# heavy key is split 16 ways and the work spreads evenly. Because mean and std
+# can be rebuilt from per-bucket sums (sum, sum-of-squares, count), we recombine
+# the buckets into the EXACT same answer as the naive join — proven by the
+# assert below. Raw telemetry samples exist only for the full-rate run subset, so
+# the samples side concentrates on a fraction of the key space. Serverless
+# compute does not allow freezing AQE (spark.sql.adaptive.enabled is locked), so
+# both variants run under identical engine settings and the timings report
+# whatever the engine showed — the point is the technique and the
+# exact-recombination math, not a rigged race.
 samples = spark.table(f"{Q}.bronze_raw_iot_telemetry_samples")
 runs = spark.table(f"{Q}.bronze_raw_test_runs").select("run_id", "test_type", "result", "vehicle_id")
 
+# Variant 1 (naive): the straightforward join, timed as the baseline.
 t0 = time.time()
 naive = (samples.join(runs, "run_id")
          .groupBy("run_id", "channel")
@@ -131,6 +192,11 @@ naive = (samples.join(runs, "run_id")
 naive_count = naive.count()
 naive_s = time.time() - t0
 
+# Variant 2 (salted): same result, spread across 16 buckets, then recombined.
+# Each sample gets a salt 0..15 (hash of its id); each run is duplicated across
+# all 16 salts so the salted keys still match. First aggregate per (run,
+# channel, salt) into partial sums, then fold the 16 partials back together —
+# mean = sum/n, std = sqrt(mean-of-squares minus mean-squared) — exactly.
 t0 = time.time()
 salted_samples = samples.withColumn("salt", F.pmod(F.xxhash64("sample_id"), F.lit(SALT_BUCKETS)))
 salted_runs = runs.withColumn("salt", F.explode(F.array(*[F.lit(i) for i in range(SALT_BUCKETS)])))
@@ -149,11 +215,16 @@ salted.write.mode("overwrite").saveAsTable(f"{Q}.silver_run_waveform_stats")
 salted_count = spark.table(f"{Q}.silver_run_waveform_stats").count()
 salted_s = time.time() - t0
 
+# Honesty check: the salted path must return the exact same number of rows as
+# the naive path. If salting changed the answer, the optimization would be wrong.
 assert naive_count == salted_count, f"salted join changed the result: {naive_count} vs {salted_count}"
 print(f"naive={naive_s:.1f}s salted={salted_s:.1f}s rows={salted_count}")
 
 # COMMAND ----------
 
+# MLflow is the experiment logbook: it records what ran, with what settings, and
+# what numbers came out, so results are reproducible and auditable later. Here we
+# log the two join wall-times (measured, not assumed) as a small evidence artifact.
 mlflow.set_experiment("/Users/paulmalmquist@gmail.com/RSFactoryML")
 with mlflow.start_run(run_name="silver_features"):
     mlflow.set_tags({"stage": "silver", "pipeline": "rs_factory_ml"})

--- a/skills/rs-factory-ml/notebooks/03_gold_feature_store.py
+++ b/skills/rs-factory-ml/notebooks/03_gold_feature_store.py
@@ -15,6 +15,50 @@
 # MAGIC Leakage rule: `pattern`, `template`, and `result` ride along as metadata
 # MAGIC for tracing (SCN-005) but are excluded from training features by the
 # MAGIC feature manifest in 04.
+# MAGIC
+# MAGIC ## ===== TEACHING NOTES (plain language) =====
+# MAGIC
+# MAGIC **WHAT THIS FILE DOES (the "gold" stage):** It builds the *feature store* —
+# MAGIC the final table the models train on — by gluing two things together:
+# MAGIC   (1) the engineered process features from notebook 02 (how the print behaved),
+# MAGIC   (2) the real-world QUALITY OUTCOMES from the quality-management system (QMS):
+# MAGIC       did the part pass inspection, did the test run fail, how much tolerance
+# MAGIC       headroom was left.
+# MAGIC A "feature store" is just a curated table of model-ready inputs + the answers
+# MAGIC you want to predict, kept in one trusted place so training and serving use
+# MAGIC the same definitions.
+# MAGIC
+# MAGIC **TARGET (a.k.a. LABEL):** the thing the model tries to predict — the "answer
+# MAGIC key" during training. This file defines three:
+# MAGIC   - `passed`        — yes/no, did every inspection pass on the first try.
+# MAGIC   - `run_failed`    — yes/no, did the test run get a fail verdict.
+# MAGIC   - `min_strength_margin` — a number: how much tolerance headroom is left
+# MAGIC                       (1.0 = dead-on nominal, 0 = right at the limit, negative =
+# MAGIC                       out of tolerance). A stand-in for tensile strength, since
+# MAGIC                       the synthetic seed has no actual MPa value.
+# MAGIC
+# MAGIC **LEAKAGE (the cardinal sin):** "leakage" is when a clue to the answer sneaks
+# MAGIC into the inputs, so the model looks brilliant in testing but is useless in
+# MAGIC real life (it was effectively peeking at the answer key). Columns like
+# MAGIC `result`, `pattern`, and `template` literally encode the outcome, so they are
+# MAGIC kept ONLY as metadata for tracing and are barred from the feature set in
+# MAGIC notebook 04. Defining targets and quarantining leaky columns is the whole job
+# MAGIC of this stage.
+# MAGIC
+# MAGIC **INPUTS -> OUTPUT:**
+# MAGIC - in:  `silver_print_aggregates` (features from 02) joined down the "digital
+# MAGIC        thread": run → test article → serialized item → part → QMS inspections.
+# MAGIC - out: `gold_print_quality_train` (the training feature store: features + targets),
+# MAGIC        `gold_layer_heatmap` (per-window z-scores -> the **LayerHeatmap** panel),
+# MAGIC        `gold_readiness_summary` (per-vehicle rollup -> the **ReadinessGauge** panel).
+# MAGIC   These gold tables are what notebook 04 / the export script turn into the
+# MAGIC   /labs/factory-ml/*.json receipts the Factory ML console reads.
+# MAGIC
+# MAGIC **HOW TO READ THE NUMBERS:**
+# MAGIC - *std_z* (heatmap) = z-score = how many standard deviations a layer's
+# MAGIC   roughness sits above/below normal. ~0 is typical; large positive = anomalous.
+# MAGIC - *readiness_score / open_ncr_count* = how launch-ready a vehicle is and how
+# MAGIC   many open quality issues (NCR = non-conformance report) it carries.
 
 # COMMAND ----------
 
@@ -25,6 +69,16 @@ spark.sql(f"USE {Q}")
 
 # COMMAND ----------
 
+# gold_print_quality_train — THE feature store the models learn from.
+# One row per test run = features (from silver) PLUS the targets (the answers).
+# The `outcomes` CTE derives the per-serial answers from the QMS inspections:
+#   - min_strength_margin: the WORST (MIN) tolerance headroom across the serial's
+#     inspections — smaller means closer to (or past) the allowed limit.
+#   - passed: BOOL_AND(first_pass) = true only if every inspection passed first time.
+# Those answers are then joined onto the engineered features along the digital
+# thread (run -> article -> serial -> part). Note `result`/`pattern`/`template`
+# are pulled in too, but ONLY as tracing metadata — notebook 04 excludes them so
+# they cannot leak the answer into the inputs.
 spark.sql(f"""
 CREATE OR REPLACE TABLE {Q}.gold_print_quality_train
 COMMENT 'Training feature store: one row per test run with silver features + QMS outcome targets. min_strength_margin is a tolerance-margin stand-in for tensile strength (synthetic seed has no MPa).'
@@ -68,12 +122,20 @@ n_train = spark.table(f"{Q}.gold_print_quality_train").count()
 n_labeled = spark.sql(
     f"SELECT COUNT(*) FROM {Q}.gold_print_quality_train WHERE min_strength_margin IS NOT NULL"
 ).first()[0]
+# "Labeled" = rows that actually have an answer attached. A model can only learn
+# from labeled rows, so if almost none came through, the outcome join silently
+# broke and training would be meaningless — fail loudly here instead.
 print(f"gold_print_quality_train: {n_train} rows, {n_labeled} labeled")
 assert n_labeled > 100, "too few labeled rows - outcome join is broken"
 
 # COMMAND ----------
 
 # gold_layer_heatmap — run × layer-window shape z-scores for the dashboard.
+# This is the data behind the **LayerHeatmap** panel. For each sensor channel we
+# learn what "normal" roughness looks like (mean mu, spread sigma), then express
+# every layer window as a z-score: (value - mu) / sigma = how many standard
+# deviations from normal. Averaged across channels per (run, layer), so a hot
+# cell on the heatmap = a layer band that ran unusually rough on this print.
 spark.sql(f"""
 CREATE OR REPLACE TABLE {Q}.gold_layer_heatmap
 COMMENT 'Dashboard heatmap input: per (run, layer window) mean z-score of rolling std across channels'
@@ -96,10 +158,12 @@ print("gold_layer_heatmap:", spark.table(f"{Q}.gold_layer_heatmap").count())
 
 # COMMAND ----------
 
-# gold_readiness_summary — vehicle rollup, reconciled against the seed's own
-# gold (bronze_gold_vehicle_launch_readiness). The reconciliation is an
-# assertion, not a hope: the SCN-001 anchor (VEH-TR-003, 4 scenario-tagged
-# open NCRs) must survive the medallion intact.
+# gold_readiness_summary — per-vehicle rollup behind the **ReadinessGauge** panel.
+# Each row is one vehicle with its launch-readiness score and counts of open
+# quality issues (open NCRs, inconclusive tests, unresolved anomalies, missing
+# sign-offs). We also independently RECOMPUTE the open-NCR count from raw records
+# and compare it to the seed's published number — a reconciliation, so the
+# dashboard figure is verified rather than trusted blindly.
 spark.sql(f"""
 CREATE OR REPLACE TABLE {Q}.gold_readiness_summary
 COMMENT 'Per-vehicle readiness rollup reconciled to the seed gold frame (SCN-001 anchor preserved)'
@@ -126,6 +190,9 @@ LEFT JOIN (
 ) o ON g.vehicle_id = o.vehicle_id
 """)
 
+# Anchor check: VEH-TR-003 is a known scenario fixture that must carry exactly 4
+# scenario-tagged open NCRs. If that anchor doesn't survive the joins intact, the
+# readiness data is corrupted upstream — so we assert it rather than ship a wrong gauge.
 anchor = spark.sql(f"""
   SELECT scenario_open_ncr_count, status_hint FROM {Q}.gold_readiness_summary
   WHERE vehicle_id = 'VEH-TR-003'

--- a/skills/rs-factory-ml/notebooks/04_train_print_quality.py
+++ b/skills/rs-factory-ml/notebooks/04_train_print_quality.py
@@ -23,6 +23,55 @@
 # MAGIC Split: **GroupKFold by part_id** — the seed has no usable event-time for a
 # MAGIC walk-forward split, and serials of one part must never straddle folds
 # MAGIC (that would leak part-family quality straight into validation).
+# MAGIC
+# MAGIC ## ===== TEACHING NOTES (plain language) =====
+# MAGIC
+# MAGIC **WHAT THIS FILE DOES (the "train" stage):** It teaches three models to
+# MAGIC predict print-quality outcomes from the process features, checks how well
+# MAGIC they actually do (honestly), records everything to MLflow, and figures out
+# MAGIC WHICH inputs drove each prediction. This is the stage that produces the
+# MAGIC numbers and bars you see on screen.
+# MAGIC
+# MAGIC **WHERE YOU SEE THIS (Factory ML console, repo-b/.../telemetry/factory-ml/):**
+# MAGIC - **FeatureImportancePanel** — the bars are the SHAP "top drivers" computed
+# MAGIC   below; the headline F1 / recall / precision / AUC come from the metrics here.
+# MAGIC - **RegistryPanel** — its rows are the three models registered below
+# MAGIC   (rs_print_strength, rs_print_passfail, rs_run_failure).
+# MAGIC
+# MAGIC **INPUTS -> OUTPUT:**
+# MAGIC - in:  `gold_print_quality_train` (the feature store from notebook 03).
+# MAGIC - out: 3 trained models + fold metrics logged to MLflow; a registry entry per
+# MAGIC        model; `gold_feature_importance` table (top drivers); JSON artifacts
+# MAGIC        top_features.json + feature_manifest.json. The export script turns these
+# MAGIC        into the /labs/factory-ml/*.json receipts the console renders.
+# MAGIC
+# MAGIC **JARGON, one phrase each:**
+# MAGIC - *XGBoost* = a strong "gradient-boosted trees" method — it stacks many small
+# MAGIC   decision trees, each fixing the previous one's mistakes. Great on tabular data.
+# MAGIC - *baseline* (Ridge / LogisticRegression) = a deliberately simple model run
+# MAGIC   alongside XGBoost for an honesty check: if the fancy model barely beats the
+# MAGIC   simple one, there isn't much real signal to find.
+# MAGIC - *GroupKFold by part_id* = a cross-validation split that keeps all serials of
+# MAGIC   the same physical part on ONE side of the train/test divide, so the model
+# MAGIC   can't "memorize a part" and then be quizzed on it — that would be cheating.
+# MAGIC - *SHAP* = a method that attributes a prediction to its inputs: how much each
+# MAGIC   feature pushed the answer up or down. The averaged magnitudes ARE the bars.
+# MAGIC - *AUC (ROC-AUC)* = chance a random pass is ranked above a random fail;
+# MAGIC   0.5 = coin-flip, 1.0 = perfect ranking.
+# MAGIC - *PR-AUC (average precision)* = same idea but focused on the rare/positive
+# MAGIC   class — the honest score when failures are uncommon.
+# MAGIC - *F1* = the balance of precision (of the things flagged, how many were right)
+# MAGIC   and recall (of the real failures, how many we caught); one number, both concerns.
+# MAGIC - *Brier* = average squared error of the predicted probabilities — lower means
+# MAGIC   the confidence levels are better calibrated (a "70%" really happens ~70% of the time).
+# MAGIC - *leakage* = letting a clue to the answer into the inputs; see the EXCLUDED set.
+# MAGIC
+# MAGIC **HOW TO READ THE RESULTS (and why "near chance" is the honest answer here):**
+# MAGIC the synthetic seed builds the pass/strength outcomes from a DIFFERENT random
+# MAGIC stream than the telemetry, so there's genuinely no link to learn — those two
+# MAGIC models SHOULD land near chance (AUC ~0.5), and the report shows that instead
+# MAGIC of faking success. The run-failure target is wired to the telemetry (limit
+# MAGIC violations are seeded toward failures), so that model should actually learn.
 
 # COMMAND ----------
 
@@ -61,8 +110,13 @@ SCHEMA = "rs_factory"
 Q = f"{CATALOG}.{SCHEMA}"
 EXPERIMENT = "/Users/paulmalmquist@gmail.com/RSFactoryML"
 
-# Metadata / leakage columns. pattern + template literally encode the seeded
-# failure mode; result IS the run verdict; ids identify rather than describe.
+# Metadata / leakage columns — the inputs the model is NOT allowed to see.
+# Why each is barred: pattern + template literally encode the seeded failure mode
+# (peeking at the answer); result IS the run verdict; the target columns are the
+# answers themselves; ids only identify a row, they don't describe the process.
+# Letting any of these in would be "leakage" — fake-good scores that collapse in
+# real use. The categoricals are excluded here only because they're re-added as
+# dummy columns below.
 EXCLUDED = {
     "run_id", "serial_id", "part_id", "vehicle_id", "scenario_id",
     "pattern", "template", "result", "run_failed",
@@ -76,23 +130,33 @@ mlflow.set_experiment(EXPERIMENT)
 
 # COMMAND ----------
 
+# Pull the feature store into pandas and keep only rows that have answers.
 df = spark.table(f"{Q}.gold_print_quality_train").toPandas()
 df = df.dropna(subset=["min_strength_margin", "passed"]).reset_index(drop=True)
 
+# X = the inputs (features). Numeric columns that aren't on the leakage blocklist,
+# plus the category columns turned into 0/1 "dummy" columns (one column per value)
+# so a tree model can use them. This X is the same width at train and serve time.
 numeric = [c for c in df.columns
            if c not in EXCLUDED and pd.api.types.is_numeric_dtype(df[c])]
 X = pd.concat(
     [df[numeric].fillna(0.0), pd.get_dummies(df[CATEGORICAL], dummy_na=True)],
     axis=1,
 ).astype(float)
-y_reg = df["min_strength_margin"].astype(float).values
-y_clf = df["passed"].astype(bool).astype(int).values
-y_run = df["run_failed"].astype(bool).astype(int).values
+# The three targets (answers) the three models predict, one per model.
+y_reg = df["min_strength_margin"].astype(float).values   # number: tolerance headroom
+y_clf = df["passed"].astype(bool).astype(int).values     # yes/no: did it pass
+y_run = df["run_failed"].astype(bool).astype(int).values # yes/no: did the run fail
+# groups = which physical part each row belongs to; GroupKFold uses this to keep
+# one part entirely on one side of every train/test split (anti-cheating).
 groups = df["part_id"].values
 
 print(f"n={len(df):,} features={X.shape[1]} pass_rate={y_clf.mean():.3f} "
       f"run_fail_rate={y_run.mean():.3f} margin: mean={y_reg.mean():.3f} min={y_reg.min():.3f}")
 
+# 5-fold cross-validation: train on 4/5 of the data, test on the held-out 1/5,
+# rotate 5 times so every row gets graded once on a model that never saw it.
+# "Group" means a whole part stays together — never split across train and test.
 gkf = GroupKFold(n_splits=5)
 
 # COMMAND ----------
@@ -108,13 +172,17 @@ with mlflow.start_run(run_name="rs_print_quality_v1") as run:
     })
     mlflow.set_tags({"model_name": "rs_print_quality", "env": "rs_factory", "stage": "v1"})
 
+    # Cross-validation loop. Each pass: `tr` = training row indices, `te` = held-out
+    # test rows. We fit on tr, predict on te, and score — repeated for all 5 folds.
     fold_metrics: list[dict] = []
     last_te = None
     for fold, (tr, te) in enumerate(gkf.split(X, y_clf, groups=groups)):
         X_tr, X_te = X.iloc[tr], X.iloc[te]
         last_te = te
 
-        # -- regression: margin --
+        # -- regression: predict the strength MARGIN (a number) --
+        # Ridge = simple linear baseline (standardized inputs) for the honesty check;
+        # XGBoost = the real model. If XGBoost barely beats Ridge, there's little signal.
         ridge = Ridge(alpha=1.0)
         scaler = StandardScaler().fit(X_tr)
         ridge.fit(scaler.transform(X_tr), y_reg[tr])
@@ -126,7 +194,11 @@ with mlflow.start_run(run_name="rs_print_quality_v1") as run:
         xgb_reg.fit(X_tr, y_reg[tr])
         p_reg = xgb_reg.predict(X_te)
 
-        # -- classification: pass/fail --
+        # -- classification: predict PASS / FAIL (yes/no) --
+        # scale_pos_weight tells XGBoost the classes are imbalanced (far more of one
+        # outcome than the other) so it doesn't just predict the majority every time.
+        # The calibrated logistic regression is the simple baseline; "isotonic"
+        # calibration makes its probabilities trustworthy (a "0.7" means ~70%).
         scale = (len(tr) - y_clf[tr].sum()) / max(y_clf[tr].sum(), 1)
         lr = CalibratedClassifierCV(
             LogisticRegression(max_iter=1000, class_weight="balanced"),
@@ -142,7 +214,9 @@ with mlflow.start_run(run_name="rs_print_quality_v1") as run:
         xgb_clf.fit(X_tr, y_clf[tr])
         p_clf = xgb_clf.predict_proba(X_te)[:, 1]
 
-        # -- classification: run failure (the target with real signal) --
+        # -- classification: predict RUN FAILURE (the target with real signal) --
+        # Unlike pass/fail and margin, this outcome IS linked to the telemetry in the
+        # seed, so this is the model expected to actually learn something useful.
         scale_run = (len(tr) - y_run[tr].sum()) / max(y_run[tr].sum(), 1)
         xgb_run = xgb.XGBClassifier(
             n_estimators=400, max_depth=5, learning_rate=0.05,
@@ -151,6 +225,13 @@ with mlflow.start_run(run_name="rs_print_quality_v1") as run:
         xgb_run.fit(X_tr, y_run[tr])
         p_run = xgb_run.predict_proba(X_te)[:, 1]
 
+        # Score every model on this fold's held-out rows. Quick reader's guide:
+        #   mae  = mean absolute error (avg miss, lower is better) — for the number target.
+        #   r2   = fraction of variance explained (1.0 perfect, 0 no better than the mean).
+        #   auc  = ranking quality, 0.5 = coin-flip, 1.0 = perfect.
+        #   pr_auc = ranking quality focused on the rare class (honest when fails are rare).
+        #   brier = calibration error of probabilities (lower = better-calibrated confidence).
+        # These per-fold numbers, averaged below, become the FeatureImportancePanel headline.
         m = {
             f"fold{fold}_ridge_mae": mean_absolute_error(y_reg[te], p_ridge),
             f"fold{fold}_xgbreg_mae": mean_absolute_error(y_reg[te], p_reg),
@@ -165,13 +246,17 @@ with mlflow.start_run(run_name="rs_print_quality_v1") as run:
         mlflow.log_metrics(m)
         fold_metrics.append(m)
 
+    # Average each metric across the 5 folds — the cross-validated headline numbers
+    # (these mean_* values are what the FeatureImportancePanel reports as F1/AUC/etc).
     agg = pd.DataFrame(fold_metrics).mean().to_dict()
     mlflow.log_metrics({
         f"mean_{k.split('_', 1)[1]}": float(v)
         for k, v in agg.items()
     })
 
-    # Final fits on all rows.
+    # Cross-validation was for HONEST scoring; now retrain each model on ALL rows so
+    # the shipped/registered model uses every available example. These are the ones
+    # that get saved and become the RegistryPanel rows.
     final_reg = xgb.XGBRegressor(n_estimators=400, max_depth=5, learning_rate=0.05, tree_method="hist")
     final_reg.fit(X, y_reg)
     scale_all = (len(y_clf) - y_clf.sum()) / max(y_clf.sum(), 1)
@@ -183,6 +268,10 @@ with mlflow.start_run(run_name="rs_print_quality_v1") as run:
                                   scale_pos_weight=scale_run_all, tree_method="hist")
     final_run.fit(X, y_run)
 
+    # Save the trained models to MLflow, then register them by name in the model
+    # registry. Registration is what makes each model a row in the RegistryPanel
+    # (champion/challenger tracking). Registry permissions vary by workspace, so a
+    # failure here is logged as a note, not treated as fatal.
     mlflow.xgboost.log_model(final_reg, "model_strength")
     mlflow.xgboost.log_model(final_clf, "model_passfail")
     mlflow.xgboost.log_model(final_run, "model_run_failure")
@@ -197,6 +286,13 @@ with mlflow.start_run(run_name="rs_print_quality_v1") as run:
     # importances otherwise. Written to a gold table (not only an MLflow
     # artifact) because this workspace blocks DBFS artifact download — the
     # export script reads tables, the one serving path everything else uses.
+    # WHICH inputs drove each model? Run SHAP on a sample of rows. SHAP gives every
+    # feature a signed push (up/down) per prediction; we take the AVERAGE ABSOLUTE
+    # push per feature = its overall importance, and keep the top 15.
+    # -> these top-15 magnitudes ARE the bars in the FeatureImportancePanel.
+    # If SHAP's loader can't read the model, fall back to XGBoost's own "gain"
+    # importance (how much each feature improved the trees' splits) so the panel
+    # still gets ranked drivers.
     sample = X.iloc[last_te[: min(1000, len(last_te))]]
     driver_rows = []
     for label, model in (("strength", final_reg), ("passfail", final_clf),
@@ -204,6 +300,7 @@ with mlflow.start_run(run_name="rs_print_quality_v1") as run:
         try:
             import shap
 
+            # TreeExplainer = fast exact SHAP for tree models like XGBoost.
             vals = shap.TreeExplainer(model).shap_values(sample)
             top = (pd.DataFrame(np.abs(vals), columns=X.columns).mean()
                    .sort_values(ascending=False).head(15))
@@ -222,6 +319,9 @@ with mlflow.start_run(run_name="rs_print_quality_v1") as run:
         json.dump([{"model": r[1], "feature": r[4], "impact": r[5]} for r in driver_rows], f, indent=2)
     mlflow.log_artifact("/tmp/top_features.json")
 
+    # The manifest is the audit record of exactly what went into training: which
+    # features were used, how the split worked, which leaky columns were barred,
+    # and what each target means. It makes the run reproducible and reviewable.
     feature_manifest = {
         "features": list(X.columns),
         "split": "GroupKFold by part_id - serials of one part never straddle folds",

--- a/skills/rs-factory-ml/run_pipeline.py
+++ b/skills/rs-factory-ml/run_pipeline.py
@@ -7,6 +7,31 @@
 
 Stages: load, silver, gold, train, export. The warehouse stops on exit even on
 failure (cost control); the serverless training job manages its own compute.
+
+===== TEACHING NOTES (plain language) =====
+
+WHAT THIS FILE DOES: this is the conductor. The real work lives in the other
+files; this script just runs them in the right order and manages the cloud
+warehouse (turn it on, do the work, turn it off — because compute costs money).
+Think of it as the "Run All" button for the whole Factory ML pipeline.
+
+THE PIPELINE, end to end:
+    load   -> copy the raw factory data up to Databricks (bronze).
+    silver -> 02_silver_features.py: engineer the shape features.
+    gold   -> 03_gold_feature_store.py: join features to outcomes, define targets.
+    train  -> 04_train_print_quality.py: train + score the 3 models, compute SHAP.
+    export -> export_dashboard_json.py: write the /labs/factory-ml/*.json receipts
+              that the Factory ML console (FeatureImportancePanel, RegistryPanel,
+              NcrPanel, ReadinessGauge, LayerHeatmap) reads.
+
+HOW TO READ THE FLAGS:
+    --from <stage>  start partway through (skip stages already done). Default: load.
+    --until <stage> stop early. Common use: `--until gold` builds the data without
+                    paying for the (more expensive) serverless training run.
+
+COST CONTROL: the warehouse is started once at the top and the `finally` block
+guarantees it stops even if a stage crashes — so a failure never leaves expensive
+compute running.
 """
 
 from __future__ import annotations
@@ -24,6 +49,8 @@ from databricks_client import RsFactoryClient  # noqa: E402
 STAGES = ["load", "silver", "gold", "train", "export"]
 
 
+# Run a local helper script (load/export) as a child process and fail loudly if
+# it errors. The notebooks (silver/gold/train) run remotely instead — see main().
 def run_script(name: str) -> None:
     result = subprocess.run([sys.executable, str(_HERE / "scripts" / name)],
                             cwd=str(_HERE / "scripts"))
@@ -36,15 +63,21 @@ def main() -> int:
     parser.add_argument("--from", dest="start", choices=STAGES, default="load")
     parser.add_argument("--until", dest="until", choices=STAGES, default="export")
     args = parser.parse_args()
+    # `todo` is the contiguous slice of stages to run, from --from through --until.
     todo = STAGES[STAGES.index(args.start): STAGES.index(args.until) + 1]
     print(f"stages: {' -> '.join(todo)}")
 
+    # Spin the warehouse up once for the whole run, and (see the finally block)
+    # always stop it afterward so we never leak cloud compute cost.
     client = RsFactoryClient()
     client.start_warehouse()
     client.wait_for_warehouse()
     try:
+        # Stage 1: load raw data up to Databricks (a local helper script).
         if "load" in todo:
             run_script("load_to_databricks.py")
+        # Stages 2-4: push each notebook to Databricks and run it as a serverless
+        # job (training gets a longer timeout because it's the heaviest step).
         for stage, notebook in (("silver", "02_silver_features.py"),
                                 ("gold", "03_gold_feature_store.py"),
                                 ("train", "04_train_print_quality.py")):
@@ -56,10 +89,13 @@ def main() -> int:
             run = client.run_notebook_job(path, f"rs_factory_ml_{stage}",
                                           timeout_s=5400 if stage == "train" else 3600)
             print(f"   {stage} done: {run.get('run_page_url', '')}")
+        # Stage 5: turn the gold tables + model outputs into the JSON receipts the
+        # Factory ML console panels read from /labs/factory-ml/.
         if "export" in todo:
             run_script("export_dashboard_json.py")
         return 0
     finally:
+        # Always stop the warehouse — even on crash — so cost never runs away.
         try:
             client.stop_warehouse()
             print("warehouse stopped")

--- a/telemetry-platform/analog_core.py
+++ b/telemetry-platform/analog_core.py
@@ -1,5 +1,24 @@
 """Pure analog-retrieval primitives (numpy only — no Databricks/deps, CI-safe).
 
+WHAT THIS FILE DOES: the math for finding historical precedents for an anomaly — "when has
+something shaped like this happened before?". The key tool is DTW (Dynamic Time Warping), which
+compares two time series by their SHAPE even if one is stretched or shifted in time, unlike a
+rigid point-by-point match.
+
+WHERE YOU SEE THIS: feeds the event-windowed analog retrieval evidence (the compute script
+writes event_windowed_analog_evidence.json; the dedicated UI card is deferred per the file's
+own note).
+
+INPUTS -> OUTPUT: two signal windows (or summaries) -> a similarity/distance and a ranked list
+of nearest precedents, scored by how often the retrieved cases are themselves real anomalies.
+
+HOW TO READ THE NUMBERS:
+  - DTW distance = shape difference allowing for time stretch (smaller = more alike).
+  - cosine = angle-based similarity between two summary vectors (1 = identical direction).
+  - z-normalize = strip out level/scale so only the shape is compared.
+  - anomalous-match rate = fraction of retrieved precedents that are truly anomalies (higher = better).
+  - top-k overlap = how much two retrieval methods agree on the same precedents.
+
 Shared by compute_event_windowed_analog.py (real SMAP/MSL data) and test_analog_core.py.
 The finding: whole-series cosine similarity is dominated by the long steady-state phase and
 buries the rare event; event-windowed DTW on the anomalous segment finds precedents that share
@@ -11,6 +30,8 @@ from __future__ import annotations
 import numpy as np
 
 
+# Strip away "how high" and "how big" so only the SHAPE of the wiggle remains. Lets a small spike
+# and a large spike count as similar events if they rise and fall the same way.
 def znorm(x: np.ndarray) -> np.ndarray:
     """Z-normalize a 1-D series (shape-only comparison; removes level/scale)."""
     x = np.asarray(x, dtype=float)
@@ -18,6 +39,11 @@ def znorm(x: np.ndarray) -> np.ndarray:
     return (x - x.mean()) / (sd if sd > 1e-9 else 1.0)
 
 
+# Compare two signals by shape, allowing one to be stretched/compressed in time so that, e.g., a
+# slow ramp and a fast ramp still match. It tries the cheapest way to line the two up point-for-
+# point and returns that total cost (small = the two events look alike). The "band" just limits
+# how far the alignment can stray, which keeps it fast. This distance is the core of finding the
+# precedents that share the EVENT shape.
 def dtw_distance(a: np.ndarray, b: np.ndarray, band: int | None = None) -> float:
     """Dynamic Time Warping distance between two 1-D series, with an optional Sakoe-Chiba
     band (|i-j| <= band) for speed. Pure numpy; returns the warped-path cost."""
@@ -41,6 +67,9 @@ def dtw_distance(a: np.ndarray, b: np.ndarray, band: int | None = None) -> float
     return float(np.sqrt(prev[m]))
 
 
+# The "naive" comparison used as the baseline: judge two channels alike if their summary numbers
+# point the same way. It ignores timing/shape, so it gets dominated by the long calm stretch and
+# is exactly what event-windowed DTW is meant to beat.
 def cosine(a: np.ndarray, b: np.ndarray) -> float:
     a = np.asarray(a, dtype=float)
     b = np.asarray(b, dtype=float)
@@ -50,6 +79,9 @@ def cosine(a: np.ndarray, b: np.ndarray) -> float:
     return float(np.dot(a, b) / (na * nb))
 
 
+# Pick the k best matches — the closest precedents. Use largest=True for similarity scores
+# (cosine) and largest=False for distances (DTW, where smaller is closer). This is the shortlist
+# that would populate a "similar past events" panel.
 def topk_indices(scores: np.ndarray, k: int, largest: bool = True) -> list[int]:
     """Indices of the top-k scores (largest similarity, or smallest distance if largest=False)."""
     scores = np.asarray(scores, dtype=float)
@@ -58,6 +90,9 @@ def topk_indices(scores: np.ndarray, k: int, largest: bool = True) -> list[int]:
     return [int(i) for i in order[:k]]
 
 
+# Quality score for a retrieval method: of the precedents it surfaced, how many were actually
+# real anomalies? A good "find me similar past failures" tool should return mostly real failures.
+# This is the headline number that lets DTW beat the cosine baseline in the finding.
 def match_rate(indices: list[int], is_anomaly: np.ndarray) -> float:
     """Fraction of retrieved candidates that are themselves anomalous (precedent quality)."""
     if not indices:
@@ -65,6 +100,9 @@ def match_rate(indices: list[int], is_anomaly: np.ndarray) -> float:
     return float(np.mean([is_anomaly[i] for i in indices]))
 
 
+# How much do the two methods agree on which precedents are best? Low overlap is the whole point:
+# it shows event-windowed DTW surfaces a different (and better) set than the cosine baseline,
+# rather than just reshuffling the same results.
 def overlap(a_idx: list[int], b_idx: list[int]) -> float:
     """Jaccard-style top-k overlap: |A ∩ B| / k (how much two methods agree on precedents)."""
     if not a_idx and not b_idx:

--- a/telemetry-platform/compute_competence_envelope.py
+++ b/telemetry-platform/compute_competence_envelope.py
@@ -1,5 +1,20 @@
 """Phase 4 / Spin 5 — Pre-test competence-envelope gate (REAL data, reproducible).
 
+WHAT THIS FILE DOES (plain version): before trusting any model prediction, it checks whether the
+new input looks like the data the model was trained on. It measures that with Mahalanobis
+distance — a "how far from the training cloud" score that accounts for how the sensors normally
+move together. Inputs that sit inside the trained region get scored; ones on the edge get REVIEW;
+ones far outside get ABSTAIN (don't issue a confident prediction). Here it trains the envelope on
+one operating condition (FD001) and proves most of a different condition (FD004) falls outside it.
+WHERE YOU SEE THIS: the frontend CompetenceEnvelopeCard (in / near-boundary / out-of-envelope
+rates and the per-sample SCORE/REVIEW/ABSTAIN action).
+INPUTS -> OUTPUT: FD001 + FD004 training rows from silver_cmapss -> competence_envelope_evidence.json.
+HOW TO READ THE NUMBERS: Mahalanobis distance = distance from the training cloud accounting for
+sensor correlations (small = familiar); tau = the boundary line set from FD001's own 99th
+percentile; in/near/out rates = share of samples inside / on the edge / outside the trained
+envelope (a high FD004 "out" rate is the point — the gate caught a regime it was never trained on).
+
+
 Flips drift from a post-deployment monitoring idea into an UPSTREAM safety check: before
 scoring a unit, ask whether its inputs are inside the operating envelope the model was trained
 on. If not, abstain/REVIEW instead of issuing a confident score.
@@ -46,6 +61,7 @@ ROOT = Path(__file__).resolve().parents[1]
 AS_OF = "2026-06-24"
 
 
+# Run a SQL query against the Databricks warehouse and return a tidy table. Plumbing only.
 def query(w: WorkspaceClient, sql: str) -> pd.DataFrame:
     resp = w.statement_execution.execute_statement(
         statement=sql, warehouse_id=WAREHOUSE_ID, wait_timeout="50s",
@@ -94,16 +110,27 @@ def main() -> None:
     fit = fd001[~fd001.unit.isin(eval_units)]
     ev1 = fd001[fd001.unit.isin(eval_units)]
 
+    # Learn the shape of "familiar" from the FD001 fit rows (its center and how the sensors
+    # co-vary), then set the boundary line tau at the 99th percentile of those training distances —
+    # so 99% of the training data itself counts as in-envelope by construction. Anything farther
+    # than tau is treated as unfamiliar.
     scaler = StandardScaler().fit(fit[active].to_numpy())
     mean, cov_inv = fit_envelope(scaler.transform(fit[active].to_numpy()))
     d2_fit = mahalanobis_sq(scaler.transform(fit[active].to_numpy()), mean, cov_inv)
     tau = float(np.quantile(d2_fit, TAU_PCTL))
 
+    # Score two sets against that envelope: held-out FD001 (should look familiar -> mostly
+    # in-envelope) and FD004 (a different operating condition the model never saw -> should land
+    # mostly out). The in/near/out rates these produce are the two bars on the CompetenceEnvelopeCard
+    # and the proof the gate catches a regime shift BEFORE scoring.
     d2_ev1 = mahalanobis_sq(scaler.transform(ev1[active].to_numpy()), mean, cov_inv)
     d2_fd4 = mahalanobis_sq(scaler.transform(fd004[active].to_numpy()), mean, cov_inv)
     rates_fd001 = band_rates(d2_ev1, tau, K_OUT)
     rates_fd004 = band_rates(d2_fd4, tau, K_OUT)
 
+    # Pull one concrete, human-readable sample for each side of the story — a familiar in-envelope
+    # case and a far-out one — so the card can show a real example with its distance, band, and
+    # action rather than just aggregate rates.
     def example(frame: pd.DataFrame, d2: np.ndarray, pick: str) -> dict:
         # last cycle of a representative unit; pick = 'in' (FD001, low d2) or 'out' (FD004, high d2)
         last = frame.sort_values(["unit", "cycle"]).groupby("unit").tail(1)
@@ -160,6 +187,8 @@ def main() -> None:
         ],
     }
 
+    # Write the evidence twice: source-of-record copy and the frontend's imported copy. This JSON
+    # is exactly what populates the CompetenceEnvelopeCard (baked at compute time, not live).
     out_src = ROOT / "telemetry-platform" / "competence_envelope_evidence.json"
     out_fe = ROOT / "repo-b" / "src" / "lib" / "telemetry" / "competenceEnvelopeEvidence.json"
     out_src.write_text(json.dumps(artifact, indent=2), encoding="utf-8")

--- a/telemetry-platform/compute_event_windowed_analog.py
+++ b/telemetry-platform/compute_event_windowed_analog.py
@@ -1,5 +1,21 @@
 """Spin 6 (compute) — event-windowed analog retrieval on SMAP/MSL (REAL data, reproducible).
 
+WHAT THIS FILE DOES (plain version): when an anomaly happens, it finds historical precedents —
+"when did something shaped like this happen before?". It compares two ways of searching: a naive
+whole-series similarity (cosine on summary stats, dominated by the long calm stretch) versus
+event-windowed DTW. DTW (Dynamic Time Warping) compares two signals by SHAPE even if one is
+stretched in time, applied only to the anomalous segment. The finding: DTW surfaces precedents
+that actually share the event; whole-series search mostly returns look-alikes that aren't anomalies.
+WHERE YOU SEE THIS: writes event_windowed_analog_evidence.json; the dedicated UI card is deferred
+(a parallel agent owns the telemetry frontend refactor), so this is the evidence artifact for it.
+INPUTS -> OUTPUT: labeled SMAP/MSL anomaly windows (gold_smap_msl_windows, test split) ->
+event_windowed_analog_evidence.json.
+HOW TO READ THE NUMBERS: anomalous-match rate = fraction of retrieved precedents that are
+themselves real anomalies (higher = better precedents); event-windowing lift = how much DTW beats
+the cosine baseline; top-k overlap = how much the two methods agree (low overlap means DTW finds a
+genuinely different, better set).
+
+
 The finding: whole-series similarity is dominated by the long steady-state phase and surfaces the
 wrong precedents; event-windowed DTW on the anomalous segment finds the cases that share the EVENT.
 
@@ -47,6 +63,7 @@ ROOT = Path(__file__).resolve().parents[1]
 AS_OF = "2026-06-24"
 
 
+# Run a SQL query against the Databricks warehouse and return a tidy table. Plumbing only.
 def query_sql(w: WorkspaceClient, sql: str) -> pd.DataFrame:
     resp = w.statement_execution.execute_statement(
         statement=sql, warehouse_id=WAREHOUSE_ID, wait_timeout="50s",
@@ -65,6 +82,9 @@ def query_sql(w: WorkspaceClient, sql: str) -> pd.DataFrame:
     return pd.DataFrame(rows, columns=cols)
 
 
+# Boil a whole channel down to a handful of summary numbers (average, spread, range, etc.). This
+# is the INPUT to the naive cosine search — and the reason it fails: averaging over the whole
+# series drowns out the brief anomaly in the long calm baseline.
 def channel_summary(values: np.ndarray) -> np.ndarray:
     """Whole-series statistical character (steady-state dominated)."""
     v = np.asarray(values, dtype=float)
@@ -77,6 +97,8 @@ def channel_summary(values: np.ndarray) -> np.ndarray:
     ])
 
 
+# Find the start/end of each continuous stretch where the mask is true — used to locate each
+# labeled anomaly episode so we can cut a window centered on it.
 def contiguous_runs(mask: np.ndarray) -> list[tuple[int, int]]:
     runs, start = [], None
     for i, m in enumerate(mask):
@@ -89,6 +111,8 @@ def contiguous_runs(mask: np.ndarray) -> list[tuple[int, int]]:
     return runs
 
 
+# Cut a fixed-length slice centered on a point (the event). Returns None if the slice would run
+# off the ends. This fixed-length event window is what DTW compares shape-to-shape.
 def window_at(values: np.ndarray, center: int) -> np.ndarray | None:
     lo = center - L // 2
     if lo < 0 or lo + L > len(values):
@@ -114,6 +138,8 @@ def main() -> None:
     df = df.dropna(subset=["t", "value"]).sort_values(["chan_id", "t"])
     print(f"[analog] rows={len(df)} channels={df.chan_id.nunique()} anomaly_rate={df.is_anomaly.mean():.3f}")
 
+    # Walk every channel and build the two ingredients each search method needs: a whole-series
+    # summary (for cosine) and a set of fixed-length event windows tagged anomaly / normal (for DTW).
     rng = np.random.default_rng(SEED)
     summaries: dict[str, np.ndarray] = {}
     anom_windows, norm_windows = [], []   # each: dict(chan, seq(z-normed), is_anomaly)
@@ -156,6 +182,11 @@ def main() -> None:
     print(f"[analog] queries={len(queries)} pool={len(pool)} "
           f"(anom {int(pool_isa.sum())} / normal {int((pool_isa==0).sum())})")
 
+    # The head-to-head. For each anomalous query, score every candidate two ways — cosine on
+    # whole-series summaries (method A, the naive baseline) and DTW on the event window (method B) —
+    # take each method's top-K precedents, and record how many of those precedents are real
+    # anomalies (match_rate) plus how much the two top-K lists overlap. Same-channel candidates are
+    # excluded so a channel can't just retrieve itself.
     mr_a, mr_b, ov, ex = [], [], [], None
     for q in queries:
         a_scores, b_dist, valid = [], [], []
@@ -165,8 +196,8 @@ def main() -> None:
             a_scores.append(cosine(summaries[q["chan"]], summaries[c["chan"]]))
             b_dist.append(dtw_distance(q["seq"], c["seq"], band=BAND))
             valid.append(i)
-        a_top = topk_indices(np.array(a_scores), K, largest=True)
-        b_top = topk_indices(np.array(b_dist), K, largest=False)
+        a_top = topk_indices(np.array(a_scores), K, largest=True)   # cosine: higher = closer
+        b_top = topk_indices(np.array(b_dist), K, largest=False)    # DTW: lower distance = closer
         ra, rb = match_rate(a_top, pool_isa), match_rate(b_top, pool_isa)
         mr_a.append(ra); mr_b.append(rb); ov.append(overlap(a_top, b_top))
         if ex is None and pool_isa[b_top[0]] == 1 and pool_isa[a_top[0]] == 0:
@@ -176,6 +207,8 @@ def main() -> None:
                 "event_windowed_dtw_top1": {"channel": pool[b_top[0]]["chan"], "is_anomaly": int(pool_isa[b_top[0]])},
             }
 
+    # Average each method's precedent-quality across all queries; "lift" is how much better DTW is
+    # than the cosine baseline. These three numbers are the headline of the evidence artifact.
     mean_a, mean_b, mean_ov = float(np.mean(mr_a)), float(np.mean(mr_b)), float(np.mean(ov))
     lift = (mean_b - mean_a) / mean_a if mean_a > 0 else float("inf")
 
@@ -212,6 +245,8 @@ def main() -> None:
         ],
     }
 
+    # Write the evidence artifact (single copy — the UI card is deferred to a parallel agent, so
+    # there's no frontend import yet). This JSON holds the head-to-head result for that future card.
     out_src = ROOT / "telemetry-platform" / "event_windowed_analog_evidence.json"
     out_src.write_text(json.dumps(artifact, indent=2), encoding="utf-8")
 

--- a/telemetry-platform/compute_regime_anomaly.py
+++ b/telemetry-platform/compute_regime_anomaly.py
@@ -1,5 +1,19 @@
 """Phase 3 — Regime-conditioned anomaly detection on C-MAPSS FD004 (REAL data, reproducible).
 
+WHAT THIS FILE DOES (plain version): it builds two anomaly detectors for jet-engine sensor data
+and shows that the naive one cries wolf. A "regime" is a distinct operating condition (cruise vs
+climb, etc.). The naive detector judges "normal" on one global scale, so it false-alarms every
+time the engine merely switches modes. The smart detector judges "normal relative to the current
+regime" (regime-conditioned) and stops those false alarms.
+WHERE YOU SEE THIS: the frontend RegimeAnomalyCard — per-regime false-positive bars for the
+global vs regime-conditioned detector, plus eta-squared (how much of the error is just regime).
+INPUTS -> OUTPUT: healthy FD004 sensor rows from silver_cmapss -> regime_anomaly_evidence.json.
+HOW TO READ THE NUMBERS: false-positive rate = % of KNOWN-HEALTHY rows wrongly flagged (lower is
+better); cross-regime spread = gap between worst and best regime (lower = fairer); eta-squared =
+share of the detector's error explained purely by which operating mode the engine was in (high =
+the detector is reacting to mode, not faults).
+
+
 The judgment artifact (Spin 1 + the degenerate-autoencoder fix): build the obvious global
 reconstruction-error detector, measure it on FD004's six operating conditions, find that its
 false positives are dominated by operating regime (not faults), then condition on regime and
@@ -49,6 +63,8 @@ ROOT = Path(__file__).resolve().parents[1]
 AS_OF = "2026-06-23"
 
 
+# Run a SQL query against the Databricks warehouse and hand back a tidy table. Plumbing only:
+# submit, poll until done, page through any chunked results.
 def query(w: WorkspaceClient, sql: str) -> pd.DataFrame:
     resp = w.statement_execution.execute_statement(
         statement=sql, warehouse_id=WAREHOUSE_ID, wait_timeout="50s",
@@ -67,6 +83,10 @@ def query(w: WorkspaceClient, sql: str) -> pd.DataFrame:
     return pd.DataFrame(rows, columns=cols)
 
 
+# eta-squared answers one plain question: of all the ups and downs in the detector's error, what
+# fraction is explained just by which operating mode the engine was in? Near 1 means the "anomaly"
+# score is really a regime indicator (bad); near 0 means it's reacting to genuine faults (good).
+# -> this is the "variance explained by regime" figure on the RegimeAnomalyCard.
 def eta_squared(errs: np.ndarray, regimes: np.ndarray) -> float:
     """Fraction of recon-error variance explained by regime (one-way ANOVA eta^2).
     High => recon error tracks operating regime; near 0 => it does not."""
@@ -99,11 +119,18 @@ def main() -> None:
     active = [s for s in SENSORS if df[s].std() > 1e-6]
     print(f"[regime] active sensors={len(active)} (dropped {len(SENSORS) - len(active)} constant)")
 
+    # Discover the operating regimes. We don't have mode labels, so we cluster the three
+    # operating-setting columns into six groups (FD004's known number of conditions); each row
+    # gets tagged with the regime it belongs to. This regime tag is what everything below
+    # conditions on.
     # Regimes from the operating-setting columns (six C-MAPSS conditions).
     rscaler = StandardScaler().fit(df[SETTINGS].to_numpy())
     km = KMeans(n_clusters=N_REGIMES, random_state=SEED, n_init=10).fit(rscaler.transform(df[SETTINGS].to_numpy()))
     df["regime"] = km.labels_
 
+    # Split engines (units) into a build set and a held-out test set so no engine is in both.
+    # Judging the detector only on engines it never saw is what makes the false-alarm numbers
+    # honest rather than memorized.
     # Grouped fit/eval split by unit (no unit in both — same discipline as the RUL work).
     rng = np.random.default_rng(SEED)
     units = np.sort(df.unit.unique())
@@ -116,6 +143,9 @@ def main() -> None:
     # ---- GLOBAL detector: the "single operating mode" assumption ----
     # The obvious thing that breaks: calibrate the detector on the operating condition you
     # have the most data for, then apply it everywhere (ignore that other conditions exist).
+    # Build the naive detector on ONLY the most common operating mode, learn its "normal" pattern
+    # (PCA) and an alarm line (tau_g), then apply that one-mode yardstick to every mode. The
+    # per-regime false-alarm rates this produces are the GLOBAL (red/baseline) bars on the card.
     dominant = int(pd.Series(reg_fit).value_counts().idxmax())
     dm = reg_fit == dominant
     gscaler = StandardScaler().fit(Xfit[dm])
@@ -125,6 +155,10 @@ def main() -> None:
     eg_ev = recon_error(gscaler.transform(Xev), gpca.mean_, gpca.components_)  # applied to ALL regimes
     fp_global = per_regime_rate(eg_ev, reg_ev, tau_g)
 
+    # Build the smart detector: first re-express every row relative to its own regime's normal
+    # (regime_zscore removes the mode-switch offset), THEN learn one shared "normal" pattern and
+    # alarm line. Because mode is already accounted for, leftover surprise should reflect real
+    # faults. These per-regime rates are the REGIME-CONDITIONED (improved) bars on the card.
     # ---- REGIME-CONDITIONED detector: per-regime standardization ----
     stats = regime_stats(Xfit, reg_fit)
     Zfit, Zev = regime_zscore(Xfit, reg_fit, stats), regime_zscore(Xev, reg_ev, stats)
@@ -133,6 +167,9 @@ def main() -> None:
     ez_ev = recon_error(Zev, zpca.mean_, zpca.components_)
     fp_regime = per_regime_rate(ez_ev, reg_ev, tau_z)
 
+    # Roll the per-regime bars up into the headline comparison: worst regime, average regime, and
+    # how much regime-conditioning explains away. The reduction percentages are the "X% fewer false
+    # alarms" claim shown on the card.
     worst_g, worst_z = max(fp_global.values()), max(fp_regime.values())
     mean_g, mean_z = float(np.mean(list(fp_global.values()))), float(np.mean(list(fp_regime.values())))
     eta_g, eta_z = eta_squared(eg_ev, reg_ev), eta_squared(ez_ev, reg_ev)
@@ -195,6 +232,9 @@ def main() -> None:
         ],
     }
 
+    # Write the evidence twice: a source-of-record copy here, and a copy the frontend imports
+    # directly. This JSON is exactly what populates the RegimeAnomalyCard (numbers are baked at
+    # compute time, not fetched live).
     out_src = ROOT / "telemetry-platform" / "regime_anomaly_evidence.json"
     out_fe = ROOT / "repo-b" / "src" / "lib" / "telemetry" / "regimeAnomalyEvidence.json"
     out_src.write_text(json.dumps(artifact, indent=2), encoding="utf-8")

--- a/telemetry-platform/compute_rul_conformal.py
+++ b/telemetry-platform/compute_rul_conformal.py
@@ -1,5 +1,19 @@
 """Phase 2 — Conformal lower-bound RUL on C-MAPSS FD001 (REAL data, reproducible).
 
+WHAT THIS FILE DOES (plain version): it predicts how much life a jet engine has left (Remaining
+Useful Life, in cycles) and — crucially — wraps that prediction in an honest uncertainty band.
+"Conformal" is a way to size that band from the model's own past errors so the true value lands
+inside it a guaranteed fraction of the time (here, ~90%). It then turns the cautious lower edge
+of the band into a GO / REVIEW / NO_GO service decision.
+WHERE YOU SEE THIS: the RulConformalCard and the RUL Calibration page (the 80%/90% interval
+ribbons around each prediction, and the gate badges).
+INPUTS -> OUTPUT: FD001 gold features + official RUL truth -> rul_conformal_evidence.json.
+HOW TO READ THE NUMBERS: PICP = how often the truth actually fell inside the band (want ~90%, the
+"coverage" figure); PINAW = how wide the band is, normalized 0-1 (narrower is better, as long as
+coverage holds); qhat = the band half-width in cycles; the lower-bound gate = the decision made on
+the worst-case remaining life, not the rosy point estimate.
+
+
 Pulls the same Gold features + RUL truth the Databricks RUL notebook uses
 (novendor_1.telemetry.gold_cmapss_features / silver_cmapss_rul, FD001), trains the
 same GBM, then computes split-conformal prediction intervals with a unit-grouped
@@ -47,6 +61,8 @@ ROOT = Path(__file__).resolve().parents[1]
 AS_OF = "2026-06-23"  # stamped (no Date.now in repo); update on recompute
 
 
+# Run a SQL query against the Databricks warehouse and return a tidy table. Plumbing only:
+# submit, poll until done, page through chunked results.
 def query(w: WorkspaceClient, sql: str) -> pd.DataFrame:
     resp = w.statement_execution.execute_statement(
         statement=sql, warehouse_id=WAREHOUSE_ID, wait_timeout="50s",
@@ -67,6 +83,8 @@ def query(w: WorkspaceClient, sql: str) -> pd.DataFrame:
     return pd.DataFrame(rows, columns=cols)
 
 
+# Local shorthand: turn a remaining-life number into GO / REVIEW / NO_GO using this file's
+# thresholds (<=30 cycles must be serviced now, <=50 needs review, else clear).
 def gate(value: float) -> str:
     return _gate(value, T_NOGO, T_REVIEW)
 
@@ -94,6 +112,9 @@ def main() -> None:
     train = feat[feat.split == "train"].copy()
     test = feat[feat.split == "test"].copy()
 
+    # Carve the training engines into two groups: one to TRAIN the model, a separate one to
+    # CALIBRATE the uncertainty band. Conformal needs the calibration errors to come from data the
+    # model didn't train on, or the band would look falsely tight. No engine appears in both.
     # Unit-grouped calibration split (no unit in both fit and calibration).
     rng = np.random.default_rng(SEED)
     train_units = np.sort(train.unit.unique())
@@ -107,6 +128,9 @@ def main() -> None:
     for df in (train, test):
         df[feat_cols] = df[feat_cols].fillna(med)
 
+    # Train the actual life-prediction model (a gradient-boosted regressor) on the fit engines.
+    # RUL is capped at RUL_CAP because very-early-life predictions are flat and uninformative; we
+    # only care about getting close as failure approaches.
     Xfit = train.loc[fit_mask, feat_cols].to_numpy()
     yfit = np.minimum(train.loc[fit_mask, "rul_target"].to_numpy(), RUL_CAP)
     gbm = GradientBoostingRegressor(n_estimators=300, max_depth=3, learning_rate=0.05,
@@ -121,11 +145,17 @@ def main() -> None:
     cal = (train[train.unit.isin(cal_units)]
            .groupby("unit", group_keys=False)
            .apply(lambda g: g.sample(1, random_state=SEED)).copy())
+    # Measure how wrong the model is on the calibration engines. abs_res = size of each miss (for
+    # the symmetric band); over_pred = only the DANGEROUS misses where the model claimed MORE life
+    # than reality (those are what a safety lower-bound must guard against).
     cal_pred = np.clip(gbm.predict(cal[feat_cols].to_numpy()), 0, RUL_CAP)
     cal_y = np.minimum(cal["rul_target"].to_numpy(), RUL_CAP)
     abs_res = np.abs(cal_y - cal_pred)
     over_pred = cal_pred - cal_y          # positive => model over-predicted remaining life (unsafe)
 
+    # Convert those calibration errors into band widths via the conformal recipe. qhat sizes the
+    # symmetric ribbon (the 90% interval on the chart); q_lower sizes the one-sided safety margin
+    # subtracted to get the cautious lower bound the gate runs on.
     qhat = conformal_quantile(abs_res, ALPHA)             # two-sided half-width
     q_lower = conformal_quantile(np.clip(over_pred, 0, None), ALPHA)  # one-sided lower margin
 
@@ -135,15 +165,25 @@ def main() -> None:
     pred = np.clip(gbm.predict(test_last[feat_cols].to_numpy()), 0, RUL_CAP)
     y_true = np.minimum(test_last["rul"].to_numpy(), RUL_CAP)
 
+    # Build the bands around each test prediction. lower2/upper2 are the visible ribbon edges;
+    # lower_os is the cautious one-sided floor used for the gate.
     lower2 = np.clip(pred - qhat, 0, RUL_CAP)
     upper2 = np.clip(pred + qhat, 0, RUL_CAP)
     lower_os = np.clip(pred - q_lower, 0, RUL_CAP)
 
+    # The honesty scorecard. picp = fraction of test engines whose true life landed inside the
+    # ribbon -> this is the "coverage" number on the RUL Calibration page (want it near 90%).
+    # lb_cov = how often the cautious floor stayed safely below the truth. pinaw = average ribbon
+    # width as a fraction of the scale (narrower is better). rmse = raw point-prediction error.
     picp = float(np.mean((y_true >= lower2) & (y_true <= upper2)))
     lb_cov = float(np.mean(y_true >= lower_os))
     pinaw = float(np.mean(upper2 - lower2) / RUL_CAP)
     rmse = float(np.sqrt(np.mean((pred - y_true) ** 2)))
 
+    # The payoff of using the band: compare the verdict you'd give from the rosy point estimate vs
+    # from the cautious lower bound. "flips" counts engines the lower bound treats more strictly —
+    # i.e. cases where ignoring uncertainty would have over-cleared an engine. This disagreement is
+    # the headline story on the RulConformalCard.
     point_gate = np.array([gate(v) for v in pred])
     lb_gate = np.array([gate(v) for v in lower_os])
     order = {"GO": 0, "REVIEW": 1, "NO_GO": 2}
@@ -206,6 +246,9 @@ def main() -> None:
         ],
     }
 
+    # Write the evidence twice: a source-of-record copy and the frontend's imported copy. This
+    # JSON is exactly what fills the RulConformalCard and the RUL Calibration ribbons (baked at
+    # compute time, not fetched live).
     out_src = ROOT / "telemetry-platform" / "rul_conformal_evidence.json"
     out_fe = ROOT / "repo-b" / "src" / "lib" / "telemetry" / "rulConformalEvidence.json"
     out_src.write_text(json.dumps(artifact, indent=2), encoding="utf-8")

--- a/telemetry-platform/conformal_core.py
+++ b/telemetry-platform/conformal_core.py
@@ -1,5 +1,23 @@
 """Pure split-conformal primitives (numpy only — no Databricks, CI-safe).
 
+WHAT THIS FILE DOES: the math for putting an honest uncertainty band around a prediction.
+"Conformal" = a recipe that turns past prediction errors into a band guaranteed to contain the
+truth a chosen fraction of the time (e.g. 90%), with no assumptions about the model. Here it
+wraps a Remaining-Useful-Life (RUL) prediction and turns its worst-case lower edge into a
+service decision.
+
+WHERE YOU SEE THIS: feeds the RulConformalCard and the RUL Calibration page (the 80%/90%
+interval ribbons and the GO / REVIEW / NO_GO gate).
+
+INPUTS -> OUTPUT: past calibration errors + a target confidence -> band half-width and a
+GO/REVIEW/NO_GO label (consumed by compute_rul_conformal.py, which writes rul_conformal_evidence.json).
+
+HOW TO READ THE NUMBERS:
+  - alpha = the allowed miss rate; coverage target = 1 - alpha (alpha 0.10 => aim for 90% coverage).
+  - qhat = how wide the band has to be (in cycles) to hit that coverage.
+  - PICP = how often the truth actually landed inside the band (want it near the target).
+  - gate = turning the cautious lower edge of the band into GO / REVIEW / NO_GO for servicing.
+
 Shared by compute_rul_conformal.py (which pulls real FD001 data) and the eval test
 test_conformal_core.py (which checks coverage on synthetic exchangeable data). Keeping
 the math here means the test runs without credentials or a warehouse.
@@ -10,6 +28,10 @@ from __future__ import annotations
 import numpy as np
 
 
+# The heart of conformal prediction. Feed in how far off the model was on a set of held-out
+# "calibration" examples; this returns the error size you must allow for to cover (1-alpha) of
+# future cases. The slightly-larger-than-plain-quantile index ((n+1)(1-alpha)) is what gives the
+# honest finite-sample coverage guarantee. The returned value becomes the band half-width qhat.
 def conformal_quantile(scores: np.ndarray, alpha: float) -> float:
     """Finite-sample split-conformal quantile of nonconformity ``scores``.
 
@@ -26,12 +48,17 @@ def conformal_quantile(scores: np.ndarray, alpha: float) -> float:
     return float(np.sort(scores)[k - 1])
 
 
+# Build the visible ribbon: take the prediction and pad it by qhat on both sides. This pair of
+# arrays is exactly the upper/lower edge of the interval ribbon on the RUL Calibration page.
 def two_sided_interval(pred: np.ndarray, qhat: float, lo: float, hi: float):
     """Symmetric [pred-qhat, pred+qhat], clipped to [lo, hi]."""
     pred = np.asarray(pred, dtype=float)
     return np.clip(pred - qhat, lo, hi), np.clip(pred + qhat, lo, hi)
 
 
+# For a safety decision we only care about the pessimistic edge: "how little life might be left?"
+# This returns just that cautious lower bound, which is what the GO/NO_GO gate is applied to (you
+# service on the worst-case estimate, not the rosy point prediction).
 def lower_bound(pred: np.ndarray, q_lower: float, lo: float, hi: float):
     """One-sided lower bound pred - q_lower, clipped. For a RUL go/no-go this is the
     worst-case remaining-life the calibration supports at the target confidence."""
@@ -39,6 +66,9 @@ def lower_bound(pred: np.ndarray, q_lower: float, lo: float, hi: float):
     return np.clip(pred - q_lower, lo, hi)
 
 
+# Translate a remaining-life number into a plain operational verdict: too little life -> NO_GO
+# (service before next use), borderline -> REVIEW, plenty -> GO. This is the colored badge the
+# RulConformalCard shows. Applied to the cautious lower bound above, not the raw prediction.
 def gate(value: float, t_nogo: float, t_review: float) -> str:
     """Three-tier clearance band on a remaining-life value (cycles)."""
     if value <= t_nogo:
@@ -48,6 +78,10 @@ def gate(value: float, t_nogo: float, t_review: float) -> str:
     return "GO"
 
 
+# The honesty check: of all the test cases, what fraction had their true value land inside the
+# band? PICP = Prediction Interval Coverage Probability. If we aimed for 90% and PICP comes back
+# ~0.90 the bands are well-calibrated. This is the headline "coverage" figure on the RUL
+# Calibration page.
 def picp(y_true: np.ndarray, lower: np.ndarray, upper: np.ndarray) -> float:
     """Prediction Interval Coverage Probability."""
     y_true = np.asarray(y_true, dtype=float)

--- a/telemetry-platform/databricks/06_gold.py
+++ b/telemetry-platform/databricks/06_gold.py
@@ -1,6 +1,30 @@
 """
 Gold — model-ready feature/label tables + the deterministic replay feed.
 
+===== TEACHING NOTES (plain language) =====
+WHAT THIS FILE DOES:
+  "Gold" is the last, model-ready layer of the data pipeline (bronze = raw, silver = cleaned, gold =
+  feature-engineered). It turns cleaned sensor rows into the exact columns every telemetry model trains
+  and scores on: rolling averages, spreads, min/max, and rate-of-change over a recent window of readings.
+  These derived "features" are what let a model see a trend instead of one isolated number.
+
+WHERE YOU SEE THIS:
+  This is the foundation behind the Runs, Monitoring, and Model Performance pages — every prediction
+  shown there was computed from these gold tables. gold_replay_feed specifically drives the demo REPLAY
+  (one fixed channel's history streamed back tick by tick).
+
+INPUTS -> OUTPUT:
+  INPUT  : silver_cmapss / silver_smap_msl (cleaned readings) + silver_smap_msl_labels (true anomaly
+           windows).
+  OUTPUT : gold_cmapss_features (RUL features + label), gold_smap_msl_windows (anomaly features + the
+           is_anomaly truth flag), gold_replay_feed (one channel's test sequence for the demo).
+
+HOW TO READ IT / KEY IDEA:
+  - look-ahead / leakage : the cardinal sin of time-series ML — letting a feature at time t peek at data
+    from AFTER t (the future). If that happens, the model looks brilliant in testing and fails in the
+    real world, where the future isn't available. Every rolling window below is built to NEVER look
+    forward (see NO-LOOK-AHEAD ENFORCEMENT). The RUL label is carried alongside, never fed in as an input.
+
 NO-LOOK-AHEAD ENFORCEMENT:
   Every rolling feature uses a window frame `ROWS BETWEEN n PRECEDING AND CURRENT ROW` partitioned by
   the series key and ordered by the time index. No frame ever references FOLLOWING rows, so a feature
@@ -33,11 +57,18 @@ CMAPSS_FEATURE_SENSORS = [2, 3, 4, 7, 11, 12, 15]
 
 
 def _roll(col: str, n: int, fn: str, part: str, order: str) -> str:
+    # Build one rolling-window feature in SQL. "ROWS BETWEEN n PRECEDING AND CURRENT ROW" is the
+    # no-look-ahead guarantee in code form: it only ever averages/spreads the CURRENT row and the n rows
+    # BEFORE it — never anything after. This is how a feature at time t stays a function of times <= t.
     return (f"{fn}({col}) OVER (PARTITION BY {part} ORDER BY {order} "
             f"ROWS BETWEEN {n} PRECEDING AND CURRENT ROW)")
 
 
 def cmapss_feature_sql() -> str:
+    # For each engine, turn each sensor into a small panel of trend features the RUL model can read:
+    # a 5-cycle rolling mean/std/min/max (recent level + how jittery + the recent envelope) and a
+    # rate-of-change vs the previous cycle (is it climbing or falling). These are the inputs behind the
+    # RUL predictions on the Model Performance / Runs pages.
     # Partition by (subset, split, unit): a train unit and a test unit can share (subset,unit),
     # so split MUST be in the partition or rolling features leak across the train/test boundary.
     part = "subset,split,unit"
@@ -55,6 +86,9 @@ def cmapss_feature_sql() -> str:
 
 def gold_statements() -> list:
     return [
+        # TABLE 1: gold_cmapss_features — the model-ready RUL training/scoring table. One row per
+        # (engine, cycle) with the raw informative sensors PLUS the rolling trend features above, and the
+        # rul_target label. This is the input the RUL champion/challenger notebooks read.
         f"DROP TABLE IF EXISTS {TEL}.gold_cmapss_features",
         f"""
         CREATE TABLE {TEL}.gold_cmapss_features AS
@@ -67,6 +101,11 @@ def gold_statements() -> list:
             'Gold: C-MAPSS model-ready RUL features. Rolling stats use ROWS BETWEEN 4 PRECEDING AND
              CURRENT ROW (no look-ahead). rul_target is the train label. Telemetry Platform.'""",
 
+        # TABLE 2: gold_smap_msl_windows — the anomaly-detection feature table. Each spacecraft channel
+        # reading gets a 50-step rolling mean/std/min/max + rate-of-change (so a model can tell "this
+        # value is far from its recent normal"), and an is_anomaly flag set to 1 when the reading falls
+        # inside a real NASA-labeled anomaly window. is_anomaly is the GROUND TRUTH the Monitoring /
+        # Model Performance pages score detections against.
         # SMAP/MSL: features + is_anomaly derived from labeled windows (test split only has labels).
         f"DROP TABLE IF EXISTS {TEL}.gold_smap_msl_windows",
         f"""
@@ -98,6 +137,9 @@ def gold_statements() -> list:
              AND CURRENT ROW (no look-ahead). is_anomaly is the labeled target on the test split.
              Telemetry Platform.'""",
 
+        # TABLE 3: gold_replay_feed — the demo's tape. It's just one fixed channel's (D-4) test sequence,
+        # in time order, with its features and the is_anomaly truth. The frontend replays this tick by tick
+        # so the live demo behaves identically every single run (no randomness, fully reproducible).
         # Deterministic replay feed: one fixed channel's test sequence, ordered, with features+label.
         f"DROP TABLE IF EXISTS {TEL}.gold_replay_feed",
         f"""

--- a/telemetry-platform/databricks/13_backfill_serving.py
+++ b/telemetry-platform/databricks/13_backfill_serving.py
@@ -1,4 +1,41 @@
 """
+===== TEACHING NOTES (plain language) =====
+WHAT THIS FILE DOES:
+  It manufactures a believable OPERATING HISTORY for the telemetry-demo tenant. A fresh demo has almost
+  nothing to show (1 run, 3 predictions, no events, no drift), which looks empty and unconvincing. This
+  script replays the REAL frozen model over REAL NASA sensor history and writes the results — predictions,
+  detected anomalies, and drift metrics — into the SERVING tables the frontend reads. Nothing is faked:
+  the scores come from the actual model rule and the anomaly labels are the actual NASA-labeled windows.
+  The ONLY invented thing is the timestamps (spread over the last ~45 days so it reads like recent
+  operation).
+
+WHERE YOU SEE THIS:
+  This is the LIVE DATA behind the frontend MONITORING and MODEL PERFORMANCE pages. Those pages call
+  /api/telemetry/* which reads tel_predictions, tel_anomaly_events, and tel_drift_metrics for the
+  telemetry-demo tenant — exactly the rows this script seeds.
+
+INPUTS -> OUTPUT:
+  INPUT  : the gold tables in novendor_1.telemetry (real NASA features + real anomaly labels) and the
+           frozen champion MAD rule.
+  OUTPUT : a committed, idempotent seed_serving_backfill.sql file. You apply it with:
+             cat telemetry-platform/databricks/seed_serving_backfill.sql | supabase db query --linked
+
+HOW TO READ IT / KEY TERMS (one phrase each):
+  - frozen rule        : the model is LOCKED to fixed parameters (here MAD_K=4.0, a fixed threshold), so
+                         re-scoring the same history always gives the same answer. A frozen rule makes the
+                         backfilled history reproducible — anyone can re-run it and get identical rows.
+  - MAD rule           : the anomaly detector — flag a reading when it deviates from its recent normal by
+                         more than K times the typical deviation. score = peak deviation / threshold;
+                         score < 1 = GO (fine), 1-2 = REVIEW, > 2 = NO_GO (anomaly).
+  - idempotent backfill: running it twice does NOT create duplicates. It tags its rows with a fixed
+                         backfill_batch_id and is_backfilled=true, and deletes only THAT batch before
+                         re-inserting — so live, real /score receipts (is_backfilled=false) are never
+                         touched and re-running is always safe.
+  - PSI (drift)        : Population Stability Index — how much the live data distribution has shifted away
+                         from the training baseline (< 0.1 stable, 0.1-0.25 watch, > 0.25 real drift).
+                         This is the drift signal on the Monitoring page.
+============================================
+
 Phase 6 — authentic operated-history backfill for the telemetry-demo tenant.
 
 Turns the thin demo (1 run, 3 predictions, empty events/drift) into a credible operated history using
@@ -41,6 +78,9 @@ D4_RUN_ID = "7e1e7a00-0000-4000-a000-000000000001"  # existing (is_backfilled=fa
 _NS = uuid.UUID("7e1e0000-0000-4000-a000-0000000000ff")  # deterministic uuid5 namespace
 
 # Frozen champion params (must match backend/app/services/telemetry_serving.py).
+# These three numbers ARE the frozen rule: a reading is anomalous if its deviation exceeds K=4 times the
+# fixed training-scale, i.e. above THRESHOLD. They're hard-coded (not recomputed) so this backfill scores
+# history with the exact same locked model the live system uses — that's what makes it reproducible.
 MAD_K = 4.0
 GLOBAL_TRAIN_SCALE = 0.033866801182436346
 THRESHOLD = MAD_K * GLOBAL_TRAIN_SCALE  # 0.135467...
@@ -52,6 +92,9 @@ N_CMAPSS = 12    # C-MAPSS units to list as ingested RUL runs
 PSI_BINS = 10
 OUT = Path(__file__).resolve().parent / "seed_serving_backfill.sql"
 
+# Turn a raw anomaly score into the traffic-light verdict shown on Monitoring: GO (looks healthy),
+# REVIEW (borderline, a human should look), NO_GO (clear anomaly). score is how many times over the
+# frozen threshold the reading's deviation was, so 1.0 is exactly at the threshold.
 # REVIEW band on the real anomaly_score (score = peak_resid / threshold).
 def verdict_for(score: float) -> str:
     if score < 1.0:
@@ -61,6 +104,9 @@ def verdict_for(score: float) -> str:
     return "NO_GO"
 
 
+# Row IDs are derived deterministically from their content (uuid5 of a fixed namespace + a key), not
+# random. Same inputs -> same IDs every run, which is what lets the backfill be re-applied without making
+# duplicate rows (the ON CONFLICT / batch-delete logic relies on stable IDs).
 def run_id_for(run_key: str) -> str:
     return str(uuid.uuid5(_NS, run_key))
 
@@ -168,6 +214,9 @@ def main() -> int:
         client.stop_warehouse()
 
     # ---- compute everything locally (real values; no fabrication) ----
+    # Everything below assembles serving ROWS from the real aggregates pulled above. The values (scores,
+    # labels, PSI) are real; we only assign synthetic timestamps spread over the last `span_days` so the
+    # history reads like recent, ongoing operation on the Monitoring timeline.
     now = datetime.now(timezone.utc)
     span_days = 45
 
@@ -198,6 +247,8 @@ def main() -> int:
         if rid is None:
             continue
         for r in rows:
+            # Score each real channel-window with the frozen rule: peak deviation / threshold -> score ->
+            # GO/REVIEW/NO_GO. One tel_predictions row per window — exactly what Model Performance reads.
             _, spacecraft, widx, wstart, wend, peak, anom_any, n = r
             peak = float(peak); wstart = int(wstart); wend = int(wend)
             score = round(peak / THRESHOLD, 6)
@@ -261,7 +312,13 @@ def main() -> int:
 
 
 def compute_psi(base_hist, win_hist, drift_ch, now, span_days):
-    """Real PSI per (channel, window) vs the train baseline. PSI = sum((c-b)*ln(c/b))."""
+    """Real PSI per (channel, window) vs the train baseline. PSI = sum((c-b)*ln(c/b)).
+
+    Plain version: bin the values into 10 buckets, compare each live window's bucket-shares (c) against
+    the training baseline's shares (b). PSI sums how different they are — near 0 means the live data still
+    looks like training (stable); larger means the world has shifted (drift). This is the drift line on
+    the Monitoring page; status is bucketed stable / watch / drift by the standard 0.1 / 0.25 thresholds.
+    """
     base = {}
     for r in base_hist:
         base.setdefault(r[0], {})[int(r[1])] = int(r[2])
@@ -328,6 +385,9 @@ def emit_sql(test_runs, channels, predictions, events, drift):
     L.append(f"-- is_backfilled=true, backfill_batch_id='{BATCH_ID}'. Live /score receipts (is_backfilled=false)")
     L.append("-- are NOT touched. Idempotent: deletes only this batch's prior rows, then re-inserts.")
     L.append("BEGIN;")
+    # This delete-then-insert, scoped to this batch_id + is_backfilled=true, is the idempotency mechanism:
+    # re-running wipes only THIS backfill's prior rows (never the live is_backfilled=false receipts) and
+    # re-inserts, so the demo data is always exactly one clean copy no matter how many times you apply it.
     # delete prior backfilled rows (FK-safe order), demo-tenant + backfill-scoped
     for t in ("tel_predictions", "tel_anomaly_events", "tel_drift_metrics",
               "tel_telemetry_channels", "tel_test_runs"):

--- a/telemetry-platform/databricks/15_run_ncr_pipeline.py
+++ b/telemetry-platform/databricks/15_run_ncr_pipeline.py
@@ -1,15 +1,29 @@
 """
 RS Demo PR 3 driver — run the Factory NCR Intelligence pipeline.
 
-Default runtime is Databricks (the real path): auth preflight (get_client + SELECT 1), upload the
-three notebooks (ncr_corpus -> ncr_clustering -> ncr_backlog_forecast), run each as a serverless
-job, and save the combined exit payloads to ncr_pipeline_result.json for 16_mirror_ncr_serving.py.
+===== TEACHING NOTES (plain language) =====
+WHAT THIS FILE DOES: this is the ORCHESTRATOR — the conductor that runs the three pipeline stages in
+order: ncr_corpus (make the demo tickets) -> ncr_clustering (group them + lay out the scatter plot)
+-> ncr_backlog_forecast (predict the backlog). It doesn't do the ML math itself; it kicks off the
+three notebooks and collects their results into one file for the next step (16_mirror_ncr_serving.py)
+to ship to the serving database.
 
-RUNTIME=local is the bounded fallback when Databricks auth is down: the SAME deterministic corpus,
-a TF-IDF + truncated-SVD 2D projection with seeded k-means in place of the
-sentence-transformer/UMAP/HDBSCAN stack, and the same drift-vs-naive walk-forward forecast — all
-labeled provenance='local_fallback' end to end. It exists so the demo never renders an empty page;
-the Databricks run is the story.
+WHERE YOU SEE THIS: indirectly, the whole FactoryNcrIntelligence page —
+repo-b/src/components/telemetry/FactoryNcrIntelligence.tsx — exists because this script ran the
+pipeline that produced its data.
+
+TWO WAYS TO RUN:
+  - DATABRICKS (the real path, default): log in, upload the three notebooks, run each on a cloud
+    cluster, and gather the results. This is the genuine model run with sentence embeddings, UMAP,
+    HDBSCAN, and MLflow tracking — the story we actually demo.
+  - LOCAL FALLBACK (RUNTIME=local): a smaller stand-in that runs entirely on this laptop when the
+    Databricks login is down, so the demo page never shows up empty. It uses the SAME made-up tickets
+    and the SAME forecast logic, but swaps the heavy ML libraries for lighter math: TF-IDF instead of
+    neural embeddings, a plain SVD projection instead of UMAP, and k-means instead of HDBSCAN. Every
+    row it produces is stamped provenance='local_fallback' so the UI is honest about where it ran.
+
+INPUTS -> OUTPUT: nothing in (it generates its own corpus) -> ncr_pipeline_result.json (the combined
+results), plus ncr_pipeline_local_data.json in local mode.
 
 Run:  python 15_run_ncr_pipeline.py            (Databricks)
       RUNTIME=local python 15_run_ncr_pipeline.py
@@ -43,13 +57,15 @@ def _load_corpus_module():
 
 
 def run_databricks() -> int:
+    # The real path: connect to Databricks, then run the three notebooks in order on cloud clusters.
     from _bootstrap import get_client
     from _jobs import ensure_dir, upload_notebook, run_notebook_and_wait, get_notebook_output, WORKSPACE_DIR
 
     client = get_client()
-    client.execute_sql("SELECT 1")  # auth preflight (owner gate)
+    client.execute_sql("SELECT 1")  # auth preflight: a tiny query to confirm we're actually logged in
     ensure_dir(client)
 
+    # Run each notebook, wait for it to finish, and stash its JSON exit payload keyed by name.
     exits: dict[str, dict] = {}
     for name in NOTEBOOKS:
         wp = upload_notebook(client, str(HERE / "notebooks" / f"{name}.py"), f"{WORKSPACE_DIR}/{name}")
@@ -70,11 +86,18 @@ def run_databricks() -> int:
 
 # ── bounded local fallback ──────────────────────────────────────────────────────────────────────
 def _local_embed_and_cluster(records: list[dict]) -> tuple[list[dict], list[dict], dict]:
-    """TF-IDF -> truncated SVD (2D) -> seeded k-means. Honest stand-in, labeled local_fallback."""
+    """TF-IDF -> truncated SVD (2D) -> seeded k-means. Honest stand-in, labeled local_fallback.
+
+    Plain language: the laptop-only version of the clustering notebook. Instead of neural sentence
+    embeddings + UMAP + HDBSCAN, it scores words by frequency (TF-IDF), squashes that to 2D with a
+    matrix trick (SVD), and groups the dots into 6 buckets with k-means. Same SHAPE of output (dots +
+    cluster summaries), simpler math. Used only when Databricks is unreachable.
+    """
     import numpy as np
 
     docs = [r["summary"] for r in records]
-    # vocabulary over unigrams+bigrams (same tokenizer family as the notebook's c-TF-IDF)
+    # Build a vocabulary of single words + adjacent word-pairs (the same tokenizer idea the real
+    # notebook's c-TF-IDF uses), so keyword extraction below behaves consistently across both paths.
     def toks(text: str) -> list[str]:
         words = [w.strip(".,;:").lower() for w in text.split()]
         words = [w for w in words if len(w) > 2 and not w.isdigit()]
@@ -89,15 +112,19 @@ def _local_embed_and_cluster(records: list[dict]) -> tuple[list[dict], list[dict
     for i, dt in enumerate(doc_tokens):
         for t in dt:
             tf[i, vocab[t]] += 1
+    # TF-IDF weighting: common-everywhere words get downweighted, distinctive words get upweighted,
+    # then each ticket's vector is scaled to unit length so they're comparable.
     df = (tf > 0).sum(axis=0)
     tfidf = tf * np.log(len(docs) / np.maximum(df, 1))
     tfidf /= np.maximum(np.linalg.norm(tfidf, axis=1, keepdims=True), 1e-9)
 
-    # truncated SVD to 2D
+    # Squash the wide word-vectors down to 2 numbers (x, y) for plotting — the no-UMAP stand-in.
+    # -> these coords ARE the scatter-plot dots on FactoryNcrIntelligence in local-fallback mode.
     u, s, _ = np.linalg.svd(tfidf, full_matrices=False)
     coords = u[:, :2] * s[:2]
 
-    # seeded k-means (k=6) on the full tfidf space; labels mapped onto the 2D scatter
+    # k-means: pick 6 starting centers, then repeatedly assign each ticket to its nearest center and
+    # recompute the centers. The SEED makes the starting picks (and thus the groups) repeatable.
     rng = np.random.RandomState(SEED)
     k = 6
     centers = tfidf[rng.choice(len(docs), k, replace=False)]
@@ -149,6 +176,8 @@ def _local_embed_and_cluster(records: list[dict]) -> tuple[list[dict], list[dict
 
 
 def _local_forecast(records: list[dict]) -> tuple[list[dict], dict]:
+    # Laptop version of the backlog forecast notebook — identical drift-vs-naive walk-forward logic,
+    # just running locally. Produces the same history+forecast rows and the same MAE/MAPE numbers.
     import numpy as np
 
     week_starts = [ANCHOR - timedelta(weeks=N_WEEKS - w) for w in range(N_WEEKS)]
@@ -170,11 +199,13 @@ def _local_forecast(records: list[dict]) -> tuple[list[dict], dict]:
             if date.fromisoformat(r["opened_at"]) <= week_end
             and (not r["closed_at"] or date.fromisoformat(r["closed_at"]) > week_end)))
 
+    # Drift forecast: last known backlog nudged by the trailing-8-week average net flow (same as the notebook).
     def drift(t: int, h: int) -> float:
         lo = max(0, t - 8)
         net = [opened[i] - closed[i] for i in range(lo, t)]
         return backlog[t - 1] + h * (sum(net) / len(net))
 
+    # Walk-forward backtest misses: rm = drift model residuals, rn = naive baseline residuals.
     rm = [backlog[t] - drift(t, 1) for t in range(8, N_WEEKS)]
     rn = [backlog[t] - backlog[t - 1] for t in range(8, N_WEEKS)]
     abs_m, abs_n = np.abs(rm), np.abs(rn)
@@ -200,9 +231,10 @@ def _local_forecast(records: list[dict]) -> tuple[list[dict], dict]:
 
 
 def run_local() -> int:
+    # Same three stages as the Databricks path, but all in-process on this machine.
     print("[ncr] RUNTIME=local — bounded fallback (provenance='local_fallback')")
     corpus_mod = _load_corpus_module()
-    records = corpus_mod.generate_corpus()
+    records = corpus_mod.generate_corpus()  # stage 1: the identical seeded demo tickets
     points, clusters, cmeta = _local_embed_and_cluster(records)
     backlog_rows, fmetrics = _local_forecast(records)
     LOCAL_DATA_PATH.write_text(json.dumps({
@@ -224,6 +256,7 @@ def run_local() -> int:
 
 
 def main() -> int:
+    # Pick the path from the RUNTIME env var; default to the real Databricks run.
     runtime = os.environ.get("RUNTIME", "databricks").lower()
     if runtime == "local":
         return run_local()

--- a/telemetry-platform/databricks/16_mirror_ncr_serving.py
+++ b/telemetry-platform/databricks/16_mirror_ncr_serving.py
@@ -1,6 +1,28 @@
 """
 RS Demo PR 3 mirror — UC NCR pipeline outputs -> idempotent Supabase seed SQL.
 
+===== TEACHING NOTES (plain language) =====
+WHAT THIS FILE DOES: the pipeline's results live in Databricks tables (or a local JSON file in
+fallback mode). The website can't read those directly. This script COPIES those results into the
+serving database (Supabase) tables that the website's API actually queries. It does this by writing
+a .sql file full of INSERT statements, which a human (or CI) then runs against the database.
+
+WHERE YOU SEE THIS: this is the bridge that makes the FactoryNcrIntelligence page light up. The
+page calls /api/telemetry/ncr, which reads the tel_ncr_* tables this script fills:
+  - tel_ncr_records        -> every ticket, its cluster, and its scatter-plot x/y
+  - tel_ncr_clusters       -> the cluster cards (keywords, examples, trend, status)
+  - tel_ncr_backlog_weekly -> the backlog line + 4-week forecast
+  - tel_model_runs         -> 2 rows so the Registry console can show the two models and their scores
+
+INPUTS -> OUTPUT: the pipeline result file(s) from step 15 in -> seed_ncr_serving.sql out (ready to
+apply to Supabase).
+
+KEY IDEA — "idempotent": you can run this and apply the SQL as many times as you like and the end
+state is always the same (no duplicate rows). It does that by deleting this batch's prior rows first
+and using stable, computed row IDs, so re-running overwrites cleanly instead of piling up copies.
+Every row also carries a "provenance" tag ('databricks' or 'local_fallback') so the UI can honestly
+show whether the numbers came from the real cloud run or the laptop stand-in.
+
 Reads the Factory NCR Intelligence outputs (ncr_records + ncr_points + ncr_clusters +
 ncr_backlog_weekly) from novendor_1.telemetry — or from ncr_pipeline_local_data.json when the last
 driver run used RUNTIME=local — and emits seed_ncr_serving.sql for the telemetry-demo tenant:
@@ -79,6 +101,7 @@ def _fetch_all(client, sql: str):
 
 
 def load_databricks():
+    # Read the four pipeline output tables back out of Databricks into plain Python lists/dicts.
     from _bootstrap import get_client
 
     client = get_client()
@@ -123,6 +146,7 @@ def load_databricks():
 
 
 def load_local():
+    # Same data, but read from the JSON file the local-fallback run wrote (no Databricks needed).
     data = json.loads(LOCAL_DATA_PATH.read_text(encoding="utf-8"))
     points = {p["ncr_key"]: {"umap_x": p["umap_x"], "umap_y": p["umap_y"],
                              "cluster_id": p["cluster_id"]} for p in data["points"]}
@@ -132,6 +156,8 @@ def load_local():
 
 
 def emit_sql(records, points, clusters, backlog, provenance: str, exits: dict) -> None:
+    # Build the seed .sql file: a header, a DELETE of this batch's old rows, then INSERTs for every
+    # ticket, cluster, backlog week, and model run. Wrapped in BEGIN/COMMIT so it applies all-or-nothing.
     e, b, bf, pv = sql_str(ENV_ID), sql_str(BUSINESS_ID), sql_str(BATCH_ID), sql_str(provenance)
     cluster_run = exits.get("ncr_clustering", {}).get("mlflow_run_id")
     forecast_run = exits.get("ncr_backlog_forecast", {}).get("mlflow_run_id")
@@ -145,11 +171,15 @@ def emit_sql(records, points, clusters, backlog, provenance: str, exits: dict) -
                 else " via the bounded local fallback (no MLflow run)."))
     L.append(f"-- provenance={provenance} on every row; idempotent per batch_id='{BATCH_ID}'.")
     L.append("BEGIN;")
+    # Idempotency step: clear out this batch's previous rows so re-running can't create duplicates.
     for t in ("tel_ncr_records", "tel_ncr_clusters", "tel_ncr_backlog_weekly"):
         L.append(f"DELETE FROM {t} WHERE env_id={e} AND business_id={b} AND batch_id={bf};")
     L.append(f"DELETE FROM tel_model_runs WHERE env_id={e} AND business_id={b} "
              f"AND model_name IN ('tel_ncr_cluster', 'tel_ncr_forecast');")
 
+    # One INSERT per ticket -> tel_ncr_records. Each ticket carries its cluster_id + umap_x/umap_y,
+    # which is what the scatter plot plots. ON CONFLICT ... DO UPDATE = "if this ticket already
+    # exists, overwrite it" (the other half of idempotency).
     for r in records:
         p = points.get(r["ncr_key"], {})
         L.append(
@@ -169,6 +199,8 @@ def emit_sql(records, points, clusters, backlog, provenance: str, exits: dict) -
             "umap_x=EXCLUDED.umap_x, umap_y=EXCLUDED.umap_y, "
             "provenance=EXCLUDED.provenance, batch_id=EXCLUDED.batch_id;")
 
+    # One INSERT per cluster -> tel_ncr_clusters. Feeds the Pareto bars (n_records), the keyword
+    # chips, the example tickets, and the rising/declining/flat status on each cluster card.
     for c in clusters:
         L.append(
             "INSERT INTO tel_ncr_clusters (id,env_id,business_id,cluster_id,label,keywords,"
@@ -186,6 +218,8 @@ def emit_sql(records, points, clusters, backlog, provenance: str, exits: dict) -
             "mlflow_run_id=EXCLUDED.mlflow_run_id, provenance=EXCLUDED.provenance, "
             "batch_id=EXCLUDED.batch_id;")
 
+    # One INSERT per week -> tel_ncr_backlog_weekly. History rows draw the solid backlog line;
+    # forecast rows (fc/lo/hi) draw the projected line and its shaded uncertainty band.
     for r in backlog:
         L.append(
             "INSERT INTO tel_ncr_backlog_weekly (id,env_id,business_id,week_start,kind,opened,"
@@ -208,6 +242,8 @@ def emit_sql(records, points, clusters, backlog, provenance: str, exits: dict) -
         "n_docs": cexit.get("n_docs"), "n_clusters": cexit.get("n_clusters"),
         "noise_count": cexit.get("noise"), "provenance": provenance,
     }
+    # A "gate" is the pass/fail rule for shipping a model. Clustering passes only if it found at
+    # least 2 real (non-noise) groups — otherwise it didn't learn anything worth showing.
     cluster_gate = {
         "metric": "n_clusters", "threshold": 2,
         "decision": "promoted" if (cexit.get("n_clusters") or 0) >= 2 else "model_not_promoted",
@@ -218,6 +254,8 @@ def emit_sql(records, points, clusters, backlog, provenance: str, exits: dict) -
         ("mae", "mae_naive", "mape_pct", "mape_naive_pct", "skill_vs_naive", "backtest_folds")
     }
     forecast_metrics["provenance"] = provenance
+    # The forecast's gate: it only ships ("promoted") if it actually beat the dumb naive baseline in
+    # the backtest (skill > 0). If it didn't, it's honestly marked "model_not_promoted".
     skill = fexit.get("skill_vs_naive") or 0.0
     forecast_gate = {
         "metric": "skill_vs_naive", "threshold": 0.0,
@@ -250,6 +288,8 @@ def emit_sql(records, points, clusters, backlog, provenance: str, exits: dict) -
 
 
 def main() -> int:
+    # Decide which source to load (Databricks tables vs. local JSON) based on how step 15 ran, build
+    # the seed SQL, and report a quick row count. The result file from step 15 must exist first.
     if not RESULT_PATH.exists():
         print("ncr_pipeline_result.json missing — run 15_run_ncr_pipeline.py first")
         return 2

--- a/telemetry-platform/databricks/notebooks/fused_state_vector.py
+++ b/telemetry-platform/databricks/notebooks/fused_state_vector.py
@@ -11,6 +11,25 @@
 # MAGIC for model development + retrieval, not simultaneous multi-sensor vehicle telemetry.
 
 # COMMAND ----------
+# ===== TEACHING NOTES =====
+# WHAT THIS FILE DOES: Feature engineering. It boils each of 32 spacecraft channels down to 8 summary
+#   numbers per time-window, then stitches them into one 256-number "state vector" (32 x 8 = 256) that
+#   describes the whole system at a moment. It then trains two "is this normal?" models on those vectors:
+#   PCA (baseline) and a small autoencoder-style neural net.
+# WHERE YOU SEE THIS: this is teaching/feature-engineering plumbing — its vectors and reconstruction
+#   errors back retrieval and the multi-signal anomaly attribution, not a single headline metric card.
+# INPUTS -> OUTPUT: gold_smap_msl_windows -> two Delta tables (gold_fused_state_vectors with the 256-d
+#   vectors + per-channel error attribution, and gold_fused_feature_manifest documenting every column).
+# HOW TO READ THE NUMBERS:
+#   - feature vector = a fixed-length list of numbers that represents one moment across all channels.
+#   - reconstruction error = how badly a model rebuilds a vector from its learned "normal" patterns;
+#     high error = the moment looks abnormal (same idea as the PCA detector in train_anomaly.py).
+#   - autoencoder = a neural net trained to copy its input through a narrow bottleneck; it copies normal
+#     data well and abnormal data poorly, so the copy error is the anomaly signal.
+#   - attribution = splitting that error back across the 32 channels to say WHICH sensor drove it.
+# HONEST CAVEAT (see the markdown cell above): channels are lined up by sequence progress, not by real
+#   simultaneous time — this is a NASA analog for model development, not true synchronized telemetry.
+# ===========================
 import json
 import numpy as np
 import pandas as pd
@@ -25,6 +44,9 @@ EXPERIMENT_ID = "3740651530987773"
 TEL = "novendor_1.telemetry"
 mlflow.set_experiment(experiment_id=EXPERIMENT_ID)
 
+# B buckets = each channel's timeline is sliced into 128 equal chunks; one 256-d vector per chunk.
+# The 8 FEATURES below are the plain-language summary of each chunk: where it ended, its average, how
+# spread out it was, its low/high, its trend slope, and two "distance from normal" residual measures.
 B = 128                      # normalized buckets per channel per split -> fused vectors per split
 N_CHANNELS = 32
 FEATURES = ["value_last", "value_mean", "value_std", "value_min", "value_max",
@@ -61,6 +83,8 @@ raw = spark.sql(f"""
 print(f"candidates (adequate): {len(candidates)}; raw rows pulled: {len(raw)}")
 
 # ---- compute 8 features per (channel, split, bucket); bucket = normalized progress in [0,B) ----
+# For one channel: slice its timeline into B buckets, then summarize each bucket into the 8 numbers.
+# This is the core "turn a raw signal into model-ready features" step.
 def channel_bucket_features(df_cs: pd.DataFrame) -> pd.DataFrame:
     df = df_cs.sort_values("t").reset_index(drop=True)
     tmin, tmax = df.t.min(), df.t.max()
@@ -153,6 +177,8 @@ feat = feat[feat.chan_id.isin(selected)].reset_index(drop=True)
 
 # COMMAND ----------
 # ---- assemble fused 256-d vectors: one per (split, bucket), channels in FIXED sorted order ----
+# Glue step: for each time-bucket, lay the 32 channels' 8 features end to end in a fixed order to form
+# one 256-number vector describing the whole system at that moment. Fixed order = every vector lines up.
 def build_vectors(split: str):
     vecs, labels, anom_chans, idxs = [], [], [], []
     for b in range(B):
@@ -206,6 +232,8 @@ for ci, chan in enumerate(chan_order):
 
 # COMMAND ----------
 # ---- evaluation helper: recon error -> threshold -> P/R/F1 vs label_any_anomaly ----
+# Turn rebuild-errors into a yes/no anomaly call: set the alarm line at the 99th percentile of TRAIN
+# errors (so ~1% of normal data trips it), flag any TEST vector above it, then score precision/recall/F1.
 def evaluate(train_err, test_err, y):
     thr = float(np.percentile(train_err, PCT))
     pred = (test_err > thr).astype(int)
@@ -217,6 +245,8 @@ def evaluate(train_err, test_err, y):
     return {"threshold": thr, "precision": prec, "recall": rec, "f1": f1, "tp": tp, "fp": fp, "fn": fn}
 
 # ---- PCA-256 baseline ----
+# PCA learns the 16 dominant patterns in normal 256-d vectors and rebuilds each vector from them; the
+# rebuild error is the anomaly score. This is the simple baseline the autoencoder below must beat.
 pca = PCA(n_components=16, random_state=0).fit(Xtr)
 def pca_err(X): return ((X - pca.inverse_transform(pca.transform(X))) ** 2).sum(axis=1)
 m_pca = evaluate(pca_err(Xtr), pca_err(Xte), yte)
@@ -231,6 +261,9 @@ with mlflow.start_run(run_name="fused_pca_256") as run:
     pca_run = run.info.run_id
 
 # ---- dense autoencoder-style bottleneck net (MLPRegressor X->X), NOT a torch/LSTM AE ----
+# The autoencoder squeezes each 256-d vector down to 16 numbers and back out to 256 (the 256->...->16->...->256
+# shape). Trained to reproduce normal data, it copies normal vectors well and abnormal ones poorly, so a
+# large copy error flags an anomaly. "X->X" = it learns to output its own input.
 ae = MLPRegressor(hidden_layer_sizes=(128, 32, 16, 32, 128), activation="relu", solver="adam",
                   alpha=1e-3, max_iter=2000, early_stopping=True, n_iter_no_change=25,
                   random_state=0).fit(Xtr, Xtr)
@@ -255,6 +288,9 @@ print("PCA", m_pca, "\nAE", m_ae)
 
 # COMMAND ----------
 # ---- per-channel attribution from AE per-feature reconstruction error ----
+# When a vector looks abnormal, this answers "which sensor is to blame?" by splitting the total rebuild
+# error back across the 32 channels and ranking the top contributors -> the per-channel attribution shown
+# alongside the anomaly so an operator can see WHICH signal drove the alarm.
 recon = ae_recon(Xte)
 sq_err = (Xte - recon) ** 2                       # (n_test, 256) per-feature squared error
 te_err_vec = ae_err(Xte)

--- a/telemetry-platform/databricks/notebooks/ncr_backlog_forecast.py
+++ b/telemetry-platform/databricks/notebooks/ncr_backlog_forecast.py
@@ -8,6 +8,38 @@
 # MAGIC band from the backtest residuals. Writes ncr_backlog_weekly to UC and logs to MLflow.
 # MAGIC The forecaster only ships as "skillful" if it beats naive in the backtest — that comparison is
 # MAGIC logged either way.
+# MAGIC
+# MAGIC ===== TEACHING NOTES (plain language) =====
+# MAGIC WHAT THIS FILE DOES: counts, week by week, how many tickets were OPENED, how many were CLOSED,
+# MAGIC and how many are still OPEN (the "backlog"). Then it predicts where the backlog is headed over
+# MAGIC the next 4 weeks, and — crucially — first proves the prediction method actually works by
+# MAGIC replaying history (a "backtest").
+# MAGIC
+# MAGIC TWO COMPETING FORECASTS:
+# MAGIC   - DRIFT model: "the backlog will keep moving in the direction it's been trending lately"
+# MAGIC     (today's backlog plus the average weekly net change over the trailing 8 weeks).
+# MAGIC   - NAIVE baseline: "next week looks exactly like this week" (a random walk). This is the dumb
+# MAGIC     yardstick — a forecast is only worth shipping if it beats this.
+# MAGIC
+# MAGIC WALK-FORWARD BACKTEST: train on the past, predict the next week, then step forward one week and
+# MAGIC repeat. We only ever use data from BEFORE the week we're predicting (no peeking at the answer).
+# MAGIC The gaps between prediction and what actually happened are the "residuals" (the misses).
+# MAGIC
+# MAGIC WHERE YOU SEE THIS (exact page + visual): FactoryNcrIntelligence.tsx — the BACKLOG FORECAST
+# MAGIC CHART. The history rows draw the solid backlog line; the 4 forecast rows draw the projected
+# MAGIC line plus the shaded uncertainty band; and the MAE / MAPE accuracy figures shown on the page
+# MAGIC come straight from the backtest below.
+# MAGIC
+# MAGIC INPUTS -> OUTPUT: ticket open/close dates in -> one table (ncr_backlog_weekly) with 16 history
+# MAGIC weeks + 4 forecast weeks, plus logged accuracy metrics.
+# MAGIC
+# MAGIC HOW TO READ THE NUMBERS (one phrase each):
+# MAGIC   - MAE  = Mean Absolute Error = on average, how many TICKETS the forecast missed by. Lower is better.
+# MAGIC   - MAPE = the same miss expressed as a PERCENTAGE of the actual backlog. Lower is better, but
+# MAGIC            it goes haywire when the backlog is near zero — that's why we show MAE beside it.
+# MAGIC   - skill_vs_naive = how much better the drift model is than the dumb baseline (>0 = better).
+# MAGIC   - the 90% band = drawn from how big the backtest misses actually were, so it honestly reflects
+# MAGIC            observed error rather than a textbook assumption.
 
 # COMMAND ----------
 import json
@@ -21,10 +53,10 @@ TEL = "novendor_1.telemetry"
 EXPERIMENT_ID = "3740651530987773"
 ANCHOR = date(2026, 6, 8)          # must match notebooks/ncr_corpus.py
 N_WEEKS = 16
-DRIFT_WINDOW = 8                   # trailing weeks of net flow used by the drift model (declared)
-BACKTEST_START = 8                 # walk-forward over weeks 8..15 (8 folds)
-HORIZON = 4                        # forecast weeks
-BAND_Q = 0.90                      # empirical band quantile from |backtest residuals|
+DRIFT_WINDOW = 8                   # the drift model looks at the trailing 8 weeks to gauge the trend
+BACKTEST_START = 8                 # replay-and-check weeks 8..15 (8 separate predict-the-next-week tests)
+HORIZON = 4                        # how many weeks into the future we forecast
+BAND_Q = 0.90                      # 90% uncertainty band, sized from the actual backtest miss sizes
 
 mlflow.set_experiment(experiment_id=EXPERIMENT_ID)
 
@@ -42,6 +74,7 @@ def _d(v):
 rows["opened_at"] = rows["opened_at"].map(_d)
 rows["closed_at"] = rows["closed_at"].map(_d)
 
+# Bucket every ticket into the week it opened and the week it closed -> two 16-long count series.
 week_starts = [ANCHOR - timedelta(weeks=N_WEEKS - w) for w in range(N_WEEKS)]
 opened = [0] * N_WEEKS
 closed = [0] * N_WEEKS
@@ -54,6 +87,7 @@ for r in rows.itertuples():
         if 0 <= wc < N_WEEKS:
             closed[wc] += 1
 # Open backlog at each week END: records opened on/before week end and not closed by week end.
+# This is the "how big is the pile of unresolved tickets" series — the line the chart forecasts.
 backlog = []
 for w in range(N_WEEKS):
     week_end = week_starts[w] + timedelta(days=6)
@@ -70,18 +104,30 @@ print("backlog", backlog)
 # Declared models. Drift: backlog_T + h * mean(net flow over trailing DRIFT_WINDOW weeks).
 # Naive: backlog_T (random walk). Walk-forward h=1 backtest over weeks BACKTEST_START..N_WEEKS-1.
 def drift_forecast(bk: list[int], op: list[int], cl: list[int], t: int, h: int) -> float:
-    """Forecast backlog at week t-1+h using only data through week t-1."""
+    """Forecast backlog at week t-1+h using only data through week t-1.
+
+    Plain language: take the most recent known backlog and nudge it h weeks forward by the average
+    weekly net flow (opened minus closed) over the trailing window. Positive net flow -> backlog
+    projected to grow; negative -> projected to shrink.
+    """
     lo = max(0, t - DRIFT_WINDOW)
-    net = [op[i] - cl[i] for i in range(lo, t)]
+    net = [op[i] - cl[i] for i in range(lo, t)]  # weekly (opened - closed) over the trailing window
     return bk[t - 1] + h * (sum(net) / len(net))
 
 
+# THE BACKTEST: for each test week, predict it using only earlier weeks, then record the miss
+# (residual = actual minus prediction) for BOTH the drift model and the naive baseline. Comparing
+# these two piles of misses is how we earn the right to call the drift model "skillful".
 resid_model, resid_naive = [], []
 for t in range(BACKTEST_START, N_WEEKS):
     actual = backlog[t]
     resid_model.append(actual - drift_forecast(backlog, opened, closed, t, 1))
-    resid_naive.append(actual - backlog[t - 1])
+    resid_naive.append(actual - backlog[t - 1])  # naive = "next week == this week"
 
+# Turn the piles of misses into the accuracy numbers shown on the page.
+# MAE  = average size of a miss, in tickets (we drop the +/- sign with abs() first).
+# MAPE = that miss as a % of the actual backlog (maximum(...,1) guards against divide-by-zero).
+# skill_vs_naive = 1 means perfect, 0 means no better than the dumb baseline, negative means worse.
 abs_m = np.abs(np.array(resid_model))
 abs_n = np.abs(np.array(resid_naive))
 actuals = np.array(backlog[BACKTEST_START:], dtype=float)
@@ -93,8 +139,10 @@ skill = float(1 - mae / mae_naive) if mae_naive > 0 else 0.0
 print(f"backtest folds={len(resid_model)}  MAE={mae:.2f} (naive {mae_naive:.2f})  "
       f"MAPE={mape:.1f}% (naive {mape_naive:.1f}%)  skill_vs_naive={skill:.3f}")
 
-# 4-week forecast from the full series; empirical band = q90(|h=1 resid|) * sqrt(h)
-# (random-walk residual scaling, declared — we only have h=1 folds on 16 weeks of history).
+# Now the real 4-week forecast (using ALL 16 weeks). The uncertainty band is set from how big the
+# backtest misses actually were: q = the 90th-percentile miss size. We widen the band the further
+# out we forecast (* sqrt(h)) because predictions get shakier the further ahead you look.
+# -> fc is the forecast line; [lo, hi] is the shaded band on the chart.
 q = float(np.quantile(abs_m, BAND_Q))
 forecast = []
 for h in range(1, HORIZON + 1):
@@ -106,6 +154,8 @@ for h in range(1, HORIZON + 1):
         "fc": round(fc, 2), "lo": round(fc - band, 2), "hi": round(fc + band, 2),
     })
 
+# The 16 weeks of actuals (kind="history") + the 4 forecast weeks (kind="forecast") are written to
+# one table. The UI draws the solid line from history rows and the projected line + band from forecast rows.
 history = [
     {"week_start": week_starts[w].isoformat(), "kind": "history",
      "opened": opened[w], "closed": closed[w], "backlog": backlog[w],
@@ -114,6 +164,8 @@ history = [
 ]
 
 # COMMAND ----------
+# Log the method, the backtest setup, and every accuracy number to MLflow — the reproducible record
+# that the MAE/MAPE/skill figures the page displays were measured honestly, not hand-typed.
 with mlflow.start_run(run_name="ncr_backlog_forecast") as run:
     mlflow.log_param("method", "drift(mean net flow, trailing 8w) vs naive(last value)")
     mlflow.log_param("backtest", f"walk-forward h=1, weeks {BACKTEST_START}..{N_WEEKS - 1}")

--- a/telemetry-platform/databricks/notebooks/ncr_clustering.py
+++ b/telemetry-platform/databricks/notebooks/ncr_clustering.py
@@ -7,6 +7,35 @@
 # MAGIC summaries) back to UC, and logs params/metrics to MLflow. The corpus is synthetic and labeled
 # MAGIC as such; everything in THIS notebook is a real model run — the UI renders the model's actual
 # MAGIC coordinates and labels, never render-time jitter.
+# MAGIC
+# MAGIC ===== TEACHING NOTES (plain language) =====
+# MAGIC WHAT THIS FILE DOES: it takes each defect ticket's free-text summary and figures out which
+# MAGIC tickets are "about the same thing," with no labels to start from. Three steps:
+# MAGIC   1) EMBEDDING — turn each sentence into a list of ~384 numbers that captures its MEANING, so
+# MAGIC      two tickets that say the same thing in different words end up as nearby number-lists.
+# MAGIC   2) UMAP — a layout method that squashes those long number-lists down to just 2 numbers (an
+# MAGIC      x and a y) while keeping similar tickets close together, so we can plot them.
+# MAGIC   3) HDBSCAN — a clustering method that finds dense blobs of points and gives each blob a
+# MAGIC      group number, while leaving lonely scattered points labeled -1 ("noise", i.e. ungrouped).
+# MAGIC Then for each group it pulls out keywords (c-TF-IDF = the words most distinctive to that group)
+# MAGIC and a few representative example tickets ("exemplars" = the tickets closest to the group center).
+# MAGIC
+# MAGIC WHERE YOU SEE THIS (exact page + visual): FactoryNcrIntelligence.tsx —
+# MAGIC   - the UMAP x/y of each ticket ARE the dots on the SCATTER PLOT (one dot per ticket).
+# MAGIC   - the HDBSCAN cluster label colors each dot and drives the PARETO BARS (count per family)
+# MAGIC     and the KEYWORD / EXEMPLAR lists shown when you select a cluster.
+# MAGIC
+# MAGIC INPUTS -> OUTPUT: the ncr_records text rows in -> two tables out: ncr_points (one row per
+# MAGIC ticket: its 2D coords + which cluster it landed in) and ncr_clusters (one row per cluster:
+# MAGIC keywords, example tickets, size, trend, median close time, reopen rate).
+# MAGIC
+# MAGIC HOW TO READ THE JARGON (one phrase each):
+# MAGIC   - embedding   = a sentence turned into a list of numbers that encodes its meaning.
+# MAGIC   - UMAP        = a layout that flattens those number-lists to 2D, keeping neighbors as neighbors.
+# MAGIC   - HDBSCAN     = density clustering that groups dense blobs and leaves outliers ungrouped (-1).
+# MAGIC   - c-TF-IDF    = "which words are special to THIS cluster vs. all clusters" -> the keyword chips.
+# MAGIC We pin random_state=SEED so the layout and groups are identical every run; the UI shows the
+# MAGIC model's actual coordinates, not random jitter added at draw time.
 
 # COMMAND ----------
 # MAGIC %pip install sentence-transformers umap-learn hdbscan
@@ -22,21 +51,31 @@ from datetime import date, timedelta
 import numpy as np
 import mlflow
 
-SEED = 20260609
+SEED = 20260609                   # same seed everywhere -> identical layout + clusters every run
 TEL = "novendor_1.telemetry"
 EXPERIMENT_ID = "3740651530987773"
 ANCHOR = date(2026, 6, 8)          # must match notebooks/ncr_corpus.py
 N_WEEKS = 16
 TREND_WEEKS = 8                    # trailing weeks shown per cluster
+# The embedding model: a small, fast off-the-shelf sentence encoder. It reads a sentence and
+# returns the ~384-number "meaning vector" described in the teaching notes.
 EMBED_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+# UMAP knobs. n_components=2 means "give me x,y so I can plot it"; metric="cosine" means "judge
+# similarity by direction of the meaning vectors"; n_neighbors/min_dist control how tightly blobs pack.
 UMAP_PARAMS = {"n_neighbors": 15, "min_dist": 0.1, "n_components": 2, "metric": "cosine"}
+# HDBSCAN knobs: a blob needs at least 6 tickets to count as a real cluster; min_samples controls
+# how conservative it is about calling a point an outlier.
 HDBSCAN_PARAMS = {"min_cluster_size": 6, "min_samples": 4}
-# Declared (not tuned post-hoc): weekly-slope thresholds for the cluster status chip.
+# A cluster gets a rising/declining/flat status chip in the UI based on its trend line's slope.
+# These thresholds were declared up front (not cherry-picked after seeing results): a slope steeper
+# than +0.35 tickets/week reads "rising", steeper than -0.35 reads "declining", anything between is "flat".
 SLOPE_RISING = 0.35
 SLOPE_DECLINING = -0.35
 
 mlflow.set_experiment(experiment_id=EXPERIMENT_ID)
 
+# Pull the ticket text (and a few fields we'll summarize later) out of the corpus table into a
+# plain pandas table. docs = just the list of summary sentences we'll feed the embedder.
 rows = (
     spark.table(f"{TEL}.ncr_records")  # type: ignore[name-defined]  # noqa: F821
     .select("ncr_key", "summary", "workcell", "severity", "opened_at", "closed_at", "reopened")
@@ -52,21 +91,32 @@ from sentence_transformers import SentenceTransformer
 import umap
 import hdbscan
 
+# STEP 1 — EMBED: turn every ticket sentence into its meaning vector (a list of numbers).
+# normalize_embeddings=True scales them to unit length so we can compare by direction (cosine).
 model = SentenceTransformer(EMBED_MODEL)
 emb = model.encode(docs, normalize_embeddings=True, show_progress_bar=False)
 
+# STEP 2 — UMAP: flatten each long meaning vector down to just (x, y) for plotting, keeping similar
+# tickets near each other. -> these 2D coords ARE the scatter-plot dots on FactoryNcrIntelligence.
 reducer = umap.UMAP(random_state=SEED, **UMAP_PARAMS)
 coords = reducer.fit_transform(emb)
 
+# STEP 3 — HDBSCAN: find the dense blobs of dots and label each one. fit_predict returns one label
+# per ticket: 0,1,2,... for real clusters, and -1 for "noise" (a lonely point that joined no group).
 clusterer = hdbscan.HDBSCAN(**HDBSCAN_PARAMS)
 labels = clusterer.fit_predict(coords)
 
+# Tally what we got: the real cluster numbers (label >= 0) and how many tickets were left ungrouped.
+# -> cluster_ids drive the Pareto bars / keyword groups; noise_count is the gray "ungrouped" dots.
 cluster_ids = sorted({int(c) for c in labels if c >= 0})
 noise_count = int((labels == -1).sum())
 print("clusters:", cluster_ids, "noise:", noise_count)
 
 # COMMAND ----------
-# c-TF-IDF keywords per cluster (BERTopic-style class-based tf-idf, unigrams + bigrams).
+# Now name each cluster. c-TF-IDF answers "which words are distinctive to THIS group of tickets,
+# compared with the other groups?" — those become the keyword chips in the UI. We count single
+# words (unigrams) and adjacent word pairs (bigrams). STOP is the throwaway-words list (the, and,
+# found...) we ignore so keywords are actually meaningful, not filler.
 STOP = {
     "a", "an", "and", "at", "after", "as", "be", "beyond", "by", "during", "for", "found", "from",
     "in", "is", "of", "on", "or", "out", "per", "the", "to", "with", "via", "near", "required",
@@ -82,6 +132,9 @@ def _tokens(text: str) -> list[str]:
 
 
 def ctfidf_keywords(cluster_docs: dict[int, list[str]], top_k: int = 5) -> dict[int, list[str]]:
+    # tf = how often each word appears WITHIN each cluster; df = in how many clusters the word shows
+    # up at all. A word scores high when it's frequent inside one cluster but rare across the others
+    # (so generic words common to every cluster get pushed down). We keep the top_k per cluster.
     tf: dict[int, dict[str, int]] = {}
     df: dict[str, int] = {}
     for cid, cdocs in cluster_docs.items():
@@ -101,19 +154,23 @@ def ctfidf_keywords(cluster_docs: dict[int, list[str]], top_k: int = 5) -> dict[
     return out
 
 
+# Group the ticket sentences by their cluster label, then compute keywords for each cluster.
 cluster_docs = {cid: [docs[i] for i in range(len(docs)) if labels[i] == cid] for cid in cluster_ids}
 keywords = ctfidf_keywords(cluster_docs)
 
 # COMMAND ----------
-# Cluster summaries: centroid exemplars (embedding space), trailing-8-week trend + declared slope
-# status, median time-to-close, reopen rate.
+# Build one summary row per cluster for the UI. For each cluster we compute: a few example tickets
+# (the ones nearest the cluster's center = "exemplars"), a trailing-8-week trend line and its
+# rising/declining/flat status chip, the median days-to-close, and the reopen rate.
 def week_idx(d: date) -> int:
     return (d - (ANCHOR - timedelta(weeks=N_WEEKS))).days // 7
 
 
 clusters_out = []
 for cid in cluster_ids:
-    idx = np.flatnonzero(labels == cid)
+    idx = np.flatnonzero(labels == cid)  # positions of all tickets in this cluster
+    # The centroid is the average meaning-vector of the cluster (its "typical" ticket). The three
+    # tickets sitting closest to that center are the clearest examples -> shown as cluster exemplars.
     centroid = emb[idx].mean(axis=0)
     dist = np.linalg.norm(emb[idx] - centroid, axis=1)
     exemplar_rows = rows.iloc[idx[np.argsort(dist)[:3]]]
@@ -122,12 +179,15 @@ for cid in cluster_ids:
         for r in exemplar_rows.itertuples()
     ]
     sub = rows.iloc[idx]
+    # Count how many of this cluster's tickets opened in each of the last 8 weeks -> the trend line.
     trend = [0] * TREND_WEEKS
     for d in sub["opened_at"]:
         w = week_idx(d if isinstance(d, date) else date.fromisoformat(str(d)))
         rel = w - (N_WEEKS - TREND_WEEKS)
         if 0 <= rel < TREND_WEEKS:
             trend[rel] += 1
+    # Fit a straight line through those 8 weekly counts; its slope = average change per week.
+    # Compare to the declared thresholds to stamp the rising / declining / flat status chip.
     x = np.arange(TREND_WEEKS, dtype=float)
     slope = float(np.polyfit(x, np.array(trend, dtype=float), 1)[0])
     status = "rising" if slope >= SLOPE_RISING else ("declining" if slope <= SLOPE_DECLINING else "flat")
@@ -150,6 +210,8 @@ for cid in cluster_ids:
         "reopen_rate": float(sub["reopened"].mean()),
     })
 
+# One row per ticket: its 2D coordinates and which cluster it joined (-1 = ungrouped/noise).
+# -> this is the literal data behind every dot on the scatter plot in FactoryNcrIntelligence.
 points_out = [
     {"ncr_key": rows.iloc[i]["ncr_key"], "umap_x": float(coords[i][0]), "umap_y": float(coords[i][1]),
      "cluster_id": int(labels[i])}
@@ -157,6 +219,9 @@ points_out = [
 ]
 
 # COMMAND ----------
+# Log the run to MLflow (an experiment tracker): record what settings we used and how it turned out
+# (number of clusters found, fraction left as noise, a clustering-quality score). This is the audit
+# trail proving the UI numbers came from a real, reproducible model run.
 with mlflow.start_run(run_name="ncr_clustering") as run:
     mlflow.log_param("embed_model", EMBED_MODEL)
     mlflow.log_param("umap_params", json.dumps(UMAP_PARAMS))
@@ -198,6 +263,9 @@ CLUSTERS_SCHEMA = StructType([
     StructField("reopen_rate", DoubleType()),
     StructField("mlflow_run_id", StringType()),
 ])
+# Write the two output tables: the per-dot coordinates and the per-cluster summaries. These are
+# what 16_mirror_ncr_serving.py later copies into the serving tables the /api/telemetry/ncr endpoint
+# reads, which is what FactoryNcrIntelligence ultimately renders.
 spark.createDataFrame(points_out, schema=POINTS_SCHEMA).write.mode("overwrite") \
     .option("overwriteSchema", "true").saveAsTable(f"{TEL}.ncr_points")  # type: ignore[name-defined]  # noqa: F821
 spark.createDataFrame(clusters_out, schema=CLUSTERS_SCHEMA).write.mode("overwrite") \

--- a/telemetry-platform/databricks/notebooks/ncr_corpus.py
+++ b/telemetry-platform/databricks/notebooks/ncr_corpus.py
@@ -10,20 +10,48 @@
 # MAGIC
 # MAGIC The generator is pure stdlib and import-safe outside Databricks: the spark write section is
 # MAGIC guarded, so backend CI imports this file by path and asserts byte-identical regeneration.
+# MAGIC
+# MAGIC ===== TEACHING NOTES (plain language) =====
+# MAGIC WHAT THIS FILE DOES: An "NCR" is a Non-Conformance Report — a quality defect ticket written
+# MAGIC by a factory inspector ("Seal witness mark out of tolerance after thermal cycle..."). This
+# MAGIC file MAKES UP a realistic-looking pile of those tickets so the rest of the pipeline has
+# MAGIC something to chew on. Nothing here is a real ticket: it is generated demo text. Because it
+# MAGIC uses a fixed random SEED, it produces the EXACT same tickets every single run, on any machine.
+# MAGIC
+# MAGIC WHERE YOU SEE THIS: every downstream visual on the FactoryNcrIntelligence page
+# MAGIC (repo-b/src/components/telemetry/FactoryNcrIntelligence.tsx) is built from these tickets —
+# MAGIC the scatter plot of dots, the Pareto bars of defect families, the keyword lists, and the
+# MAGIC backlog forecast line all trace back to the text produced here. The UI labels this layer as
+# MAGIC synthetic so a viewer knows the tickets are demo data (but the models run on them are real).
+# MAGIC
+# MAGIC INPUTS -> OUTPUT: a seed number in -> a list of ~140 ticket records out (each with a defect
+# MAGIC family, workcell, severity, free-text summary, open/close dates). Written to the
+# MAGIC novendor_1.telemetry.ncr_records table inside Databricks.
+# MAGIC
+# MAGIC HOW TO READ IT: 6 "engineered" defect families have deliberately shaped weekly counts —
+# MAGIC seal/thermal is designed to RISE week over week, fastener torque to DECLINE, the rest to stay
+# MAGIC FLAT. We bake those trends in here on purpose so the clustering + forecast steps later have a
+# MAGIC real story to discover and show. The ~18 "noise" tickets are random odds-and-ends that should
+# MAGIC NOT form a tidy group — they test whether the clusterer correctly leaves outliers ungrouped.
 
 # COMMAND ----------
 import json
 import random
 from datetime import date, timedelta
 
+# SEED is the single knob that makes everything repeatable: feed the same number to Python's random
+# generator and you get the identical sequence of "random" choices forever. That is why this demo
+# corpus is byte-for-byte identical on every run (CI even asserts it).
 SEED = 20260609
-N_WEEKS = 16
+N_WEEKS = 16  # we generate 16 weeks of history
 # Fixed anchor (Monday) so the corpus is identical on every run, everywhere. Weeks are
 # [anchor - 16w, anchor); week index 0 is the oldest.
 ANCHOR = date(2026, 6, 8)
 
-# Each family: workcell pool, severity weights, median time-to-close, reopen probability, and a
-# per-week count schedule (len 16, oldest first) that encodes the intended dynamics.
+# Each family = one kind of recurring defect. For each we store: which workcells (stations) it shows
+# up in, how severe it tends to be, how long it usually takes to close, how often it reopens, and —
+# most importantly — a 16-number "weekly" schedule that says how many tickets to mint each week.
+# That weekly schedule is where we hand-author the trend each family should display in the UI.
 FAMILIES = {
     "seal_thermal": {
         "workcells": ["assembly_wc_09", "assembly_wc_12"],
@@ -99,9 +127,10 @@ FAMILIES = {
     },
 }
 
-# One-off noise topics — heterogeneous fillers outside the 6 engineered families. Whether the
-# clusterer marks them noise or groups some of them is the model's call (topics repeat across
-# weeks, so small misc clusters are a legitimate outcome, not a failure).
+# One-off noise topics — grab-bag tickets that DON'T belong to any of the 6 engineered families.
+# Their job is to be messy: a good clusterer should leave most of them ungrouped (shown as gray
+# "noise" dots on the scatter plot). If a couple of repeated topics happen to form a tiny cluster,
+# that's a legitimate model call, not a bug.
 NOISE_TOPICS = [
     ("paint_finish", "logistics_wc_01", "Paint thickness above spec on secondary structure panel."),
     ("fod", "integration_wc_05", "FOD found during closeout inspection; lockwire fragment recovered."),
@@ -128,16 +157,24 @@ SEVERITY_WEIGHTS = [0.62, 0.33, 0.05]
 
 
 def generate_corpus(seed: int = SEED) -> list[dict]:
-    """Deterministic synthetic NCR corpus. Returns records sorted by (opened_at, ncr_key)."""
-    rng = random.Random(seed)
+    """Deterministic synthetic NCR corpus. Returns records sorted by (opened_at, ncr_key).
+
+    Plain language: walk week by week, and for each defect family mint the exact number of tickets
+    its weekly schedule calls for, picking a workcell / template / severity at random (but a
+    SEEDED random, so the picks are identical every run). Then sprinkle in a little noise. The
+    result is the full pile of demo tickets the whole pipeline runs on.
+    """
+    rng = random.Random(seed)  # one seeded generator drives every "random" choice below
     records = []
     for week in range(N_WEEKS):
         week_start = ANCHOR - timedelta(weeks=N_WEEKS - week)
         for family, spec in FAMILIES.items():
+            # spec["weekly"][week] = how many tickets this family gets THIS week (the trend we baked in)
             for _ in range(spec["weekly"][week]):
                 wc = rng.choice(spec["workcells"])
                 template = rng.choice(spec["templates"])
                 opened = week_start + timedelta(days=rng.randrange(7))
+                # time-to-close: a bell-curve draw around the family's typical days, never below 1
                 ttc = max(1, round(rng.gauss(spec["ttc_median"], spec["ttc_median"] * 0.4)))
                 closed = opened + timedelta(days=ttc)
                 records.append({
@@ -165,6 +202,8 @@ def generate_corpus(seed: int = SEED) -> list[dict]:
                 "closed_at": closed.isoformat() if closed <= ANCHOR else None,
                 "reopened": rng.random() < 0.04,
             })
+    # Sort into a stable order, then hand out sequential ticket IDs (ncr_2026_00001, ...). Sorting
+    # before numbering is what keeps the IDs identical run to run — the seed alone isn't enough.
     records.sort(key=lambda r: (r["opened_at"], r["summary"]))
     for i, r in enumerate(records, start=1):
         r["ncr_key"] = f"ncr_2026_{i:05d}"
@@ -173,7 +212,8 @@ def generate_corpus(seed: int = SEED) -> list[dict]:
 
 # COMMAND ----------
 # Spark write section — only runs inside Databricks (backend CI imports this file locally and only
-# calls generate_corpus()).
+# calls generate_corpus()). "spark" only exists when this notebook runs on a Databricks cluster, so
+# we test for it: if it's missing we're being imported as a plain module and skip the table write.
 try:
     _SPARK = spark  # type: ignore[name-defined]  # noqa: F821
 except NameError:

--- a/telemetry-platform/databricks/notebooks/promote_models.py
+++ b/telemetry-platform/databricks/notebooks/promote_models.py
@@ -6,6 +6,23 @@
 # MAGIC honestly. This is the operated-platform step: the gate is enforced against the tracking store.
 
 # COMMAND ----------
+# ===== TEACHING NOTES =====
+# WHAT THIS FILE DOES: This is the PROMOTION GATE. It reads the trained models' honest metrics (from
+#   MLflow, never hand-typed), checks them against fixed pass/fail thresholds, and decides which model
+#   becomes the "champion" (the one used live) vs which is held back. It is fail-closed: if a model
+#   doesn't clearly clear every bar, it is NOT promoted.
+# WHERE YOU SEE THIS: it drives the gate checks on the frontend "Registry Console"
+#   (repo-b/src/components/telemetry/RegistryConsole.tsx) and the champion/challenger display on the
+#   "Model Performance" page.
+# INPUTS -> OUTPUT: logged metrics in MLflow -> a champion/held-back decision per model + (if promoted)
+#   a registration into the Unity Catalog Model Registry with the alias "champion."
+# HOW TO READ THE NUMBERS:
+#   - champion = the model promoted to live use; challenger = a model that exists but did not win.
+#   - "fail-closed" = a missing or borderline metric defaults to FAIL, never to pass.
+#   - the anomaly gate uses the honest/affiliation thresholds; among passers it picks highest affiliation_f1.
+#   - the RUL gate requires beating the naive baseline by a margin, a low enough "late rate," better PHM
+#     than naive, and a passing leakage control; among passers it picks the SAFEST (lowest PHM).
+# ===========================
 import json
 import mlflow
 from mlflow.tracking import MlflowClient
@@ -34,11 +51,15 @@ RUL_GATE = {
 }
 
 
+# Anomaly gate test: the detector must meet or beat EVERY honest threshold. One miss = held back.
 def passes_honest_gate(m: dict) -> bool:
     """Fail-closed: every declared honest threshold must be met (missing metric -> 0 -> fail)."""
     return all(float(m.get(k, 0.0)) >= thr for k, thr in HONEST_GATE.items())
 
 
+# RUL gate test: RMSE alone must NOT be able to promote a dangerous model. Each named check below is a
+# safety condition; the model passes only if ALL of them are true. Returns the per-check breakdown that
+# the Registry Console shows when explaining why a model passed or was held back.
 def rul_gate_eval(m: dict) -> dict:
     """Fail-closed RUL gate. Reads metrics logged by train_rul.py. Missing metric -> fails that check."""
     rmse = float(m.get("rmse", 1e9))
@@ -58,6 +79,8 @@ def rul_gate_eval(m: dict) -> dict:
             "rmse_ratio_vs_naive": ratio, "phm_improvement": phm_improve}
 
 # COMMAND ----------
+# Pull the most recent MLflow run for each model name. The gate reads metrics from the tracking store,
+# not from numbers passed by hand — so what gets gated is exactly what was logged during training.
 def latest_run(run_name: str):
     runs = client.search_runs([EXPERIMENT_ID], filter_string=f"tags.mlflow.runName = '{run_name}'",
                               order_by=["attributes.start_time DESC"], max_results=1)
@@ -75,6 +98,8 @@ print(json.dumps(metrics, indent=2))
 # COMMAND ----------
 # ---- Gate: anomaly (Track A). Fail-closed honest/affiliation gate; among models that CLEAR it, promote
 # the one with the highest affiliation_f1 (range-aware). Legacy F1 is reported for reference only. ----
+# Run both anomaly detectors through the gate; keep only the ones that cleared it; the champion is the
+# eligible model with the best (highest) affiliation_f1. -> this choice is the champion on Model Performance.
 anom_names = ["anomaly_baseline_mad", "anomaly_pca_recon"]
 anom_pass = {n: passes_honest_gate(metrics[n]) for n in anom_names}
 anom_eligible = [n for n in anom_names if anom_pass[n]]
@@ -91,6 +116,8 @@ anom_f1 = float(metrics[anom_winner].get("f1", 0.0))  # legacy point-adjusted �
 # ---- Gate: RUL (PR-1). PHM-/late-rate-aware + beats-naive + leakage-control, fail-closed. Among models
 # ---- that CLEAR the gate, promote the SAFEST (lowest PHM — i.e. least dangerous late behavior), then
 # ---- lowest late-rate, then lowest RMSE. RMSE alone can no longer promote a model. ----
+# Same for the RUL models: gate each one, keep the passers, and among passers promote the SAFEST
+# (lowest PHM, then lowest late-rate, then lowest RMSE). A low RMSE on its own cannot win here.
 rul_names = ["rul_linear_baseline", "rul_gbm"]
 rul_eval = {n: rul_gate_eval(metrics[n]) for n in rul_names}
 rul_eligible = [n for n in rul_names if rul_eval[n]["passed"]]
@@ -110,6 +137,8 @@ print(f"rul winner={rul_winner} rmse={rul_rmse:.4f} phm={rul_eval[rul_winner]['p
 
 # COMMAND ----------
 # Register promoted models to the Unity Catalog registry with an alias 'champion'.
+# "Registering with alias champion" = stamping this exact trained model as the live one, so downstream
+# jobs (like score_replay_feed.py) can load "@champion" and always get the promoted model.
 def register(model_name: str, run_id: str, metric_tags: dict) -> dict:
     full = f"{CATALOG}.{SCHEMA}.{model_name}"
     try:

--- a/telemetry-platform/databricks/notebooks/score_replay_feed.py
+++ b/telemetry-platform/databricks/notebooks/score_replay_feed.py
@@ -7,6 +7,19 @@
 # MAGIC The flag the demo flips on is the model's output, not a hand-authored value.
 
 # COMMAND ----------
+# ===== TEACHING NOTES =====
+# WHAT THIS FILE DOES: Takes the live "champion" anomaly model and runs it over one fixed, replayable
+#   sequence of spacecraft ticks, recording where the model fires an alarm. This produces the data the
+#   replay/runs demo flips through, and the GO / REVIEW / NO_GO style verdicts come from the model's
+#   own output — not a hand-authored flag.
+# WHERE YOU SEE THIS: the replay/runs demo (the timeline that "fires" an anomaly as it plays back).
+# INPUTS -> OUTPUT: the fixed replay feed (novendor_1.telemetry.gold_replay_feed) + the champion model
+#   -> a scored table (gold_replay_feed_scored) of the same ticks plus the model's score and flag.
+# HOW TO READ THE NUMBERS:
+#   - model_pred = 1 means the model raised an alarm on that tick; is_anomaly = 1 is the NASA truth label.
+#   - anomaly_score = a continuous "how abnormal" trace (standardized residual) for the overlay chart.
+#   - deterministic = same input + same model always gives the same output (the demo is reproducible).
+# ===========================
 import json
 import numpy as np
 import pandas as pd
@@ -21,11 +34,14 @@ feed = spark.table(f"{TEL}.gold_replay_feed").toPandas().sort_values("t").reset_
 print("replay feed rows", len(feed), "label anomaly ticks", int(feed.is_anomaly.sum()))
 
 # Load the promoted MAD detector (champion). It expects columns chan_id, value, value_rmean50.
+# "@champion" pulls whatever model promote_models.py last stamped as live — so the demo always uses the
+# currently approved detector. model_pred = the model's per-tick GO(0)/alarm(1) call that the demo flips on.
 model = mlflow.pyfunc.load_model(f"models:/{TEL}.tel_anomaly_detector@champion")
 pred = np.asarray(model.predict(feed[["chan_id", "value", "value_rmean50"]])).astype(int)
 feed["model_pred"] = pred
 
 # A continuous score for the trace overlay = standardized residual (the quantity the rule thresholds).
+# This is the rising "how abnormal is it right now" line the demo draws; the alarm fires when it crosses.
 resid = (feed["value"] - feed["value_rmean50"]).abs()
 scale = resid.median() or 1.0
 feed["anomaly_score"] = (resid / scale).round(6)
@@ -42,7 +58,8 @@ spark.sql(f"COMMENT ON TABLE {TEL}.gold_replay_feed_scored IS "
           f"label. The demo flips on model_pred, not a hand-authored flag. Telemetry Platform.'")
 
 # COMMAND ----------
-# Determinism + agreement evidence: first model-fired tick, and overlap with the labeled region.
+# Evidence the demo is honest: which tick the model FIRST fired on, and how often its alarms landed on
+# the real NASA-labeled anomaly. Agreement near the labeled region = the model genuinely caught the event.
 fired = feed.index[feed.model_pred == 1].tolist()
 first_fire = int(feed.loc[fired[0], "t"]) if fired else None
 agree = int(((feed.model_pred == 1) & (feed.is_anomaly == 1)).sum())

--- a/telemetry-platform/databricks/notebooks/telemetry_calibration_baseline.py
+++ b/telemetry-platform/databricks/notebooks/telemetry_calibration_baseline.py
@@ -17,6 +17,45 @@
 # MAGIC Plan: `docs/plans/03-implementation-plans/active/telemetry-calibration-layer.md`
 
 # COMMAND ----------
+# ===== TEACHING NOTES (plain language) =====
+# WHAT THIS FILE DOES:
+#   It takes a model that predicts an engine's Remaining Useful Life (RUL = how many cycles of life
+#   are left) and makes its UNCERTAINTY honest. A point prediction like "42 cycles left" is not enough;
+#   we also want an HONEST RANGE ("between 25 and 60, and we're 90% sure"). "Calibration" means making
+#   those confidence claims trustworthy: if the model says it's 90% sure the truth lands inside a range,
+#   the truth really should land inside that range about 90% of the time — no more, no less.
+#
+# WHERE YOU SEE THIS:
+#   This is the baseline evidence behind the RUL / anomaly CALIBRATION surfaces (the reliability table
+#   and the "is the model's confidence honest?" panels). It is the CHAMPION (current best, GBM) that the
+#   deep-learning challenger in telemetry_calibration_challenger_cnnlstm.py must beat.
+#
+# INPUTS -> OUTPUT:
+#   INPUT  : gold_cmapss_features (model-ready sensor features) + silver_cmapss_rul (official RUL truth).
+#   OUTPUT : an evidence JSON (metrics + a reliability table) returned via dbutils.notebook.exit — no UI,
+#            no new table, no API. The numbers feed the calibration evidence surfaces.
+#
+# HOW TO READ THE NUMBERS (jargon in one phrase each):
+#   - RMSE            : typical size of the prediction error, in cycles. Lower = more accurate.
+#   - PHM08           : NASA's asymmetric error score that punishes LATE/optimistic RUL harder than early
+#                       (predicting more life than there really is is the dangerous mistake). Lower = safer.
+#   - calibration     : making the model's stated confidence match reality (70% sure -> right ~70% of time).
+#   - PICP            : the share of truths that actually fell inside the predicted range. For a "90%"
+#                       range you want PICP near 0.90. PICP near nominal = well calibrated.
+#   - reliability     : the whole table of "we claimed X% confidence -> we actually hit Y%" across levels;
+#                       a perfectly honest model has observed == nominal on every row.
+#   - MPIW / PINAW    : how WIDE the ranges are (PINAW = width normalized so it's comparable). Narrower is
+#                       better ONLY if coverage stays honest — a huge range is trivially "right".
+#   - CRPS            : a single score blending accuracy and honest-uncertainty (lower = better).
+#   - Brier score     : the standard "is this probability honest?" yardstick for yes/no predictions —
+#                       the mean squared gap between the predicted probability and what actually happened
+#                       (0 = perfect, lower = better-calibrated). RUL here is a number not a yes/no, so we
+#                       use PICP + reliability instead; Brier is the same honest-confidence idea applied to
+#                       the anomaly (yes/no) scores on the calibration surfaces.
+#   - conformal       : the technique used here to build the honest ranges. It looks at how big the model's
+#                       errors were on a held-out CALIBRATION set, then pads each prediction by that
+#                       measured error so the range has the right coverage by construction.
+# ============================================
 import json
 import numpy as np
 import pandas as pd
@@ -34,6 +73,9 @@ def rmse(a, b):
     return float(np.sqrt(np.mean((np.asarray(a) - np.asarray(b)) ** 2)))
 
 def phm_score(y_true, y_pred):
+    # PHM08 = NASA's safety-weighted error score. Predicting MORE life than reality (late, d>0) is the
+    # dangerous mistake (you run the part past failure), so it costs more (divisor 10) than predicting
+    # too little life (early, divisor 13). Lower total = a safer, less optimistic model.
     # NASA PHM'08 asymmetric: late (pred>true => d>0) penalized harder (a=10) than early (a=13).
     d = np.asarray(y_pred) - np.asarray(y_true)
     s = np.where(d < 0, np.exp(-d / 13.0) - 1.0, np.exp(d / 10.0) - 1.0)
@@ -58,6 +100,10 @@ print("FD001 | feat cols", len(FEAT_COLS), "| train rows", len(train_all),
 # ============================================================================================
 # PART 1 — REPRODUCE the shipped benchmark (GBM on all train rows, last-cycle-per-unit eval)
 # ============================================================================================
+# First we re-fit the existing champion (a Gradient Boosting model — many small trees, each fixing the
+# last one's mistakes) and confirm we get the SAME accuracy the shipped system reports. This proves we
+# are calibrating the real deployed model, not a different one. "Last-cycle-per-unit" = score each engine
+# only at its final observed reading, which is the standard FD001 benchmark setup.
 gbm_full = GradientBoostingRegressor(n_estimators=300, max_depth=3, learning_rate=0.05,
                                      subsample=0.8, random_state=0).fit(
     train_all[FEAT_COLS].to_numpy(), train_all["y"].to_numpy())
@@ -77,6 +123,12 @@ print("  (shipped reference: RMSE ~20.32 / PHM ~1423; NOT literature-competitive
 # PART 2 — CALIBRATION via split-conformal, UNITS DISJOINT (fit / calib / internal-test)
 # Per-cycle truth exists only on the TRAIN split, so the calibrated eval lives there.
 # ============================================================================================
+# To build honest ranges we split the engines into THREE disjoint groups (no engine appears in two):
+#   fit (60%)  -> teaches the model,
+#   calib (20%)-> measures how big the model's errors really are (sets the range width),
+#   test (20%) -> never touched until the end; where we CHECK that the ranges cover the truth.
+# Splitting by engine (not by row) is what keeps the honesty check fair — the test engines are genuinely
+# unseen, so the coverage number is real, not memorized.
 units = np.sort(train_all.unit.unique())
 perm = rng.permutation(units)
 n = len(units)
@@ -109,9 +161,14 @@ print("internal-test per-cycle point metrics:",
 
 # COMMAND ----------
 # ---- Split-conformal absolute-residual intervals + calibration metrics ----
+# Core trick: look at how far off the model was on the CALIBRATION engines (the residuals = |truth -
+# prediction|). To make a "90% range", pad every prediction by the 90th-percentile residual. By
+# construction the range then covers ~90% of cases. This is what the reliability/coverage panels report.
 cal_resid = np.abs(cal_true - cal_pred)
 
 def conformal_q(level):
+    # The residual size to pad by for a given confidence level (e.g. 0.90). Picking it from the sorted
+    # calibration errors with this (m+1) rule is what makes the coverage guarantee hold on finite data.
     # finite-sample-valid split-conformal quantile of |residual|
     m = len(cal_resid)
     k = int(np.ceil((m + 1) * level))
@@ -119,6 +176,8 @@ def conformal_q(level):
     return float(np.sort(cal_resid)[k - 1])
 
 def picp(true, lo, hi):
+    # PICP = the fraction of truths that actually landed inside [lo, hi]. This is THE calibration number:
+    # for a "90%" range you want this near 0.90. It's the bar the reliability panel plots against nominal.
     return float(np.mean((true >= lo) & (true <= hi)))
 
 def crps_from_intervals(true, pred, qfun):
@@ -137,6 +196,9 @@ def crps_from_intervals(true, pred, qfun):
         tot += w
     return float(np.mean(tot / len(levels)))
 
+# For each promised confidence level, build the range, then measure: did coverage (PICP) match the
+# promise, and how wide (MPIW/PINAW) was the range? "within_pm_0.03" is the pass/fail honesty flag the
+# calibration gate reads — coverage must be within 3 points of what we promised.
 interval_metrics = {}
 rng_y = float(ite_true.max() - ite_true.min()) or 1.0
 for lvl in NOMINAL:
@@ -158,6 +220,9 @@ print("approx CRPS (interval-integrated):", round(crps, 3))
 
 # COMMAND ----------
 # ---- Reliability table (observed coverage vs nominal across levels) ----
+# This table is exactly what the RELIABILITY panel draws: for each promised level (nominal) we record the
+# coverage we actually got (observed_PICP). A perfectly honest model has observed == nominal on every row;
+# observed well below nominal = overconfident, well above = needlessly cautious (ranges too wide).
 reliability = []
 for lvl in RELIABILITY_LEVELS:
     q = conformal_q(lvl)
@@ -168,6 +233,9 @@ for r in reliability:
 
 # COMMAND ----------
 # ---- Late-prediction callout (PHM08 penalizes late/optimistic RUL harder) ----
+# Safety lens: how often, and by how much, did the model OVERESTIMATE remaining life? Late predictions
+# are the dangerous ones (you'd run a part past its real failure point). This callout surfaces that risk
+# explicitly so the calibration evidence isn't just "coverage looks fine on average".
 err = ite_pred - ite_true                      # >0 = late (predicted more life than real)
 late_frac = float(np.mean(err > 0))
 late_mean_overshoot = float(np.mean(err[err > 0])) if (err > 0).any() else 0.0
@@ -181,6 +249,8 @@ print("late-prediction callout:", late_callout)
 
 # COMMAND ----------
 # ---- Gate check ----
+# The single go/no-go: are ALL the promised confidence levels honest (coverage within 3 points)? PASS
+# here is what licenses showing these calibrated ranges on the surfaces; FAIL means recalibrate first.
 picp_gate_pass = all(interval_metrics[k]["within_pm_0.03"] for k in interval_metrics)
 print("CALIBRATION GATE (PICP within +/-0.03 at all nominal levels):", "PASS" if picp_gate_pass else "FAIL")
 

--- a/telemetry-platform/databricks/notebooks/telemetry_calibration_challenger_cnnlstm.py
+++ b/telemetry-platform/databricks/notebooks/telemetry_calibration_challenger_cnnlstm.py
@@ -17,6 +17,36 @@
 # MAGIC Pin `torch==2.2.2`, `scikit-learn==1.4.2`. Plan: `telemetry-calibration-layer.md`.
 
 # COMMAND ----------
+# ===== TEACHING NOTES (plain language) =====
+# WHAT THIS FILE DOES:
+#   This is the CHALLENGER in a "challenger-vs-champion" bake-off: a new model tries to beat the current
+#   best, and only replaces it if it clears every gate. The current champion is the GBM in
+#   telemetry_calibration_baseline.py. The challenger here is a CNN-LSTM, a deep neural net that reads
+#   each engine's sensor history two ways: the CNN (convolution) spots short patterns ACROSS sensors at a
+#   moment, and the LSTM remembers how those patterns evolve OVER TIME. Together they predict Remaining
+#   Useful Life (RUL = cycles of life left) from a 30-cycle sliding window of readings.
+#
+# WHERE YOU SEE THIS:
+#   Same RUL / anomaly CALIBRATION surfaces as the baseline. This notebook decides whether the fancier
+#   model "graduates" to champion. If it doesn't clear the gates, the GBM stays — the bar is deliberately
+#   strict so we never ship a flashier-but-less-honest model.
+#
+# INPUTS -> OUTPUT:
+#   INPUT  : silver_cmapss (raw per-cycle sensor readings, all 21 sensors) + silver_cmapss_rul (truth).
+#   OUTPUT : an evidence JSON (accuracy + honesty metrics + a graduate yes/no) via dbutils.notebook.exit.
+#            No UI, no new table, no API.
+#
+# HOW TO READ THE NUMBERS (jargon in one phrase each):
+#   - champion vs challenger : the deployed model vs a contender that only wins if it beats it on EVERY gate.
+#   - RMSE        : typical prediction error in cycles (lower = more accurate). Must beat GBM's 20.32.
+#   - PHM08       : NASA's safety score that punishes LATE/optimistic RUL harder than early (lower = safer).
+#   - PICP        : share of truths that actually fell inside the predicted range; "90%" range wants ~0.90.
+#   - calibration : making stated confidence honest (a 90% range should really contain truth ~90% of time).
+#   - MPIW/PINAW  : how WIDE the ranges are; narrower is better only if coverage stays honest.
+#   - conformal   : build honest ranges by padding predictions with the model's own measured errors.
+#   - early stopping : quit training once a held-out VALIDATION set stops improving, so the net doesn't
+#                      memorize the training data (overfit).
+# ============================================
 import json, time
 import numpy as np
 import pandas as pd
@@ -48,12 +78,18 @@ print("FD001 silver | train rows", len(train_raw), "units", train_raw.unit.nuniq
       "| test rows", len(test_raw), "units", test_raw.unit.nunique(), "| sensors", len(SENSORS))
 
 # ---- Normalization fit on TRAIN ONLY ----
+# Put every sensor on the same scale (z-score: subtract mean, divide by spread) so no single sensor
+# dominates just because its raw numbers are bigger. Crucially the mean/spread come from TRAIN ONLY —
+# letting the test data influence the scaling would be a subtle form of cheating (leakage).
 mu = train_raw[SENSORS].mean(); sd = train_raw[SENSORS].std().replace(0,1.0)
 def norm(df):
     x=df.copy(); x[SENSORS]=(x[SENSORS]-mu)/sd; return x
 train_raw = norm(train_raw); test_raw = norm(test_raw)
 
 # ---- Sliding 30-cycle windows; target = capped RUL at window's LAST cycle ----
+# The net reads a movie, not a snapshot: each training example is a 30-cycle window of sensor readings,
+# and the answer it must predict is the RUL at the LAST cycle of that window. Sliding the window forward
+# one cycle at a time turns each engine's run into many overlapping examples.
 def windows(df, has_truth=True):
     X, y, meta = [], [], []
     for u, g in df.groupby("unit"):
@@ -88,6 +124,9 @@ print("windows | fit", len(Xf), "val", len(Xv), "calib", len(Xc), "internal-test
 
 # COMMAND ----------
 # ---- CNN-LSTM (Conv1D x2 -> LSTM -> Dense) ----
+# The model in three stages: (1) two Conv1d layers scan the window for short local patterns across the
+# sensors; (2) the LSTM walks those patterns through time and keeps a running memory of the engine's
+# trajectory; (3) a small Dense head turns the final memory into one number — the predicted RUL.
 class CNNLSTM(nn.Module):
     def __init__(self, F):
         super().__init__()
@@ -109,6 +148,9 @@ def predict(m, X, bs=512):
             out.append(m(torch.tensor(X[s:s+bs])).numpy())
     return np.clip(np.concatenate(out),0,RUL_CAP)
 
+# Train the net while watching a held-out VALIDATION set. We keep the weights from the best validation
+# score and stop early if validation stops improving for `patience` epochs — that's how we avoid
+# overfitting (memorizing training data instead of learning the real degradation signal).
 def train_model(Xtr, ytr, Xval, yval, max_epochs=60, bs=256, lr=1e-3, patience=8):
     m=CNNLSTM(Xtr.shape[2]); opt=torch.optim.Adam(m.parameters(), lr=lr); loss=nn.MSELoss()
     dl=torch.utils.data.DataLoader(torch.utils.data.TensorDataset(torch.tensor(Xtr),torch.tensor(ytr)),
@@ -135,6 +177,9 @@ def train_model(Xtr, ytr, Xval, yval, max_epochs=60, bs=256, lr=1e-3, patience=8
                "patience":patience,"max_epochs":max_epochs}
 
 t0=time.time(); model, train_log = train_model(Xf,yf,Xv,yv); train_wall=round(time.time()-t0,1)
+# fit_verdict is a quick health check on training: if validation error is much worse than training error
+# the net memorized (overfit); if both are high it never learned (underfit). We don't want to crown a
+# challenger that only won by luck on an unstable training run.
 # under/overfit read: ratio of final val to final train MSE
 ratio = train_log["final_val_mse"]/max(train_log["final_train_mse"],1e-6)
 fit_verdict = ("overfit" if ratio>1.5 else "underfit" if train_log["best_val_mse"]>1500 else "reasonable")
@@ -143,6 +188,8 @@ print("train wall", train_wall, "s | fit verdict:", fit_verdict, "| val/train", 
 
 # COMMAND ----------
 # ---- LAST-CYCLE benchmark on official test set (compare to GBM 20.32 / 1423) ----
+# The head-to-head accuracy test: score each engine at its final reading and compare RMSE/PHM directly
+# against the champion GBM's 20.32 / 1423. This is the apples-to-apples number the graduation gate uses.
 Xte_all, _, meta_te = windows(test_raw, has_truth=False)
 te_df = pd.DataFrame(meta_te, columns=["unit","cycle"])
 te_df["pred"]=predict(model, Xte_all)
@@ -171,7 +218,10 @@ def conformal_band(level, pred):
     t = (1+level)/2
     ql = max(q_at(lo_res, t), 0.0); qh = max(q_at(hi_res, t), 0.0)
     return np.clip(pred-ql,0,RUL_CAP), np.clip(pred+qh,0,RUL_CAP), ql, qh
-def picp(t,lo,hi): return float(np.mean((t>=lo)&(t<=hi)))
+# Same honest-range idea as the baseline, but ASYMMETRIC: RUL errors lean one way, so we pad the bottom
+# and top of the range by DIFFERENT amounts (separate lower/upper error quantiles). This fits reality
+# better than a symmetric +/- band and still reports honest coverage on the untouched internal-test units.
+def picp(t,lo,hi): return float(np.mean((t>=lo)&(t<=hi)))  # share of truths inside the range (want ~nominal)
 ite_point={"rmse_per_cycle":rmse(yi,ite_pred),"n_windows":int(len(Xi)),"n_units":len(ite_u)}
 rng_y=float(yi.max()-yi.min()) or 1.0
 print(f"conformal calib residuals: {n_cal_resid} (calib {len(yc)} + val {len(yv)} windows, no retrain)")
@@ -190,6 +240,9 @@ for l in RELIABILITY_LEVELS:
 
 # COMMAND ----------
 # ---- GRADUATION GATE (mechanical) ----
+# The verdict, by rule (no judgment calls). The challenger replaces the champion ONLY if it is more
+# accurate (RMSE), no less safe (PHM), still honest (PICP calibrated), AND its ranges aren't wider —
+# unless it is MATERIALLY safer, the one allowed exception. Anything else: GBM stays champion.
 # Ticket 1 baseline conformal widths (MPIW) for the "narrower or defensibly similar" test:
 GBM_MPIW = {"80": 42.98, "90": 55.98}
 picp_ok = all(interval_metrics[k]["within_pm_0.03"] for k in interval_metrics)

--- a/telemetry-platform/databricks/notebooks/telemetry_trust_gate0_distance_error.py
+++ b/telemetry-platform/databricks/notebooks/telemetry_trust_gate0_distance_error.py
@@ -20,6 +20,39 @@
 # MAGIC Parent ticket: `docs/plans/03-implementation-plans/active/telemetry-trust-gate0-ticket.md`
 
 # COMMAND ----------
+# ===== TEACHING NOTES (plain language) =====
+# WHAT THIS FILE DOES:
+#   It tests a TRUST GATE that runs BEFORE the model is even allowed to judge a reading. The idea: a model
+#   is only trustworthy on inputs that look like what it was trained on. So for each new reading we ask
+#   "how far is this from the training fleet?" using MAHALANOBIS-style distance — distance that accounts
+#   for how the sensors normally move together, not just raw gaps. A reading deep inside familiar territory
+#   is one the model is competent to judge; one far outside should be flagged as "out of my depth".
+#   This notebook is the FALSIFICATION test: does that distance actually predict bigger model errors? If
+#   far-from-fleet readings really do have larger errors, the gate carries real trust information.
+#
+# WHERE YOU SEE THIS:
+#   This is the evidence behind the COMPETENCE / trust-gate surfaces (the CompetenceEnvelopeCard family) —
+#   the "is the model even in its zone of competence for this input?" check shown before a verdict.
+#
+# INPUTS -> OUTPUT:
+#   INPUT  : gold_cmapss_features (sensor features) + the frozen registered champion tel_rul_regressor.
+#   OUTPUT : an evidence JSON (distance-vs-error correlation per band + a continue/train/kill call) via
+#            dbutils.notebook.exit. No training, no new model, no UI/API/schema.
+#
+# HOW TO READ THE NUMBERS (jargon in one phrase each):
+#   - trust gate     : a check that runs BEFORE scoring to decide if the model is competent on THIS input.
+#   - Mahalanobis distance : "how unusual is this reading" measured with the sensors' normal correlations
+#                            built in, so being off in a way the sensors never normally move counts as far.
+#                            (Here approximated by z-scoring + PCA, then kNN distance in that space.)
+#   - kNN distance   : distance to the k nearest training readings — small = lots of close analogs (safe),
+#                      large = no analogs (novel, risky). The gate's "how far from the fleet" signal.
+#   - embedding      : a cleaned-up coordinate space (z-score + PCA) where distance is meaningful.
+#   - Spearman rho   : rank correlation between distance and error; >0 means farther readings tend to have
+#                      bigger errors — exactly the signal that makes the trust gate worth shipping.
+#   - bootstrap CI   : a confidence range for rho from resampling; if it stays above 0 the signal is real,
+#                      not noise. The gate's decision hinges on this excluding zero.
+#   - frozen inference : the champion is reused exactly as shipped (no retraining) so this is an honest read.
+# ============================================
 import json
 import numpy as np
 import pandas as pd
@@ -49,6 +82,10 @@ n_hold = max(1, int(round(len(all_units) * HOLDOUT_FRAC)))
 hold_units = set(rng.choice(all_units, size=n_hold, replace=False).tolist())
 fleet_units = [u for u in all_units if u not in hold_units]
 
+# Split the engines into two disjoint groups so the distance test is honest:
+#   FLEET    = the "known population" the gate measures distance against (and fits the embedding on).
+#   HELD-OUT = genuinely unseen engines we score, to ask "are the far-from-fleet ones the high-error ones?"
+# Holding engines out by id (not by row) is what makes the distance reflect real novelty, not memorization.
 # FLEET = the reference population (kNN target, embedding fit, no leakage of held-out units).
 # HELD-OUT = the evaluation windows scored for distance-vs-error.
 train = src[src.unit.isin(fleet_units)].copy()      # naming kept: 'train' = fleet reference
@@ -62,6 +99,9 @@ assert len(test) > 0 and len(train) > 0, "empty fleet or held-out — check spli
 
 # COMMAND ----------
 # ---- Frozen-inference predictions from the registered champion (NO training) ----
+# We load the SHIPPED model and just run it ("frozen inference" = reused as-is, no retraining). abs_err is
+# how wrong each prediction was — the quantity we'll check against distance. The whole gate stands or
+# falls on whether bigger distance lines up with bigger abs_err.
 model = mlflow.sklearn.load_model(MODEL_URI)
 Xtr = train[FEAT_COLS].to_numpy()
 Xte = test[FEAT_COLS].to_numpy()
@@ -77,6 +117,10 @@ print("held-out windows scored", len(test), "| held-out per-cycle RMSE", round(o
 
 # COMMAND ----------
 # ---- Cheap embedding: z-score on TRAIN stats (+ optional PCA). A feature transform, not training ----
+# Before measuring distance we put the features in a fair coordinate space: z-score (equal scale per
+# feature) then PCA (keep the few directions that carry most of the variation, drop noise). Distance in
+# THIS space is the Mahalanobis-style "how unusual is this reading" signal. It's a transform of existing
+# features fit on FLEET only — no model is trained here.
 mu = Xtr.mean(axis=0)
 sd = Xtr.std(axis=0)
 sd[sd == 0] = 1.0
@@ -98,6 +142,9 @@ print("embedding:", emb_method, "| dim", Etr.shape[1])
 
 # COMMAND ----------
 # ---- kNN distance: each HELD-OUT window -> nearest FLEET windows (L2 on the embedding) ----
+# The "how far from the fleet" number: for each unseen reading, find its k closest fleet readings and
+# average those distances. Small = the model has seen plenty like this (competent, trust it); large = no
+# close analog (novel, the gate should flag it). This knn_dist is what the competence/trust panels show.
 # Held-out units are disjoint from fleet units by the unit-level split above, so distance reflects
 # fleet novelty, not memorization. Chunk to bound memory.
 tr_units = train.unit.to_numpy()
@@ -118,13 +165,19 @@ test["nn_train_cycle"] = train["cycle"].to_numpy()[nn_train_idx]
 
 # COMMAND ----------
 # ---- Within-band Spearman rho(knn_dist, abs_err) + bootstrap CI ----
+# The core question, made into a number: within readings of SIMILAR predicted RUL (so we compare like
+# with like), does greater distance-from-fleet go with greater error? Spearman rho > 0 says yes. We
+# compute it inside RUL "bands" so the signal isn't just "low-RUL readings happen to be far AND wrong".
 def spearman(a, b):
+    # Spearman = correlation of RANKS (does b tend to rise when a rises, regardless of exact scale).
     ra = pd.Series(a).rank().to_numpy()
     rb = pd.Series(b).rank().to_numpy()
     ra -= ra.mean(); rb -= rb.mean()
     den = np.sqrt((ra**2).sum() * (rb**2).sum())
     return float((ra * rb).sum() / den) if den > 0 else 0.0
 
+# Bootstrap CI: re-sample the data many times and recompute rho each time to get a plausible range. If
+# the whole range stays above 0, the distance->error link is real signal, not a fluke of this one sample.
 def boot_ci(a, b, n=N_BOOT):
     a = np.asarray(a); b = np.asarray(b); m = len(a)
     if m < 8:
@@ -169,6 +222,9 @@ for b in per_band:
 
 # COMMAND ----------
 # ---- A/B pair discovery: similar pred RUL, different knn_dist, different abs_err ----
+# Concrete demo examples for the surface: find pairs where the model predicted ABOUT THE SAME RUL, but one
+# reading was close to the fleet (A, low distance) and one was far (B, high distance) — and show that the
+# far one had the bigger error. These are the "trust the near one, doubt the far one" stories the gate tells.
 pairs = []
 t = test.reset_index(drop=True)
 for lo, hi in BANDS:
@@ -209,6 +265,9 @@ print("A/B candidate pairs:", len(pairs))
 
 # COMMAND ----------
 # ---- Decision rule (three-way) ----
+# The verdict on whether distance carries trust info: strong, consistent positive signal -> "continue"
+# (ship the gate as-is); weak-but-real -> "train_contrastive" (the signal exists, invest in a better
+# embedding); nothing above zero -> "kill" (distance doesn't predict error here, drop the idea).
 real_bands = [b for b in per_band if b["rho"] is not None]
 pos_bands = [b for b in real_bands if b["ci95"][0] is not None and b["ci95"][0] > 0]   # CI excludes 0
 strong = [b for b in pos_bands if b["rho"] >= 0.30]

--- a/telemetry-platform/databricks/notebooks/train_anomaly.py
+++ b/telemetry-platform/databricks/notebooks/train_anomaly.py
@@ -7,6 +7,24 @@
 # MAGIC only; the TEST split is scored once with those frozen thresholds.
 
 # COMMAND ----------
+# ===== TEACHING NOTES =====
+# WHAT THIS FILE DOES: Trains two "anomaly detectors" (programs that flag when a sensor reading looks
+#   abnormal) on NASA SMAP/MSL spacecraft data. One is a simple rule (MAD), one is a smarter statistical
+#   model (PCA). It scores both honestly and writes the scores to MLflow (the model bookkeeping system).
+# WHERE YOU SEE THIS: the numbers logged here become the cards on the frontend "Model Performance" page
+#   (repo-b/src/components/telemetry/ModelPerformance.tsx) and the ModelEvidenceCard.
+# INPUTS -> OUTPUT: Gold feature tables (novendor_1.telemetry.gold_smap_msl_windows) -> two trained,
+#   scored, MLflow-logged detectors + a metrics summary the promotion gate later reads.
+# HOW TO READ THE NUMBERS:
+#   - MAD = Median Absolute Deviation: a robust way to measure "how far is this value from normal?"
+#   - F1 = one 0-1 score balancing recall (real anomalies caught) and precision (alarms that were right).
+#   - "point-adjusted" F1 = the flattering academic version (one hit credits a whole window). "honest"
+#     (pointwise) F1 = per-timestep truth, much harder, and what the promotion gate actually uses.
+#   - event_recall = fraction of labeled anomaly events the detector caught at all.
+#   - alarm_precision = fraction of fired alarms that landed on a real anomaly (low = noisy/false alarms).
+#   - affiliation_f1 = a range-aware F1 that rewards firing NEAR a real event without letting long
+#     windows inflate the score (proximity capped at AFFIL_CAP_D ticks).
+# ===========================
 import json
 import numpy as np
 import pandas as pd
@@ -43,6 +61,8 @@ print("train rows", len(train), "test rows", len(test),
 # COMMAND ----------
 # Point-adjusted evaluation: a labeled anomaly window counts as detected if ANY point in it is
 # flagged; flagged points outside any window are false positives. This is the telemanom convention.
+# Plain version: if you catch even one tick of a real anomaly stretch, you get credit for the WHOLE
+# stretch. Generous on purpose — it inflates the score, so it is reference-only, not the gate.
 def point_adjust(df: pd.DataFrame, pred_col: str) -> dict:
     # Work entirely in positional space (reset_index) so numpy positions and labels never diverge.
     df = df.sort_values(["chan_id", "t"]).reset_index(drop=True)
@@ -69,22 +89,28 @@ def point_adjust(df: pd.DataFrame, pred_col: str) -> dict:
     tp = int(((adj == 1) & (y == 1)).sum())
     fp = int(((adj == 1) & (y == 0)).sum())
     fn = int(((adj == 0) & (y == 1)).sum())
+    # precision = of the alarms we raised, how many were right; recall = of real anomalies, how many we
+    # caught; f1 = their balanced blend. These (point-adjusted) feed the reference-only F1 on the page.
     prec = tp / (tp + fp) if (tp + fp) else 0.0
     rec = tp / (tp + fn) if (tp + fn) else 0.0
     f1 = 2 * prec * rec / (prec + rec) if (prec + rec) else 0.0
     return {"precision": prec, "recall": rec, "f1": f1, "tp": tp, "fp": fp, "fn": fn}
 
 
+# The HONEST scorer. Same predictions, but no per-window credit inflation. This is what the promotion
+# gate reads, and what the "honest F1 / event recall / alarm precision" cards on Model Performance show.
 def honest_and_affiliation(df: pd.DataFrame, pred_col: str, cap_d: int = AFFIL_CAP_D) -> dict:
     """Honest (no point-adjustment) + capped-affiliation metrics on the SAME predictions, for the gate.
     Affiliation proximity = max(0, 1 - dist/cap_d) within each channel, so long labeled windows cannot
     inflate it. Mirrors telemetry-platform/eval_honest_metrics.py."""
     df = df.sort_values(["chan_id", "t"]).reset_index(drop=True)
-    y = df["is_anomaly"].to_numpy().astype(int)
-    p = df[pred_col].to_numpy().astype(int)
+    y = df["is_anomaly"].to_numpy().astype(int)   # truth: 1 = real NASA-labeled anomaly tick
+    p = df[pred_col].to_numpy().astype(int)        # our detector: 1 = we raised an alarm this tick
+    # Straight per-tick counts (no window credit): tp = right alarms, fp = false alarms, fn = misses.
     tp = int(((p == 1) & (y == 1)).sum())
     fp = int(((p == 1) & (y == 0)).sum())
     fn = int(((p == 0) & (y == 1)).sum())
+    # -> these honest precision/recall/f1_pointwise values are the "honest F1" card on Model Performance.
     prec = tp / (tp + fp) if (tp + fp) else 0.0
     rec = tp / (tp + fn) if (tp + fn) else 0.0
     f1 = 2 * prec * rec / (prec + rec) if (prec + rec) else 0.0
@@ -127,11 +153,17 @@ def honest_and_affiliation(df: pd.DataFrame, pred_col: str, cap_d: int = AFFIL_C
                 pr = 0.0
             rec_prox += pr
             rec_cnt += 1
+    # affiliation precision/recall/f1: "how close did alarms land to real events, and vice versa."
+    # -> affiliation_f1 is the range-aware score the promotion gate ranks anomaly models by.
     ap = prec_prox / prec_cnt if prec_cnt else 0.0
     ar = rec_prox / rec_cnt if rec_cnt else 0.0
     af1 = 2 * ap * ar / (ap + ar) if (ap + ar) else 0.0
+    # alarm_precision = of every alarm fired, the share that hit a real anomaly tick.
+    # -> this is the "Alarm precision" card on Model Performance (low = lots of noisy false alarms).
     alarms = int((p == 1).sum())
     alarm_prec = (int(((p == 1) & (y == 1)).sum()) / alarms) if alarms else 0.0
+    # event_recall = fraction of labeled anomaly events we touched at all (caught >=1 tick of).
+    # -> this is the "Event recall" card on Model Performance.
     return {
         "f1_pointwise": f1, "precision_pointwise": prec, "recall_pointwise": rec,
         "event_recall": (seg_hit / seg_total if seg_total else 0.0), "alarm_precision": alarm_prec,
@@ -139,6 +171,8 @@ def honest_and_affiliation(df: pd.DataFrame, pred_col: str, cap_d: int = AFFIL_C
     }
 
 
+# The fail-closed check: a detector "passes" only if it clears EVERY honest threshold (a missing metric
+# counts as 0 and fails). This boolean is what promote_models.py trusts to decide champion vs held-back.
 def passes_honest_gate(m: dict) -> bool:
     """Fail-closed: every declared honest threshold must be met."""
     return all(float(m.get(k, 0.0)) >= thr for k, thr in HONEST_GATE.items())
@@ -147,6 +181,9 @@ def passes_honest_gate(m: dict) -> bool:
 # ---- BASELINE: rolling-median / MAD dynamic threshold on the raw value ----
 # Per channel: robust center = rolling median proxy (value_rmean50), spread = MAD from train residuals.
 # Threshold k chosen on TRAIN to flag ~ the train-implied rate, then frozen and applied to TEST.
+# Plain idea of MAD: measure each reading's distance from "normal," divide by the typical distance, and
+# alarm when it is more than k typical-distances out. This simple rule is the eventual CHAMPION the
+# replay demo (score_replay_feed.py) uses to flip its GO/REVIEW/NO_GO flag.
 def mad_resid(df):
     df = df.copy()
     df["resid"] = (df["value"] - df["value_rmean50"]).abs()
@@ -167,6 +204,7 @@ def baseline_flag(df):
     df["pred"] = (df["resid"].to_numpy() > BASELINE_K * s).astype(int)
     return df
 
+# Score the baseline on the held-out TEST split: both the flattering and the honest way.
 test_b = baseline_flag(test_b)
 m_base = point_adjust(test_b, "pred")            # legacy point-adjusted (reference only)
 h_base = honest_and_affiliation(test_b, "pred")  # honest + affiliation (the gate)
@@ -208,6 +246,9 @@ with mlflow.start_run(run_name="anomaly_baseline_mad") as run:
 
 # COMMAND ----------
 # ---- STRONGER: PCA reconstruction error over the rolling-feature vector ----
+# PCA = Principal Component Analysis: it learns the few patterns that explain "normal" data, then tries
+# to rebuild each reading from those patterns. Normal readings rebuild cleanly; weird ones don't — the
+# rebuild error is the anomaly score. Bigger error -> more likely an anomaly.
 FEATS = ["value", "value_rmean50", "value_rstd50", "value_rmin50", "value_rmax50", "value_roc"]
 tr = train.dropna(subset=FEATS).copy()
 te = test.dropna(subset=FEATS).copy()
@@ -248,6 +289,8 @@ with mlflow.start_run(run_name="anomaly_pca_recon") as run:
     pca_run_id = run.info.run_id
 
 # COMMAND ----------
+# Final summary handed back to the orchestrator (and ultimately surfaced on Model Performance):
+# both detectors' honest + reference metrics and whether each cleared the gate.
 result = {
     "baseline": {"run_id": baseline_run_id, **m_base, **h_base,
                  "honest_gate_pass": passes_honest_gate(h_base), "k": BASELINE_K},

--- a/telemetry-platform/databricks/notebooks/train_rul.py
+++ b/telemetry-platform/databricks/notebooks/train_rul.py
@@ -12,6 +12,25 @@
 # MAGIC only safe to promote when it ALSO keeps late predictions low and clears the leakage control.
 
 # COMMAND ----------
+# ===== TEACHING NOTES =====
+# WHAT THIS FILE DOES: Trains models that predict RUL — Remaining Useful Life, i.e. how many cycles a
+#   jet-engine unit has left before it fails — on NASA C-MAPSS turbofan data. It trains a simple model
+#   (linear regression) and a stronger one (gradient boosting), then scores them honestly.
+# WHERE YOU SEE THIS: the metrics here feed the frontend "RUL Calibration" page and its calibration
+#   evidence (repo-b/src/components/telemetry/RulCalibration.tsx).
+# INPUTS -> OUTPUT: Gold engine features (novendor_1.telemetry.gold_cmapss_features) + the official RUL
+#   truth table -> two trained, scored, MLflow-logged regressors + per-model "model cards."
+# HOW TO READ THE NUMBERS:
+#   - RUL = cycles of safe life left before failure (higher = more life remaining).
+#   - RMSE = typical prediction error in cycles (lower is better).
+#   - PHM score = NASA's official asymmetric error score; LOWER is better, and it punishes "late"
+#     predictions harder than "early" ones (see next point) because late is the dangerous direction.
+#   - "late rate" = share of predictions that say MORE life remains than really does. That is the unsafe
+#     mode (you'd run a failing engine), so we track and cap it separately from RMSE.
+#   - naive baseline = a dumb constant guess; a real model must beat it or it isn't actually learning.
+#   - leakage control = sanity check: shuffle the answers, retrain; if score stays good, the model was
+#     cheating off leaked labels. We require it to collapse.
+# ===========================
 import json
 import numpy as np
 import pandas as pd
@@ -47,6 +66,8 @@ train = train.dropna(subset=FEAT_COLS).copy()
 train["y"] = np.minimum(train["rul_target"].to_numpy(), RUL_CAP)
 
 # Test design: one row per unit = its LAST observed cycle; truth = official RUL_FD001.
+# In plain terms: for each test engine, take its most recent snapshot and ask "how many cycles left?",
+# then compare to NASA's published answer. This last-cycle-per-unit framing is the calibration evidence.
 test_last = test.sort_values(["unit", "cycle"]).groupby("unit").tail(1).copy()
 test_last = test_last.merge(rul_truth[["unit", "rul"]], on="unit", how="inner")
 test_last["y_true"] = np.minimum(test_last["rul"].to_numpy(), RUL_CAP)
@@ -58,22 +79,30 @@ Xte, yte = test_last[FEAT_COLS].to_numpy(), test_last["y_true"].to_numpy()
 units = test_last["unit"].to_numpy()
 
 # COMMAND ----------
+# rmse = root-mean-square error: the typical size of a miss, in cycles. -> the headline error on the
+# RUL Calibration page. Lower is better.
 def rmse(a, b):
     return float(np.sqrt(np.mean((np.asarray(a, float) - np.asarray(b, float)) ** 2)))
 
+# mae = mean absolute error: average miss size in cycles (less sensitive to big outliers than RMSE).
 def mae(a, b):
     return float(np.mean(np.abs(np.asarray(a, float) - np.asarray(b, float))))
 
 def phm_score(y_true, y_pred):
     # NASA PHM'08 asymmetric score. LOWER IS BETTER. Late predictions (pred > true => d>0) penalized
     # more (a=10) than early (a=13), because over-stating remaining life is the dangerous direction.
+    # In words: it's an exam where guessing "too much life left" loses you more points than "too little,"
+    # because in the field, optimism is what gets equipment run to failure. -> this is the PHM score on
+    # the RUL Calibration evidence.
     d = np.asarray(y_pred, float) - np.asarray(y_true, float)
     s = np.where(d < 0, np.exp(-d / 13.0) - 1.0, np.exp(d / 10.0) - 1.0)
     return float(np.sum(s))
 
 def late_diagnostics(y_true, y_pred):
     """RUL 'late' = predicted RUL HIGHER than actual (model thinks more safe life remains than truth).
-    That is the dangerous failure mode. Returns a dict of late/early metrics."""
+    That is the dangerous failure mode. Returns a dict of late/early metrics.
+    -> rul_late_prediction_rate here is the 'late rate' the promotion gate caps and the RUL Calibration
+    page reports: the share of engines the model wrongly judged to have more life left than they do."""
     err = np.asarray(y_pred, float) - np.asarray(y_true, float)   # >0 late (optimistic), <0 early
     late = err > 0
     early = err < 0
@@ -87,7 +116,9 @@ def late_diagnostics(y_true, y_pred):
     }
 
 def regime_late_rates(y_true, y_pred):
-    """Late-prediction rate sliced by RUL regime (single-regime FD001 -> slice by remaining life)."""
+    """Late-prediction rate sliced by RUL regime (single-regime FD001 -> slice by remaining life).
+    Plain version: is the model especially unsafe on near-failure engines (low remaining life)? That's
+    the slice that matters most, so we break the late rate out by how much life actually remained."""
     err = np.asarray(y_pred, float) - np.asarray(y_true, float)
     out = {}
     for name, lo, hi in [("low_RUL_<50", 0, 50), ("mid_RUL_50_100", 50, 100), ("high_RUL_>=100", 100, RUL_CAP + 1)]:
@@ -101,6 +132,8 @@ def regime_late_rates(y_true, y_pred):
 # ── the MEAN baseline, then use the STRONGEST (lowest-RMSE) naive as the bar a model must beat. A simple
 # ── per-unit "linear degradation" naive is NOT well-defined here (no per-unit total-life at last cycle),
 # ── so it is intentionally omitted rather than faked.
+# Build the "dumb guess" bars: always predict the training mean, or the training median. A real model
+# has to beat the best of these or it has learned nothing. -> shown as the baseline on RUL Calibration.
 train_mean = float(ytr.mean())
 train_median = float(np.median(ytr))
 naive_preds = {
@@ -116,6 +149,9 @@ print("naive baselines", json.dumps(naive_scores), "| strongest naive:", best_na
 
 # ── NEGATIVE CONTROL (diagnostic only; never trains/influences the champion): shuffle TRAIN labels,
 # ── refit GBM. With no target leakage, performance must collapse toward naive/random.
+# Leakage sanity check: scramble the answers so features no longer match their true RUL, then retrain.
+# If the model still scores well, it was secretly reading the answer through the features (leakage); a
+# clean setup makes the scrambled model collapse to roughly the dumb-guess level.
 rng = np.random.RandomState(0)
 ytr_shuf = ytr.copy(); rng.shuffle(ytr_shuf)
 gbm_shuf = GradientBoostingRegressor(n_estimators=300, max_depth=3, learning_rate=0.05,
@@ -179,8 +215,11 @@ def model_card(model_label, m, late, regimes):
     }
 
 
+# Train one model, score it on the held-out engines, compute the safety diagnostics, and log everything
+# to MLflow so promote_models.py can later read the numbers and the RUL Calibration page can show them.
 def fit_log(model_label, run_name, estimator):
     estimator.fit(Xtr, ytr)
+    # clip predictions to the valid 0..RUL_CAP range (negative or absurdly large life is meaningless)
     pred = np.clip(estimator.predict(Xte), 0, RUL_CAP)
     m = {"rmse": rmse(yte, pred), "mae": mae(yte, pred), "phm": phm_score(yte, pred)}
     late = late_diagnostics(yte, pred)
@@ -213,6 +252,8 @@ def fit_log(model_label, run_name, estimator):
     return rid, m, late, card
 
 # COMMAND ----------
+# Train both candidates: the simple linear baseline and the stronger gradient-boosted model. The
+# promotion gate (promote_models.py) later picks the SAFEST one that clears every threshold.
 lin_run_id, m_lin, late_lin, card_lin = fit_log("linear_regression", "rul_linear_baseline", LinearRegression())
 gbm_run_id, m_gbm, late_gbm, card_gbm = fit_log(
     "gradient_boosting", "rul_gbm",

--- a/telemetry-platform/envelope_core.py
+++ b/telemetry-platform/envelope_core.py
@@ -1,5 +1,23 @@
 """Pure competence-envelope primitives (numpy only — no Databricks/sklearn, CI-safe).
 
+WHAT THIS FILE DOES: a pre-test safety gate. Before trusting a model's prediction, it asks "is
+this new input similar to the data the model was trained on?" using Mahalanobis distance — a
+distance that accounts for how the sensors normally move together, so it isn't fooled by
+correlated readings. Far-away inputs get held back (REVIEW or ABSTAIN) instead of scored.
+
+WHERE YOU SEE THIS: the numbers here drive the frontend CompetenceEnvelopeCard (the
+in-envelope / near-boundary / out-of-envelope rates and the per-sample action).
+
+INPUTS -> OUTPUT: training rows + a new sample -> a distance and an IN/NEAR/OUT band with a
+SCORE/REVIEW/ABSTAIN action (consumed by compute_competence_envelope.py, which writes
+competence_envelope_evidence.json).
+
+HOW TO READ THE NUMBERS:
+  - Mahalanobis distance = how far a sample is from the training cloud, accounting for sensor
+    correlations (0 = dead center, large = far outside what was seen).
+  - tau = the distance line that marks the edge of "trained territory".
+  - in/near/out rates = fraction of samples that are safely inside, on the edge, or outside.
+
 Shared by compute_competence_envelope.py (which pulls real FD001/FD004 data) and the eval
 test test_envelope_core.py. The envelope is a transparent Mahalanobis distance to the
 training distribution: in-envelope = close to what the model was trained on; out-of-envelope
@@ -10,11 +28,17 @@ from __future__ import annotations
 
 import numpy as np
 
-# Band labels + the operational action each implies.
+# Band labels + the operational action each implies. These three labels are the colored zones on
+# the CompetenceEnvelopeCard: inside = trust the score, edge = have a human review, outside =
+# don't issue a confident prediction at all.
 IN, NEAR, OUT = "in_envelope", "near_boundary", "out_of_envelope"
 ACTION = {IN: "score", NEAR: "review", OUT: "abstain"}
 
 
+# Describe the shape of the training data: where its center is and how the sensors co-vary
+# (which move together, and how much). That shape is what Mahalanobis distance measures against.
+# The small "ridge" is just numerical insurance so the math stays stable when two sensors are
+# nearly redundant.
 def fit_envelope(X: np.ndarray, ridge: float = 1e-3) -> tuple[np.ndarray, np.ndarray]:
     """Mean + (ridge-regularized) inverse covariance from the training rows only.
     Ridge keeps the inverse stable when sensors are collinear."""
@@ -25,12 +49,19 @@ def fit_envelope(X: np.ndarray, ridge: float = 1e-3) -> tuple[np.ndarray, np.nda
     return mean, np.linalg.pinv(cov)
 
 
+# The actual distance score for each new sample: how far from the training center, scaled by the
+# normal spread in each direction. A sample that's extreme along a sensor that usually barely
+# moves scores high; one that drifts along a naturally wide sensor scores low. This per-row number
+# is what gets compared to tau to assign the band.
 def mahalanobis_sq(X: np.ndarray, mean: np.ndarray, cov_inv: np.ndarray) -> np.ndarray:
     """Squared Mahalanobis distance of each row to the training distribution."""
     d = np.asarray(X, dtype=float) - mean
     return np.einsum("ij,jk,ik->i", d, cov_inv, d)
 
 
+# Turn one distance into one of the three zones. Inside the line (tau) = trusted; a bit past it =
+# borderline; well past it (k_out times the line) = outside trained territory. This is the
+# per-sample verdict shown on the CompetenceEnvelopeCard.
 def band(d2: float, tau: float, k_out: float) -> str:
     """in-envelope (<= tau) -> score; near-boundary (tau..k_out*tau) -> review; out -> abstain."""
     if d2 <= tau:
@@ -40,6 +71,9 @@ def band(d2: float, tau: float, k_out: float) -> str:
     return OUT
 
 
+# Summarize a whole batch: what share of samples landed in / near / outside the envelope. These
+# three fractions are the headline rates on the CompetenceEnvelopeCard — e.g. "X% of the shifted
+# dataset fell outside what the model was trained on".
 def band_rates(d2: np.ndarray, tau: float, k_out: float) -> dict:
     """Fraction of rows in each band."""
     d2 = np.asarray(d2, dtype=float)

--- a/telemetry-platform/regime_core.py
+++ b/telemetry-platform/regime_core.py
@@ -1,5 +1,21 @@
 """Pure regime-conditioning primitives (numpy only — no Databricks/sklearn, CI-safe).
 
+WHAT THIS FILE DOES: the small, shared math used to judge a machine as "normal relative to
+the operating mode it's in right now" instead of "normal on one global scale". A "regime" is a
+distinct operating condition (e.g. cruise vs climb). These functions standardize per regime,
+measure how badly a reconstruction model misses, and turn that into a false-alarm rate.
+
+WHERE YOU SEE THIS: the numbers these produce flow up to the frontend RegimeAnomalyCard
+(per-regime false-positive rates; global detector vs regime-conditioned detector).
+
+INPUTS -> OUTPUT: sensor rows + a regime label per row -> per-regime false-positive rates and
+spreads (consumed by compute_regime_anomaly.py, which writes regime_anomaly_evidence.json).
+
+HOW TO READ THE NUMBERS:
+  - reconstruction error = how far a row is from what a simple model expected (big = surprising).
+  - false-positive rate = fraction of KNOWN-HEALTHY rows the detector wrongly flagged (lower is better).
+  - cross-regime spread = max minus min false-positive rate across regimes (lower = fairer across modes).
+
 Shared by compute_regime_anomaly.py (which pulls real FD004 data + fits PCA) and the
 eval test test_regime_core.py. The PCA fit itself lives in the compute script (sklearn);
 these are the regime-normalization + reconstruction-error + false-positive primitives that
@@ -11,6 +27,9 @@ from __future__ import annotations
 import numpy as np
 
 
+# Learn, separately for each operating mode, what a typical sensor reading looks like (its
+# average and how much it normally wobbles). This is the reference point used later to ask
+# "is this row unusual FOR ITS REGIME?" rather than "unusual on one global scale?".
 def regime_stats(X: np.ndarray, regimes: np.ndarray) -> dict:
     """Per-regime mean/std of each feature, from the fit rows only (no leakage)."""
     stats: dict = {}
@@ -23,6 +42,9 @@ def regime_stats(X: np.ndarray, regimes: np.ndarray) -> dict:
     return stats
 
 
+# Re-express every row as "how many standard deviations from normal FOR ITS OWN REGIME".
+# This is the core trick: after this, a healthy cruise row and a healthy climb row both look
+# ~average, so the detector stops flagging a machine just because it switched modes.
 def regime_zscore(X: np.ndarray, regimes: np.ndarray, stats: dict) -> np.ndarray:
     """Standardize each row using its regime's mean/std — removes the operating-condition
     offset so reconstruction error reflects faults, not regime."""
@@ -34,6 +56,10 @@ def regime_zscore(X: np.ndarray, regimes: np.ndarray, stats: dict) -> np.ndarray
     return out
 
 
+# The anomaly score itself. PCA learns the handful of patterns that explain healthy data; we
+# squash each row down to those patterns and rebuild it. A healthy row rebuilds almost
+# perfectly (small error); a faulty/odd row can't be rebuilt from healthy patterns (large
+# error). The per-row number returned here is what gets compared against the alarm threshold.
 def recon_error(X: np.ndarray, mean: np.ndarray, components: np.ndarray) -> np.ndarray:
     """Squared reconstruction error of X under a linear projection (PCA components, rows =
     components). center -> project -> reconstruct -> squared residual per row."""
@@ -43,10 +69,15 @@ def recon_error(X: np.ndarray, mean: np.ndarray, components: np.ndarray) -> np.n
     return np.sum((Xc - recon) ** 2, axis=1)
 
 
+# Set the alarm line. Pick the error level that, say, 95% of healthy training rows fall under;
+# anything above it counts as an alarm. By construction this gives ~5% false alarms on the fit
+# data — the test is whether it stays low on held-out rows and across all regimes.
 def threshold_quantile(errs: np.ndarray, q: float) -> float:
     return float(np.quantile(errs, q))
 
 
+# For each operating mode, what fraction of KNOWN-HEALTHY rows tripped the alarm. These are the
+# bars on the RegimeAnomalyCard: high bars = the detector false-alarms in that mode.
 def per_regime_rate(errs: np.ndarray, regimes: np.ndarray, tau: float) -> dict:
     """Fraction of rows per regime exceeding tau (the false-positive rate on healthy rows)."""
     out: dict = {}
@@ -56,6 +87,9 @@ def per_regime_rate(errs: np.ndarray, regimes: np.ndarray, tau: float) -> dict:
     return out
 
 
+# One fairness number: the gap between the worst and best regime's false-alarm rate. A big gap
+# means the detector treats some operating modes much more harshly than others; conditioning on
+# regime should shrink this gap (visible as flatter bars on the card).
 def spread(rates: dict) -> float:
     """Cross-regime spread of the per-regime rates (max - min)."""
     vals = list(rates.values())


### PR DESCRIPTION
## What
Adds **plain-language teaching comments** to every live machine-learning source file, working **backwards from each ML-output page** to the code that runs the ML, and explaining what it means in simple terms + **which visual each output drives**. Comments and docstrings only.

Every file gets a header — **WHAT THIS FILE DOES / WHERE YOU SEE THIS / INPUTS→OUTPUT / HOW TO READ THE NUMBERS** — plus inline notes that name the exact page + chart each value produces (e.g. "this `event_recall` is the 'Event recall' card on Model Performance"; "these UMAP x/y are the scatter dots on FactoryNcrIntelligence"). Jargon (MAD, F1, RUL, PHM, conformal/PICP/PINAW, Mahalanobis, PSI, SHAP, XGBoost, GroupKFold, UMAP, HDBSCAN, MAE/MAPE, regime, ADC, fail-closed, receipt) is defined in one phrase on first use.

## Coverage — 38 files across every live ML pipeline
- **Telemetry training:** `train_anomaly`, `train_rul`, `promote_models`, `score_replay_feed`, `fused_state_vector` → Model Performance, Registry Console, replay.
- **Evaluators + math cores:** `compute_regime_anomaly`, `compute_rul_conformal`, `compute_competence_envelope`, `compute_event_windowed_analog` + `regime_core`/`conformal_core`/`envelope_core`/`analog_core` → RegimeAnomalyCard, RulConformalCard, CompetenceEnvelopeCard, RUL Calibration.
- **NCR intelligence:** `ncr_corpus`, `ncr_clustering`, `ncr_backlog_forecast` + orchestrators `15`/`16` → FactoryNcrIntelligence (UMAP scatter, Pareto, forecast MAE/MAPE).
- **Calibration/trust + foundation:** `telemetry_calibration_baseline`, `..._challenger_cnnlstm`, `trust_gate0`, `06_gold`, `13_backfill_serving` → the live data behind Monitoring + Model Performance.
- **Factory ML:** `02_silver_features`, `03_gold_feature_store`, `04_train_print_quality`, `run_pipeline` → Factory ML console (FeatureImportance / Registry / NCR / Readiness / LayerHeatmap).
- **History Rhymes:** `02_build_features`, `03_classify_regime`, `04_score_analogs`, `run_pipeline` + `market_regime_engine` + `ml_demo_materialize` → regime surfaces + ML Algorithm Lab.
- **GCP/Vertex runbooks:** `gemma_vertex_stage` deploy/run/teardown + `gemma_vertex_provider` + `telemetry_receipts` → Control Tower + Workbench/MES receipt panels.

## Safety — proven comments-only
- The **3 live backend files** (`telemetry_receipts`, `gemma_vertex_provider`, `market_regime_engine`) are **byte-identical after stripping comments/docstrings** via the Python tokenizer.
- Notebook `# COMMAND`/`# MAGIC` cell markers preserved; embedded SQL logic unchanged (**95/95 identical** non-comment lines in the regime classifier — only `--` SQL comments added).
- All **38 `.py` files `py_compile` clean**; backend receipt + MES tests pass (**37**), confirming the live loader behaves identically.
- +1862 / −84 (the deletions are existing docstrings/comments folded into the new headers).

No logic, ordering, or names changed anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)