### PR TITLE
fix(auth): unblock Agent Builder for the telemetry reviewer login

### DIFF
--- a/repo-b/src/lib/server/platformMembershipRehydrate.test.ts
+++ b/repo-b/src/lib/server/platformMembershipRehydrate.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { getActiveRichMembership } from "./platformMembershipRehydrate";
+import { buildTelemetryReviewerClaims } from "./telemetryReviewer";
+
+const TELEMETRY_ENV = "dc82d39d-9be2-49b0-a01d-c7181b13a8b6";
+
+describe("getActiveRichMembership — telemetry reviewer guard", () => {
+  it("synthesizes the rich membership for a reviewer session without a DB lookup", async () => {
+    // A reviewer session's platform_user_id is the literal "telemetry-reviewer" (not a UUID).
+    // If this hit loadRichMembershipByEnvId it would throw on the ::uuid cast (no DB pool here),
+    // so resolving successfully proves the short-circuit avoids the DB entirely.
+    const { claims } = buildTelemetryReviewerClaims(TELEMETRY_ENV);
+    const rich = await getActiveRichMembership(claims);
+    expect(rich).not.toBeNull();
+    expect(rich?.env_id).toBe(TELEMETRY_ENV);
+    expect(rich?.role).toBe("telemetry_reviewer");
+    // Critical: no business_id → Agent Builder resolves the demo-scope param fallback,
+    // never a real tenant, and write tools stay disabled.
+    expect(rich?.business_id).toBeNull();
+    expect(rich?.tenant_id).toBeNull();
+  });
+});

--- a/repo-b/src/lib/server/platformMembershipRehydrate.ts
+++ b/repo-b/src/lib/server/platformMembershipRehydrate.ts
@@ -4,6 +4,7 @@ import {
   getActiveMembership,
 } from "@/lib/server/sessionAuth";
 import { withClient } from "@/lib/server/db";
+import { isTelemetryReviewerSession } from "@/lib/server/telemetryReviewer";
 
 function rowToSummary(row: Record<string, unknown>): PlatformMembershipSummary {
   return {
@@ -95,5 +96,27 @@ export async function getActiveRichMembership(
   if (!session?.platform_user_id) return null;
   const slim = getActiveMembership(session);
   if (!slim) return null;
+  // Telemetry reviewer sessions are synthetic: there is no DB membership row, and the
+  // platform_user_id is the literal "telemetry-reviewer" — not a UUID — so the ::uuid cast
+  // in loadRichMembershipByEnvId would throw and 502 any header-building proxy the reviewer
+  // can reach (Agent Builder). Build the rich membership from the signed session instead.
+  // business_id stays null, so Agent Builder resolves the demo-scope param fallback and the
+  // reviewer never carries a real tenant.
+  if (isTelemetryReviewerSession(session)) {
+    return {
+      env_id: slim.env_id,
+      env_slug: slim.env_slug,
+      client_name: "Telemetry Demo Console",
+      role: slim.role,
+      status: slim.status,
+      auth_mode: "private",
+      is_default: slim.is_default ?? true,
+      business_id: null,
+      tenant_id: null,
+      industry: null,
+      industry_type: null,
+      workspace_template_key: null,
+    };
+  }
   return loadRichMembershipByEnvId(session.platform_user_id, slim.env_id);
 }


### PR DESCRIPTION
## Summary

Restoring the production telemetry reviewer login (`telemetry`) surfaced a second, latent bug: the reviewer **could not use Agent Builder** even with valid credentials.

## Root cause

The reviewer login mints a *synthetic* session — `platform_user_id` is the literal string `"telemetry-reviewer"` (not a UUID) and there is no DB membership row. `getActiveRichMembership` passed that straight into `loadRichMembershipByEnvId`, whose SQL casts `platform_user_id::uuid` → Postgres throws `invalid input syntax for type uuid`. The throw propagates through `buildPlatformSessionHeaders` into the **only header-building proxy a reviewer can reach** — the Agent Builder proxy — turning every `/api/agent-builder/*` call into a **502**.

The reviewer's `/telemetry` data pages were unaffected (they use the telemetry proxy, which never builds platform-session headers), which is why this stayed hidden until Agent Builder shipped (#481).

## Fix

Short-circuit reviewer sessions in `getActiveRichMembership` before the DB lookup and build the rich membership from the signed session. `business_id` stays **null**, so Agent Builder resolves the demo-scope param fallback (never a real tenant) and write tools remain disabled — tenant isolation preserved.

## Tests

- `repo-b/src/lib/server/platformMembershipRehydrate.test.ts` (new): a reviewer session resolves a rich membership with `business_id: null` **without a DB pool** (proving the short-circuit avoids the throwing `::uuid` lookup).
- `telemetryReviewer.test.ts` (6) + agent-builder proxy `route.test.ts` (4) still green; typecheck clean.

## Notes

- Frontend-only change. No backend redeploy, no migration.
- Paired with restoring the empty `TELEMETRY_REVIEWER_*` Vercel prod env vars (canonical `TELEMETRY_REVIEWER_ENV_ID` = the lab env UUID `dc82d39d-…`, per `telemetryReviewer.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)