### PR TITLE
feat(telemetry): Overview hero + Bottleneck Map polish

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4840,3 +4840,37 @@ Turned the cosmetic `relativity_mes` BigQuery medallion (silver = `SELECT * FROM
 - **Telemetry reviewer login: `TELEMETRY_REVIEWER_ENV_ID` is the lab-env UUID, not the serving scope.** The value is used verbatim as the `/lab/env/<ENV_ID>/telemetry` route segment and as the middleware path-gate (`telemetryReviewerHome` / `telemetryReviewerAllowedPath` in `repo-b/src/lib/server/telemetryReviewer.ts`). Canonical value = the Telemetry Demo Console **env UUID `dc82d39d-9be2-49b0-a01d-c7181b13a8b6`** (the same value `telemetryReviewer.test.ts` hardcodes). Do NOT use `telemetry-demo` — that's the *serving* scope (`TELEMETRY_DEMO_ENV_ID`, used as agent-builder/telemetry query params), not a lab-env route id; the runbook's `telemetry-demo`/`localdemo` line is a local-dev example. All three vars (`USERNAME`/`PASSWORD`/`ENV_ID`) must be set or the login fail-closes (config()→null→401). On `consulting-app` (the novendor.ai Vercel project, rootDir repo-b) production auto-deploys on merge to main; env-var changes need a fresh deploy to take effect.
 - **`vercel env pull` returns blank for *sensitive* vars — it is NOT proof a var is empty.** `DATABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `TELEMETRY_REVIEWER_*` all pull as `""` even when set, because Vercel won't decrypt sensitive vars to a local dotenv. To verify a sensitive var's value, exercise the runtime path (e.g. `POST /api/auth/telemetry-login` with a known password → 200 vs 401), not `env pull`. Set with `printf "value" | vercel env add VAR production` (never `echo`); if the var already exists, `vercel env rm VAR production --yes` first.
 - **Synthetic sessions must skip the rich-membership DB lookup.** The telemetry reviewer session has `platform_user_id="telemetry-reviewer"` (a literal, not a UUID) and no DB membership row. `getActiveRichMembership` → `loadRichMembershipByEnvId` casts `platform_user_id::uuid` and **throws** on a non-UUID, which propagates through `buildPlatformSessionHeaders` and 502s the only header-building proxy a reviewer can reach (Agent Builder). The reviewer's `/telemetry` pages were fine because the telemetry proxy never builds platform-session headers — so this only bit once Agent Builder shipped. Fix: short-circuit `isTelemetryReviewerSession` and synthesize the membership from the signed session (`business_id: null` → Agent Builder uses the demo-scope param fallback, write tools stay disabled). Any future synthetic session needs the same guard.
+
+---
+
+## Telemetry Overview hero + Bottleneck Map polish (2026-06-29)
+
+Reusable findings from refining the Overview hero + chart interaction:
+
+- **The stray x-axis "active dot" was recharts' shared `<Tooltip>` across mismatched datasets.** The
+  `ComposedChart` data is the 70-row `YEAR_SERIES` (bars/area) but the bubbles are a separate 16-row
+  `<Scatter>`. A shared `<Tooltip>` computes one active index across series, so hovering a bubble dropped
+  an "active dot" on a stale year. Fix: remove the shared `<Tooltip>` (and set `activeDot={false}` on the
+  `Area`), and own hover on the bubbles — `onMouseEnter/Leave` on the bubble `<g>` sets a local
+  `hover={event,cx,cy}`, which drives a custom absolutely-positioned tooltip (anchored at `cx,cy` inside a
+  `position:relative` wrapper around `ResponsiveContainer`) and a `ReferenceLine` at the
+  hovered/selected event's year. One accurate mark, one tooltip — no cross-series confusion.
+- **Tooltip year-context fields:** `data.ts` `YEAR_SERIES` already has per-year `attempts`,
+  `commercialPct` (true 0–100), and `governmentPct` (= `100 - commercialPct`). Join an event to its year
+  with **`Math.floor(event.year)`** (the fractional year encodes the month; `2025.9`→2025, `2026.75`→2026
+  which is null). New exported helper `eventYearStats(event)` returns these or `null` (fail closed for
+  planned/2026+ years) — never fabricated. `MapTipBody({event})` is exported pure so the rows are unit-
+  testable without driving SVG hover.
+- **Lifting the presenter control:** the Bottleneck Map owns the step index; the Overview hero renders an
+  icon-only Play/Stop. Two thin channels mirror the existing `resetSignal` pattern — `onPresentingChange`
+  (which icon to show) and a bumped `presenterToggleSignal` counter (flip on/off, map flips
+  `setPresenterIdx(i => i===null?0:null)`). Keep keyboard P/←/→/Esc on the map.
+- **Hero-image fact marks:** the backdrop layer sits at `zIndex:0` behind the hero content (`zIndex:1`),
+  so marks added there can *never* cover the title/CTA — the foreground paints over them and they peek
+  through negative space. Read values from `event.metrics` only; guard `event.metrics?.length` (test
+  events pass partial objects). They duplicate KPI values, so component tests must use `getAllByText` for
+  those strings.
+- **y-axis labels:** recharts `YAxis` ticks don't wrap; long band labels clipped at `width:210`. Shorten
+  the band copy in `BANDS` rather than only widening, then bump `fontSize` (10→12.5) + brighter fill.
+- **Shell chrome:** removing the "serving · prod" footer dot frees the vertical space that was nudging the
+  collapse toggle below the fold; keep the toggle icon-only (`‹`/`›`) with `aria-label` only.

--- a/repo-b/src/components/telemetry/LaunchEventHero.test.tsx
+++ b/repo-b/src/components/telemetry/LaunchEventHero.test.tsx
@@ -10,13 +10,15 @@ import type { DecoratedEvent } from "./context/BottleneckMap/types";
 const sputnik = EVENTS.find((e) => e.id === "sputnik")!;
 const event: DecoratedEvent = { ...sputnik, color: "#6CA8F0", dimLabel: "Mission achievement", sizeValue: sputnik.scale };
 
+const noop = () => {};
+
 describe("LaunchEventHero", () => {
-  it("renders the selected event as the hero: eyebrow, title, caption, KPIs, cards, and CTA", () => {
-    render(<LaunchEventHero event={event} envId="env-test" onBack={() => {}} />);
+  it("renders the selected event as the hero: eyebrow, title, caption, KPIs, three fact cards, and CTA", () => {
+    render(<LaunchEventHero event={event} envId="env-test" onBack={noop} presenting={false} onTogglePresenter={noop} />);
 
     // Eyebrow = date · vehicle · dimension.
     expect(screen.getByText(/1957-10-04 · R-7 \/ Sputnik 8K71PS \(USSR\) · Mission achievement/)).toBeInTheDocument();
-    // Title is the launch name (the leading word is isolated for the accent color; textContent is intact).
+    // Title is the launch name.
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Sputnik 1");
     // Body is the event caption.
     expect(screen.getByText(/Orbit access itself is the achievement/)).toBeInTheDocument();
@@ -30,28 +32,38 @@ describe("LaunchEventHero", () => {
     expect(screen.getByText("92 days")).toBeInTheDocument();
     expect(screen.getByText("World launches that year")).toBeInTheDocument();
 
-    // The four explanation cards.
-    expect(screen.getByText("What changed · bottleneck solved")).toBeInTheDocument();
+    // The three compact fact cards (the generic "what this demo shows next" card was folded into the
+    // slim forward line below to tighten the hero).
+    expect(screen.getByText("Bottleneck solved")).toBeInTheDocument();
     expect(screen.getByText("Reaching orbit at all")).toBeInTheDocument();
-    expect(screen.getByText("What got harder · operational question")).toBeInTheDocument();
+    expect(screen.getByText("What got harder")).toBeInTheDocument();
     expect(screen.getByText("Doing anything useful once there")).toBeInTheDocument();
-    expect(screen.getByText("New data that had to be trusted")).toBeInTheDocument();
+    expect(screen.getByText("New data to trust")).toBeInTheDocument();
     expect(screen.getByText("Doppler tracking as the first orbital data pipeline")).toBeInTheDocument();
-    expect(screen.getByText("What this demo shows next")).toBeInTheDocument();
 
-    // Forward framing + CTA to the page that proves the pattern next.
-    expect(screen.getByText(/Once you have a signal, what do you do with it\?/)).toBeInTheDocument();
+    // Slim forward line + CTA to the page that proves the pattern next.
+    expect(screen.getByText(/Proves the pattern next/i)).toBeInTheDocument();
     expect(screen.getByText(/Mission Control/).closest("a")).toHaveAttribute("href", "/lab/env/env-test/telemetry/stream");
+
+    // Icon-only Play control in the header (no "Play the story" text).
+    expect(screen.getByRole("button", { name: "Play story" })).toBeInTheDocument();
+    expect(screen.queryByText(/Play the story/i)).toBeNull();
+  });
+
+  it("shows the Stop control while presenting", () => {
+    render(<LaunchEventHero event={event} envId="env-test" onBack={noop} presenting onTogglePresenter={noop} />);
+    expect(screen.getByRole("button", { name: "Stop story" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Play story" })).not.toBeInTheDocument();
   });
 
   it("fails closed on the downstream CTA when envId is absent", () => {
-    render(<LaunchEventHero event={event} envId="" onBack={() => {}} />);
+    render(<LaunchEventHero event={event} envId="" onBack={noop} presenting={false} onTogglePresenter={noop} />);
     expect(screen.getByText(/downstream link unavailable/i)).toBeInTheDocument();
   });
 
   it("fires onBack from the Back to overview action", () => {
     const onBack = vi.fn();
-    render(<LaunchEventHero event={event} envId="env-test" onBack={onBack} />);
+    render(<LaunchEventHero event={event} envId="env-test" onBack={onBack} presenting={false} onTogglePresenter={noop} />);
     fireEvent.click(screen.getByRole("button", { name: "Back to overview" }));
     expect(onBack).toHaveBeenCalledTimes(1);
   });

--- a/repo-b/src/components/telemetry/LaunchEventHero.tsx
+++ b/repo-b/src/components/telemetry/LaunchEventHero.tsx
@@ -1,34 +1,34 @@
 "use client";
 
 // Selected-node hero for the Overview page. When a Bottleneck Map node is selected (by click or by the
-// "Play the story" walkthrough), the page hero ADAPTS to that launch event instead of staying on the
-// generic thesis. The map becomes the selector; this hero is the single explanation surface — so the
-// lower per-node panel (the old EventRecord) is gone and nothing is duplicated below the map.
+// guided walkthrough), the page hero ADAPTS to that launch event instead of staying on the generic
+// thesis. The map becomes the selector; this hero is the single explanation surface — so the lower
+// per-node panel (the old EventRecord) is gone and nothing is duplicated below the map.
 //
 // State invariant (owned by TelemetryOverview): the hero renders whenever `selectedEvent !== null`. This
 // component never decides the mode; it just renders a resolved DecoratedEvent. Every value is read off
-// the typed event + EVENT_NARRATIVE — nothing is invented here.
+// the typed event + EVENT_NARRATIVE — nothing is invented here. Kept compact so it fits the first
+// viewport: one headline (caption), the node's KPIs, three fact cards, one slim forward line.
 
 import type { CSSProperties, ReactNode } from "react";
 import Link from "next/link";
 
 import { C, StatGrid, TelemetryActionButton } from "./primitives";
 import { TelemetryPageHeader } from "./TelemetryPageHeader";
-import { RS, RS_MONO, RS_SANS } from "./rsTokens";
+import PresenterToggleButton from "./PresenterToggleButton";
+import { RS, RS_MONO } from "./rsTokens";
 import { telemetryHref } from "./telemetryNav";
 import { EVENT_NARRATIVE } from "./context/BottleneckMap/data";
 import type { DecoratedEvent } from "./context/BottleneckMap/types";
 
-// Generic, event-independent forward framing (same for every node) — the demo's through-line, not a
-// per-event fact, so it lives as a constant rather than in the event data.
-const DEMO_NEXT_QUESTION = "Can build, test & quality evidence connect fast enough to improve the next decision?";
-const DEMO_NEXT_CHAIN = "Stargate Live → Resume Evidence → Replay → Trust & Lineage";
+// The demo's through-line (same for every node) — a constant, not a per-event fact.
+const DEMO_NEXT_CHAIN = "Stargate → Evidence → Replay → Trust";
 
 function HeroKpi({ label, value }: { label: string; value: string }) {
   return (
-    <div style={{ background: RS.panelAlt, border: `1px solid ${RS.line}`, borderRadius: 8, padding: "11px 13px" }}>
+    <div style={{ background: RS.panelAlt, border: `1px solid ${RS.line}`, borderRadius: 8, padding: "9px 11px" }}>
       <div style={{ fontFamily: RS_MONO, fontSize: 9.5, color: RS.faint, letterSpacing: 1, textTransform: "uppercase" }}>{label}</div>
-      <div style={{ fontFamily: RS_MONO, fontSize: 14, color: RS.text, marginTop: 5, lineHeight: 1.35 }}>{value}</div>
+      <div style={{ fontFamily: RS_MONO, fontSize: 13.5, color: RS.text, marginTop: 4, lineHeight: 1.3 }}>{value}</div>
     </div>
   );
 }
@@ -37,23 +37,26 @@ function RecordCell({ heading, color, children, style }: {
   heading: string; color: string; children: ReactNode; style?: CSSProperties;
 }) {
   return (
-    <div style={{ background: RS.panelAlt, border: `1px solid ${RS.line}`, borderRadius: 6, padding: "11px 13px", ...style }}>
+    <div style={{ background: RS.panelAlt, border: `1px solid ${RS.line}`, borderRadius: 6, padding: "9px 11px", ...style }}>
       <div style={{ fontFamily: RS_MONO, fontSize: 9, color, letterSpacing: 1, textTransform: "uppercase" }}>{heading}</div>
-      <div style={{ fontSize: 12.5, marginTop: 4, color: RS.text, lineHeight: 1.5 }}>{children}</div>
+      <div style={{ fontSize: 12, marginTop: 4, color: RS.text, lineHeight: 1.45 }}>{children}</div>
     </div>
   );
 }
 
-export default function LaunchEventHero({ event, envId, onBack }: {
+export default function LaunchEventHero({ event, envId, onBack, presenting, onTogglePresenter }: {
   event: DecoratedEvent;
   envId: string;
   onBack: () => void;
+  presenting: boolean;
+  onTogglePresenter: () => void;
 }) {
   const narrative = EVENT_NARRATIVE[event.id];
   return (
     <div>
       {/* Adaptive header: eyebrow (date · vehicle · dimension), the launch name as the hero title in the
-          era color, the event caption as the body, and a Back-to-overview affordance in the actions slot. */}
+          era color, the event caption as the one-line body, and the icon-only Play/Stop + Back affordances
+          in the actions slot. */}
       <TelemetryPageHeader
         variant="hero"
         accent={event.color}
@@ -61,13 +64,16 @@ export default function LaunchEventHero({ event, envId, onBack }: {
         title={event.name}
         description={event.caption}
         actions={
-          <TelemetryActionButton variant="secondary" onClick={onBack} aria-label="Back to overview">
-            ← Back to overview
-          </TelemetryActionButton>
+          <>
+            <PresenterToggleButton presenting={presenting} onToggle={onTogglePresenter} />
+            <TelemetryActionButton variant="secondary" onClick={onBack} aria-label="Back to overview">
+              ← Back to overview
+            </TelemetryActionButton>
+          </>
         }
       />
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 14, marginTop: -8, marginBottom: 28 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 12, marginTop: -8, marginBottom: 18 }}>
         {/* KPI cards — the node's own metrics replace the historical Big Numbers row. */}
         <StatGrid cols={4}>
           {event.metrics.map(([label, value]) => (
@@ -75,48 +81,35 @@ export default function LaunchEventHero({ event, envId, onBack }: {
           ))}
         </StatGrid>
 
-        {/* The four explanation cards (moved up from the old EventRecord). */}
-        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-          <RecordCell heading="What changed · bottleneck solved" color={RS.green}>{event.bottleneckSolved}</RecordCell>
-          <RecordCell heading="What got harder · operational question" color={RS.amber}>{event.bottleneckCreated}</RecordCell>
-          <RecordCell heading="New data that had to be trusted" color={RS.blue}>{event.dataProduct}</RecordCell>
-          <RecordCell heading="What this demo shows next" color={RS.violet}
-            style={{ background: `${RS.violet}10`, border: `1px solid ${RS.violet}30` }}>
-            {DEMO_NEXT_QUESTION}{" "}
-            <span style={{ fontFamily: RS_MONO, fontSize: 11, color: RS.dim }}>{DEMO_NEXT_CHAIN}</span>
-          </RecordCell>
+        {/* Three fact cards: what the era solved, what got harder, and the new data that had to be
+            trusted. Compact 3-up on desktop. */}
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+          <RecordCell heading="Bottleneck solved" color={RS.green}>{event.bottleneckSolved}</RecordCell>
+          <RecordCell heading="What got harder" color={RS.amber}>{event.bottleneckCreated}</RecordCell>
+          <RecordCell heading="New data to trust" color={RS.blue}>{event.dataProduct}</RecordCell>
         </div>
 
-        {/* Forward framing: the operational question this era created + the page that proves the pattern
-            next (the optional CTA, e.g. "Mission Control →"). Fails closed when envId is unavailable. */}
+        {/* One slim forward line: the page that proves the pattern next + the demo through-line. Fails
+            closed when envId/narrative is unavailable. */}
         <div style={{
+          display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap",
           border: `1px solid ${event.color}33`, borderLeft: `2px solid ${event.color}`,
-          borderRadius: 9, background: `${event.color}0a`, padding: "12px 15px",
-          display: "grid", gridTemplateColumns: "minmax(220px, 2fr) minmax(180px, 1fr)", gap: "11px 22px", alignItems: "start",
+          borderRadius: 8, background: `${event.color}0a`, padding: "8px 13px",
         }}>
-          <div>
-            <div style={{ fontFamily: RS_MONO, fontSize: 8.5, letterSpacing: 0.6, textTransform: "uppercase", color: RS.faint, marginBottom: 4 }}>
-              Question that got harder
-            </div>
-            <div style={{ fontFamily: RS_SANS, fontSize: 12.5, color: RS.text, lineHeight: 1.45 }}>
-              {narrative?.harderQuestion ?? "—"}
-            </div>
-          </div>
-          <div>
-            <div style={{ fontFamily: RS_MONO, fontSize: 8.5, letterSpacing: 0.6, textTransform: "uppercase", color: RS.faint, marginBottom: 6 }}>
-              Proves the pattern next
-            </div>
-            {narrative && envId ? (
-              <Link href={telemetryHref(envId, narrative.provesNextSlug)}
-                style={{ display: "inline-flex", alignItems: "center", gap: 6, textDecoration: "none",
-                  fontFamily: RS_MONO, fontSize: 11.5, color: C.cyan, border: `1px solid ${C.cyan}55`,
-                  background: `${C.cyan}12`, borderRadius: 6, padding: "5px 11px" }}>
-                {narrative.provesNextLabel} →
-              </Link>
-            ) : (
-              <span style={{ fontFamily: RS_MONO, fontSize: 10.5, color: RS.faint }}>downstream link unavailable</span>
-            )}
-          </div>
+          <span style={{ fontFamily: RS_MONO, fontSize: 9, letterSpacing: 0.6, textTransform: "uppercase", color: RS.faint }}>
+            Proves the pattern next
+          </span>
+          {narrative && envId ? (
+            <Link href={telemetryHref(envId, narrative.provesNextSlug)}
+              style={{ display: "inline-flex", alignItems: "center", gap: 6, textDecoration: "none",
+                fontFamily: RS_MONO, fontSize: 11.5, color: C.cyan, border: `1px solid ${C.cyan}55`,
+                background: `${C.cyan}12`, borderRadius: 6, padding: "4px 10px" }}>
+              {narrative.provesNextLabel} →
+            </Link>
+          ) : (
+            <span style={{ fontFamily: RS_MONO, fontSize: 10.5, color: RS.faint }}>downstream link unavailable</span>
+          )}
+          <span style={{ marginLeft: "auto", fontFamily: RS_MONO, fontSize: 10, color: RS.dim }}>{DEMO_NEXT_CHAIN}</span>
         </div>
       </div>
     </div>

--- a/repo-b/src/components/telemetry/OverviewBackdrop.tsx
+++ b/repo-b/src/components/telemetry/OverviewBackdrop.tsx
@@ -60,6 +60,27 @@ export default function OverviewBackdrop({ event }: { event: DecoratedEvent | nu
       {/* scrim for readability + fade to background before the chart */}
       <div style={{ position: "absolute", inset: 0, background: SCRIM }} />
 
+      {/* Translucent fact marks — a few of the selected event's own metrics, stamped over the image as
+          faint mission annotations so the background participates in the story. They live in this
+          backdrop layer (zIndex 0), so the hero title/cards/CTA always paint over them — the marks only
+          show through the negative space, never covering foreground. Decorative echo of the KPI cards
+          (same values), so aria-hidden. Hidden on narrow widths; renders only as many as exist. */}
+      {event && event.metrics && event.metrics.length > 0 && (
+        <div className="hidden lg:flex" aria-hidden style={{
+          position: "absolute", top: 78, right: 24,
+          flexDirection: "column", gap: 12, alignItems: "flex-end", maxWidth: "42%", opacity: 0.6,
+        }}>
+          {event.metrics.slice(0, 3).map(([label, value]) => (
+            <div key={label} style={{ textAlign: "right", borderRight: `2px solid ${event.color}66`, paddingRight: 9 }}>
+              <div style={{ fontFamily: C.mono, fontSize: 16, color: event.color, lineHeight: 1.05,
+                textShadow: "0 1px 10px rgba(0,0,0,0.7)" }}>{value}</div>
+              <div style={{ fontFamily: C.mono, fontSize: 8.5, letterSpacing: "0.16em", textTransform: "uppercase",
+                color: C.faint, marginTop: 3 }}>{label}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
       {/* honesty label — illustrative atmosphere, never evidence. Curated era photos show their
           credit/license; generative motifs say so. */}
       {bd && (

--- a/repo-b/src/components/telemetry/PresenterToggleButton.tsx
+++ b/repo-b/src/components/telemetry/PresenterToggleButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+// Icon-only Play/Stop control for the guided Bottleneck Map walkthrough, rendered in the Overview hero
+// header action area. No visible text — the accessible name lives on aria-label ("Play story" /
+// "Stop story"). The map owns the step index; this just toggles it via the parent's signal.
+import { RS } from "./rsTokens";
+
+export default function PresenterToggleButton({ presenting, onToggle }: {
+  presenting: boolean;
+  onToggle: () => void;
+}) {
+  const color = presenting ? RS.red : RS.green;
+  return (
+    <button type="button" onClick={onToggle} aria-pressed={presenting}
+      aria-label={presenting ? "Stop story" : "Play story"}
+      title={presenting ? "Stop story" : "Play story"}
+      style={{ width: 36, height: 36, display: "inline-flex", alignItems: "center", justifyContent: "center",
+        borderRadius: 999, cursor: "pointer", background: `${color}1f`, border: `1px solid ${color}`, color }}>
+      <span aria-hidden style={{ fontSize: 11, lineHeight: 1 }}>{presenting ? "■" : "▶"}</span>
+    </button>
+  );
+}

--- a/repo-b/src/components/telemetry/TelemetryOverview.presenter.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.presenter.test.tsx
@@ -27,7 +27,7 @@ describe("TelemetryOverview — walkthrough drives the hero", () => {
     render(<TelemetryOverview />);
 
     // Play → the hero becomes the first chronological event and the Big Numbers row is replaced.
-    fireEvent.click(screen.getByRole("button", { name: "Play guided walkthrough" }));
+    fireEvent.click(screen.getByRole("button", { name: "Play story" }));
     expect(screen.getByRole("heading", { name: EVENTS_CHRONO[0].name })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Why Launch Became A Data Problem" })).not.toBeInTheDocument();
     expect(screen.queryByText("Launch attempts")).not.toBeInTheDocument();
@@ -44,7 +44,7 @@ describe("TelemetryOverview — walkthrough drives the hero", () => {
 
   it("returns to overview when Back to overview is pressed mid-walkthrough", () => {
     render(<TelemetryOverview />);
-    fireEvent.click(screen.getByRole("button", { name: "Play guided walkthrough" }));
+    fireEvent.click(screen.getByRole("button", { name: "Play story" }));
     expect(screen.getByRole("heading", { name: EVENTS_CHRONO[0].name })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Back to overview" }));

--- a/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.test.tsx
@@ -6,9 +6,10 @@ import { vi } from "vitest";
 // event via onSelectedEventChange, so both the Overview→backdrop wiring (Phase 9B) and the new
 // selected-node hero are testable here. (The real presenter→hero path is covered in the .presenter test.)
 vi.mock("./context/BottleneckMap/BottleneckMap", () => ({
-  default: ({ onSelectedEventChange, onSelectNode }: {
+  default: ({ onSelectedEventChange, onSelectNode, onPresentingChange }: {
     onSelectedEventChange?: (e: unknown) => void;
     onSelectNode?: (id: string | null) => void;
+    onPresentingChange?: (p: boolean) => void;
   }) => {
     const sample = {
       id: "sputnik", name: "Sputnik 1", date: "1957-10-04",
@@ -26,6 +27,8 @@ vi.mock("./context/BottleneckMap/BottleneckMap", () => ({
         <button type="button" onClick={() => { onSelectNode?.("sputnik"); onSelectedEventChange?.(sample); }}>
           select mission event
         </button>
+        {/* mimic the real map reporting walkthrough state up so the hero can render Play vs Stop */}
+        <button type="button" onClick={() => onPresentingChange?.(true)}>mock start presenting</button>
       </div>
     );
   },
@@ -94,6 +97,18 @@ describe("TelemetryOverview — thesis-led Overview", () => {
     expect(screen.getByText(/illustrative/i)).toBeInTheDocument();
   });
 
+  it("shows an icon-only Play control in the hero (no 'Play the story' text) and swaps to Stop while presenting", () => {
+    render(<TelemetryOverview />);
+    // Not presenting: an icon-only Play control with an accessible label, no visible Play/Stop text.
+    expect(screen.getByRole("button", { name: "Play story" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Stop story" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Play the story/i)).not.toBeInTheDocument();
+    // Map reports the walkthrough started → the control flips to Stop.
+    fireEvent.click(screen.getByRole("button", { name: /mock start presenting/i }));
+    expect(screen.getByRole("button", { name: "Stop story" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Play story" })).not.toBeInTheDocument();
+  });
+
   it("does not render the serving KPI strip, the Trace-lineage CTA, or Mission Summary scaffolding", () => {
     render(<TelemetryOverview />);
     expect(screen.queryByText("Promoted models")).not.toBeInTheDocument();
@@ -116,7 +131,8 @@ describe("TelemetryOverview — thesis-led Overview", () => {
     // The hero now IS the node: title, caption, the node's KPIs, an explanation card, and the CTA.
     expect(screen.getByRole("heading", { name: "Sputnik 1" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Why Launch Became A Data Problem" })).not.toBeInTheDocument();
-    expect(screen.getByText("83.6 kg")).toBeInTheDocument();
+    // "83.6 kg" appears in the hero KPI card AND as a faint backdrop fact mark — assert ≥1.
+    expect(screen.getAllByText("83.6 kg").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Reaching orbit at all")).toBeInTheDocument();
     // The hero CTA anchor reads "Mission Control →" (the demo bridge link below reads "Mission Control").
     expect(screen.getByText("Mission Control →").closest("a")).toHaveAttribute("href", "/lab/env/env-test/telemetry/stream");

--- a/repo-b/src/components/telemetry/TelemetryOverview.tsx
+++ b/repo-b/src/components/telemetry/TelemetryOverview.tsx
@@ -18,6 +18,7 @@ import { telemetryHref } from "./telemetryNav";
 import BottleneckMap from "./context/BottleneckMap/BottleneckMap";
 import LaunchEventHero from "./LaunchEventHero";
 import OverviewBackdrop from "./OverviewBackdrop";
+import PresenterToggleButton from "./PresenterToggleButton";
 import { computeBigNumbers, type BigNumber, type BigNumberAccent } from "./context/BottleneckMap/data";
 import type { DecoratedEvent } from "./context/BottleneckMap/types";
 
@@ -123,6 +124,12 @@ export default function TelemetryOverview() {
   const [selectedEvent, setSelectedEvent] = useState<DecoratedEvent | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [resetSignal, setResetSignal] = useState(0);
+  // Presenter (guided walkthrough) is owned by the map; the hero header renders the icon-only Play/Stop.
+  //   - `presenting` (mirrored up via onPresentingChange) chooses the Play vs Stop icon.
+  //   - bumping `presenterToggleSignal` flips the walkthrough on/off in the map.
+  const [presenting, setPresenting] = useState(false);
+  const [presenterToggleSignal, setPresenterToggleSignal] = useState(0);
+  const togglePresenter = () => setPresenterToggleSignal((s) => s + 1);
 
   // Back to overview: clear the hero immediately (deterministic) and signal the map to stop presenter +
   // deselect, so it cannot re-emit a presenter event back into the hero.
@@ -135,7 +142,8 @@ export default function TelemetryOverview() {
   // Two-mode hero. Overview: the thesis states the argument once (Big Numbers render below as larger
   // anchors). Selected: the hero ADAPTS to the chosen launch event (the map is the selector).
   const heading = selectedEvent ? (
-    <LaunchEventHero event={selectedEvent} envId={envId} onBack={handleBack} />
+    <LaunchEventHero event={selectedEvent} envId={envId} onBack={handleBack}
+      presenting={presenting} onTogglePresenter={togglePresenter} />
   ) : (
     <TelemetryPageHeader
       variant="hero"
@@ -148,6 +156,7 @@ export default function TelemetryOverview() {
         { text: " Problem" },
       ]}
       description="Spaceflight moves by breaking what holds it back. First, reaching orbit. Then lowering the cost. Then flying again. Then building at scale. Now the hard part is speed of judgment: reading the telemetry, trusting the model, tracing the source, and acting before delay becomes risk."
+      actions={<PresenterToggleButton presenting={presenting} onToggle={togglePresenter} />}
     />
   );
 
@@ -161,7 +170,8 @@ export default function TelemetryOverview() {
               hero, so this row is replaced rather than duplicated. */}
           {!selectedEvent && <BigNumbersBand onDrill={setDrillNum} />}
           <BottleneckMap envId={envId} onSelectedEventChange={setSelectedEvent}
-            selectedId={selectedId} onSelectNode={setSelectedId} resetSignal={resetSignal} />
+            selectedId={selectedId} onSelectNode={setSelectedId} resetSignal={resetSignal}
+            onPresentingChange={setPresenting} presenterToggleSignal={presenterToggleSignal} />
           <SourceHonestyStrip />
           {envId && <DemoBridge envId={envId} />}
           <MetricInspectorDrawer

--- a/repo-b/src/components/telemetry/TelemetryShell.test.tsx
+++ b/repo-b/src/components/telemetry/TelemetryShell.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ envId: "env-1" }),
+  usePathname: () => "/lab/env/env-1/telemetry",
+}));
+
+import TelemetryShell from "./TelemetryShell";
+
+describe("TelemetryShell chrome", () => {
+  it("drops the 'serving · prod' status + the visible 'Collapse' word, keeping an icon-only collapse control", () => {
+    render(<TelemetryShell envId="env-1">content</TelemetryShell>);
+    expect(screen.queryByText(/serving/i)).toBeNull();
+    expect(screen.queryByText(/reviewer access/i)).toBeNull();
+    expect(screen.queryByText(/^Collapse$/)).toBeNull();
+    // The collapse affordance remains, icon-only, with its accessible name on aria-label.
+    expect(screen.getByRole("button", { name: "Collapse sidebar" })).toBeInTheDocument();
+  });
+});

--- a/repo-b/src/components/telemetry/TelemetryShell.tsx
+++ b/repo-b/src/components/telemetry/TelemetryShell.tsx
@@ -71,22 +71,21 @@ export default function TelemetryShell({ envId, children }: { envId: string; chi
           onNavigate={() => setDrawerOpen(false)}
           onExpandRequest={() => setCollapsed(false)} />
       </div>
-      <div style={{ paddingTop: 18, borderTop: `1px solid ${C.border}` }}>
-        <div style={{ display: "flex", justifyContent: railCollapsed ? "center" : "flex-start", marginBottom: 14 }} title="serving · prod">
-          <span style={{ width: 8, height: 8, borderRadius: 999, background: C.green, boxShadow: `0 0 8px ${C.green}` }} />
-        </div>
-        {showToggle && (
+      {/* Footer = the icon-only collapse toggle, docked at the bottom. No "serving · prod" status dot
+          or "Collapse" label (both removed — they nudged the toggle below the fold); the accessible
+          name lives on aria-label. Only rendered for the desktop rail (the mobile drawer needs none). */}
+      {showToggle && (
+        <div style={{ paddingTop: 18, borderTop: `1px solid ${C.border}` }}>
           <button type="button" onClick={toggleCollapsed}
             aria-label={railCollapsed ? "Expand sidebar" : "Collapse sidebar"} aria-pressed={railCollapsed}
-            style={{ marginTop: 14, width: railCollapsed ? 40 : "100%", marginLeft: railCollapsed ? "auto" : 0,
+            style={{ width: railCollapsed ? 40 : "100%", marginLeft: railCollapsed ? "auto" : 0,
               marginRight: railCollapsed ? "auto" : 0, display: "flex", alignItems: "center",
-              justifyContent: "center", gap: 8, height: 36, borderRadius: 8, cursor: "pointer",
-              background: "transparent", border: `1px solid ${C.border}`, color: C.dim, fontFamily: C.mono, fontSize: 12 }}>
+              justifyContent: "center", height: 36, borderRadius: 8, cursor: "pointer",
+              background: "transparent", border: `1px solid ${C.border}`, color: C.dim }}>
             <span aria-hidden style={{ fontSize: 14, lineHeight: 1 }}>{railCollapsed ? "›" : "‹"}</span>
-            {!railCollapsed && <span>Collapse</span>}
           </button>
-        )}
-      </div>
+        </div>
+      )}
     </aside>
   );
 

--- a/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.controlled.test.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.controlled.test.tsx
@@ -32,14 +32,14 @@ describe("BottleneckMap — controlled selection", () => {
     expect(onSelectNode).toHaveBeenCalledWith("sputnik");
   });
 
-  it("surfaces the resolved event and shows the orientation strip for a controlled selection", () => {
+  it("surfaces the resolved event up on a controlled selection (no in-map orientation strip)", () => {
     const onSelectedEventChange = vi.fn();
     const onSelectNode = vi.fn();
     const { rerender } = render(<BottleneckMap envId="env-x" selectedId={null} onSelectNode={onSelectNode} onSelectedEventChange={onSelectedEventChange} />);
     rerender(<BottleneckMap envId="env-x" selectedId="sputnik" onSelectNode={onSelectNode} onSelectedEventChange={onSelectedEventChange} />);
     expect(onSelectedEventChange).toHaveBeenLastCalledWith(expect.objectContaining({ id: "sputnik", name: "Sputnik 1" }));
-    expect(screen.getByText(/Selected:/)).toBeInTheDocument();
-    expect(screen.getByText("Sputnik 1")).toBeInTheDocument();
+    // The selected-node story moved to the page hero — the map renders no in-chart orientation strip.
+    expect(screen.queryByText(/Selected:/)).not.toBeInTheDocument();
   });
 
   it("toggles off when the selected node is clicked again", () => {

--- a/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.test.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.test.tsx
@@ -37,26 +37,26 @@ describe("BottleneckMap rendering", () => {
     expect(screen.getByText(/makes no\s+domain-expertise claims/)).toBeInTheDocument();
   });
 
-  it("shows a non-narrative orientation strip for the default-pinned node (standalone mode)", () => {
-    // Standalone (uncontrolled) the module keeps its terran1 pin; the full story now lives in the page
-    // hero, so the map only carries a compact "Selected: …" reminder, not the explanation cards.
+  it("no longer renders an orientation strip or EventRecord cells — the node story lives in the page hero", () => {
+    // The Play/Stop control and the selected-node story moved to the page hero; standalone the map keeps
+    // its terran1 pin (a ring on the chart) but renders no "Selected: …" strip or explanation cards.
     render(<BottleneckMap />);
-    expect(screen.getByText(/Selected:/)).toBeInTheDocument();
-    expect(screen.getByText("Terran 1: Good Luck, Have Fun")).toBeInTheDocument();
-    // The old EventRecord relay cells are gone from the map.
+    expect(screen.queryByText(/Selected:/)).not.toBeInTheDocument();
     expect(screen.queryByText("What changed · bottleneck solved")).not.toBeInTheDocument();
+    expect(screen.getByText(/makes no\s+domain-expertise claims/)).toBeInTheDocument();
   });
 
-  it("enters presenter mode from the button, steps with the on-screen controls, exits on Escape", () => {
+  it("enters presenter mode (keyboard P), steps with the on-screen controls, exits on Escape", () => {
+    // The Play/Stop button now lives in the page hero (TelemetryOverview); the map's keyboard P still
+    // starts the walkthrough, and the PresenterBanner carries the on-screen step controls.
     render(<BottleneckMap />);
-    fireEvent.click(screen.getByRole("button", { name: "Play guided walkthrough" }));
+    fireEvent.keyDown(window, { key: "p" });
     expect(screen.getByText(/1 \/ 16/)).toBeInTheDocument();
     expect(screen.getByText(EVENTS_CHRONO[0].caption)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Next step" }));
     expect(screen.getByText(/2 \/ 16/)).toBeInTheDocument();
     fireEvent.keyDown(window, { key: "Escape" });
     expect(screen.queryByText(/2 \/ 16/)).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Play guided walkthrough" })).toBeInTheDocument();
   });
 
   it("enters presenter mode on P but not while focus is in a form field", () => {

--- a/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/BottleneckMap.tsx
@@ -35,7 +35,8 @@ function decorate(e: LaunchEvent, colorBy: ColorByKey, sizeMode: SizeModeKey): D
 }
 
 export default function BottleneckMap(
-  { envId, onSelectedEventChange, selectedId: selectedIdProp, onSelectNode, resetSignal }: {
+  { envId, onSelectedEventChange, selectedId: selectedIdProp, onSelectNode, resetSignal,
+    onPresentingChange, presenterToggleSignal }: {
     envId?: string;
     /** Phase 9B: surface the selected/presented event so the Overview can drive its hero backdrop. */
     onSelectedEventChange?: (e: DecoratedEvent | null) => void;
@@ -45,6 +46,10 @@ export default function BottleneckMap(
     onSelectNode?: (id: string | null) => void;
     /** Bump this from the parent to fully reset — stops the walkthrough AND clears the selection. */
     resetSignal?: number;
+    /** Emits whether the guided walkthrough is running, so the parent can render Play vs Stop. */
+    onPresentingChange?: (presenting: boolean) => void;
+    /** Bump from the parent to toggle the walkthrough on/off (the map owns the step index). */
+    presenterToggleSignal?: number;
   } = {},
 ) {
   // Hybrid controlled/uncontrolled: when the parent passes `onSelectNode` the page owns selection (and may
@@ -55,7 +60,6 @@ export default function BottleneckMap(
   const [chipFilter, setChipFilter] = useState<string | null>(null);
   const [sizeMode, setSizeMode] = useState<SizeModeKey>("scale");
   const [colorBy, setColorBy] = useState<ColorByKey>("type");
-  const [hoveredYear, setHoveredYear] = useState<number | null>(null);
   const [presenterIdx, setPresenterIdx] = useState<number | null>(null);
 
   const setSelected = useCallback((id: string | null) => {
@@ -82,6 +86,20 @@ export default function BottleneckMap(
   }, [resetSignal, clearAll]);
 
   const presenting = presenterIdx !== null;
+
+  // Lifted presenter control. The map owns the step index; the parent renders the icon-only Play/Stop in
+  // the hero header and drives it through two thin channels (mirrors the resetSignal pattern):
+  //   - onPresentingChange tells the parent which icon to show.
+  //   - presenterToggleSignal (a bumped counter) flips the walkthrough on/off here.
+  useEffect(() => { onPresentingChange?.(presenting); }, [presenting, onPresentingChange]);
+  const prevToggleSignal = useRef(presenterToggleSignal);
+  useEffect(() => {
+    if (presenterToggleSignal !== prevToggleSignal.current) {
+      prevToggleSignal.current = presenterToggleSignal;
+      setPresenterIdx((i) => (i === null ? 0 : null));
+    }
+  }, [presenterToggleSignal]);
+
   const presenterEvent = presenterIdx !== null ? EVENTS_CHRONO[presenterIdx] : null;
   const presenterYear = presenterEvent ? presenterEvent.year : Infinity;
   const revealedIds = useMemo<ReadonlySet<string>>(
@@ -131,7 +149,6 @@ export default function BottleneckMap(
     return () => window.removeEventListener("keydown", onKey);
   }, [presenting, selectedId, setSelected]);
 
-  const onHoverYear = useCallback((y: number | null) => setHoveredYear(y), []);
   // Clicking the already-selected node toggles back to overview.
   const onSelect = useCallback((id: string) => setSelected(selectedId === id ? null : id), [selectedId, setSelected]);
 
@@ -139,26 +156,8 @@ export default function BottleneckMap(
 
   return (
     <div style={{ fontFamily: RS_SANS, color: RS.text, background: "#000", borderRadius: 10, padding: "12px 14px" }}>
-      {/* Play / Stop — a guided story walkthrough that steps through the eras (orbit proof → lower cost →
-          reuse → manufacturing scale → telemetry/data operations → continue to Stargate/Evidence). The
-          thesis itself lives once in the page header above. */}
-      <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 4 }}>
-        <button type="button" className={styles.control}
-          aria-label={presenting ? "Stop walkthrough" : "Play guided walkthrough"}
-          aria-pressed={presenting}
-          onClick={() => setPresenterIdx(presenting ? null : 0)}
-          style={{
-            display: "inline-flex", alignItems: "center", gap: 8,
-            background: presenting ? `${RS.red}22` : `${RS.green}1f`,
-            border: `1px solid ${presenting ? RS.red : RS.green}`,
-            color: presenting ? RS.red : RS.green,
-            borderRadius: 999, padding: "8px 18px", cursor: "pointer",
-            fontFamily: RS_MONO, fontSize: 11.5, letterSpacing: 0.6, whiteSpace: "nowrap",
-          }}>
-          <span aria-hidden style={{ fontSize: 10, lineHeight: 1 }}>{presenting ? "■" : "▶"}</span>
-          {presenting ? "Stop (Esc)" : "Play the story"}
-        </button>
-      </div>
+      {/* Play/Stop now lives as an icon-only control in the page hero header (lifted to TelemetryOverview);
+          the map just owns the step index. Keyboard P/←/→/Esc still drive the walkthrough. */}
 
       {/* presenter banner */}
       {presenting && presenterEvent && presenterIdx !== null && (
@@ -227,32 +226,14 @@ export default function BottleneckMap(
       <div style={{ marginTop: 12 }}>
         <MapPanel events={mapEvents} selectedId={selected?.id ?? null}
           presenting={presenting} revealedIds={revealedIds} presenterYear={presenterYear}
-          timeWindow={null} hoveredYear={hoveredYear}
+          timeWindow={null}
           sizeModeLabel={SIZE_MODES.find((m) => m.key === sizeMode)?.label ?? ""}
           focused dimmed={false}
-          onHoverYear={onHoverYear} onSelect={onSelect} />
+          onSelect={onSelect} />
       </div>
 
-      {/* Orientation strip near the chart. The full node story now lives in the page hero above; this is
-          a non-narrative reminder of what is selected plus a quick way back. Suppressed during the
-          walkthrough, where the PresenterBanner already carries the near-map context. */}
-      {selected && !presenting && (
-        <div style={{
-          marginTop: 12, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap",
-          border: `1px solid ${selected.color}33`, borderLeft: `2px solid ${selected.color}`,
-          borderRadius: 8, background: `${selected.color}0a`, padding: "8px 13px",
-        }}>
-          <span style={{ fontFamily: RS_MONO, fontSize: 11, color: RS.dim }}>
-            <span style={{ color: RS.faint }}>Selected: </span>
-            <span style={{ color: RS.text }}>{selected.name}</span> · {selected.dimLabel}
-          </span>
-          <button type="button" className={styles.control} onClick={clearAll}
-            style={{ fontFamily: RS_MONO, fontSize: 10.5, color: RS.dim, background: "transparent",
-              border: `1px solid ${RS.line}`, borderRadius: 6, padding: "4px 10px", cursor: "pointer", whiteSpace: "nowrap" }}>
-            Back to overview
-          </button>
-        </div>
-      )}
+      {/* The selected node's full story + "Back to overview" live in the page hero above; no duplicate
+          orientation strip here. */}
 
       {/* methodology footer (verbatim; the module makes no domain-expertise claims) */}
       <div style={{ marginTop: 12, fontFamily: RS_MONO, fontSize: 9.5, color: RS.faint, lineHeight: 1.6 }}>

--- a/repo-b/src/components/telemetry/context/BottleneckMap/MapPanel.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/MapPanel.tsx
@@ -2,23 +2,21 @@
 
 // Panel 1: the Bottleneck Map. Bubbles are milestone events on capability bands; bars are world
 // orbital launch attempts per year. Bubble opacity transitions give presenter mode its motion.
-import React from "react";
+import React, { useState } from "react";
 import {
-  Area, Bar, CartesianGrid, Cell, ComposedChart, ReferenceLine, ResponsiveContainer, Scatter, Tooltip,
+  Area, Bar, CartesianGrid, Cell, ComposedChart, ReferenceLine, ResponsiveContainer, Scatter,
   XAxis, YAxis,
 } from "recharts";
-import type { ScatterProps, TooltipProps } from "recharts";
+import type { ScatterProps } from "recharts";
 
 import { RS, RS_MONO } from "../../rsTokens";
 import styles from "./BottleneckMap.module.css";
-import { BANDS, YEAR_SERIES } from "./data";
-import PanelShell, { yearFromChartState } from "./PanelShell";
+import { BANDS, YEAR_SERIES, eventYearStats } from "./data";
+import PanelShell from "./PanelShell";
 import type { DecoratedEvent, TimeWindow } from "./types";
 
 // TODO(P1 backlog): connecting arc between the Terran 1 and Terran R bubbles (pathfinder-to-scale
 // lineage), drawn on selection of either.
-// TODO(P1 backlog): bottleneck relay highlighting; selecting an event highlights the event whose
-// solved bottleneck matches the selected event's created bottleneck.
 
 interface BubblePointProps {
   cx?: number;
@@ -36,27 +34,46 @@ const DATA_BURDEN_RAIL: { era: string; burden: string; color: string }[] = [
   { era: "Production", burden: "sensor streams, NCRs, model evidence, lineage, operator decisions", color: RS.violet },
 ];
 
-function MapTip({ active, payload }: TooltipProps<number, string>) {
-  if (!active || !payload || payload.length === 0) return null;
-  const d = payload.map((p) => p.payload as DecoratedEvent | undefined).find((p) => p?.id != null);
-  if (!d) return null;
+// Tooltip body for a hovered/selected milestone. Pure + exported so a unit test can assert the launch-
+// attempt and commercial/government rows render (and fail closed) without driving SVG hover. The
+// year-context row reads only from eventYearStats() — never fabricated; out-of-range years show
+// "Year context: not available".
+export function MapTipBody({ event }: { event: DecoratedEvent }) {
+  const stats = eventYearStats(event);
   return (
-    <div style={{ background: RS.panel, border: `1px solid ${d.color}40`, borderRadius: 6,
-      padding: "10px 12px", maxWidth: 280, boxShadow: "0 8px 24px rgba(0,0,0,0.5)" }}>
-      <div style={{ color: d.color, fontFamily: RS_MONO, fontSize: 10, letterSpacing: 1, textTransform: "uppercase" }}>
-        {d.date} · {d.dimLabel}
+    <div style={{ background: RS.panel, border: `1px solid ${event.color}55`, borderRadius: 7,
+      padding: "10px 12px", width: 250, boxShadow: "0 10px 28px rgba(0,0,0,0.55)" }}>
+      <div style={{ color: event.color, fontFamily: RS_MONO, fontSize: 10, letterSpacing: 1, textTransform: "uppercase" }}>
+        {event.date} · {event.dimLabel}
       </div>
-      <div style={{ color: RS.text, fontWeight: 600, fontSize: 13, marginTop: 4 }}>{d.name}</div>
-      <div style={{ color: RS.dim, fontSize: 11, marginTop: 4 }}>Solved: {d.bottleneckSolved}</div>
-      <div style={{ color: RS.faint, fontSize: 10, marginTop: 4, fontFamily: RS_MONO, textTransform: "uppercase", letterSpacing: 0.5 }}>{d.outcome}</div>
-      <div style={{ color: RS.faint, fontSize: 10, marginTop: 6, fontFamily: RS_MONO }}>Click to pin full record</div>
+      <div style={{ color: RS.text, fontWeight: 600, fontSize: 13, marginTop: 4 }}>{event.name}</div>
+      <div style={{ color: RS.dim, fontSize: 11, marginTop: 4, lineHeight: 1.4 }}>Solved: {event.bottleneckSolved}</div>
+      {stats ? (
+        <div style={{ marginTop: 7, fontFamily: RS_MONO, fontSize: 10.5, color: RS.dim, lineHeight: 1.5 }}>
+          <div><span style={{ color: RS.faint }}>World attempts {stats.year}: </span><span style={{ color: RS.text }}>{stats.attempts}</span></div>
+          <div>
+            <span style={{ color: RS.green }}>Commercial {Math.round(stats.commercialPct)}%</span>
+            <span style={{ color: RS.faint }}>  ·  </span>
+            <span style={{ color: RS.blue }}>Government {Math.round(stats.governmentPct)}%</span>
+          </div>
+        </div>
+      ) : (
+        <div style={{ marginTop: 7, fontFamily: RS_MONO, fontSize: 10, color: RS.faint }}>
+          Year context: not available
+        </div>
+      )}
+      <div style={{ color: RS.faint, fontSize: 9.5, marginTop: 7, fontFamily: RS_MONO, textTransform: "uppercase", letterSpacing: 0.5 }}>
+        {event.outcome} · click to pin
+      </div>
     </div>
   );
 }
 
+interface HoverState { event: DecoratedEvent; cx: number; cy: number; }
+
 export default function MapPanel({
-  events, selectedId, presenting, revealedIds, presenterYear, timeWindow, hoveredYear,
-  sizeModeLabel, focused, dimmed, onHoverYear, onSelect,
+  events, selectedId, presenting, revealedIds, presenterYear, timeWindow,
+  sizeModeLabel, focused, dimmed, onSelect,
 }: {
   events: DecoratedEvent[];
   selectedId: string | null;
@@ -64,19 +81,22 @@ export default function MapPanel({
   revealedIds: ReadonlySet<string>;
   presenterYear: number;
   timeWindow: TimeWindow | null;          // null when the full range is active
-  hoveredYear: number | null;
   sizeModeLabel: string;
   focused: boolean;
   dimmed: boolean;
-  onHoverYear: (year: number | null) => void;
   onSelect: (id: string) => void;
 }) {
+  // Bubble-driven hover: the milestone under the cursor owns the tooltip + the x-axis mark (replacing
+  // recharts' shared cross-series tooltip, whose active index could land the mark on a stale year).
+  const [hover, setHover] = useState<HoverState | null>(null);
+
   const renderBubble = (props: BubblePointProps): React.ReactElement => {
     const { cx, cy, payload } = props;
     if (cx == null || cy == null || !payload) return <g />;
     const r = Math.max(6, Math.sqrt(payload.sizeValue) * 2.4);
     const color = payload.color;
     const isSelected = selectedId === payload.id;
+    const isHovered = hover?.event.id === payload.id;
     const dash =
       payload.outcome === "partial" ? "4 3" :
       payload.outcome === "planned" ? "2 4" : "none";
@@ -92,17 +112,23 @@ export default function MapPanel({
       <g
         style={{ cursor: presenting ? "default" : "pointer", opacity, transition: "opacity 650ms ease" }}
         onClick={() => { if (!presenting) onSelect(payload.id); }}
+        onMouseEnter={() => { if (!presenting) setHover({ event: payload, cx, cy }); }}
+        onMouseLeave={() => { if (!presenting) setHover((h) => (h?.event.id === payload.id ? null : h)); }}
       >
+        {/* selected = persistent ring; hovered = temporary brighter ring (visually distinct) */}
         {isSelected && presenting && (
           <circle className={styles.pulse} cx={cx} cy={cy} r={r + 5} fill="none" stroke={color} strokeWidth={2} />
         )}
         {isSelected && !presenting && (
-          <circle cx={cx} cy={cy} r={r + 6} fill="none" stroke={color} strokeOpacity={0.35} strokeWidth={2} />
+          <circle cx={cx} cy={cy} r={r + 6} fill="none" stroke={color} strokeOpacity={0.4} strokeWidth={2} />
+        )}
+        {isHovered && !isSelected && (
+          <circle cx={cx} cy={cy} r={r + 4} fill="none" stroke={color} strokeOpacity={0.7} strokeWidth={1.5} />
         )}
         <circle
           cx={cx} cy={cy} r={r}
-          fill={color} fillOpacity={isSelected ? 0.45 : 0.22}
-          stroke={color} strokeWidth={isSelected ? 2 : 1.5}
+          fill={color} fillOpacity={isSelected ? 0.45 : isHovered ? 0.34 : 0.22}
+          stroke={color} strokeWidth={isSelected || isHovered ? 2 : 1.5}
           strokeDasharray={dash}
         />
         <circle cx={cx} cy={cy} r={2.5} fill={color} />
@@ -110,14 +136,21 @@ export default function MapPanel({
     );
   };
 
+  // The active milestone for the x-axis mark: hovered (temporary) or, if none, the pinned selection.
+  // Uses the event's own (fractional) year so the mark sits directly under its bubble.
+  const activeEvent = hover?.event ?? events.find((e) => e.id === selectedId) ?? null;
+  const markYear = activeEvent?.year ?? null;
+
+  // Place the tooltip above the bubble, flipping below when near the top edge so it never clips.
+  const tipBelow = hover != null && hover.cy < 150;
+
   return (
     <PanelShell title="Bottleneck Map: Hardware Limits → Data Limits" accent={RS.blue}
       sub="Each era solved one constraint and created a larger burden of telemetry, testing, manufacturing evidence, and operational interpretation · bubbles: milestones · bars: world orbital attempts/yr · green wave: commercial share of attempts (context)"
       focused={focused} dimmed={dimmed}>
-      <div className="h-[460px] lg:h-[560px]">
+      <div className="h-[460px] lg:h-[560px]" style={{ position: "relative" }}>
         <ResponsiveContainer width="100%" height="100%">
-          <ComposedChart data={YEAR_SERIES} margin={{ top: 12, right: 28, bottom: 4, left: 8 }}
-            onMouseMove={(s) => onHoverYear(yearFromChartState(s))} onMouseLeave={() => onHoverYear(null)}>
+          <ComposedChart data={YEAR_SERIES} margin={{ top: 12, right: 28, bottom: 4, left: 4 }}>
             <CartesianGrid stroke={RS.line} strokeDasharray="2 6" vertical={false} />
             <XAxis type="number" dataKey="year" domain={[1955, 2031]}
               ticks={[1957, 1969, 1981, 1998, 2010, 2015, 2023, 2026, 2030]}
@@ -125,26 +158,20 @@ export default function MapPanel({
               stroke={RS.line} tickLine={false} allowDataOverflow />
             <YAxis yAxisId="band" type="number" domain={[0.4, 5.6]} ticks={[1, 2, 3, 4, 5]}
               tickFormatter={(v: number) => BANDS.find((b) => b.y === v)?.label || ""}
-              tick={{ fill: RS.dim, fontSize: 10, fontFamily: RS_MONO }}
+              tick={{ fill: RS.text, fontSize: 12.5, fontFamily: RS_MONO }}
               width={210} stroke={RS.line} tickLine={false} />
             <YAxis yAxisId="cadence" orientation="right" type="number" domain={[0, 347]}
               ticks={[0, 165, 330]}
               tick={{ fill: RS.crosshair, fontSize: 9, fontFamily: RS_MONO }}
               width={34} stroke={RS.line} tickLine={false} />
-            {/* Commercial-share underlay axis: a TRUE 0-100% scale (0% bottom, 100% top). The observed
-                wave only reaches ~70%, so it naturally sits in the lower-to-mid chart on its own scale —
-                no rescaling to full height. The gutter axis stays hidden; faint labeled reference lines
-                at 0/50/100 (below) give the reading without crowding the band/cadence axes. */}
+            {/* Commercial-share underlay axis: a TRUE 0-100% scale (0% bottom, 100% top). */}
             <YAxis yAxisId="share" hide type="number" domain={[0, 100]} />
-            <Tooltip content={<MapTip />} cursor={false} />
-            {/* Commercial-share contextual underlay (rendered first = painted behind everything). The
-                rising wave is the story backdrop: cadence and commercialization climbed together, and the
-                data/interpretation burden climbed with them. Honest label in the sub + footnote. */}
+            {/* No shared recharts <Tooltip>: it computed an active index across the 70-row YEAR_SERIES
+                while the hovered bubble lives in the 16-row Scatter, dropping a stray "active dot" on a
+                stale year. Hover is now owned by the bubbles (below) — one accurate mark, one tooltip. */}
             <Area yAxisId="share" dataKey="commercialPct" stroke={RS.green} strokeWidth={1}
               strokeOpacity={0.32} fill={RS.green} fillOpacity={0.06} connectNulls
-              isAnimationActive={false} />
-            {/* Faint labeled true-scale gridlines for the share underlay (0/50/100%). Drawn after the
-                Area but before the bars/bubbles so the wave's own scale is readable yet subordinate. */}
+              isAnimationActive={false} activeDot={false} />
             {[0, 50, 100].map((pct) => (
               <ReferenceLine key={`share-${pct}`} yAxisId="share" y={pct} stroke={RS.green}
                 strokeOpacity={pct === 0 ? 0.1 : 0.16} strokeDasharray="2 7"
@@ -159,9 +186,11 @@ export default function MapPanel({
                   style={{ transition: "fill-opacity 650ms ease" }} />
               ))}
             </Bar>
-            {hoveredYear != null && (
-              <ReferenceLine yAxisId="band" x={hoveredYear} stroke={RS.crosshair}
-                strokeDasharray="2 4" strokeOpacity={0.8} />
+            {/* x-axis mark: snaps to the hovered (or, idle, the selected) milestone's year — so the mark
+                always corresponds to the bubble in focus, never a stale year. */}
+            {markYear != null && (
+              <ReferenceLine yAxisId="band" x={markYear} stroke={RS.crosshair}
+                strokeDasharray="2 4" strokeOpacity={0.85} />
             )}
             <ReferenceLine yAxisId="band" x={2023.22} stroke={RS.violet} strokeOpacity={0.25} strokeDasharray="3 5" />
             <Scatter yAxisId="band" data={events} dataKey="band"
@@ -169,10 +198,16 @@ export default function MapPanel({
               isAnimationActive={false} />
           </ComposedChart>
         </ResponsiveContainer>
+        {/* Custom hover tooltip, anchored to the hovered bubble's pixel position (so content + position
+            match exactly). Pointer-events off so it never steals the hover. */}
+        {hover && !presenting && (
+          <div style={{ position: "absolute", left: hover.cx, top: hover.cy, zIndex: 5, pointerEvents: "none",
+            transform: tipBelow ? "translate(-50%, 16px)" : "translate(-50%, calc(-100% - 16px))" }}>
+            <MapTipBody event={hover.event} />
+          </div>
+        )}
       </div>
-      {/* Data-burden rail: makes the hardware→data thesis explicit. Each era solved a constraint and
-          created a new evidence burden the modern data platform has to carry. Qualitative framing — no
-          fabricated telemetry-volume numbers. */}
+      {/* Data-burden rail: makes the hardware→data thesis explicit. */}
       <div style={{ padding: "2px 16px 6px" }}>
         <div style={{ fontFamily: RS_MONO, fontSize: 8.5, letterSpacing: 0.8, color: RS.faint,
           textTransform: "uppercase", marginBottom: 6 }}>

--- a/repo-b/src/components/telemetry/context/BottleneckMap/MapTipBody.test.tsx
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/MapTipBody.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MapTipBody } from "./MapPanel";
+import { EVENTS } from "./data";
+import type { DecoratedEvent } from "./types";
+
+// MapTipBody is the pure tooltip body for a hovered/selected milestone — unit-tested directly so the
+// launch-attempt + commercial/government rows (and their fail-closed behavior) are covered without
+// driving SVG hover.
+const decorate = (id: string): DecoratedEvent => {
+  const e = EVENTS.find((ev) => ev.id === id)!;
+  return { ...e, color: "#6CA8F0", dimLabel: "Mission achievement", sizeValue: e.scale };
+};
+
+describe("MapTipBody", () => {
+  it("renders launch attempts + commercial/government share when the event's year has data", () => {
+    render(<MapTipBody event={decorate("sputnik")} />);
+    expect(screen.getByText(/World attempts 1957/)).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText(/Commercial 0%/)).toBeInTheDocument();
+    expect(screen.getByText(/Government 100%/)).toBeInTheDocument();
+  });
+
+  it("fails closed with 'Year context: not available' when the year has no cadence data", () => {
+    render(<MapTipBody event={decorate("terranR")} />);
+    expect(screen.getByText(/Year context: not available/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Commercial/)).toBeNull();
+    expect(screen.queryByText(/Government/)).toBeNull();
+  });
+});

--- a/repo-b/src/components/telemetry/context/BottleneckMap/data.ts
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/data.ts
@@ -81,12 +81,13 @@ export function resolveBackdrop(e: LaunchEvent | null): EventBackdrop | null {
   return e.backdrop ?? NODE_BACKDROPS[e.id] ?? THEME_BACKDROPS[e.type] ?? null;
 }
 
+// Capability bands (y-axis). Kept concise so the larger y-axis labels read without clipping.
 export const BANDS: { y: number; label: string }[] = [
-  { y: 1, label: "Government proof of possibility" },
+  { y: 1, label: "Government proof of orbit" },
   { y: 2, label: "Operational spaceflight" },
   { y: 3, label: "Commercial launch" },
-  { y: 4, label: "Reusable fleet operations" },
-  { y: 5, label: "Autonomous, data-driven production" },
+  { y: 4, label: "Reusable fleet ops" },
+  { y: 5, label: "Autonomous production" },
 ];
 
 export const SIZE_MODES: { key: SizeModeKey; label: string; note: string }[] = [
@@ -168,6 +169,29 @@ for (let y = 1957; y <= 2026; y++) {
   });
 }
 export const FULL_WINDOW: TimeWindow = [1957, 2026];
+
+// World launch-attempt + commercial/government-share context for an event's calendar year, joined to
+// YEAR_SERIES. An event's fractional `year` encodes the month, so Math.floor() yields the calendar year
+// (2025.9 -> 2025). Fails closed (null) when that year has no cadence data — e.g. planned events in
+// 2026+ — so the tooltip never fabricates a share or attempt count. commercialPct is a true 0-100 share;
+// governmentPct is its complement (already precomputed in YEAR_SERIES).
+export interface EventYearStats {
+  year: number;
+  attempts: number;
+  commercialPct: number;
+  governmentPct: number;
+}
+export function eventYearStats(event: { year: number }): EventYearStats | null {
+  const y = Math.floor(event.year);
+  const row = YEAR_SERIES.find((p) => p.year === y);
+  if (!row || row.attempts == null || row.commercialPct == null) return null;
+  return {
+    year: y,
+    attempts: row.attempts,
+    commercialPct: row.commercialPct,
+    governmentPct: row.governmentPct ?? 100 - row.commercialPct,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Event data. Public, widely cited values; approximations marked.

--- a/repo-b/src/components/telemetry/context/BottleneckMap/eventYearStats.test.ts
+++ b/repo-b/src/components/telemetry/context/BottleneckMap/eventYearStats.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { EVENTS, eventYearStats } from "./data";
+
+const byId = (id: string) => EVENTS.find((e) => e.id === id)!;
+
+// The tooltip's launch-attempt + commercial/government rows read from this helper. It joins an event to
+// its calendar year (Math.floor of the fractional year) and fails closed where cadence data is absent —
+// it must never fabricate a share or attempt count.
+describe("eventYearStats", () => {
+  it("returns attempts + true commercial/government shares for years with cadence data", () => {
+    expect(eventYearStats(byId("sputnik"))).toEqual({ year: 1957, attempts: 3, commercialPct: 0, governmentPct: 100 });
+    expect(eventYearStats(byId("fleetscale"))).toEqual({ year: 2025, attempts: 330, commercialPct: 70, governmentPct: 30 });
+    const f9 = eventYearStats(byId("falcon9"));
+    expect(f9?.year).toBe(2010);                       // 2010.42 -> 2010 (floor, not round)
+    expect(f9?.attempts).toBe(74);
+    expect((f9?.commercialPct ?? 0) + (f9?.governmentPct ?? 0)).toBe(100);
+  });
+
+  it("fails closed (null) for years without cadence data — never fabricates", () => {
+    expect(eventYearStats(byId("terranR"))).toBeNull(); // 2026.75 -> 2026 (attempts null)
+    expect(eventYearStats(byId("artemis"))).toBeNull(); // 2028.4  -> 2028 (no row)
+  });
+});


### PR DESCRIPTION
Refines the selected-era Overview hero and the Bottleneck Map interaction. **Frontend-only** — no backend, schema, or launch-data methodology change.

### What changed
1. **Tighter hero** (`LaunchEventHero`) — caption headline + node KPIs + **three** compact fact cards + one slim "proves the pattern next" line (dropped the redundant 4th card and the bulky 2-col forward block). Fits the first viewport better.
2. **Icon-only Play/Stop in the hero header** — beside Back (and on the generic overview header). No visible "Play the story"/"Stop" text; accessible via `aria-label="Play story"/"Stop story"`. Presenter is lifted out of the map via `onPresentingChange` + a `presenterToggleSignal` counter (mirrors `resetSignal`); the in-map Play pill + duplicate orientation strip are gone. Keyboard P/←/→/Esc unchanged; Back/Escape still stop+clear.
3. **x-axis mark correspondence (the bug)** — the stray dot stuck on a stale year was recharts' shared cross-series `<Tooltip>` (70-row `YEAR_SERIES` vs the 16-row bubble `<Scatter>`). Removed the shared tooltip/`activeDot`; **the bubbles now own hover** — a custom tooltip and the x-axis mark snap to the bubble under the cursor. Selected = persistent ring; hovered = temporary emphasis.
4. **Enriched tooltip** — adds **Launch attempts** + **Commercial%/Government%** for the event's year via new `eventYearStats()` (joins on `Math.floor(event.year)`; **fails closed** to "Year context: not available" for 2026+/no-data years — never fabricated).
5. **Larger y-axis labels** — shortened the band copy + bumped font so they read without clipping.
6. **Translucent hero-image fact marks** — faint per-event metric stamps over the backdrop (from `event.metrics`); they sit *behind* the hero content so they can't cover the title/CTA; `lg+` only, with a safe fallback.
7. **Shell cleanup** — removed the "serving · prod" footer and the visible "Collapse" word; the collapse control stays icon-only with its `aria-label`, no longer nudged below the fold.

### Honesty
Tooltip shares are sourced from `YEAR_SERIES` (`commercialPct` true 0–100; `governmentPct = 100 − commercial`) or fail closed. Hero marks read only existing `event.metrics`. No new facts invented.

### Tests
New: `eventYearStats`, `MapTipBody` (renders attempts/commercial/gov + fails closed), `TelemetryShell` (no "serving"/"Collapse" text, aria-label kept). Updated hero/presenter/controlled/map specs to the new contract. **327 telemetry tests green**, `tsc -p tsconfig.typecheck.json` + `next lint` clean.

> Not covered by unit tests: deep recharts SVG hover (jsdom can't drive it) — the per-bubble hover/tooltip/x-axis-mark needs a manual/Playwright pass on `/lab/env/<envId>/telemetry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)