### PR TITLE
feat(telemetry): rename scoped reviewer session to "Relativity" + fix MissionControl test

### DIFF
--- a/repo-b/src/components/telemetry/MissionControlStream.test.tsx
+++ b/repo-b/src/components/telemetry/MissionControlStream.test.tsx
@@ -131,9 +131,10 @@ describe("MissionControlStream — actionable fail-closed states (hardening)", (
     });
     render(<MissionControlStream />);
     await waitFor(() => expect(screen.queryByTestId("stream-unavailable")).toBeNull());
-    // CAPTURE source chip is shown (honest label), and the channel strip exists
+    // CAPTURE source chip is shown (honest label), and the channel strip exists — the strip now
+    // renders the friendly ISS node name (channelLabel), not the raw channel id.
     expect(screen.getByText(/CAPTURE/)).toBeInTheDocument();
-    expect(screen.getByText("USLAB000058")).toBeInTheDocument();
+    expect(screen.getAllByText(/US Lab · cabin pressure/).length).toBeGreaterThan(0);
   });
 
   it("relabels the poll control to Pause and exports the live anomaly events as CSV (8C)", async () => {

--- a/repo-b/src/lib/server/telemetryReviewer.ts
+++ b/repo-b/src/lib/server/telemetryReviewer.ts
@@ -75,7 +75,7 @@ export function buildTelemetryReviewerClaims(envId: string): {
     platform_user_id: "telemetry-reviewer",
     supabase_user_id: null,
     email: "telemetry-reviewer@local", // intentionally NOT @novendor.ai (never bootstraps admin)
-    display_name: "Telemetry Reviewer",
+    display_name: "Relativity",
     issued_at: now,
     expires_at: buildSessionExpiryTimestampSeconds(),
     platform_admin: false,


### PR DESCRIPTION
Two telemetry-scoped changes.

## 1. Rename scoped reviewer session to "Relativity"
The dedicated, telemetry-only reviewer login now mints a session whose **display name reads "Relativity"** instead of "Telemetry Reviewer" (`telemetryReviewer.ts`). Scope, routing, and fail-closed behavior unchanged: single telemetry membership, `platform_admin: false`, no Supabase row, middleware-confined to `/lab/env/<env>/telemetry*`. URL slug stays `telemetry-demo`.

Credential rotation (`relativity` / new password) is a production env-var change on the `consulting-app` Vercel project, applied separately (takes effect on this deploy).

## 2. Fix MissionControlStream test (un-break main)
The last merged commit (56376a52, "friendly names for Mission Control ISS nodes") made channel strips render `channelLabel()` (e.g. "US Lab · cabin pressure") instead of the raw `USLAB000058`, but didn't update the test — leaving **main red**. Test now asserts the friendly label.

## Tests
`telemetryReviewer.test.ts`, `me/route.test.ts`, `telemetry-login/route.test.ts`, `MissionControlStream.test.tsx` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)