### PR TITLE
feat(orchestration): Coding Relay runnable spine (Claude builds, Codex reviews, receipts + draft PR)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ trainingkey.txt
 .orchestration/logs/*.json
 .orchestration/logs/*.jsonl
 .orchestration/sessions/*.json
+.orchestration/runs/
 claw-code-main/
 # OS files
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,9 @@ orchestration\:validate: ## Validate orchestration contracts + tests
 orchestration\:verify-logs: ## Verify orchestration log hash chain
 	python3 scripts/codex_orchestrator.py log verify-chain
 
+relay: ## Coding Relay: Claude builds, Codex reviews (docs/reference/CODING_RELAY.md)
+	python scripts/coding_relay.py $(ARGS)
+
 # ── Help ──────────────────────────────────────────────────────────
 help:  ## Show this help
 	@grep -E '^[a-zA-Z_:/-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'

--- a/backend/tests/test_orchestration_relay_intake.py
+++ b/backend/tests/test_orchestration_relay_intake.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestration.coding_relay import intake  # noqa: E402
+from orchestration.coding_relay.intake import IntakeError  # noqa: E402
+from orchestration.coding_relay.runs import safe_slug  # noqa: E402
+
+PLAN_WITH_CRITERIA = """# Add widget counter
+
+Do the thing.
+
+## Success Criteria
+
+- The dashboard page shows a widget counter component
+- GET /api/widgets returns a count field with status 200
+- pytest backend tests pass
+- existing widget rendering must not break
+
+## Out of scope
+
+- Anything else
+"""
+
+PLAN_WITH_SECTIONS = """# Sectioned plan
+
+## Acceptance Criteria
+
+### Screen
+- counter renders
+
+### API
+- Not applicable
+
+### Evals/tests
+- vitest suite green
+"""
+
+
+def test_missing_criteria_is_refused():
+    with pytest.raises(IntakeError) as exc:
+        intake.normalize_criteria("")  # not reached via load_plan, direct check below
+    assert "concrete" in str(exc.value) or "criteria" in str(exc.value).lower()
+
+
+def test_load_plan_refuses_plan_without_criteria(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text("# No criteria here\n\nJust vibes.\n", encoding="utf-8")
+    with pytest.raises(IntakeError) as exc:
+        intake.load_plan(tmp_path, str(plan), None)
+    assert "Acceptance Criteria" in str(exc.value)
+
+
+def test_extract_and_normalize_keyword_classification(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text(PLAN_WITH_CRITERIA, encoding="utf-8")
+    result = intake.load_plan(tmp_path, str(plan), None)
+    assert result.title == "Add widget counter"
+    checklist = result.criteria.checklist()
+    assert len(checklist) == 4
+    # Exact per-bullet routing: id shifts here would silently desync the
+    # reviewer's criteria_status from the report checklist.
+    assert ("S1", "Screen", "The dashboard page shows a widget counter component") in checklist
+    assert ("A1", "API", "GET /api/widgets returns a count field with status 200") in checklist
+    assert ("T1", "Evals-tests", "pytest backend tests pass") in checklist
+    assert ("R1", "Regression guard", "existing widget rendering must not break") in checklist
+    # Out-of-scope section is not swallowed into criteria.
+    assert all("Anything else" not in text for _, _, text in checklist)
+
+
+def test_short_keywords_do_not_fire_inside_words(tmp_path):
+    # 'db' in 'feedback' and 'ci' in 'decision' must not classify these
+    # UI bullets as DB-Data or Evals-tests.
+    plan = tmp_path / "plan.md"
+    plan.write_text(
+        "# T\n\n## Acceptance Criteria\n\n"
+        "- Surface reviewer feedback in the sidebar page\n"
+        "- Render the decision summary on the overview page\n",
+        encoding="utf-8",
+    )
+    result = intake.load_plan(tmp_path, str(plan), None)
+    sections = {text: sec for _, sec, text in result.criteria.checklist()}
+    assert sections["Surface reviewer feedback in the sidebar page"] == "Screen"
+    assert sections["Render the decision summary on the overview page"] == "Screen"
+
+
+def test_explicit_subsections_respected(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text(PLAN_WITH_SECTIONS, encoding="utf-8")
+    result = intake.load_plan(tmp_path, str(plan), None)
+    md = result.criteria.to_markdown()
+    checklist = result.criteria.checklist()
+    assert ("S1", "Screen", "counter renders") in checklist
+    assert ("T1", "Evals-tests", "vitest suite green") in checklist
+    # "Not applicable" bullets are dropped, and the section renders as such.
+    assert "### API\nNot applicable." in md
+
+
+def test_markdown_renders_all_six_sections(tmp_path):
+    plan = tmp_path / "plan.md"
+    plan.write_text(PLAN_WITH_CRITERIA, encoding="utf-8")
+    result = intake.load_plan(tmp_path, str(plan), None)
+    md = result.criteria.to_markdown()
+    for name in ("Screen", "API", "DB-Data", "AI behavior", "Evals-tests", "Regression guard"):
+        assert f"### {name}" in md
+
+
+def test_resolve_plan_path_by_prefix(tmp_path):
+    active = tmp_path / "docs" / "plans" / "03-implementation-plans" / "active"
+    active.mkdir(parents=True)
+    (active / "0042-demo-plan.md").write_text("# x\n", encoding="utf-8")
+    (active / "0043-other.md").write_text("# y\n", encoding="utf-8")
+    assert intake.resolve_plan_path(tmp_path, "0042").name == "0042-demo-plan.md"
+    with pytest.raises(IntakeError):
+        intake.resolve_plan_path(tmp_path, "004")  # ambiguous
+    with pytest.raises(IntakeError):
+        intake.resolve_plan_path(tmp_path, "9999")  # no match
+
+
+def test_safe_slug():
+    assert safe_slug("Add Widget Counter!") == "add-widget-counter"
+    assert safe_slug("///") == "task"
+    assert len(safe_slug("a" * 100)) <= 24

--- a/backend/tests/test_orchestration_relay_loop_fixture.py
+++ b/backend/tests/test_orchestration_relay_loop_fixture.py
@@ -1,0 +1,411 @@
+"""End-to-end fixture runs: the full relay loop against a throwaway git repo,
+driven by FakeProviders. No CLIs, no tokens, no network (base ref is HEAD so
+preflight never fetches; the fetch tests use a nonexistent local remote).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestration.coding_relay.__main__ import main  # noqa: E402
+
+FIXTURE = ROOT / "orchestration" / "coding_relay" / "fixtures" / "demo"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_git_config(monkeypatch):
+    # A developer's global core.hooksPath / init templates must not leak
+    # into the throwaway repos these tests create.
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+
+
+@pytest.fixture()
+def tmp_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=str(repo), capture_output=True, text=True)
+    _git(repo, "config", "user.email", "relay-test@example.com")
+    _git(repo, "config", "user.name", "Relay Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    assert _git(repo, "commit", "-m", "seed").returncode == 0
+    return repo
+
+
+def make_fixture(tmp_path: Path, name: str, review_json: str | None,
+                 files: dict | None = None, build_exit: int | None = None) -> Path:
+    """Build a one-iteration fixture dir for failure-path tests."""
+    fx = tmp_path / name
+    it = fx / "iterations" / "1"
+    (it / "files").mkdir(parents=True)
+    fx.joinpath("plan.md").write_text(
+        (FIXTURE / "plan.md").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    for rel, content in (files or {"RELAY_NOTE.md": "note\n"}).items():
+        target = it / "files" / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    if review_json is not None:
+        (it / "review.json").write_text(review_json, encoding="utf-8")
+    if build_exit is not None:
+        (it / "build-exit").write_text(str(build_exit), encoding="utf-8")
+    return fx
+
+
+def verdict_json(status: str, **extra) -> str:
+    base = {
+        "status": status,
+        "summary": f"fixture verdict: {status}",
+        "criteria_status": [],
+        "required_next_steps": [],
+        "plan_refinements": [],
+        "tests_to_run_next": [],
+        "risk_flags": [],
+        "should_open_pr": False,
+    }
+    base.update(extra)
+    return json.dumps(base)
+
+
+def run_relay(tmp_repo: Path, tmp_path: Path, extra: list) -> int:
+    argv = [
+        "--repo-root", str(tmp_repo),
+        "--plan", str(FIXTURE / "plan.md"),
+        "--fixture", str(FIXTURE),
+        "--base", "HEAD",
+        "--no-pr",
+        "--worktree-root", str(tmp_path / "wts"),
+    ] + extra
+    return main(argv)
+
+
+def find_run_dir(tmp_repo: Path) -> Path:
+    runs = list((tmp_repo / ".orchestration" / "runs").iterdir())
+    assert len(runs) == 1
+    return runs[0]
+
+
+def test_fixture_loop_passes_end_to_end(tmp_repo: Path, tmp_path: Path):
+    exit_code = run_relay(tmp_repo, tmp_path, ["--max-iterations", "2"])
+    assert exit_code == 0
+
+    run_dir = find_run_dir(tmp_repo)
+    # Full manifest: plan, env, two iterations, report.
+    assert (run_dir / "plan" / "original-plan.md").is_file()
+    assert (run_dir / "plan" / "normalized-criteria.md").is_file()
+    assert (run_dir / "env" / "preflight.json").is_file()
+    for it in ("01", "02"):
+        it_dir = run_dir / "iterations" / it
+        for name in (
+            "build-prompt.md", "build-output.md", "build-meta.json",
+            "diff.patch", "safety.json",
+            "review-prompt.md", "review-output.txt", "verdict.json",
+        ):
+            assert (it_dir / name).is_file(), f"missing iterations/{it}/{name}"
+        assert (it_dir / "review-bundle" / "diff.patch").is_file()
+    assert (run_dir / "report" / "final-report.md").is_file()
+    assert (run_dir / "report" / "PR_BODY.md").is_file()
+
+    run_meta = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    assert run_meta["state"] == "PASS"
+    assert run_meta["exit_code"] == 0
+    assert run_meta["iterations_run"] == 2
+
+    # Iteration 1 verdict was continue; iteration 2 pass.
+    v1 = json.loads((run_dir / "iterations" / "01" / "verdict.json").read_text(encoding="utf-8"))
+    v2 = json.loads((run_dir / "iterations" / "02" / "verdict.json").read_text(encoding="utf-8"))
+    assert v1["status"] == "continue"
+    assert v2["status"] == "pass"
+
+    # Reviewer feedback from iteration 1 reached the iteration 2 builder prompt.
+    prompt2 = (run_dir / "iterations" / "02" / "build-prompt.md").read_text(encoding="utf-8")
+    assert "Extend RELAY_NOTE.md" in prompt2
+
+    # Redaction: the planted token never survives anywhere in the run folder.
+    planted = "ghp_" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
+    for f in run_dir.rglob("*"):
+        if f.is_file():
+            assert planted not in f.read_text(encoding="utf-8", errors="replace"), f
+    build_out = (run_dir / "iterations" / "01" / "build-output.md").read_text(encoding="utf-8")
+    assert "[REDACTED:github-token]" in build_out
+
+    # The worktree exists on a relay/ branch and contains the fixture's file.
+    worktrees = list((tmp_path / "wts").iterdir())
+    assert len(worktrees) == 1
+    wt = worktrees[0]
+    assert (wt / "RELAY_NOTE.md").is_file()
+    branch = _git(wt, "branch", "--show-current").stdout.strip()
+    assert branch.startswith("relay/")
+
+    # Final report is honest about the outcome.
+    report = (run_dir / "report" / "final-report.md").read_text(encoding="utf-8")
+    assert "PASS" in report
+    assert "RELAY_NOTE.md" in report
+
+
+def test_fixture_loop_max_iterations_exit_1(tmp_repo: Path, tmp_path: Path):
+    # Only one iteration allowed; fixture iteration 1 says "continue".
+    exit_code = run_relay(tmp_repo, tmp_path, ["--max-iterations", "1"])
+    assert exit_code == 1
+    run_dir = find_run_dir(tmp_repo)
+    run_meta = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    assert run_meta["state"] == "MAX_ITER"
+
+
+def test_secret_written_by_builder_triggers_safety_stop(tmp_repo: Path, tmp_path: Path):
+    # Build a one-iteration fixture whose "builder" writes a secret to a file.
+    fx = tmp_path / "fx-secret"
+    (fx / "iterations" / "1" / "files").mkdir(parents=True)
+    (fx / "plan.md").write_text(
+        (FIXTURE / "plan.md").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (fx / "iterations" / "1" / "files" / "config.py").write_text(
+        'AWS_KEY = "AKIAIOSFODNN7EXAMPLE"\n', encoding="utf-8"
+    )
+    argv = [
+        "--repo-root", str(tmp_repo),
+        "--plan", str(fx / "plan.md"),
+        "--fixture", str(fx),
+        "--base", "HEAD",
+        "--no-pr",
+        "--worktree-root", str(tmp_path / "wts2"),
+        "--max-iterations", "2",
+    ]
+    exit_code = main(argv)
+    assert exit_code == 4
+    run_dir = find_run_dir(tmp_repo)
+    safety = json.loads(
+        (run_dir / "iterations" / "01" / "safety.json").read_text(encoding="utf-8")
+    )
+    assert any(v["rule"] == "secrets_in_diff" for v in safety)
+    # No review happened after the stop.
+    assert not (run_dir / "iterations" / "01" / "verdict.json").exists()
+
+
+def test_dry_run_writes_nothing(tmp_repo: Path, tmp_path: Path, capsys):
+    argv = [
+        "--repo-root", str(tmp_repo),
+        "--plan", str(FIXTURE / "plan.md"),
+        "--fixture", str(FIXTURE),
+        "--base", "HEAD",
+        "--dry-run",
+    ]
+    exit_code = main(argv)
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "wrote nothing" in out
+    assert not (tmp_repo / ".orchestration").exists()
+    # No worktree, no branch.
+    branches = _git(tmp_repo, "branch", "--list").stdout
+    assert "relay/" not in branches
+
+
+def test_missing_criteria_refused_exit_2(tmp_repo: Path, tmp_path: Path):
+    bad = tmp_path / "bad-plan.md"
+    bad.write_text("# Vague wish\n\nMake it better.\n", encoding="utf-8")
+    exit_code = main([
+        "--repo-root", str(tmp_repo), "--plan", str(bad),
+        "--fixture", str(FIXTURE), "--base", "HEAD",
+    ])
+    assert exit_code == 2
+    assert not (tmp_repo / ".orchestration").exists()
+
+
+def test_blocked_verdict_exit_5(tmp_repo: Path, tmp_path: Path):
+    fx = make_fixture(tmp_path, "fx-blocked", verdict_json("blocked"))
+    code = main([
+        "--repo-root", str(tmp_repo), "--plan", str(fx / "plan.md"),
+        "--fixture", str(fx), "--base", "HEAD", "--no-pr",
+        "--worktree-root", str(tmp_path / "w1"), "--max-iterations", "2",
+    ])
+    assert code == 5
+    run_meta = json.loads((find_run_dir(tmp_repo) / "run.json").read_text(encoding="utf-8"))
+    assert run_meta["state"] == "BLOCKED"
+
+
+def test_risk_escalation_verdict_exit_5(tmp_repo: Path, tmp_path: Path):
+    fx = make_fixture(
+        tmp_path, "fx-risk",
+        verdict_json("risk_escalation", risk_flags=["touches auth"]),
+    )
+    code = main([
+        "--repo-root", str(tmp_repo), "--plan", str(fx / "plan.md"),
+        "--fixture", str(fx), "--base", "HEAD", "--no-pr",
+        "--worktree-root", str(tmp_path / "w2"),
+    ])
+    assert code == 5
+    report = (find_run_dir(tmp_repo) / "report" / "final-report.md").read_text(encoding="utf-8")
+    assert "touches auth" in report
+
+
+def test_escalate_safety_stops_before_review_exit_5(tmp_repo: Path, tmp_path: Path):
+    # Builder touches CI workflows: escalate severity ends the run with NO review.
+    fx = make_fixture(
+        tmp_path, "fx-wf", verdict_json("pass"),
+        files={".github/workflows/evil.yml": "on: push\n"},
+    )
+    code = main([
+        "--repo-root", str(tmp_repo), "--plan", str(fx / "plan.md"),
+        "--fixture", str(fx), "--base", "HEAD", "--no-pr",
+        "--worktree-root", str(tmp_path / "w3"),
+    ])
+    assert code == 5
+    run_dir = find_run_dir(tmp_repo)
+    assert not (run_dir / "iterations" / "01" / "verdict.json").exists()
+    safety = json.loads((run_dir / "iterations" / "01" / "safety.json").read_text(encoding="utf-8"))
+    assert any(v["rule"] == "workflow_hooks" for v in safety)
+
+
+def test_garbage_verdict_retries_once_then_blocked_exit_5(tmp_repo: Path, tmp_path: Path):
+    fx = make_fixture(tmp_path, "fx-garbage", "utter nonsense, no json here")
+    code = main([
+        "--repo-root", str(tmp_repo), "--plan", str(fx / "plan.md"),
+        "--fixture", str(fx), "--base", "HEAD", "--no-pr",
+        "--worktree-root", str(tmp_path / "w4"),
+    ])
+    assert code == 5
+    it_dir = find_run_dir(tmp_repo) / "iterations" / "01"
+    # The retry happened (same iteration file re-read, still garbage).
+    assert (it_dir / "review-output-retry.txt").is_file()
+    assert not (it_dir / "verdict.json").exists()
+
+
+def test_builder_failure_exit_6(tmp_repo: Path, tmp_path: Path):
+    fx = make_fixture(tmp_path, "fx-bfail", verdict_json("pass"), build_exit=2)
+    code = main([
+        "--repo-root", str(tmp_repo), "--plan", str(fx / "plan.md"),
+        "--fixture", str(fx), "--base", "HEAD", "--no-pr",
+        "--worktree-root", str(tmp_path / "w5"),
+    ])
+    assert code == 6
+    run_meta = json.loads((find_run_dir(tmp_repo) / "run.json").read_text(encoding="utf-8"))
+    assert run_meta["state"] == "ERROR"
+
+
+def test_pass_without_pr_flags_degrades_to_manual_pr(tmp_repo: Path, tmp_path: Path):
+    # No origin remote: on pass the relay commits, the push fails, and the
+    # MANUAL_PR.md fallback is written; the loop outcome still owns exit 0.
+    code = main([
+        "--repo-root", str(tmp_repo),
+        "--plan", str(FIXTURE / "plan.md"),
+        "--fixture", str(FIXTURE),
+        "--base", "HEAD",
+        "--worktree-root", str(tmp_path / "w6"),
+        "--max-iterations", "2",
+    ])
+    assert code == 0
+    manual = find_run_dir(tmp_repo) / "report" / "MANUAL_PR.md"
+    assert manual.is_file()
+    text = manual.read_text(encoding="utf-8")
+    assert "--draft" in text
+    assert "PR_BODY.md" in text
+    assert "gh pr merge" not in text
+
+
+def test_draft_pr_never_fires_after_safety_stop(tmp_repo: Path, tmp_path: Path):
+    fx = make_fixture(
+        tmp_path, "fx-secret2", verdict_json("pass"),
+        files={"config.py": 'AWS_KEY = "AKIAIOSFODNN7EXAMPLE"\n'},
+    )
+    code = main([
+        "--repo-root", str(tmp_repo), "--plan", str(fx / "plan.md"),
+        "--fixture", str(fx), "--base", "HEAD", "--draft-pr",
+        "--worktree-root", str(tmp_path / "w7"),
+    ])
+    assert code == 4
+    run_dir = find_run_dir(tmp_repo)
+    # The flagged diff was neither committed nor offered for manual push.
+    assert not (run_dir / "report" / "MANUAL_PR.md").exists()
+    assert not (run_dir / "report" / "pr.json").exists()
+    wt = next((tmp_path / "w7").iterdir())
+    log = _git(wt, "log", "--oneline")
+    assert len(log.stdout.strip().splitlines()) == 1  # seed commit only
+
+
+def test_missing_clis_exit_3(tmp_repo: Path, tmp_path: Path, monkeypatch):
+    import orchestration.coding_relay.preflight as pf
+
+    real_which = pf.shutil.which
+    monkeypatch.setattr(
+        pf.shutil, "which",
+        lambda name: None if name in ("claude", "codex") else real_which(name),
+    )
+    code = main([
+        "--repo-root", str(tmp_repo), "--plan", str(FIXTURE / "plan.md"),
+        "--base", "HEAD", "--no-pr",
+    ])
+    assert code == 3
+    assert not list((tmp_repo / ".orchestration" / "runs").glob("*"))
+    assert "relay/" not in _git(tmp_repo, "branch", "--list").stdout
+
+
+def test_fetch_failure_is_hard_stop_exit_2(tmp_repo: Path, tmp_path: Path):
+    _git(tmp_repo, "remote", "add", "origin", str(tmp_path / "no-such-remote"))
+    _git(tmp_repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    code = main([
+        "--repo-root", str(tmp_repo), "--plan", str(FIXTURE / "plan.md"),
+        "--fixture", str(FIXTURE), "--base", "origin/main", "--no-pr",
+        "--worktree-root", str(tmp_path / "w8"),
+    ])
+    assert code == 2
+    assert not list((tmp_repo / ".orchestration" / "runs").glob("*"))
+    assert "relay/" not in _git(tmp_repo, "branch", "--list").stdout
+
+
+def test_allow_stale_base_proceeds_and_is_recorded(tmp_repo: Path, tmp_path: Path):
+    _git(tmp_repo, "remote", "add", "origin", str(tmp_path / "no-such-remote"))
+    _git(tmp_repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    code = main([
+        "--repo-root", str(tmp_repo), "--plan", str(FIXTURE / "plan.md"),
+        "--fixture", str(FIXTURE), "--base", "origin/main", "--no-pr",
+        "--allow-stale-base", "--worktree-root", str(tmp_path / "w9"),
+        "--max-iterations", "2",
+    ])
+    assert code == 0
+    run_meta = json.loads((find_run_dir(tmp_repo) / "run.json").read_text(encoding="utf-8"))
+    assert any("--allow-stale-base" in e for e in run_meta["escalations"])
+
+
+def test_bad_fixture_dir_fails_preflight_before_mutation(tmp_repo: Path, tmp_path: Path):
+    code = main([
+        "--repo-root", str(tmp_repo), "--plan", str(FIXTURE / "plan.md"),
+        "--fixture", str(tmp_path / "does-not-exist"), "--base", "HEAD", "--no-pr",
+    ])
+    assert code == 2
+    assert not list((tmp_repo / ".orchestration" / "runs").glob("*"))
+    branches = _git(tmp_repo, "branch", "--list").stdout
+    assert "relay/" not in branches
+
+
+def test_snapshot_diffs_against_base_even_after_builder_commit(tmp_repo: Path, tmp_path: Path):
+    from orchestration.coding_relay.loop import collect_snapshot, head_moved
+    from orchestration.coding_relay.worktree import create_worktree
+
+    wt = create_worktree(tmp_repo, "snaptest", "HEAD", tmp_path / "w10")
+    (wt.path / "committed.txt").write_text("smuggled\n", encoding="utf-8")
+    _git(wt.path, "add", "-A")
+    assert _git(wt.path, "commit", "-m", "builder smuggle").returncode == 0
+    (wt.path / "uncommitted.txt").write_text("visible\n", encoding="utf-8")
+
+    snap = collect_snapshot(wt.path, wt.base_sha)
+    assert "committed.txt" in snap.changed_paths  # NOT invisible to the scanner
+    assert "uncommitted.txt" in snap.changed_paths
+    assert head_moved(wt.path, wt.base_sha)

--- a/backend/tests/test_orchestration_relay_redact.py
+++ b/backend/tests/test_orchestration_relay_redact.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestration.coding_relay.redact import redact  # noqa: E402
+
+
+def test_github_tokens_redacted():
+    assert "ghp_" not in redact("x ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345 y")
+    assert "github_pat_" not in redact("github_pat_11ABCDEFGHIJKLMNOPQRST_more")
+
+
+def test_openai_and_aws_and_slack():
+    assert "sk-" not in redact("key sk-abcdefghijklmnopqrstuvwxyz123456")
+    assert "AKIA" not in redact("id AKIAIOSFODNN7EXAMPLE")
+    assert "xoxb-" not in redact("tok xoxb-123456789012-abcdef")
+
+
+def test_db_url_password_redacted_but_scheme_kept():
+    out = redact("postgres://winston:s3cretpass@db.example.com:5432/app")
+    assert "s3cretpass" not in out
+    assert out.startswith("postgres://")
+    assert "@db.example.com" in out
+
+
+def test_generic_assignment_keeps_key_name():
+    out = redact("API_KEY=abcdefghijklmnop123456")
+    assert "abcdefghijklmnop123456" not in out
+    assert "API_KEY" in out
+    out = redact('password: "supersecretvalue99"')
+    assert "supersecretvalue99" not in out
+
+
+def test_underscore_prefixed_env_names_redacted():
+    # Assembled at runtime so the source file itself never contains a
+    # token-shaped literal (GitHub push protection flags those).
+    fake_dapi = "dapi" + "0123456789abcdef" * 2
+    out = redact(f"DATABRICKS_TOKEN={fake_dapi}")
+    assert fake_dapi not in out
+    out = redact("DB_PASSWORD=hunter2hunter2hunter2")
+    assert "hunter2hunter2hunter2" not in out
+    assert "DB_PASSWORD" in out
+    out = redact("MY_SECRET: some_long_secret_value_123")
+    assert "some_long_secret_value_123" not in out
+
+
+def test_jwt_and_pem_and_gcp_redacted():
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abcdef123"
+    assert jwt not in redact(f"key: {jwt}")
+    pem = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBg\nqhkiG9w0BAQEFAASC\n-----END PRIVATE KEY-----"
+    out = redact(pem)
+    assert "MIIEvQIBADANBg" not in out
+    assert "AIza" not in redact("gcp AIzaSyA1234567890abcdefghijklmnopqrstuvw")
+
+
+def test_clean_text_untouched():
+    text = "nothing secret here, just a diff line + return 42\n"
+    assert redact(text) == text
+
+
+def test_ordinary_code_assignments_untouched():
+    text = "token = create_access_token(user)\n"
+    assert redact(text) == text
+
+
+def test_empty_text():
+    assert redact("") == ""

--- a/backend/tests/test_orchestration_relay_report.py
+++ b/backend/tests/test_orchestration_relay_report.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestration.coding_relay import pr as pr_mod  # noqa: E402
+from orchestration.coding_relay.report import (  # noqa: E402
+    RunSummary,
+    final_report,
+    pr_body,
+    strip_style,
+)
+
+
+def summary() -> RunSummary:
+    return RunSummary(
+        run_id="20260707-120000-demo",
+        state="PASS",
+        exit_code=0,
+        title="Demo",
+        plan_path="plan.md",
+        branch="relay/demo-x",
+        worktree_path="C:/wt",
+        base_ref="origin/main",
+        base_sha="abc123def456",
+        iterations_run=2,
+        max_iterations=3,
+        criteria_checklist=[
+            ("S1", "Screen", "renders"),
+            ("A1", "API", "returns 200"),
+            ("D1", "DB-Data", "row exists"),
+            ("T1", "Evals-tests", "tests pass"),
+        ],
+        final_criteria_status=[
+            {"id": "S1", "status": "met", "evidence": "diff hunk"},
+            {"id": "A1", "status": "unmet", "evidence": "no route"},
+            {"id": "D1", "status": "not_applicable", "evidence": ""},
+            # T1 absent: never reviewed.
+        ],
+        verdict_history=[(1, "continue", "half done"), (2, "pass", "all met")],
+        test_results=[
+            {"name": "backend-pytest", "skipped": False, "exit_code": 0, "duration_s": 12, "log": "l.log"},
+            {"name": "frontend-unit", "skipped": True, "reason": "node_modules missing; run manually: cd x && npm ci && npm run test:unit"},
+        ],
+        violations=[],
+        files_changed=["1\t2\tfoo.py"],
+        risk_notes=["watch the thing"],
+        removal_instructions="git worktree remove ...",
+        codex_summary="all met",
+        escalation_flags=["--codex-repo-access: reviewer was given full worktree access"],
+    )
+
+
+def test_criteria_marks_are_honest():
+    report = final_report(summary())
+    # Only "met" earns [x]; not_applicable and unmet stay unchecked with status text.
+    assert "- [x] S1 (Screen): renders -- met" in report
+    assert "- [ ] A1 (API): returns 200 -- unmet" in report
+    assert "- [ ] D1 (DB-Data): row exists -- not_applicable" in report
+    assert "- [ ] T1 (Evals-tests): tests pass -- not reviewed" in report
+
+
+def test_skipped_suite_carries_manual_command():
+    report = final_report(summary())
+    assert "frontend-unit: SKIPPED" in report
+    assert "npm ci" in report
+    body = pr_body(summary())
+    assert "npm ci" in body
+
+
+def test_pr_body_has_verdicts_escalations_and_rollback():
+    body = pr_body(summary())
+    assert "iteration 1: continue. half done" in body
+    assert "iteration 2: pass. all met" in body
+    assert "--codex-repo-access" in body
+    assert "never merges" in body or "Close this PR" in body
+
+
+def test_strip_style_removes_em_dashes():
+    assert "—" not in strip_style("a—b — c")
+    assert "—" not in final_report(summary())
+
+
+def test_create_draft_pr_always_passes_draft(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run(cmd, cwd, timeout=300, env=None):
+        captured["cmd"] = cmd
+
+        class R:
+            returncode = 0
+            stdout = "https://github.com/x/y/pull/1\n"
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(pr_mod, "_run", fake_run)
+    monkeypatch.setattr(pr_mod.shutil, "which", lambda n: "/fake/gh")
+    ok, detail = pr_mod.create_draft_pr(tmp_path, "relay/x", "title", tmp_path / "b.md")
+    assert ok
+    assert "--draft" in captured["cmd"]
+    assert "merge" not in " ".join(str(c) for c in captured["cmd"])
+
+
+def test_manual_pr_instructions_use_absolute_body_path(tmp_path):
+    body = tmp_path / "runs" / "r1" / "report" / "PR_BODY.md"
+    text = pr_mod.manual_pr_instructions(
+        tmp_path, tmp_path / "wt", "relay/x", "title", body, "gh missing"
+    )
+    assert str(body) in text
+    assert "--draft" in text
+    assert "gh pr merge" not in text

--- a/backend/tests/test_orchestration_relay_safety.py
+++ b/backend/tests/test_orchestration_relay_safety.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestration.coding_relay.safety import (  # noqa: E402
+    DiffSnapshot,
+    ESCALATE,
+    STOP,
+    escalations,
+    scan,
+    stops,
+)
+
+PLAN = "Build a widget counter page."
+RELAY_PLAN = "Improve the coding relay loop module."
+
+
+def snap(paths=None, deleted=None, diff="") -> DiffSnapshot:
+    return DiffSnapshot(
+        diff_text=diff,
+        changed_paths=paths or [],
+        deleted_paths=deleted or [],
+        numstat=[],
+    )
+
+
+def rules(violations):
+    return {v.rule for v in violations}
+
+
+def test_clean_diff_has_no_violations(tmp_path):
+    s = snap(paths=["repo-b/src/components/W.tsx"], diff="+ hello\n")
+    assert scan(tmp_path, s, PLAN) == []
+
+
+def test_mass_deletion_stop(tmp_path):
+    s = snap(deleted=[f"old/{i}.py" for i in range(101)])
+    v = scan(tmp_path, s, PLAN)
+    assert "mass_deletion" in rules(stops(v))
+
+
+def test_mass_deletion_boundary_100_allowed(tmp_path):
+    s = snap(deleted=[f"old/{i}.py" for i in range(100)])
+    assert "mass_deletion" not in rules(scan(tmp_path, s, PLAN))
+
+
+def test_outside_worktree_traversal_stop(tmp_path):
+    v = scan(tmp_path, snap(paths=["../evil.txt"]), PLAN)
+    assert "outside_worktree_write" in rules(stops(v))
+
+
+def test_outside_worktree_absolute_stop(tmp_path):
+    abs_path = "C:/evil.txt" if sys.platform == "win32" else "/tmp/evil.txt"
+    v = scan(tmp_path, snap(paths=[abs_path]), PLAN)
+    assert "outside_worktree_write" in rules(stops(v))
+
+
+def test_symlink_in_diff_stop(tmp_path):
+    diff = (
+        "diff --git a/link b/link\n"
+        "new file mode 120000\n"
+        "--- /dev/null\n"
+        "+++ b/link\n"
+        "+../outside\n"
+    )
+    v = scan(tmp_path, snap(paths=[], diff=diff), PLAN)
+    assert "outside_worktree_write" in rules(stops(v))
+
+
+def test_db_migration_stop_and_override(tmp_path):
+    s = snap(paths=["repo-b/db/schema/300_new_table.sql"])
+    assert "db_migration" in rules(stops(scan(tmp_path, s, PLAN)))
+    assert "db_migration" not in rules(scan(tmp_path, s, PLAN, allow_migrations=True))
+    s2 = snap(paths=["supabase/config.toml"])
+    assert "db_migration" in rules(stops(scan(tmp_path, s2, PLAN)))
+
+
+def test_secrets_in_diff_stop(tmp_path):
+    diff = "+++ b/x\n+token = ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345\n"
+    v = scan(tmp_path, snap(paths=["x"], diff=diff), PLAN)
+    assert "secrets_in_diff" in rules(stops(v))
+
+
+def test_secret_only_in_removed_line_is_not_a_stop(tmp_path):
+    diff = "--- a/x\n-old = ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345\n+clean = value\n"
+    assert "secrets_in_diff" not in rules(scan(tmp_path, snap(paths=["x"], diff=diff), PLAN))
+
+
+def test_ordinary_token_code_is_not_a_stop(tmp_path):
+    # The stop gate uses high-confidence literal shapes only; normal auth
+    # code must never kill a run.
+    diff = (
+        "+++ b/x\n"
+        "+token = create_access_token(user)\n"
+        "+password = hash_password(raw_input)\n"
+        "+token = secrets.token_urlsafe(32)\n"
+    )
+    assert "secrets_in_diff" not in rules(scan(tmp_path, snap(paths=["x"], diff=diff), PLAN))
+
+
+def test_quoted_literal_secret_assignment_is_a_stop(tmp_path):
+    fake_dapi = "dapi" + "0123456789abcdef" * 2  # assembled: no literal at rest
+    diff = f'+++ b/x\n+DATABRICKS_TOKEN = "{fake_dapi}"\n'
+    assert "secrets_in_diff" in rules(stops(scan(tmp_path, snap(paths=["x"], diff=diff), PLAN)))
+
+
+def test_pem_and_jwt_added_lines_are_stops(tmp_path):
+    diff = "+++ b/key\n+-----BEGIN PRIVATE KEY-----\n"
+    assert "secrets_in_diff" in rules(stops(scan(tmp_path, snap(paths=["key"], diff=diff), PLAN)))
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abcdef123"
+    diff = f"+++ b/cfg\n+SUPABASE_KEY = {jwt}\n"
+    assert "secrets_in_diff" in rules(stops(scan(tmp_path, snap(paths=["cfg"], diff=diff), PLAN)))
+
+
+def test_workflow_and_hooks_escalate(tmp_path):
+    v = scan(tmp_path, snap(paths=[".github/workflows/ci.yml"]), PLAN)
+    assert "workflow_hooks" in rules(escalations(v))
+    v = scan(tmp_path, snap(paths=[".githooks/pre-commit"]), PLAN)
+    assert "workflow_hooks" in rules(escalations(v))
+    # Host-executable root files also escalate.
+    v = scan(tmp_path, snap(paths=["Makefile"]), PLAN)
+    assert "workflow_hooks" in rules(escalations(v))
+    v = scan(tmp_path, snap(paths=["dev.sh"]), PLAN)
+    assert "workflow_hooks" in rules(escalations(v))
+
+
+def test_auth_security_escalate(tmp_path):
+    v = scan(tmp_path, snap(paths=["backend/app/routes/auth_login.py"]), PLAN)
+    assert "auth_security" in rules(escalations(v))
+    # Non-auth backend path does not escalate.
+    v = scan(tmp_path, snap(paths=["backend/app/routes/widgets.py"]), PLAN)
+    assert "auth_security" not in rules(v)
+
+
+def test_self_edit_always_escalates_unless_flagged(tmp_path):
+    s = snap(paths=["orchestration/coding_relay/loop.py"])
+    # Plan text NEVER suppresses the escalation: it is author-controlled.
+    assert "orchestration_self_edit" in rules(escalations(scan(tmp_path, s, PLAN)))
+    assert "orchestration_self_edit" in rules(escalations(scan(tmp_path, s, RELAY_PLAN)))
+    # Only the explicit, recorded flag suppresses it.
+    assert "orchestration_self_edit" not in rules(
+        scan(tmp_path, s, RELAY_PLAN, allow_relay_self_edit=True)
+    )
+
+
+def test_severities_are_partitioned(tmp_path):
+    s = snap(
+        paths=[".github/workflows/ci.yml", "../evil.txt"],
+        deleted=[],
+    )
+    v = scan(tmp_path, s, PLAN)
+    # Exact partition for this input, so a severity swap on either rule fails.
+    assert rules(stops(v)) == {"outside_worktree_write"}
+    assert rules(escalations(v)) == {"workflow_hooks"}
+    assert all(x.severity == STOP for x in stops(v))
+    assert all(x.severity == ESCALATE for x in escalations(v))

--- a/backend/tests/test_orchestration_relay_suites.py
+++ b/backend/tests/test_orchestration_relay_suites.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestration.coding_relay.test_runner import (  # noqa: E402
+    Suite,
+    infer_suites,
+    resolve_python,
+    run_suites,
+)
+
+PY = "python"
+
+
+def names(suites):
+    return [s.name for s in suites]
+
+
+def test_backend_changes_map_to_ruff_pytest_and_repe_lint():
+    got = names(infer_suites(["backend/app/services/x.py"], PY))
+    assert got == ["backend-ruff", "backend-pytest", "repe-lint"]
+
+
+def test_frontend_changes_map_to_lint_typecheck_unit_and_repe_lint():
+    got = names(infer_suites(["repo-b/src/components/W.tsx"], PY))
+    assert got == ["frontend-lint", "frontend-typecheck", "frontend-unit", "repe-lint"]
+
+
+def test_rs_factory_maps_to_pytest_only():
+    got = names(infer_suites(["rs_factory_seed/generator.py"], PY))
+    assert got == ["rs-factory-pytest"]
+
+
+def test_docs_only_changes_run_nothing():
+    assert infer_suites(["docs/reference/X.md", "README.md"], PY) == []
+
+
+def test_windows_style_paths_are_normalized():
+    got = names(infer_suites(["backend\\app\\x.py"], PY))
+    assert "backend-pytest" in got
+
+
+def test_missing_node_modules_is_honest_skip(tmp_path, monkeypatch):
+    import orchestration.coding_relay.test_runner as tr
+
+    # Deterministic branch: npm "exists", node_modules does not.
+    monkeypatch.setattr(tr.shutil, "which", lambda name: "/fake/npm" if name == "npm" else None)
+    (tmp_path / "repo-b").mkdir()
+    suites = [Suite("frontend-unit", "repo-b", ["npm", "run", "test:unit"], 60, "npm")]
+    results = run_suites(tmp_path, suites, "iterations/01/tests")
+    assert results[0].skipped
+    assert "node_modules" in results[0].reason
+    # The skip reason carries the exact manual command.
+    assert "npm ci" in results[0].reason
+    assert "npm run test:unit" in results[0].reason
+    assert results[0].exit_code is None
+
+
+def test_no_python_interpreter_is_honest_skip(tmp_path):
+    # infer_suites keeps command[0] empty when no interpreter resolved.
+    suites = infer_suites(["backend/app/x.py"], None)
+    assert suites[0].command[0] == ""
+    (tmp_path / "backend").mkdir()
+    results = run_suites(tmp_path, suites[:1], "t")
+    assert results[0].skipped
+    assert "no python interpreter" in results[0].reason
+    assert "run manually" in results[0].reason
+
+
+def test_missing_directory_is_honest_skip(tmp_path):
+    suites = [Suite("backend-pytest", "backend", [PY, "-m", "pytest"], 60, "python")]
+    results = run_suites(tmp_path, suites, "iterations/01/tests")
+    assert results[0].skipped
+    assert "missing directory" in results[0].reason
+
+
+def test_real_command_runs_and_logs(tmp_path):
+    (tmp_path / "proj").mkdir()
+    suites = [
+        Suite("echo", "proj", [sys.executable, "-c", "print('suite-ran-ok')"], 60, "python")
+    ]
+    written = {}
+
+    def write(rel, text):
+        written[rel] = text
+
+    results = run_suites(tmp_path, suites, "iterations/01/tests", "test-python", write=write)
+    assert results[0].exit_code == 0 and results[0].ok
+    assert "iterations/01/tests/echo.log" in written
+    assert "suite-ran-ok" in written["iterations/01/tests/echo.log"]
+
+
+def test_failure_is_reported_not_faked(tmp_path):
+    (tmp_path / "proj").mkdir()
+    suites = [Suite("boom", "proj", [sys.executable, "-c", "raise SystemExit(3)"], 60, "python")]
+    results = run_suites(tmp_path, suites, "t")
+    assert not results[0].ok
+    assert results[0].exit_code == 3
+    assert "FAIL" in results[0].summary_line()
+
+
+def test_resolve_python_prefers_worktree_venv(tmp_path):
+    wt = tmp_path / "wt"
+    exe_rel = ("Scripts", "python.exe") if sys.platform == "win32" else ("bin", "python")
+    venv_py = wt / "backend" / ".venv" / exe_rel[0] / exe_rel[1]
+    venv_py.parent.mkdir(parents=True)
+    venv_py.write_text("", encoding="utf-8")
+    py, desc = resolve_python(wt, None)
+    assert py == str(venv_py)
+    assert "venv" in desc

--- a/backend/tests/test_orchestration_relay_verdict.py
+++ b/backend/tests/test_orchestration_relay_verdict.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestration.coding_relay.verdict import parse_verdict  # noqa: E402
+
+VALID = {
+    "status": "continue",
+    "summary": "half done",
+    "criteria_status": [
+        {"id": "S1", "section": "Screen", "text": "renders", "status": "unmet", "evidence": "no diff hunk"}
+    ],
+    "required_next_steps": ["finish the component"],
+    "plan_refinements": [],
+    "tests_to_run_next": ["npm run test:unit"],
+    "risk_flags": [],
+    "should_open_pr": False,
+}
+
+
+def test_parses_raw_json():
+    v = parse_verdict(json.dumps(VALID))
+    assert v is not None
+    assert v.status == "continue"
+    assert v.required_next_steps == ["finish the component"]
+    assert v.should_open_pr is False
+
+
+def test_parses_fenced_json_with_prose():
+    text = "Here is my verdict:\n```json\n" + json.dumps(VALID) + "\n```\nthanks"
+    v = parse_verdict(text)
+    assert v is not None and v.status == "continue"
+
+
+def test_parses_json_embedded_in_prose():
+    text = "prelude {not json} then " + json.dumps(VALID) + " trailing"
+    v = parse_verdict(text)
+    assert v is not None and v.summary == "half done"
+
+
+def test_rejects_garbage():
+    assert parse_verdict("no json here at all") is None
+    assert parse_verdict("{broken json") is None
+
+
+def test_rejects_bad_status_and_missing_summary():
+    bad = dict(VALID, status="approve")
+    assert parse_verdict(json.dumps(bad)) is None
+    bad = dict(VALID)
+    bad.pop("summary")
+    assert parse_verdict(json.dumps(bad)) is None
+    bad = dict(VALID, summary="   ")
+    assert parse_verdict(json.dumps(bad)) is None
+
+
+def test_coerces_invalid_criterion_status_to_unknown():
+    v = parse_verdict(json.dumps(dict(VALID, criteria_status=[
+        {"id": "A1", "section": "API", "text": "x", "status": "kinda", "evidence": ""}
+    ])))
+    assert v is not None
+    assert v.criteria_status[0]["status"] == "unknown"
+
+
+def test_non_list_fields_become_empty_lists():
+    v = parse_verdict(json.dumps(dict(VALID, required_next_steps="do it", risk_flags=None)))
+    assert v is not None
+    assert v.required_next_steps == []
+    assert v.risk_flags == []
+
+
+def test_decoy_pass_object_cannot_beat_real_verdict():
+    # A quoted example verdict lacks the full schema, so it can never win;
+    # the real (full-shape) verdict later in the text is taken.
+    decoy = '{"status": "pass", "summary": "example only"}'
+    text = f"If done I would return {decoy} but instead:\n" + json.dumps(VALID)
+    v = parse_verdict(text)
+    assert v is not None
+    assert v.status == "continue"
+
+
+def test_decoy_in_fenced_block_cannot_beat_real_verdict():
+    decoy = '```json\n{"status": "pass", "summary": "example"}\n```'
+    text = decoy + "\nReal verdict:\n" + json.dumps(VALID)
+    v = parse_verdict(text)
+    assert v is not None and v.status == "continue"
+
+
+def test_incomplete_object_embedded_in_prose_is_rejected():
+    # Embedded candidates must carry every schema key.
+    text = 'prose {"status": "pass", "summary": "ok"} more prose'
+    assert parse_verdict(text) is None
+
+
+def test_last_full_object_wins():
+    first = json.dumps(dict(VALID, status="pass"))
+    second = json.dumps(VALID)  # continue
+    v = parse_verdict(f"a {first} b {second} c")
+    assert v is not None and v.status == "continue"

--- a/docs/plans/03-implementation-plans/active/0016-coding-relay-agent.md
+++ b/docs/plans/03-implementation-plans/active/0016-coding-relay-agent.md
@@ -1,0 +1,139 @@
+# 0016 - Coding Relay (Claude implements, Codex reviews, receipts + draft PR)
+
+- Status: PR 1 (runnable spine) implemented; follow-up tickets below are open
+- Date: 2026-07-07
+- ADO: Story #765 under Feature #764 (Coding Relay) under Epic #359 (Orchestration: Codex + Agent Workflows)
+- Risk: Medium (orchestration governance surface; no schema, auth, or prod changes)
+- Reference doc: [docs/reference/CODING_RELAY.md](../../../reference/CODING_RELAY.md)
+- Code: `orchestration/coding_relay/`, entry `scripts/coding_relay.py`, tests `backend/tests/test_orchestration_relay_*.py`
+
+## Outcome
+
+A local coding cockpit: give it a plan with explicit success criteria and it
+validates the plan, preflights the environment, isolates work in a throwaway
+worktree on a `relay/<slug>-<timestamp>` branch off fresh `origin/main`, runs
+a bounded loop (Claude CLI builds, safety scanner checks the diff, repo tests
+run, Codex CLI audits from an artifact bundle and returns a structured JSON
+verdict), writes receipts to `.orchestration/runs/<run_id>/`, and on pass
+opens a draft PR. It never merges, never force-pushes, never deploys.
+
+Design decisions of record:
+
+- Codex is artifact-review by default: it sees only the run's review bundle,
+  never the repo. `--codex-repo-access` is an explicit, recorded escalation.
+- `git fetch origin main` failure is a hard stop; `--allow-stale-base` is the
+  explicit, recorded override.
+- `--dry-run` is strict: no worktree, no branch, no run folder, no writes, no
+  provider calls (capability probes only with `--probe-clis`).
+- Safety scanner severities: stop (exit 4) for mass deletion, out-of-worktree
+  writes or symlinks, unapproved migrations, secrets in the diff; escalate
+  (exit 5) for workflow/hook edits, auth surfaces, relay self-edits.
+- Adapter core copied (with attribution) from
+  `skills/winston-plan-relay/scripts/adapters/`; the proven CLI invocations
+  come from `build_review_loop.py` (Ticket 3B lineage). The skill itself is
+  untouched.
+- `docs/instruction-index.md` is generated from
+  `config/instruction-routing.json`; no hand-edited row. Discovery is the
+  reference doc, the orchestration README section, and the Makefile `relay`
+  target. A routed skill wrapper can come later if wanted.
+
+## Tickets
+
+| # | Ticket | Status |
+|---|---|---|
+| 1 | Repo inventory and relay architecture | Done (approved plan, 2026-07-07) |
+| 2 | Plan intake, validation, preflight, run receipts | Done (PR 1) |
+| 3 | Claude/Codex provider adapters with capability probes | Done (PR 1) |
+| 4 | Relay loop: bounded build/scan/test/review, verdict JSON | Done (PR 1) |
+| 5 | Test/evidence integration (basic suites, honest skips) | Done (PR 1, basic mapping only) |
+| 6 | PR body and draft PR creation with manual fallback | Done (PR 1) |
+| 7 | Usability wrapper (`make relay`, no-args plan list) | Done (PR 1, non-interactive) |
+| 8 | Documentation, fixture dry-run eval, tips.md | Done (PR 1) |
+
+## Adversarial review round (2026-07-07)
+
+A multi-agent review over the finished diff surfaced 48 raw findings; the
+confirmed ones were fixed before the PR:
+
+- `--draft-pr` could commit and push a diff a safety stop had flagged
+  (including detected secrets). Fixed: PR creation only on PASS or, with
+  `--draft-pr`, MAX_ITER; `--no-pr` and `--draft-pr` are mutually exclusive.
+- The verdict parser took the first JSON object in reviewer output, so a
+  quoted example `{"status": "pass"}` could fake a PASS. Fixed: strict
+  whole-output parse first; embedded candidates must carry every schema key
+  and the last one wins.
+- The scanner diffed against HEAD, so builder-made commits bypassed every
+  rule. Fixed: diff against the recorded base sha; builder commits are
+  themselves a stop.
+- Rename detection hid mass moves from the deletion gate. Fixed:
+  `-c diff.renames=false` for the deletion count.
+- Redaction missed underscore-prefixed env names, JWTs, PEM blocks, dapi
+  and AIza tokens; the same gaps defeated the secrets stop. Fixed with a
+  two-tier pattern set (aggressive redaction, high-confidence stop), and
+  the stop no longer false-positives on `token = mint_token(user)` code.
+- The self-edit escalation could be disabled by plan text mentioning the
+  relay. Fixed: always escalates unless `--allow-relay-self-edit` (recorded).
+- probe() wrote `--help` caches around the redaction choke point. Fixed.
+- Uncaught timeouts/AdapterUnavailable crashed with exit 1 (colliding with
+  MAX_ITER). Fixed: preflight/pr subprocess calls degrade, the loop is
+  wrapped, exit codes stay truthful, `GIT_TERMINAL_PROMPT=0` on push.
+- run_id minute-granularity collisions could corrupt a previous run's
+  receipts. Fixed: seconds plus a collision guard.
+- FakeProviders could fabricate a default pass on a missing fixture file
+  and desynced on verdict retries. Fixed: iteration-keyed, blocked default.
+- Plus: dry-run mirrors real exit codes, non-origin bases record a
+  freshness warning, honest reviewer prompt under `--codex-repo-access`,
+  every skip reason carries the manual command, intake keywords use word
+  boundaries, MANUAL_PR.md uses the absolute PR body path.
+
+## Acceptance evidence
+
+| # | Item | Result | Evidence |
+|---|---|---|---|
+| 1 | Relay refuses plans without success criteria | PASS | `test_missing_criteria_refused_exit_2` (exit 2, no receipts, no branch) |
+| 2 | Fixture E2E: 2-iteration continue-then-pass loop, exit 0, full manifest | PASS | `test_fixture_loop_passes_end_to_end` |
+| 3 | Max iterations enforced (exit 1, worktree kept) | PASS | `test_fixture_loop_max_iterations_exit_1` |
+| 4 | Safety stop on secret in diff (exit 4, no review after stop) | PASS | `test_secret_written_by_builder_triggers_safety_stop` |
+| 5 | `--draft-pr` never publishes a safety-stopped diff | PASS | `test_draft_pr_never_fires_after_safety_stop` (no commit, no MANUAL_PR) |
+| 6 | Exit 5 routes: blocked, risk_escalation, escalate-scan, garbage verdict | PASS | four `..._exit_5` tests; scan route asserts no verdict.json |
+| 7 | Exit 6 (builder failure) and exit 3 (missing CLIs) | PASS | `test_builder_failure_exit_6`, `test_missing_clis_exit_3` |
+| 8 | Fetch failure hard stop; `--allow-stale-base` recorded | PASS | `test_fetch_failure_is_hard_stop_exit_2`, `test_allow_stale_base_proceeds_and_is_recorded` |
+| 9 | Builder commits cannot bypass the scanner | PASS | `test_snapshot_diffs_against_base_even_after_builder_commit` |
+| 10 | PR fallback writes MANUAL_PR.md with `--draft` and absolute body path | PASS | `test_pass_without_pr_flags_degrades_to_manual_pr` |
+| 11 | Strict dry run writes nothing, mirrors exit codes | PASS | `test_dry_run_writes_nothing` + manual run on this repo |
+| 12 | Secrets redacted in every receipt; decoy verdicts rejected | PASS | planted `ghp_...` swept across the run folder; 4 decoy tests |
+| 13 | Ruff clean; all relay tests green | PASS | 78 passed locally (61 unit + 17 E2E); ruff clean on package + tests |
+
+## Follow-up tickets (open)
+
+- Guided interactive flow: numbered plan menu, paste mode, criteria
+  confirm/edit screen, per-iteration continue prompts, final PR offer.
+- Cockpit UI: read-only viewer over `.orchestration/runs/` (self-contained
+  HTML status page per run). The `run.json` state schema from PR 1 is the
+  data contract.
+- Broader test inference: Playwright/e2e, AI-eval suites, migration/schema
+  verification classes.
+- PR polish: `scripts/winston/merge_gate.ps1` integration, richer evidence
+  linking, approve-and-continue flag for escalations.
+- Optional: routed skill wrapper so the relay is discoverable through the
+  instruction registry.
+
+## Honest caveats
+
+- PR 1 is non-interactive; `--yes` is a forward-compatibility no-op.
+- The reviewer's default sandbox behavior on Windows may require the bypass
+  retry (still pointed only at the bundle dir); first real CLI run should
+  confirm which path executes and record it in `review-meta.json`.
+- A real (token-spending) end-to-end run with live `claude`/`codex` CLIs was
+  not part of the test suite; the loop is proven by fixture providers and by
+  the CLIs' own `--help` probes. Run one small real task before relying on
+  it for daily work.
+- Out-of-worktree containment is diff-based plus the Claude CLI's own
+  edit scoping; `--claude-permission-mode bypassPermissions` weakens it and
+  is recorded as an escalation, not blocked.
+- The adversarial review's verification phase was cut short by a session
+  usage limit; the 48 raw findings were verified and triaged by hand
+  against the code instead of by independent verifier agents.
+- `python -m orchestration.coding_relay` needs cwd at repo root; the wrapper
+  script works from anywhere.
+- Ruff is not CI-gated for `orchestration/`; it was run manually for PR 1.

--- a/docs/reference/CODING_RELAY.md
+++ b/docs/reference/CODING_RELAY.md
@@ -1,0 +1,241 @@
+# Coding Relay - reference
+
+A local coding cockpit for the Winston repo. You give it an implementation
+plan with explicit success criteria. It isolates the work in a throwaway git
+worktree, has the Claude CLI implement in bounded passes, has the Codex CLI
+audit each pass against the criteria, runs the repo's real tests, and ends
+with receipts and (on pass) a draft PR. It is controlled automation with
+checkpoints, not an autonomous agent: every stop condition halts the run and
+tells you what to do next. It never merges, never force-pushes, never
+deploys.
+
+## Launch
+
+```
+python -m orchestration.coding_relay --plan <path|NNNN>   # from repo root
+python scripts/coding_relay.py --plan <path|NNNN>         # from anywhere
+make relay ARGS="--plan 0016"                             # POSIX shells
+```
+
+Run with no arguments to get usage plus a numbered list of the active plans
+in `docs/plans/03-implementation-plans/active/`.
+
+## Required CLIs
+
+| CLI | Role | If missing |
+|---|---|---|
+| `claude` | Builder (edits files in the worktree) | hard stop, exit 3 |
+| `codex` | Reviewer (reads the artifact bundle) | hard stop, exit 3 |
+| `gh` | Draft PR creation | degrade: PR body + MANUAL_PR.md |
+| `git` | Everything | hard stop |
+
+Model flags are gated on each CLI's `--help` output (cached in the run
+folder). If the installed CLI does not advertise model selection, the relay
+uses the CLI default and records that fact in `run.json`.
+
+## Plan format
+
+The relay refuses vague work (exit 2). A plan must contain a heading named
+`Success Criteria`, `Acceptance Criteria`, or `Definition of Done` followed
+by concrete bullets. Criteria are normalized into six sections with stable
+ids the reviewer judges one by one:
+
+```
+## Acceptance Criteria
+
+### Screen          (S1, S2, ...)
+### API             (A1, ...)
+### DB/Data         (D1, ...)
+### AI behavior     (B1, ...)
+### Evals/tests     (T1, ...)
+### Regression guard (R1, ...)
+```
+
+Sections that do not apply render "Not applicable." Bullets that fit no
+section land in a General (G) group. The normalized form is written to
+`plan/normalized-criteria.md` in the run folder.
+
+Provide the plan by path (`--plan docs/plans/.../0016-foo.md`), by active-dir
+prefix (`--plan 0016`), or as pasted text saved to a file
+(`--paste-file my-task.md`).
+
+## How Claude and Codex divide the work
+
+Claude is the only writer. Each iteration it runs as
+`claude -p --permission-mode acceptEdits --add-dir <worktree>` with cwd
+pinned to the worktree, receives the plan, the normalized criteria, prior
+reviewer feedback, and failing-test excerpts, and edits files.
+
+Codex never edits and, by default, never sees the repo. After each build
+pass the relay assembles a review bundle (diff, changed-file list, test
+summary, builder summary) under
+`iterations/NN/review-bundle/` and runs
+`codex exec --cd <bundle-dir> --skip-git-repo-check -m <model>
+-c model_reasoning_effort=<effort> -`. Codex must answer with one JSON
+verdict: `pass`, `continue`, `blocked`, or `risk_escalation`, plus
+per-criterion status, required next steps, plan refinements, and risk flags.
+On `continue`, that feedback goes into the next Claude pass. The review on
+the final allowed iteration runs at `--codex-max-effort`.
+
+`--codex-repo-access` gives Codex the prototype's full-worktree invocation
+instead. That is a recorded risk escalation: it lands in `run.json`, the
+final report, and the PR body.
+
+If Codex output cannot be parsed as the JSON verdict, the relay retries once
+with a JSON-only nudge, then treats the review as blocked. A parse failure
+is never treated as approval.
+
+## Loop and exit codes
+
+`INTAKE -> PREFLIGHT -> WORKTREE -> [BUILD -> SCAN -> TEST -> REVIEW] x N -> FINALIZE`
+
+| Exit | Meaning |
+|---|---|
+| 0 | PASS: every criterion met or not applicable, no risk flags |
+| 1 | Max iterations reached (default 3, `--max-iterations`); worktree kept |
+| 2 | Intake or preflight refusal (missing criteria, bad plan, failed fetch) |
+| 3 | `claude` or `codex` CLI missing |
+| 4 | Safety stop (see hard stops below) |
+| 5 | Blocked or risk escalation; a human decides how to proceed |
+| 6 | Provider or internal error (nonzero exit, timeout) |
+
+A final report and PR body are written on every run that gets past
+preflight, whatever the outcome.
+
+## Hard stops and safety rules
+
+Stop (exit 4), checked after every build pass against the diff from the
+recorded base commit (so changes smuggled into builder-made commits are
+still seen; builder commits are themselves a stop, the relay owns commits):
+
+- more than 100 deleted files, counted with git rename detection off so a
+  mass move counts too (stricter than `.githooks/pre-commit`)
+- tracked writes resolving outside the relay worktree, `..` traversal, or
+  any new symlink in the diff
+- DB schema/migration paths (`supabase/`, `repo-b/db/schema/`, any
+  `migrations/`) without `--allow-migrations`
+- high-confidence secret shapes in added lines (known token prefixes, JWTs,
+  PEM headers, DB URLs with credentials, quoted literal assignments to
+  secret-named keys; ordinary code like `token = mint_token(user)` does not
+  trip it)
+
+Escalate (exit 5): `.github/` or `.githooks/` edits, root `Makefile` or
+`dev.sh` edits, auth/security surface edits, or any edit to
+`orchestration/coding_relay/` itself (override only with the recorded
+`--allow-relay-self-edit` flag; plan wording never disables this).
+
+Structural rules with no override: the relay never calls `gh pr merge`,
+never force-pushes (`GIT_TERMINAL_PROMPT=0`, no credential prompts), never
+deploys, never deletes worktrees, and PR creation always passes `--draft`.
+Preflight `git fetch origin main` failure is a hard stop unless you pass
+`--allow-stale-base` (recorded in the receipts); a non-origin `--base` skips
+the fetch and is recorded as a freshness warning. Every artifact write goes
+through the secret-redaction choke point (including the CLI `--help`
+caches), and the relay never prints environment variables.
+
+Containment honesty: the outside-worktree stop is diff-based. It sees what
+git sees inside the worktree; a builder writing to an absolute path
+elsewhere on disk is contained by the Claude CLI's own `acceptEdits`
+scoping, not by the scanner. `--claude-permission-mode bypassPermissions`
+weakens that boundary and is therefore recorded as an escalation in
+`run.json` and the report.
+
+## Tests
+
+Suites are inferred from changed paths and run inside the worktree with the
+CI-matching commands:
+
+| Changed | Suites |
+|---|---|
+| `backend/**` | `python -m ruff check app tests`, `python -m pytest tests -q` |
+| `repo-b/**` | `npm run lint`, `npm run typecheck`, `npm run test:unit` |
+| `rs_factory_seed/**` | `python -m pytest tests -q` |
+| backend, repo-b, or verification | `python -m verification.lint.no_legacy_repe_reads --json` |
+
+The backend interpreter prefers `backend/.venv` (worktree, then primary
+checkout) and falls back to the PATH interpreter, recording which. Missing
+prerequisites (no node_modules junction, no interpreter) produce a SKIPPED
+result with the exact manual command. Results are recorded as-is; the relay
+never claims a test passed unless it ran and exited 0. Playwright/e2e and
+AI-eval inference are follow-up scope (plan 0016).
+
+## Run folder
+
+Receipts live under `.orchestration/runs/<run_id>/` (git-ignored):
+
+```
+run.json                        config, state, base sha, models, exit code
+plan/original-plan.md           plan/normalized-criteria.md
+env/preflight.json              env/claude-help.txt  env/codex-help.txt
+iterations/NN/build-prompt.md   build-output.md  build-meta.json
+iterations/NN/diff.patch        diff-stat.txt    safety.json
+iterations/NN/review-bundle/    diff.patch, files.txt, tests-summary.md, ...
+iterations/NN/tests/<suite>.log tests/summary.json
+iterations/NN/review-prompt.md  review-output.txt  verdict.json
+report/final-report.md          report/PR_BODY.md  report/pr.json | MANUAL_PR.md
+```
+
+The relay worktree lives outside the repo in a short sibling directory
+(default `<repo-parent>/<repo>_relay/r-<slug8>-<hhmmss>`, override with
+`--worktree-root`) on branch `relay/<slug>-<timestamp>`.
+
+## PR creation
+
+On PASS the relay commits everything in the worktree, pushes the relay
+branch, and opens a DRAFT PR against `main` with the PR body from
+`report/PR_BODY.md` (plan, criteria checklist, files changed, tests,
+evidence paths, reviewer verdicts, risks, rollback). `--draft-pr` extends
+that to MAX_ITER runs only; nothing is ever committed or pushed after a
+safety stop, a block, or an error, because publishing a diff the scanner
+flagged would defeat the safety layer. `--no-pr` and `--draft-pr` are
+mutually exclusive. A reviewer that passes the work but sets
+`should_open_pr` to false suppresses the automatic PR (force with
+`--draft-pr`). If `gh` is missing or unauthenticated, or the push fails,
+the relay writes `report/MANUAL_PR.md` with the exact commands instead.
+
+## Dry run
+
+`--dry-run` is strict: it validates the plan, runs read-only preflight (no
+fetch, no write probes), prints the normalized criteria and every command a
+real run would execute, and exits without creating a worktree, branch, run
+folder, or any file. It mirrors the real exit codes (3 for a missing
+provider CLI, 2 for any other failed check), so it works as an automation
+gate. Add `--probe-clis` to also run the `--help` capability probes (the
+only provider invocations allowed in a dry run).
+
+`--fixture <dir>` drives the whole loop from scripted fake providers (see
+`orchestration/coding_relay/fixtures/demo/`): no CLIs, no tokens. This is
+how the E2E tests exercise the loop.
+
+## Failure recovery
+
+- The relay never cleans up after itself; every run prints and records the
+  exact `git worktree remove` and `git branch -D` commands.
+- Exit 1 (max iterations): inspect the worktree, then either finish by hand
+  or re-run with a sharper plan. The diff survives in the worktree and in
+  `iterations/NN/diff.patch`.
+- Exit 4/5: read `iterations/NN/safety.json` or the last `verdict.json`,
+  decide, act by hand. The relay does not continue past a stop on its own.
+- Exit 6: read `iterations/NN/build-stderr.txt` or `review-stderr.txt`.
+- Stale worktree path collision: remove the old worktree (command above) or
+  pass a different `--worktree-root`.
+
+## Known limitations (PR 1)
+
+- Non-interactive: no guided menu flow yet; `--yes` is accepted as a no-op
+  for forward compatibility. Run with no args to see the plan list.
+- Test inference covers the four basic suite groups only.
+- Escalations (exit 5) have no generic approve-and-continue flag; a human
+  finishes by hand or re-runs (`--allow-relay-self-edit` and
+  `--allow-migrations` are the only scoped overrides).
+- The secrets stop has no override: a fixture with a quoted dummy
+  credential will stop the run; rename the dummy or drop the quotes.
+- The cockpit UI is a planned follow-up
+  (`docs/plans/03-implementation-plans/active/0016-coding-relay-agent.md`).
+
+## Relay tests
+
+```
+cd backend && python -m pytest tests/test_orchestration_relay_*.py -q
+python -m ruff check orchestration/coding_relay scripts/coding_relay.py
+```

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4910,3 +4910,29 @@ Redesign of `/lab/env/[envId]/telemetry/calibration` into an inspectable evidenc
 - **Root-anchor artifact ignores to avoid hiding real source.** `/*.png`, `/*.jpg`, `/*.zip` (leading slash) match only the repo root, where genuine one-offs pile up, and never a subdirectory asset like `repo-b/public/**/*.jpg`. Before adding any glob, prove it hides nothing tracked: `git ls-files | git check-ignore --stdin --verbose` must return no legit path, and `git ls-files ':(glob)*.png'` (etc.) at root must be empty. `*.pdf` was already ignored, so the resume + Relativity expense receipts were safe; the gaps were `mlflow.db`, root images, and `*.zip`.
 - **Verify a Confluent manifest's `cluster_type` before trusting an export diff.** `infra/confluent/stargate/manifest.json` showed `cluster_type: STANDARD → PROTOBUF`; PROTOBUF is a *schema format*, never a cluster type (valid: BASIC/STANDARD/ENTERPRISE/DEDICATED/FREIGHT). It was an export-script field mix-up. Revert **only** that field — the same diff's other hunks (a new `*.triage` subject, `connectors: []`, and the paired schema evolution) were legitimate. Reverting the whole file with `git checkout --` would have destroyed real workstream edits; surgically edit the one field instead.
 - **Untracked skills routed only in an uncommitted `M CLAUDE.md` are NOT dangling on main.** Confirm with `git grep -l <skill> origin/main -- CLAUDE.md config/instruction-routing.json` before deciding to commit vs ticket. If main doesn't route them, ticket them for a proper generated-artifact landing (skill body + `npm run generate:instructions` + route in `config/instruction-routing.json`) rather than committing bodies whose index edits live in someone else's workstream.
+
+## Coding Relay + agent-loop testing patterns (2026-07-07)
+
+- **Coding Relay exists**: `python scripts/coding_relay.py --plan <path|NNNN>`
+  runs a bounded Claude-builds/Codex-reviews loop with receipts under
+  `.orchestration/runs/<run_id>/` and draft-PR-only output. Reference:
+  `docs/reference/CODING_RELAY.md`. Codex reviews from an artifact bundle by
+  default (no repo access); `--codex-repo-access` is a recorded escalation.
+- **Test agent loops without spending tokens**: inject providers as
+  callables and drive them from a fixture dir
+  (`orchestration/coding_relay/fixtures.py` + `fixtures/demo/`). The fake
+  builder copies `iterations/N/files/**` into a tmp git repo's worktree; the
+  fake reviewer returns `iterations/N/review.json` verbatim. The whole loop,
+  safety scanner, redaction, and exit codes are then testable in pytest
+  (`backend/tests/test_orchestration_relay_loop_fixture.py`).
+- **Do not assume `backend/.venv` exists.** The Windows dev box runs backend
+  tests with the system PATH interpreter; CI installs requirements into
+  system Python too. Tooling that wraps backend tests must resolve the
+  interpreter with a fallback chain (worktree venv, primary venv, PATH) and
+  record which one ran, instead of hard-coding `.venv/bin/python` like the
+  Makefile targets do.
+- **`docs/instruction-index.md` is generated** from
+  `config/instruction-routing.json` (`npm run generate:instructions`); never
+  hand-edit the table. Register new routed surfaces in the JSON, or skip the
+  registry when the thing is a tool with a reference doc rather than a
+  skill/agent.

--- a/orchestration/README.md
+++ b/orchestration/README.md
@@ -90,3 +90,20 @@ python3 scripts/codex_orchestrator.py merge-gate --branch-a feature/<idA>/<inten
 python3 scripts/codex_orchestrator.py log show --session-id <uuid>
 python3 scripts/codex_orchestrator.py log verify-chain
 ```
+
+## Coding Relay
+
+`orchestration/coding_relay/` is a separate tool on the same substrate: a
+bounded build/review loop where the Claude CLI implements inside a throwaway
+worktree and the Codex CLI audits each pass from an artifact bundle,
+returning a structured JSON verdict per acceptance criterion. Plans without
+explicit success criteria are refused. Receipts land under
+`.orchestration/runs/<run_id>/`; on pass it opens a draft PR (never merges).
+
+```bash
+python -m orchestration.coding_relay --plan <path|NNNN>   # repo root
+python scripts/coding_relay.py --plan 0016 --dry-run      # anywhere
+```
+
+Full reference: `docs/reference/CODING_RELAY.md`. Tests:
+`backend/tests/test_orchestration_relay_*.py`.

--- a/orchestration/coding_relay/__init__.py
+++ b/orchestration/coding_relay/__init__.py
@@ -1,0 +1,17 @@
+"""Coding Relay: bounded Claude-builds / Codex-reviews loop with receipts.
+
+Claude CLI is the primary implementer inside an isolated git worktree.
+Codex CLI reviews each pass from a neutral artifact bundle (never the repo)
+and returns a structured JSON verdict. The loop stops on pass, blocker,
+risk escalation, safety violation, or max iterations, then writes a final
+report and (on pass) can open a draft PR.
+
+Entry points:
+    python -m orchestration.coding_relay   (from repo root)
+    python scripts/coding_relay.py         (from anywhere)
+
+Reference doc: docs/reference/CODING_RELAY.md
+"""
+from __future__ import annotations
+
+RELAY_VERSION = "0.1.0"

--- a/orchestration/coding_relay/__main__.py
+++ b/orchestration/coding_relay/__main__.py
@@ -1,0 +1,407 @@
+"""Coding Relay CLI.
+
+    python -m orchestration.coding_relay --plan docs/plans/.../0016-foo.md
+    python scripts/coding_relay.py --plan 0016 --max-iterations 3
+
+Run with no arguments for usage plus the numbered list of active plans.
+Exit codes: 0 pass, 1 max-iterations, 2 intake/preflight, 3 missing CLI,
+4 safety stop, 5 blocked/risk escalation, 6 provider/internal error.
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+from orchestration.coding_relay import RELAY_VERSION, intake as intake_mod
+from orchestration.coding_relay.intake import IntakeError
+from orchestration.coding_relay.loop import (
+    LoopConfig,
+    MAX_ITER,
+    PASS,
+    collect_snapshot,
+    run_loop,
+)
+from orchestration.coding_relay.preflight import PreflightConfig, run_preflight
+from orchestration.coding_relay.providers import (
+    AdapterUnavailable,
+    claude as claude_mod,
+    codex as codex_mod,
+    probe,
+)
+from orchestration.coding_relay.report import RunSummary, final_report, pr_body
+from orchestration.coding_relay.runs import RunPaths, new_run_id
+from orchestration.coding_relay.worktree import (
+    create_worktree,
+    default_worktree_root,
+    ensure_deps_links,
+    removal_instructions,
+)
+from orchestration.coding_relay import pr as pr_mod
+
+DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="coding_relay",
+        description="Bounded Claude-builds / Codex-reviews relay with receipts.",
+    )
+    p.add_argument("--plan", help="Plan file path, or a filename prefix (e.g. 0016) in docs/plans/03-implementation-plans/active/")
+    p.add_argument("--paste-file", help="Read the plan text from this file instead of --plan")
+    p.add_argument("--repo-root", type=Path, default=DEFAULT_REPO_ROOT, help=argparse.SUPPRESS)
+    p.add_argument("--yes", action="store_true", help="Accepted for forward compatibility (PR 1 is non-interactive)")
+    p.add_argument("--max-iterations", type=int, default=3, help="Build/review iterations cap (default 3)")
+    p.add_argument("--base", default="origin/main", help="Base ref for the relay worktree (default origin/main)")
+    p.add_argument("--allow-stale-base", action="store_true", help="Proceed on the local base ref if git fetch fails (recorded)")
+    p.add_argument("--worktree-root", type=Path, help="Directory for relay worktrees (default: sibling <repo>_relay)")
+    p.add_argument("--claude-model", help="Builder model; passed only if the installed CLI advertises --model")
+    p.add_argument("--claude-permission-mode", default="acceptEdits", choices=["acceptEdits", "bypassPermissions"])
+    p.add_argument("--claude-timeout", type=int, default=1800)
+    p.add_argument("--codex-model", default="gpt-5.4", help="Reviewer model, pinned for the run (default gpt-5.4)")
+    p.add_argument("--codex-effort", default="low", choices=list(codex_mod.EFFORT_LADDER))
+    p.add_argument("--codex-max-effort", default="medium", choices=list(codex_mod.EFFORT_LADDER),
+                   help="Effort used for the final allowed iteration's review")
+    p.add_argument("--codex-timeout", type=int, default=900)
+    p.add_argument("--codex-repo-access", action="store_true",
+                   help="RISK ESCALATION (recorded): give the reviewer full worktree access instead of the artifact bundle")
+    p.add_argument("--no-tests", action="store_true", help="Skip test suites (reported honestly)")
+    pr_group = p.add_mutually_exclusive_group()
+    pr_group.add_argument("--no-pr", action="store_true", help="Never create a PR")
+    pr_group.add_argument("--draft-pr", action="store_true",
+                          help="Also create a draft PR on MAX_ITER (never after a safety stop or block)")
+    p.add_argument("--allow-migrations", action="store_true", help="Let the builder touch DB schema/migration paths")
+    p.add_argument("--allow-relay-self-edit", action="store_true",
+                   help="RECORDED: let the builder edit orchestration/coding_relay/ itself")
+    p.add_argument("--keep-env", action="store_true", help="Do not scrub CLAUDE* env vars from the builder subprocess")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Validate the plan and preflight, print every command; no worktree, no writes, no providers")
+    p.add_argument("--probe-clis", action="store_true", help="With --dry-run: also run `--help` capability probes")
+    p.add_argument("--fixture", type=Path, help="Drive the loop from a fixture dir (no CLIs, no tokens)")
+    p.add_argument("--version", action="version", version=f"coding-relay {RELAY_VERSION}")
+    return p
+
+
+def print_no_args_help(repo_root: Path) -> int:
+    print("Coding Relay: give it a plan with explicit success criteria.\n")
+    print("Usage:  python -m orchestration.coding_relay --plan <path|NNNN>")
+    print("        python scripts/coding_relay.py --plan <path|NNNN>\n")
+    plans = intake_mod.list_active_plans(repo_root)
+    if plans:
+        print("Active plans (docs/plans/03-implementation-plans/active/):")
+        for i, p in enumerate(plans, 1):
+            print(f"  {i:2d}. {p.name}")
+        print("\nExample:")
+        print(f"  python -m orchestration.coding_relay --plan {plans[0].name.split('-')[0]} --dry-run")
+    else:
+        print("No active plans found; pass --plan <path> or --paste-file <path>.")
+    print("\nA plan MUST contain a 'Success Criteria' / 'Acceptance Criteria' /")
+    print("'Definition of Done' heading with concrete bullets, or the relay refuses.")
+    print("Docs: docs/reference/CODING_RELAY.md")
+    return 2
+
+
+def do_dry_run(args, result) -> int:
+    """Strict dry run: nothing written, no worktree, no providers.
+    Capability probes only with --probe-clis."""
+    print(f"[dry-run] plan accepted: {result.title} (slug {result.slug})")
+    print("[dry-run] normalized acceptance criteria:\n")
+    print(result.criteria.to_markdown())
+    cfg = PreflightConfig(
+        repo_root=args.repo_root,
+        base_ref=args.base,
+        allow_stale_base=args.allow_stale_base,
+        pr_requested=not args.no_pr,
+        plan_path=result.plan_path,
+        worktree_root=args.worktree_root,
+        fixture_mode=args.fixture is not None,
+        fixture_dir=args.fixture,
+        read_only=True,
+    )
+    checks = run_preflight(cfg)
+    for c in checks.checks:
+        print(f"[preflight] {c.name}: {c.status} - {c.detail}")
+    wt_root = args.worktree_root or default_worktree_root(args.repo_root)
+    print("\n[dry-run] a real run would:")
+    print(f"  1. create worktree under {wt_root} on branch relay/{result.slug}-<timestamp> from {args.base}")
+    print(f"  2. write receipts to {args.repo_root / '.orchestration' / 'runs'}/<run_id>/")
+    if args.fixture:
+        print(f"  3. drive the loop from fixture {args.fixture}")
+    else:
+        print(f"  3. builder:  claude -p --permission-mode {args.claude_permission_mode} --add-dir <worktree>")
+        print(f"  4. reviewer: codex exec --cd <review-bundle> --skip-git-repo-check -m {args.codex_model} "
+              f"-c model_reasoning_effort={args.codex_effort} -")
+    print(f"  5. iterate up to {args.max_iterations}x: build -> safety scan -> tests -> review")
+    print("  6. on pass: draft PR via gh (never merge, never force-push)" if not args.no_pr
+          else "  6. no PR (--no-pr)")
+    if args.probe_clis:
+        for name in ("claude", "codex"):
+            exe = shutil.which(name)
+            if exe:
+                caps = probe(exe)
+                print(f"[probe] {name}: {len(caps.flags)} flags advertised"
+                      f"{'; --model supported' if '--model' in caps.flags else ''}")
+            else:
+                print(f"[probe] {name}: not on PATH")
+    # A dry run is a validation gate: mirror the real exit codes.
+    if checks.failed:
+        failed_names = {c.name for c in checks.failures()}
+        code = 3 if {"claude-cli", "codex-cli"} & failed_names else 2
+        print(f"\n[dry-run] wrote nothing, changed nothing. Preflight FAILED; a real run would exit {code}.")
+        return code
+    print("\n[dry-run] wrote nothing, changed nothing. Exit 0.")
+    return 0
+
+
+def main(argv: list | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    repo_root: Path = args.repo_root.resolve()
+
+    if not args.plan and not args.paste_file:
+        return print_no_args_help(repo_root)
+
+    # ---- INTAKE (exit 2 on refusal)
+    try:
+        result = intake_mod.load_plan(repo_root, args.plan, args.paste_file)
+    except IntakeError as exc:
+        print(f"[intake] REFUSED: {exc}", file=sys.stderr)
+        return 2
+    print(f"[intake] plan: {result.title}")
+    print(f"[intake] criteria: {len(result.criteria.checklist())} normalized "
+          f"(sections with content: "
+          f"{sum(1 for _, v in result.criteria.sections.items() if v) + (1 if result.criteria.general else 0)})")
+
+    if args.dry_run:
+        return do_dry_run(args, result)
+
+    # ---- PREFLIGHT
+    pf_cfg = PreflightConfig(
+        repo_root=repo_root,
+        base_ref=args.base,
+        allow_stale_base=args.allow_stale_base,
+        pr_requested=not args.no_pr,
+        plan_path=result.plan_path,
+        worktree_root=args.worktree_root,
+        fixture_mode=args.fixture is not None,
+        fixture_dir=args.fixture,
+    )
+    checks = run_preflight(pf_cfg)
+    for c in checks.checks:
+        print(f"[preflight] {c.name}: {c.status} - {c.detail}")
+    if checks.failed:
+        failed_names = {c.name for c in checks.failures()}
+        if {"claude-cli", "codex-cli"} & failed_names:
+            return 3
+        print("[preflight] FAILED; nothing was created.", file=sys.stderr)
+        return 2
+
+    # ---- RUN FOLDER (refuse to reuse an existing run's receipts)
+    run_id = new_run_id(result.slug)
+    suffix = 1
+    while RunPaths(repo_root, run_id).root.exists():
+        suffix += 1
+        run_id = f"{new_run_id(result.slug)}-{suffix}"
+    run_paths = RunPaths(repo_root, run_id)
+    run_paths.write("plan/original-plan.md", result.plan_text)
+    run_paths.write("plan/normalized-criteria.md", result.criteria.to_markdown())
+    run_paths.write_json("env/preflight.json", checks.to_payload())
+    escalation_flags: list = []
+    if args.codex_repo_access:
+        escalation_flags.append(
+            "--codex-repo-access: reviewer was given full worktree access "
+            "(default is artifact-bundle only)"
+        )
+    if args.claude_permission_mode == "bypassPermissions":
+        escalation_flags.append(
+            "--claude-permission-mode bypassPermissions: builder ran without "
+            "the CLI's edit-scoping sandbox; out-of-worktree containment "
+            "relied on the diff-based scanner alone"
+        )
+    if args.allow_relay_self_edit:
+        escalation_flags.append(
+            "--allow-relay-self-edit: builder was allowed to edit the relay's own code"
+        )
+    if args.allow_stale_base and any(c.name == "base-fetch" and c.status == "warn" for c in checks.checks):
+        escalation_flags.append("--allow-stale-base: run based on a stale local ref (fetch failed)")
+    run_paths.update_run_json(
+        run_id=run_id, relay_version=RELAY_VERSION, title=result.title,
+        plan_path=str(result.plan_path), base_ref=args.base,
+        max_iterations=args.max_iterations, escalations=escalation_flags,
+        codex_model=args.codex_model, state="STARTED",
+    )
+    print(f"[run] receipts: {run_paths.root}")
+
+    # ---- WORKTREE
+    try:
+        wt = create_worktree(repo_root, result.slug, args.base, args.worktree_root)
+    except RuntimeError as exc:
+        print(f"[worktree] FAILED: {exc}", file=sys.stderr)
+        run_paths.update_run_json(state="ERROR", detail=str(exc), exit_code=6)
+        return 6
+    print(f"[worktree] {wt.path} (branch {wt.branch}, base {wt.base_sha[:12]})")
+    links = ensure_deps_links(repo_root, wt)
+    for name, detail in links.items():
+        print(f"[worktree] deps {name}: {detail}")
+    run_paths.update_run_json(branch=wt.branch, worktree=str(wt.path), base_sha=wt.base_sha)
+
+    # ---- PROVIDERS
+    if args.fixture:
+        from orchestration.coding_relay.fixtures import FakeProviders
+
+        fakes = FakeProviders(args.fixture, wt.path)
+        build_fn = fakes.build
+        review_fn = fakes.review
+        run_paths.update_run_json(providers="fixture", fixture=str(args.fixture))
+    else:
+        claude_exe = shutil.which("claude")
+        codex_exe = shutil.which("codex")
+        # Probe results are written through the redaction choke point, not
+        # by probe() itself: no run-folder write may bypass RunPaths.write.
+        claude_caps = probe(claude_exe)
+        codex_caps = probe(codex_exe)
+        run_paths.write("env/claude-help.txt", claude_caps.help_text)
+        run_paths.write("env/codex-help.txt", codex_caps.help_text)
+        _, model_note = claude_mod.build_coding_command(
+            claude_exe, wt.path, args.claude_permission_mode, args.claude_model, claude_caps,
+        )
+        if model_note:
+            print(f"[providers] {model_note}")
+        run_paths.update_run_json(
+            providers="cli",
+            claude_model=args.claude_model or "(cli default)",
+            claude_model_note=model_note or "",
+        )
+
+        def build_fn(prompt: str):
+            return claude_mod.invoke_builder(
+                prompt, wt.path, claude_exe,
+                permission_mode=args.claude_permission_mode,
+                model=args.claude_model, caps=claude_caps,
+                timeout_s=args.claude_timeout, keep_env=args.keep_env,
+            )
+
+        def review_fn(prompt: str, review_dir: Path, effort: str):
+            target = wt.path if args.codex_repo_access else review_dir
+            target.mkdir(parents=True, exist_ok=True)
+            return codex_mod.invoke_reviewer(
+                prompt, target, codex_exe,
+                model=args.codex_model, effort=effort, caps=codex_caps,
+                timeout_s=args.codex_timeout, repo_access=args.codex_repo_access,
+            )
+
+    # ---- LOOP (any unexpected crash still lands in the exit-code table)
+    loop_cfg = LoopConfig(
+        max_iterations=args.max_iterations,
+        run_tests=not args.no_tests,
+        allow_migrations=args.allow_migrations,
+        allow_relay_self_edit=args.allow_relay_self_edit,
+        codex_effort=args.codex_effort,
+        codex_max_effort=args.codex_max_effort,
+        codex_repo_access=args.codex_repo_access,
+        primary_root=repo_root,
+    )
+    try:
+        outcome = run_loop(loop_cfg, result, wt, run_paths, build_fn, review_fn)
+    except AdapterUnavailable as exc:
+        print(f"[loop] provider CLI vanished mid-run: {exc}", file=sys.stderr)
+        run_paths.update_run_json(state="ERROR", exit_code=3, detail=str(exc))
+        return 3
+    except Exception as exc:  # noqa: BLE001 - exit-code table integrity
+        print(f"[loop] internal error: {type(exc).__name__}: {exc}", file=sys.stderr)
+        run_paths.update_run_json(state="ERROR", exit_code=6, detail=f"{type(exc).__name__}: {exc}")
+        print(removal_instructions(repo_root, wt))
+        return 6
+
+    # ---- FINALIZE: report + PR body always. PR only on PASS, or on
+    # MAX_ITER with --draft-pr. Never after a safety stop, block, or error:
+    # pushing a diff the scanner flagged (e.g. secrets) would defeat the
+    # whole safety layer, and --no-pr always wins.
+    snapshot = collect_snapshot(wt.path, wt.base_sha)
+    last_verdict = outcome.verdicts[-1] if outcome.verdicts else None
+    summary = RunSummary(
+        run_id=run_id,
+        state=outcome.state,
+        exit_code=outcome.exit_code,
+        title=result.title,
+        plan_path=str(result.plan_path),
+        branch=wt.branch,
+        worktree_path=str(wt.path),
+        base_ref=wt.base_ref,
+        base_sha=wt.base_sha,
+        iterations_run=outcome.iterations_run,
+        max_iterations=args.max_iterations,
+        criteria_checklist=result.criteria.checklist(),
+        final_criteria_status=last_verdict.criteria_status if last_verdict else [],
+        verdict_history=[
+            (i + 1, v.status, v.summary) for i, v in enumerate(outcome.verdicts)
+        ],
+        test_results=[r.to_payload() for r in outcome.last_test_results],
+        violations=[v.__dict__ for v in outcome.violations],
+        files_changed=snapshot.numstat,
+        risk_notes=(last_verdict.risk_flags if last_verdict else []) + ([outcome.detail] if outcome.detail else []),
+        removal_instructions=removal_instructions(repo_root, wt),
+        codex_summary=last_verdict.summary if last_verdict else "",
+        escalation_flags=escalation_flags,
+    )
+    run_paths.write("report/final-report.md", final_report(summary))
+    run_paths.write("report/PR_BODY.md", pr_body(summary))
+    run_paths.update_run_json(
+        state=outcome.state, exit_code=outcome.exit_code, detail=outcome.detail,
+        iterations_run=outcome.iterations_run,
+    )
+
+    do_pr = (not args.no_pr) and (
+        outcome.state == PASS or (args.draft_pr and outcome.state == MAX_ITER)
+    )
+    if do_pr and outcome.state == PASS and last_verdict and not last_verdict.should_open_pr:
+        # The reviewer passed the work but explicitly voted against a PR
+        # (e.g. needs a human sign-off first). Honor it unless forced.
+        if not args.draft_pr:
+            do_pr = False
+            print("[pr] skipped: reviewer set should_open_pr=false (pass --draft-pr to override)")
+    if do_pr and snapshot.changed_paths:
+        committed, commit_detail = pr_mod.commit_all(wt.path, result.slug, run_id, result.title)
+        if committed:
+            pushed, push_detail = pr_mod.push(wt.path, wt.branch)
+            print(f"[pr] {push_detail}")
+            if pushed:
+                ok, pr_detail = pr_mod.create_draft_pr(
+                    wt.path, wt.branch, result.title, run_paths.report_dir / "PR_BODY.md",
+                )
+                if ok:
+                    print(f"[pr] draft PR: {pr_detail}")
+                    run_paths.write_json("report/pr.json", {"url": pr_detail, "draft": True})
+                else:
+                    run_paths.write(
+                        "report/MANUAL_PR.md",
+                        pr_mod.manual_pr_instructions(
+                            repo_root, wt.path, wt.branch, result.title,
+                            run_paths.report_dir / "PR_BODY.md", pr_detail,
+                        ),
+                    )
+                    print(f"[pr] fell back to MANUAL_PR.md: {pr_detail}")
+            else:
+                run_paths.write(
+                    "report/MANUAL_PR.md",
+                    pr_mod.manual_pr_instructions(
+                        repo_root, wt.path, wt.branch, result.title,
+                        run_paths.report_dir / "PR_BODY.md", push_detail,
+                    ),
+                )
+                print(f"[pr] fell back to MANUAL_PR.md: {push_detail}")
+        else:
+            print(f"[pr] skipped: {commit_detail}")
+    elif do_pr:
+        print("[pr] skipped: no changes to commit")
+
+    print(f"\n[done] {outcome.state} (exit {outcome.exit_code}). {outcome.detail}")
+    print(f"[done] final report: {run_paths.report_dir / 'final-report.md'}")
+    print(removal_instructions(repo_root, wt))
+    return outcome.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/orchestration/coding_relay/fixtures.py
+++ b/orchestration/coding_relay/fixtures.py
@@ -1,0 +1,98 @@
+"""FakeProviders: drive the whole relay loop from a fixture directory.
+
+No CLIs, no tokens. A fixture dir looks like:
+
+    plan.md
+    iterations/1/files/<relpath>      files the fake builder writes verbatim
+    iterations/1/build-output.md      fake builder stdout
+    iterations/1/review.json          fake reviewer verdict (JSON object)
+    iterations/2/...
+
+The fake builder copies iterations/N/files/** into the worktree (simulating
+edits) and returns build-output.md as stdout. The fake reviewer returns
+review.json as stdout. Missing per-iteration files fall back to minimal
+defaults so short fixtures stay short.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from orchestration.coding_relay.providers import AdapterResult
+
+
+class FakeProviders:
+    def __init__(self, fixture_dir: Path, worktree: Path):
+        self.fixture_dir = Path(fixture_dir)
+        self.worktree = Path(worktree)
+        self.build_calls = 0
+        self.review_calls = 0
+        if not self.fixture_dir.is_dir():
+            raise FileNotFoundError(f"fixture dir not found: {self.fixture_dir}")
+
+    def _iter_dir(self, n: int) -> Path:
+        return self.fixture_dir / "iterations" / str(n)
+
+    def build(self, prompt: str) -> AdapterResult:
+        self.build_calls += 1
+        n = self.build_calls
+        it = self._iter_dir(n)
+        files_root = it / "files"
+        if files_root.is_dir():
+            for src in files_root.rglob("*"):
+                if src.is_file():
+                    rel = src.relative_to(files_root)
+                    dest = self.worktree / rel
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copyfile(src, dest)
+        out_file = it / "build-output.md"
+        stdout = (
+            out_file.read_text(encoding="utf-8", errors="replace")
+            if out_file.is_file()
+            else f"(fixture iteration {n}: no build-output.md)\nBUILD_COMPLETE"
+        )
+        # Optional failure injection: iterations/N/build-exit holds an int.
+        exit_code = 0
+        exit_file = it / "build-exit"
+        if exit_file.is_file():
+            try:
+                exit_code = int(exit_file.read_text(encoding="utf-8").strip())
+            except ValueError:
+                exit_code = 1
+        return AdapterResult(
+            agent="fixture-builder", adapter="fixture", command=["fixture", "build", str(n)],
+            exit_code=exit_code, duration_ms=1, stdout=stdout, stderr="",
+        )
+
+    def review(self, prompt: str, review_dir: Path, effort: str) -> AdapterResult:
+        self.review_calls += 1
+        # The iteration number comes from the bundle path
+        # (.../iterations/NN/review-bundle), NOT the call count: the loop's
+        # verdict retry calls review() twice for one iteration, and a
+        # call-count index would silently consume the next iteration's file.
+        try:
+            n = int(review_dir.parent.name)
+        except (ValueError, AttributeError):
+            n = self.review_calls
+        v_file = self._iter_dir(n) / "review.json"
+        if v_file.is_file():
+            stdout = v_file.read_text(encoding="utf-8", errors="replace")
+        else:
+            # A missing fixture file must NEVER fabricate success.
+            stdout = json.dumps(
+                {
+                    "status": "blocked",
+                    "summary": f"fixture iteration {n}: no review.json scripted",
+                    "criteria_status": [],
+                    "required_next_steps": [],
+                    "plan_refinements": [],
+                    "tests_to_run_next": [],
+                    "risk_flags": ["fixture gap: iterations/" + str(n) + "/review.json missing"],
+                    "should_open_pr": False,
+                }
+            )
+        return AdapterResult(
+            agent="fixture-reviewer", adapter="fixture", command=["fixture", "review", str(n)],
+            exit_code=0, duration_ms=1, stdout=stdout, stderr="",
+        )

--- a/orchestration/coding_relay/fixtures/demo/iterations/1/build-output.md
+++ b/orchestration/coding_relay/fixtures/demo/iterations/1/build-output.md
@@ -1,0 +1,5 @@
+Added RELAY_NOTE.md at the repository root. A stray credential for the
+redaction check: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345 should never survive
+into the receipts.
+
+Added the note file. BUILD_COMPLETE

--- a/orchestration/coding_relay/fixtures/demo/iterations/1/files/RELAY_NOTE.md
+++ b/orchestration/coding_relay/fixtures/demo/iterations/1/files/RELAY_NOTE.md
@@ -1,0 +1,4 @@
+# Relay note
+
+The coding relay fixture exercised this repository. First pass: note added
+but missing the required closing line.

--- a/orchestration/coding_relay/fixtures/demo/iterations/1/review.json
+++ b/orchestration/coding_relay/fixtures/demo/iterations/1/review.json
@@ -1,0 +1,15 @@
+{
+  "status": "continue",
+  "summary": "RELAY_NOTE.md exists but the note does not state clearly that the relay exercised the repo end to end.",
+  "criteria_status": [
+    {"id": "T1", "section": "Evals-tests", "text": "The fixture loop runs to completion without invoking any real CLI.", "status": "unknown", "evidence": "loop still in progress"},
+    {"id": "R1", "section": "Regression guard", "text": "No file other than RELAY_NOTE.md is created or modified.", "status": "met", "evidence": "files.txt lists only RELAY_NOTE.md"}
+  ],
+  "required_next_steps": [
+    "Extend RELAY_NOTE.md with a final line confirming the end-to-end pass."
+  ],
+  "plan_refinements": [],
+  "tests_to_run_next": [],
+  "risk_flags": [],
+  "should_open_pr": false
+}

--- a/orchestration/coding_relay/fixtures/demo/iterations/2/build-output.md
+++ b/orchestration/coding_relay/fixtures/demo/iterations/2/build-output.md
@@ -1,0 +1,2 @@
+Extended RELAY_NOTE.md with the confirmation line the reviewer required.
+BUILD_COMPLETE

--- a/orchestration/coding_relay/fixtures/demo/iterations/2/files/RELAY_NOTE.md
+++ b/orchestration/coding_relay/fixtures/demo/iterations/2/files/RELAY_NOTE.md
@@ -1,0 +1,6 @@
+# Relay note
+
+The coding relay fixture exercised this repository. First pass: note added
+but missing the required closing line.
+
+End-to-end fixture pass confirmed.

--- a/orchestration/coding_relay/fixtures/demo/iterations/2/review.json
+++ b/orchestration/coding_relay/fixtures/demo/iterations/2/review.json
@@ -1,0 +1,13 @@
+{
+  "status": "pass",
+  "summary": "RELAY_NOTE.md now contains the confirmation line; only that file changed; every criterion is met or not applicable.",
+  "criteria_status": [
+    {"id": "T1", "section": "Evals-tests", "text": "The fixture loop runs to completion without invoking any real CLI.", "status": "met", "evidence": "both iterations ran via FakeProviders"},
+    {"id": "R1", "section": "Regression guard", "text": "No file other than RELAY_NOTE.md is created or modified.", "status": "met", "evidence": "files.txt lists only RELAY_NOTE.md"}
+  ],
+  "required_next_steps": [],
+  "plan_refinements": [],
+  "tests_to_run_next": [],
+  "risk_flags": [],
+  "should_open_pr": true
+}

--- a/orchestration/coding_relay/fixtures/demo/plan.md
+++ b/orchestration/coding_relay/fixtures/demo/plan.md
@@ -1,0 +1,24 @@
+# Demo fixture plan: add a relay smoke note
+
+Add a file named RELAY_NOTE.md at the repository root containing a short
+note that the coding relay exercised this repository.
+
+## Acceptance Criteria
+
+### Screen
+- Not applicable
+
+### API
+- Not applicable
+
+### DB/Data
+- Not applicable
+
+### AI behavior
+- Not applicable
+
+### Evals/tests
+- The fixture loop runs to completion without invoking any real CLI.
+
+### Regression guard
+- No file other than RELAY_NOTE.md is created or modified.

--- a/orchestration/coding_relay/intake.py
+++ b/orchestration/coding_relay/intake.py
@@ -1,0 +1,325 @@
+"""Plan intake: source a plan, require success criteria, normalize them.
+
+The relay refuses to run without explicit success criteria. Criteria are
+normalized into six fixed sections so the reviewer can judge each one by a
+stable id:
+
+    General (G) — bullets that fit no section
+    Screen (S) / API (A) / DB-Data (D) / AI behavior (B) /
+    Evals-tests (T) / Regression guard (R)
+
+Sections with no criteria render "Not applicable."
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ACTIVE_PLANS_REL = Path("docs/plans/03-implementation-plans/active")
+
+CRITERIA_HEADING_RE = re.compile(
+    r"^#{1,6}\s+.*((success|acceptance)\s+criteria|definition\s+of\s+done)",
+    re.IGNORECASE,
+)
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)")
+BULLET_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+(.*)")
+
+# Canonical section order with (id-prefix, keyword list). Scored per bullet;
+# highest hit count wins, ties resolved by this order.
+SECTIONS: list[tuple[str, str, tuple[str, ...]]] = [
+    (
+        "Regression guard",
+        "R",
+        ("regression", "must not break", "unchanged", "still work", "still pass",
+         "existing behavior", "no change to", "not regress"),
+    ),
+    (
+        "Evals-tests",
+        "T",
+        ("test", "tests", "pytest", "vitest", "eval", "evals", "lint",
+         "typecheck", "ci", "coverage", "assert"),
+    ),
+    (
+        "DB-Data",
+        "D",
+        ("db", "database", "table", "migration", "schema", "row", "column",
+         "seed", "sql", "supabase", "data model", "dataset"),
+    ),
+    (
+        "API",
+        "A",
+        ("api", "endpoint", "route", "http", "status code", "response",
+         "request", "payload", "rest", "fastapi"),
+    ),
+    (
+        "AI behavior",
+        "B",
+        ("ai", "prompt", "model", "llm", "assistant", "rag",
+         "tool call", "agent", "fail-closed", "fail closed", "hallucinat"),
+    ),
+    (
+        "Screen",
+        "S",
+        ("screen", "ui", "page", "component", "render", "display", "button",
+         "css", "style", "visual", "frontend", "layout", "browser"),
+    ),
+]
+SECTION_NAMES = tuple(name for name, _, _ in SECTIONS)
+# Aliases for explicit "### <section>" sub-headings inside a criteria block.
+SECTION_ALIASES = {
+    "screen": "Screen",
+    "ui": "Screen",
+    "api": "API",
+    "db/data": "DB-Data",
+    "db-data": "DB-Data",
+    "db": "DB-Data",
+    "data": "DB-Data",
+    "ai behavior": "AI behavior",
+    "ai": "AI behavior",
+    "evals/tests": "Evals-tests",
+    "evals-tests": "Evals-tests",
+    "tests": "Evals-tests",
+    "evals": "Evals-tests",
+    "regression guard": "Regression guard",
+    "regression": "Regression guard",
+    "general": "General",
+}
+
+TEMPLATE = """## Acceptance Criteria
+
+### Screen
+- ...
+
+### API
+- ...
+
+### DB/Data
+- ...
+
+### AI behavior
+- ...
+
+### Evals/tests
+- ...
+
+### Regression guard
+- ...
+
+Write "Not applicable" under any section that does not apply. The relay
+refuses to run a plan without a "Success Criteria" / "Acceptance Criteria" /
+"Definition of Done" heading followed by concrete bullets.
+"""
+
+
+class IntakeError(Exception):
+    """Plan cannot be accepted. Message is user-facing; exit code 2."""
+
+
+@dataclass
+class AcceptanceCriteria:
+    # section name -> list of criterion texts ([] means Not applicable)
+    sections: dict[str, list[str]]
+    general: list[str]
+    raw_block: str
+
+    def checklist(self) -> list[tuple[str, str, str]]:
+        """Stable (id, section, text) triples, e.g. ("S1", "Screen", ...)."""
+        items: list[tuple[str, str, str]] = []
+        for i, text in enumerate(self.general, 1):
+            items.append((f"G{i}", "General", text))
+        for name, prefix, _ in SECTIONS:
+            for i, text in enumerate(self.sections.get(name, []), 1):
+                items.append((f"{prefix}{i}", name, text))
+        return items
+
+    def to_markdown(self) -> str:
+        lines = ["## Acceptance Criteria", ""]
+        if self.general:
+            lines.append("### General")
+            lines += [f"- [{cid}] {text}" for cid, sec, text in self.checklist() if sec == "General"]
+            lines.append("")
+        # Render in the canonical order the template uses.
+        display_order = ["Screen", "API", "DB-Data", "AI behavior", "Evals-tests", "Regression guard"]
+        by_section = {name: [] for name in display_order}
+        for cid, sec, text in self.checklist():
+            if sec in by_section:
+                by_section[sec].append(f"- [{cid}] {text}")
+        for name in display_order:
+            lines.append(f"### {name}")
+            lines += by_section[name] or ["Not applicable."]
+            lines.append("")
+        return "\n".join(lines)
+
+
+@dataclass
+class IntakeResult:
+    plan_path: Path | None
+    plan_text: str
+    title: str
+    slug: str
+    criteria: AcceptanceCriteria = field(repr=False, default=None)  # type: ignore[assignment]
+
+
+def list_active_plans(repo_root: Path) -> list[Path]:
+    active = repo_root / ACTIVE_PLANS_REL
+    if not active.is_dir():
+        return []
+    return sorted(p for p in active.glob("*.md") if p.is_file())
+
+
+def resolve_plan_path(repo_root: Path, plan_arg: str) -> Path:
+    """Resolve --plan as a path, or as a filename prefix in the active dir."""
+    direct = Path(plan_arg)
+    for candidate in (direct, repo_root / plan_arg):
+        if candidate.is_file():
+            return candidate.resolve()
+    matches = [p for p in list_active_plans(repo_root) if p.name.startswith(plan_arg)]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        names = ", ".join(p.name for p in matches)
+        raise IntakeError(f"--plan {plan_arg!r} is ambiguous in the active plans dir: {names}")
+    raise IntakeError(
+        f"--plan {plan_arg!r} is neither a file nor a unique prefix in "
+        f"{ACTIVE_PLANS_REL}. Run with no arguments to list active plans."
+    )
+
+
+def extract_title(plan_text: str, fallback: str) -> str:
+    for line in plan_text.splitlines():
+        m = HEADING_RE.match(line.strip())
+        if m:
+            return m.group(2).strip()
+        if line.strip():
+            return line.strip()[:80]
+    return fallback
+
+
+def extract_criteria(plan_text: str) -> str | None:
+    """Return the raw criteria block (heading through end of its section)."""
+    lines = plan_text.splitlines()
+    start: int | None = None
+    level = 0
+    for i, line in enumerate(lines):
+        m = CRITERIA_HEADING_RE.match(line.strip())
+        if m:
+            start = i
+            level = len(HEADING_RE.match(line.strip()).group(1))  # type: ignore[union-attr]
+            break
+    if start is None:
+        return None
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        m = HEADING_RE.match(lines[j].strip())
+        if m and len(m.group(1)) <= level:
+            end = j
+            break
+    return "\n".join(lines[start:end]).strip()
+
+
+def _kw_hit(kw: str, text: str) -> bool:
+    """Multi-word keywords match as phrases. Short tokens need full word
+    boundaries so 'ci' never fires inside 'decision' or 'db' inside
+    'feedback'; longer tokens allow a suffix ('migration' matches
+    'migrations', 'hallucinat' matches 'hallucination')."""
+    if " " in kw or "-" in kw:
+        return kw in text
+    if len(kw) <= 4:
+        return re.search(rf"\b{re.escape(kw)}\b", text) is not None
+    return re.search(rf"\b{re.escape(kw)}", text) is not None
+
+
+def _classify(bullet: str) -> str:
+    text = bullet.lower()
+    best_name = "General"
+    best_score = 0
+    for name, _, keywords in SECTIONS:
+        score = sum(1 for kw in keywords if _kw_hit(kw, text))
+        if score > best_score:
+            best_name, best_score = name, score
+    return best_name
+
+
+def normalize_criteria(raw_block: str) -> AcceptanceCriteria:
+    """Turn a raw criteria block into the fixed six-section shape.
+
+    If the block already uses explicit sub-headings that match the section
+    names (or aliases), bullets are assigned by heading. Otherwise each
+    bullet is keyword-scored into a section; no hits -> General.
+    """
+    sections: dict[str, list[str]] = {name: [] for name in SECTION_NAMES}
+    general: list[str] = []
+    current_explicit: str | None = None
+    saw_bullet = False
+    for line in raw_block.splitlines():
+        m = HEADING_RE.match(line.strip())
+        if m:
+            alias = re.sub(r"[^a-z/ -]", "", m.group(2).strip().lower()).strip()
+            current_explicit = SECTION_ALIASES.get(alias)
+            continue
+        b = BULLET_RE.match(line)
+        if not b:
+            continue
+        text = b.group(1).strip()
+        if not text or text.lower().rstrip(".") in ("not applicable", "n/a", "..."):
+            continue
+        saw_bullet = True
+        target = current_explicit or _classify(text)
+        if target == "General":
+            general.append(text)
+        else:
+            sections[target].append(text)
+    if not saw_bullet:
+        raise IntakeError(
+            "The success-criteria section contains no concrete bullets.\n"
+            "Add at least one measurable criterion, for example:\n\n" + TEMPLATE
+        )
+    return AcceptanceCriteria(sections=sections, general=general, raw_block=raw_block)
+
+
+def load_plan(
+    repo_root: Path,
+    plan_arg: str | None,
+    paste_file: str | None,
+) -> IntakeResult:
+    """Load and validate the plan from --plan or --paste-file."""
+    from orchestration.coding_relay.runs import safe_slug
+
+    if plan_arg and paste_file:
+        raise IntakeError("Pass either --plan or --paste-file, not both.")
+    if paste_file:
+        p = Path(paste_file)
+        if not p.is_file():
+            raise IntakeError(f"--paste-file {paste_file} does not exist.")
+        plan_path: Path | None = p.resolve()
+        plan_text = p.read_text(encoding="utf-8", errors="replace")
+        fallback = p.stem
+    elif plan_arg:
+        plan_path = resolve_plan_path(repo_root, plan_arg)
+        plan_text = plan_path.read_text(encoding="utf-8", errors="replace")
+        fallback = plan_path.stem
+    else:
+        raise IntakeError("No plan given. Pass --plan <path|NNNN> or --paste-file <path>.")
+
+    if not plan_text.strip():
+        raise IntakeError(f"Plan file {plan_path} is empty.")
+
+    raw_block = extract_criteria(plan_text)
+    if raw_block is None:
+        raise IntakeError(
+            "The plan has no success criteria. The relay refuses vague work.\n"
+            "Add a section with one of these headings: 'Success Criteria',\n"
+            "'Acceptance Criteria', or 'Definition of Done', shaped like:\n\n"
+            + TEMPLATE
+        )
+    criteria = normalize_criteria(raw_block)
+    title = extract_title(plan_text, fallback)
+    result = IntakeResult(
+        plan_path=plan_path,
+        plan_text=plan_text,
+        title=title,
+        slug=safe_slug(title),
+    )
+    result.criteria = criteria
+    return result

--- a/orchestration/coding_relay/loop.py
+++ b/orchestration/coding_relay/loop.py
@@ -1,0 +1,347 @@
+"""The bounded build/scan/test/review loop.
+
+States: ITERATING{BUILD -> SCAN -> TEST -> REVIEW} -> terminal.
+
+Terminal states and exit codes (also in docs/reference/CODING_RELAY.md):
+
+    PASS         0   reviewer verdict "pass"
+    MAX_ITER     1   iterations exhausted on "continue"
+    (intake)     2   handled before the loop
+    (cli)        3   handled before the loop
+    SAFETY_STOP  4   stop-severity safety violation
+    BLOCKED      5   reviewer "blocked", "risk_escalation", unparseable
+                     verdict after retry, or an escalate-severity violation
+    ERROR        6   builder/reviewer nonzero exit, timeout, internal error
+
+Providers are injected as callables so fixtures.FakeProviders can drive
+the whole loop without any CLI.
+"""
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+from orchestration.coding_relay import prompts, safety, test_runner, verdict as verdict_mod
+from orchestration.coding_relay.intake import IntakeResult
+from orchestration.coding_relay.providers import AdapterResult
+from orchestration.coding_relay.runs import RunPaths
+from orchestration.coding_relay.worktree import RelayWorktree
+
+PASS, MAX_ITER, SAFETY_STOP, BLOCKED, ERROR = (
+    "PASS", "MAX_ITER", "SAFETY_STOP", "BLOCKED", "ERROR",
+)
+EXIT_CODES = {PASS: 0, MAX_ITER: 1, SAFETY_STOP: 4, BLOCKED: 5, ERROR: 6}
+
+# Prompt-embedded diff cap. The full diff (itself capped at DIFF_ARTIFACT_CAP)
+# lives in the review bundle the reviewer can open.
+DIFF_PROMPT_CAP = 150_000
+DIFF_ARTIFACT_CAP = 2_000_000
+
+
+@dataclass
+class LoopConfig:
+    max_iterations: int = 3
+    run_tests: bool = True
+    allow_migrations: bool = False
+    allow_relay_self_edit: bool = False
+    codex_effort: str = "low"
+    codex_max_effort: str = "medium"
+    codex_repo_access: bool = False  # changes bundle wording only
+    primary_root: Optional[Path] = None  # for venv resolution
+
+
+@dataclass
+class LoopOutcome:
+    state: str
+    exit_code: int
+    iterations_run: int = 0
+    verdicts: list = field(default_factory=list)  # Verdict objects, in order
+    last_test_results: list = field(default_factory=list)  # SuiteResult objects
+    violations: list = field(default_factory=list)  # Violation objects
+    detail: str = ""
+
+
+def _git(worktree: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(worktree), *args],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+
+
+def collect_snapshot(worktree: Path, base_sha: str) -> safety.DiffSnapshot:
+    """Stage everything and read the cumulative diff vs the recorded base.
+
+    Diffing against base_sha (not HEAD) means changes the builder smuggled
+    into its own commits are still visible to the scanner, the tests, and
+    the reviewer. Deletions are counted with rename detection off so a mass
+    move counts as deletions (the pre-commit hook it mirrors misses that).
+    """
+    _git(worktree, "add", "-A")
+    diff = _git(worktree, "diff", "--cached", base_sha).stdout
+    changed = [
+        p for p in _git(worktree, "diff", "--cached", base_sha, "--name-only").stdout.splitlines()
+        if p.strip()
+    ]
+    deleted = [
+        p for p in _git(
+            worktree, "-c", "diff.renames=false",
+            "diff", "--cached", base_sha, "--diff-filter=D", "--name-only",
+        ).stdout.splitlines()
+        if p.strip()
+    ]
+    numstat = [
+        ln for ln in _git(worktree, "diff", "--cached", base_sha, "--numstat").stdout.splitlines()
+        if ln.strip()
+    ]
+    return safety.DiffSnapshot(
+        diff_text=diff, changed_paths=changed, deleted_paths=deleted, numstat=numstat,
+    )
+
+
+def _diff_stat(worktree: Path, base_sha: str) -> str:
+    return _git(worktree, "diff", "--cached", base_sha, "--stat").stdout
+
+
+def head_moved(worktree: Path, base_sha: str) -> bool:
+    """True when the builder created commits (the relay owns all commits)."""
+    head = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+    return bool(head) and head != base_sha
+
+
+def _bundle_summary(
+    run_paths: RunPaths,
+    iteration: int,
+    snapshot: safety.DiffSnapshot,
+    diff_stat: str,
+    test_results: list,
+    builder_tail: str,
+    repo_access: bool = False,
+) -> str:
+    """Write the review bundle files and return the prompt-embedded summary."""
+    n = iteration
+    bundle_rel = f"iterations/{n:02d}/review-bundle"
+    diff_for_artifact = snapshot.diff_text
+    truncated_artifact = len(diff_for_artifact) > DIFF_ARTIFACT_CAP
+    if truncated_artifact:
+        diff_for_artifact = diff_for_artifact[:DIFF_ARTIFACT_CAP] + "\n[diff truncated at 2MB]\n"
+    run_paths.write(f"{bundle_rel}/diff.patch", diff_for_artifact)
+    run_paths.write(f"{bundle_rel}/diff-stat.txt", diff_stat)
+    run_paths.write(f"{bundle_rel}/files.txt", "\n".join(snapshot.changed_paths) + "\n")
+    tests_md = "\n".join(r.summary_line() for r in test_results) or "No suites were run."
+    run_paths.write(f"{bundle_rel}/tests-summary.md", tests_md + "\n")
+    run_paths.write(f"{bundle_rel}/builder-summary.md", builder_tail + "\n")
+
+    bundle_abs = run_paths.review_bundle_dir(n)
+    if repo_access:
+        bundle_line = (
+            f"You have repository access at your working directory; the review "
+            f"bundle files (diff.patch, diff-stat.txt, files.txt, "
+            f"tests-summary.md, builder-summary.md) live at {bundle_abs}"
+        )
+        diff_location = f"the full diff is {bundle_abs / 'diff.patch'}"
+    else:
+        bundle_line = (
+            "Bundle files in your working directory: diff.patch, "
+            "diff-stat.txt, files.txt, tests-summary.md, builder-summary.md"
+        )
+        diff_location = "the full diff is diff.patch in your working directory"
+    diff_for_prompt = snapshot.diff_text
+    diff_note = ""
+    if len(diff_for_prompt) > DIFF_PROMPT_CAP:
+        diff_for_prompt = diff_for_prompt[:DIFF_PROMPT_CAP]
+        diff_note = f"\n[diff truncated in this prompt; {diff_location}]\n"
+    return (
+        f"{bundle_line}\n\n"
+        f"### Changed files ({len(snapshot.changed_paths)})\n"
+        + "\n".join(snapshot.changed_paths[:200])
+        + "\n\n### Diff stat\n" + diff_stat
+        + "\n### Tests\n" + tests_md
+        + "\n\n### Builder summary (tail)\n" + builder_tail
+        + "\n\n### Diff\n```diff\n" + diff_for_prompt + "\n```" + diff_note
+    )
+
+
+def _feedback_text(v) -> str:
+    lines = [f"Reviewer summary: {v.summary}", ""]
+    unmet = [c for c in v.criteria_status if c.get("status") in ("unmet", "unknown")]
+    if unmet:
+        lines.append("Unmet or unverified criteria:")
+        lines += [f"- {c['id']}: {c['text']} ({c['status']}; {c.get('evidence', '')})" for c in unmet]
+        lines.append("")
+    if v.required_next_steps:
+        lines.append("Required next steps:")
+        lines += [f"- {s}" for s in v.required_next_steps]
+        lines.append("")
+    if v.plan_refinements:
+        lines.append("Plan refinements (repo facts invalidated assumptions):")
+        lines += [f"- {s}" for s in v.plan_refinements]
+        lines.append("")
+    if v.tests_to_run_next:
+        lines.append("Tests the reviewer wants run:")
+        lines += [f"- {s}" for s in v.tests_to_run_next]
+    return "\n".join(lines)
+
+
+def run_loop(
+    cfg: LoopConfig,
+    intake: IntakeResult,
+    wt: RelayWorktree,
+    run_paths: RunPaths,
+    build: Callable[[str], AdapterResult],
+    review: Callable[[str, Path, str], AdapterResult],
+    log: Callable[[str], None] = print,
+) -> LoopOutcome:
+    outcome = LoopOutcome(state=ERROR, exit_code=EXIT_CODES[ERROR])
+    reviewer_feedback: Optional[str] = None
+    test_failures: Optional[str] = None
+
+    for iteration in range(1, cfg.max_iterations + 1):
+        outcome.iterations_run = iteration
+        it_rel = f"iterations/{iteration:02d}"
+        log(f"[iteration {iteration}/{cfg.max_iterations}] BUILD")
+
+        # ---- BUILD
+        b_prompt = prompts.builder_prompt(
+            intake.plan_text, intake.criteria, iteration, cfg.max_iterations,
+            reviewer_feedback, test_failures,
+        )
+        run_paths.write(f"{it_rel}/build-prompt.md", b_prompt)
+        b_res = build(b_prompt)
+        run_paths.write(f"{it_rel}/build-output.md", b_res.stdout)
+        if b_res.stderr.strip():
+            run_paths.write(f"{it_rel}/build-stderr.txt", b_res.stderr)
+        run_paths.write_json(f"{it_rel}/build-meta.json", b_res.meta())
+        if not b_res.ok:
+            outcome.state, outcome.exit_code = ERROR, EXIT_CODES[ERROR]
+            outcome.detail = f"builder exited {b_res.exit_code}; see {it_rel}/build-stderr.txt"
+            log(f"[iteration {iteration}] builder failed (exit {b_res.exit_code}); stopping")
+            return outcome
+
+        # ---- SCAN
+        snapshot = collect_snapshot(wt.path, wt.base_sha)
+        diff_stat = _diff_stat(wt.path, wt.base_sha)
+        run_paths.write(f"{it_rel}/diff.patch", snapshot.diff_text[:DIFF_ARTIFACT_CAP])
+        run_paths.write(f"{it_rel}/diff-stat.txt", diff_stat)
+        violations = safety.scan(
+            wt.path, snapshot, intake.plan_text,
+            allow_migrations=cfg.allow_migrations,
+            allow_relay_self_edit=cfg.allow_relay_self_edit,
+        )
+        if head_moved(wt.path, wt.base_sha):
+            violations.append(
+                safety.Violation(
+                    "builder_committed", safety.STOP,
+                    "The builder created git commits; the relay owns all "
+                    "commits. The diff above still covers the committed "
+                    "changes (diffed against the base), but the run stops.",
+                )
+            )
+        run_paths.write_json(f"{it_rel}/safety.json", [v.__dict__ for v in violations])
+        outcome.violations.extend(violations)
+        if safety.stops(violations):
+            outcome.state, outcome.exit_code = SAFETY_STOP, EXIT_CODES[SAFETY_STOP]
+            outcome.detail = "; ".join(f"{v.rule}: {v.detail}" for v in safety.stops(violations))
+            log(f"[iteration {iteration}] SAFETY STOP: {outcome.detail}")
+            return outcome
+        if safety.escalations(violations):
+            outcome.state, outcome.exit_code = BLOCKED, EXIT_CODES[BLOCKED]
+            outcome.detail = (
+                "risk escalation from safety scan: "
+                + "; ".join(f"{v.rule}: {v.detail}" for v in safety.escalations(violations))
+                + f". Inspect the worktree at {wt.path} and decide by hand; the "
+                "relay does not continue past escalations on its own."
+            )
+            log(f"[iteration {iteration}] RISK ESCALATION: {outcome.detail}")
+            return outcome
+
+        # ---- TEST
+        test_results: list = []
+        if cfg.run_tests and snapshot.changed_paths:
+            py, py_desc = test_runner.resolve_python(wt.path, cfg.primary_root)
+            suites = test_runner.infer_suites(snapshot.changed_paths, py)
+            if suites:
+                log(f"[iteration {iteration}] TEST ({len(suites)} suites)")
+            test_results = test_runner.run_suites(
+                wt.path, suites, f"{it_rel}/tests", py_desc, write=run_paths.write,
+            )
+            run_paths.write_json(
+                f"{it_rel}/tests/summary.json", [r.to_payload() for r in test_results]
+            )
+            for r in test_results:
+                log(f"  {r.summary_line()}")
+        outcome.last_test_results = test_results
+        test_failures = test_runner.failing_excerpt(test_results, run_paths.root) or None
+
+        # ---- REVIEW
+        # A stricter final review: bump effort to the ceiling on the last
+        # allowed iteration (model never changes).
+        effort = cfg.codex_effort if iteration < cfg.max_iterations else cfg.codex_max_effort
+        builder_tail = b_res.stdout.strip()[-2000:]
+        bundle_summary = _bundle_summary(
+            run_paths, iteration, snapshot, diff_stat, test_results, builder_tail,
+            repo_access=cfg.codex_repo_access,
+        )
+        r_prompt = prompts.reviewer_prompt(
+            intake.plan_text, intake.criteria, iteration, bundle_summary,
+        )
+        run_paths.write(f"{it_rel}/review-prompt.md", r_prompt)
+        bundle_dir = run_paths.review_bundle_dir(iteration)
+        log(f"[iteration {iteration}] REVIEW (effort {effort})")
+        r_res = review(r_prompt, bundle_dir, effort)
+        run_paths.write(f"{it_rel}/review-output.txt", r_res.stdout)
+        if r_res.stderr.strip():
+            run_paths.write(f"{it_rel}/review-stderr.txt", r_res.stderr)
+        run_paths.write_json(f"{it_rel}/review-meta.json", r_res.meta())
+        if not r_res.ok:
+            outcome.state, outcome.exit_code = ERROR, EXIT_CODES[ERROR]
+            outcome.detail = f"reviewer exited {r_res.exit_code}; see {it_rel}/review-stderr.txt"
+            log(f"[iteration {iteration}] reviewer failed (exit {r_res.exit_code}); stopping")
+            return outcome
+
+        v = verdict_mod.parse_verdict(r_res.stdout)
+        if v is None:
+            log(f"[iteration {iteration}] verdict unparseable; one JSON-only retry")
+            retry_res = review(r_prompt + verdict_mod.RETRY_NUDGE, bundle_dir, effort)
+            run_paths.write(f"{it_rel}/review-output-retry.txt", retry_res.stdout)
+            run_paths.write_json(f"{it_rel}/review-retry-meta.json", retry_res.meta())
+            v = verdict_mod.parse_verdict(retry_res.stdout) if retry_res.ok else None
+        if v is None:
+            outcome.state, outcome.exit_code = BLOCKED, EXIT_CODES[BLOCKED]
+            outcome.detail = (
+                "reviewer did not return a valid JSON verdict after one retry; "
+                f"raw output saved under {it_rel}/. Treating as blocked."
+            )
+            log(f"[iteration {iteration}] {outcome.detail}")
+            return outcome
+
+        run_paths.write_json(f"{it_rel}/verdict.json", v.to_payload())
+        outcome.verdicts.append(v)
+        log(f"[iteration {iteration}] verdict: {v.status} - {v.summary[:120]}")
+
+        if v.status == "pass":
+            outcome.state, outcome.exit_code = PASS, EXIT_CODES[PASS]
+            outcome.detail = v.summary
+            return outcome
+        if v.status == "blocked":
+            outcome.state, outcome.exit_code = BLOCKED, EXIT_CODES[BLOCKED]
+            outcome.detail = f"reviewer blocked: {v.summary}"
+            return outcome
+        if v.status == "risk_escalation":
+            outcome.state, outcome.exit_code = BLOCKED, EXIT_CODES[BLOCKED]
+            outcome.detail = (
+                f"reviewer escalated risk: {v.summary}. Risk flags: "
+                f"{'; '.join(v.risk_flags) or '(none listed)'}. A human must "
+                f"approve before this continues; inspect {wt.path}."
+            )
+            return outcome
+        # "continue": carry feedback into the next builder pass.
+        reviewer_feedback = _feedback_text(v)
+
+    outcome.state, outcome.exit_code = MAX_ITER, EXIT_CODES[MAX_ITER]
+    outcome.detail = (
+        f"max iterations ({cfg.max_iterations}) reached; last verdict was "
+        "'continue'. The worktree is preserved for inspection or a re-run."
+    )
+    return outcome

--- a/orchestration/coding_relay/pr.py
+++ b/orchestration/coding_relay/pr.py
@@ -1,0 +1,96 @@
+"""Commit, push, and draft-PR creation, with a manual fallback.
+
+Structural rules: the relay never force-pushes, never merges, and always
+passes --draft. Any failure along the way degrades to MANUAL_PR.md with
+the exact commands for a human.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+CO_AUTHOR = "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+
+
+def _run(cmd: list, cwd: Path, timeout: int = 300, env: dict | None = None) -> subprocess.CompletedProcess:
+    """Never raises: hangs and launch failures degrade to a failed result so
+    every PR-step failure lands in the MANUAL_PR.md fallback, not a traceback."""
+    try:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, encoding="utf-8",
+            errors="replace", cwd=str(cwd), timeout=timeout, env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(cmd, 124, stdout="", stderr=f"timed out after {timeout}s")
+    except OSError as exc:
+        return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(exc))
+
+
+def commit_all(worktree: Path, slug: str, run_id: str, title: str) -> tuple[bool, str]:
+    _run(["git", "add", "-A"], worktree)
+    staged = _run(["git", "diff", "--cached", "--name-only"], worktree)
+    if not staged.stdout.strip():
+        return False, "nothing to commit"
+    msg = f"relay: {title[:60]} (run {run_id})\n\n{CO_AUTHOR}\n"
+    res = _run(["git", "commit", "-m", msg], worktree)
+    if res.returncode != 0:
+        return False, f"git commit failed: {(res.stderr or res.stdout).strip()[:400]}"
+    return True, _run(["git", "rev-parse", "HEAD"], worktree).stdout.strip()
+
+
+def push(worktree: Path, branch: str) -> tuple[bool, str]:
+    # GIT_TERMINAL_PROMPT=0 plus the gh credential helper: a credential
+    # prompt hang (Git Credential Manager) must fail fast, not block 10min.
+    env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
+    res = _run(
+        ["git", "-c", "credential.helper=", "-c", "credential.helper=!gh auth git-credential",
+         "push", "-u", "origin", branch],
+        worktree, timeout=600, env=env,
+    )
+    if res.returncode != 0:
+        return False, f"git push failed: {(res.stderr or res.stdout).strip()[:400]}"
+    return True, f"pushed origin/{branch}"
+
+
+def create_draft_pr(
+    worktree: Path,
+    branch: str,
+    title: str,
+    body_file: Path,
+    base: str = "main",
+) -> tuple[bool, str]:
+    gh = shutil.which("gh")
+    if gh is None:
+        return False, "gh not on PATH"
+    res = _run(
+        [gh, "pr", "create", "--draft",
+         "--title", f"relay: {title[:70]}",
+         "--body-file", str(body_file),
+         "--base", base, "--head", branch],
+        worktree, timeout=300,
+    )
+    if res.returncode != 0:
+        return False, f"gh pr create failed: {(res.stderr or res.stdout).strip()[:400]}"
+    return True, res.stdout.strip().splitlines()[-1] if res.stdout.strip() else "created"
+
+
+def manual_pr_instructions(
+    repo_root: Path, worktree: Path, branch: str, title: str, body_file: Path, reason: str
+) -> str:
+    return (
+        "# Manual PR instructions\n\n"
+        f"Automatic draft-PR creation was skipped: {reason}\n\n"
+        "Run these commands yourself:\n\n"
+        "```\n"
+        f"cd {worktree}\n"
+        "git add -A\n"
+        f'git commit -m "relay: {title[:60]}"\n'
+        f"git push -u origin {branch}\n"
+        f'gh pr create --draft --title "relay: {title[:70]}" '
+        f'--body-file "{body_file}" --base main --head {branch}\n'
+        "```\n\n"
+        "The PR body draft is saved next to this file as PR_BODY.md.\n"
+        "The relay never merges; review and merge by hand.\n"
+    )

--- a/orchestration/coding_relay/preflight.py
+++ b/orchestration/coding_relay/preflight.py
@@ -1,0 +1,214 @@
+"""Preflight checks: everything the relay verifies before touching git.
+
+Fail-closed rules:
+- `git fetch origin main` failure is a hard stop; a stale local base
+  requires the explicit --allow-stale-base flag.
+- Missing `claude` or `codex` CLI is a hard stop (exit 3 downstream).
+- `gh` problems only degrade PR creation to a manual-instructions file.
+
+No check ever prints environment variable values; details are names,
+paths, and booleans only.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+OK, WARN, FAIL, INFO = "ok", "warn", "fail", "info"
+
+
+@dataclass
+class Check:
+    name: str
+    status: str  # ok | warn | fail | info
+    detail: str
+
+
+@dataclass
+class PreflightConfig:
+    repo_root: Path
+    base_ref: str = "origin/main"
+    allow_stale_base: bool = False
+    pr_requested: bool = True
+    plan_path: Path | None = None
+    worktree_root: Path | None = None
+    fixture_mode: bool = False  # fixture runs skip the CLI checks
+    fixture_dir: Path | None = None  # validated before any mutation
+    read_only: bool = False  # strict --dry-run: no fetch, no write probes
+
+
+@dataclass
+class PreflightResult:
+    checks: list[Check] = field(default_factory=list)
+
+    def add(self, name: str, status: str, detail: str) -> None:
+        self.checks.append(Check(name, status, detail))
+
+    @property
+    def failed(self) -> bool:
+        return any(c.status == FAIL for c in self.checks)
+
+    def failures(self) -> list[Check]:
+        return [c for c in self.checks if c.status == FAIL]
+
+    def to_payload(self) -> list[dict]:
+        return [c.__dict__ for c in self.checks]
+
+
+def _run(cmd: list[str], cwd: Path | None = None, timeout: int = 120) -> subprocess.CompletedProcess:
+    """Run a check command. A hang degrades to returncode 124 instead of an
+    uncaught TimeoutExpired crashing preflight (exit-code table integrity)."""
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=str(cwd) if cwd else None,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            cmd, 124, stdout="", stderr=f"timed out after {timeout}s"
+        )
+    except OSError as exc:
+        return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(exc))
+
+
+def run_preflight(cfg: PreflightConfig) -> PreflightResult:
+    r = PreflightResult()
+    root = cfg.repo_root
+
+    # Git repo present.
+    if not (root / ".git").exists():
+        r.add("git-repo", FAIL, f"{root} is not a git repository (no .git).")
+        return r
+    r.add("git-repo", OK, str(root))
+
+    # Branch / detached state is informational: the relay works in its own worktree.
+    branch = _run(["git", "-C", str(root), "branch", "--show-current"])
+    branch_name = branch.stdout.strip() or "(detached HEAD)"
+    r.add("current-branch", INFO, branch_name)
+
+    # Dirty primary checkout: warn only. Untracked scratch never blocks.
+    dirty = _run(["git", "-C", str(root), "status", "--porcelain", "--untracked-files=no"])
+    if dirty.stdout.strip():
+        n = len(dirty.stdout.strip().splitlines())
+        r.add(
+            "primary-dirty", WARN,
+            f"{n} tracked file(s) modified in the primary checkout. The relay "
+            "works in its own worktree and never touches these.",
+        )
+    else:
+        r.add("primary-dirty", OK, "primary checkout clean (tracked files)")
+
+    # Base freshness: fetch is mandatory unless explicitly waived.
+    if cfg.read_only:
+        r.add("base-fetch", INFO, "skipped in --dry-run (a real run fetches, and a fetch failure is a hard stop)")
+    elif cfg.base_ref.startswith("origin/"):
+        remote_branch = cfg.base_ref.split("/", 1)[1]
+        fetch = _run(["git", "-C", str(root), "fetch", "origin", remote_branch], timeout=180)
+        if fetch.returncode == 0:
+            r.add("base-fetch", OK, f"fetched origin/{remote_branch}")
+        elif cfg.allow_stale_base:
+            r.add(
+                "base-fetch", WARN,
+                "git fetch failed; proceeding on the STALE local ref because "
+                "--allow-stale-base was passed. This is recorded in run.json.",
+            )
+        else:
+            r.add(
+                "base-fetch", FAIL,
+                f"git fetch origin {remote_branch} failed: {fetch.stderr.strip()[:300]}\n"
+                "Fix connectivity/auth, or re-run with --allow-stale-base to "
+                "accept a stale local base (recorded as a warning).",
+            )
+    else:
+        r.add(
+            "base-fetch", WARN,
+            f"non-remote base ref {cfg.base_ref!r}: no fetch performed, "
+            "freshness not verified.",
+        )
+    verify = _run(["git", "-C", str(root), "rev-parse", "--verify", cfg.base_ref])
+    if verify.returncode == 0:
+        r.add("base-ref", OK, f"{cfg.base_ref} = {verify.stdout.strip()[:12]}")
+    else:
+        r.add("base-ref", FAIL, f"base ref {cfg.base_ref} does not resolve.")
+
+    # Provider CLIs. Fixture mode replaces them with fakes.
+    if cfg.fixture_mode:
+        r.add("claude-cli", INFO, "fixture mode: real CLI not required")
+        r.add("codex-cli", INFO, "fixture mode: real CLI not required")
+    else:
+        for name in ("claude", "codex"):
+            path = shutil.which(name)
+            if path:
+                r.add(f"{name}-cli", OK, path)
+            else:
+                r.add(
+                    f"{name}-cli", FAIL,
+                    f"`{name}` not found on PATH. Install it, or run with "
+                    "--fixture for a no-CLI dry exercise.",
+                )
+
+    # gh: degrades PR creation, never blocks the loop. Short timeout: `gh
+    # auth status` does network I/O and a hang must not stall preflight.
+    gh = shutil.which("gh")
+    if not gh:
+        r.add("gh-cli", WARN, "gh not on PATH; PR creation will fall back to MANUAL_PR.md")
+    else:
+        auth = _run([gh, "auth", "status"], timeout=20)
+        if auth.returncode == 0:
+            r.add("gh-cli", OK, "gh present and authenticated")
+        else:
+            r.add(
+                "gh-cli", WARN,
+                "gh is installed but not authenticated or not responding "
+                "(`gh auth login`). PR creation will fall back to MANUAL_PR.md.",
+            )
+
+    # Fixture dir must exist before any mutation happens.
+    if cfg.fixture_dir is not None and not cfg.fixture_dir.is_dir():
+        r.add("fixture-dir", FAIL, f"--fixture {cfg.fixture_dir} is not a directory")
+
+    # Toolchains that affect which test suites can run (warn only).
+    for name in ("node", "npm"):
+        r.add(f"{name}", OK if shutil.which(name) else WARN,
+              shutil.which(name) or f"{name} not on PATH; frontend suites will be skipped honestly")
+    venv = root / "backend" / ".venv"
+    r.add(
+        "backend-venv",
+        OK if venv.is_dir() else WARN,
+        str(venv) if venv.is_dir() else
+        "backend/.venv not found; backend suites use the PATH interpreter (recorded)",
+    )
+
+    # Plan path (when given as a file).
+    if cfg.plan_path is not None:
+        if cfg.plan_path.is_file():
+            r.add("plan-path", OK, str(cfg.plan_path))
+        else:
+            r.add("plan-path", FAIL, f"plan file {cfg.plan_path} does not exist")
+
+    # Writability of the two directories the relay needs.
+    if cfg.read_only:
+        r.add("runs-dir", INFO, "write probe skipped in --dry-run")
+        r.add("worktree-root", INFO, "write probe skipped in --dry-run")
+        return r
+    for label, target in (
+        ("runs-dir", root / ".orchestration" / "runs"),
+        ("worktree-root", cfg.worktree_root or root.parent),
+    ):
+        try:
+            target.mkdir(parents=True, exist_ok=True)
+            probe = target / ".relay-write-probe"
+            probe.write_text("ok", encoding="utf-8")
+            probe.unlink()
+            r.add(label, OK, str(target))
+        except OSError as exc:
+            r.add(label, FAIL, f"cannot write {target}: {exc}")
+
+    return r

--- a/orchestration/coding_relay/prompts.py
+++ b/orchestration/coding_relay/prompts.py
@@ -1,0 +1,122 @@
+"""Prompt templates for the builder (Claude) and reviewer (Codex)."""
+from __future__ import annotations
+
+from orchestration.coding_relay.intake import AcceptanceCriteria
+
+BUILD_COMPLETE_MARKER = "BUILD_COMPLETE"
+
+BUILDER_RULES = """## Hard rules
+- Make the actual file edits in this working directory. Do not just describe changes.
+- Edit ONLY inside this working directory. Never write outside it, never create
+  symlinks or junctions, never use .. paths. The relay stops the run if you do.
+- Stay inside the surfaces the plan names. No unrelated refactors, no gold-plating.
+- Do not commit, push, create branches, or change git or tool configuration.
+- Do not touch .github/workflows/, .githooks/, supabase/, DB schema/migration
+  files, auth/security code, or .orchestration/ unless the plan explicitly
+  scopes them. The relay's safety scanner stops the run on violations.
+- Never print, embed, or copy secrets, tokens, or environment variable values.
+- Do not fake success. If something cannot be done, say so plainly.
+- Run nothing destructive: no deploys, no database writes, no mass deletions.
+"""
+
+
+def builder_prompt(
+    plan_text: str,
+    criteria: AcceptanceCriteria,
+    iteration: int,
+    max_iterations: int,
+    reviewer_feedback: str | None = None,
+    test_failures: str | None = None,
+) -> str:
+    parts = [
+        "You are the BUILDER in a bounded build/review relay. You implement; "
+        "a separate reviewer audits your work against acceptance criteria "
+        "after every pass.",
+        "",
+        f"This is iteration {iteration} of at most {max_iterations}.",
+        "",
+        "## Plan to implement",
+        "",
+        plan_text.rstrip(),
+        "",
+        "## Acceptance criteria (the reviewer judges each id)",
+        "",
+        criteria.to_markdown().rstrip(),
+        "",
+    ]
+    if reviewer_feedback:
+        parts += [
+            "## Reviewer feedback from the previous iteration (address ALL of it)",
+            "",
+            reviewer_feedback.rstrip(),
+            "",
+        ]
+    if test_failures:
+        parts += [
+            "## Failing test output from the previous iteration",
+            "",
+            "```",
+            test_failures.rstrip(),
+            "```",
+            "",
+        ]
+    parts += [
+        BUILDER_RULES,
+        "When you believe the implementation is complete, end your final "
+        "message with a one-line summary of what you changed and the literal "
+        f'marker: "{BUILD_COMPLETE_MARKER}".',
+    ]
+    return "\n".join(parts) + "\n"
+
+
+REVIEWER_SCHEMA = """{
+  "status": "pass" | "continue" | "blocked" | "risk_escalation",
+  "summary": "one paragraph, plain text",
+  "criteria_status": [
+    {"id": "<criterion id>", "section": "<section>", "text": "<criterion>",
+     "status": "met" | "unmet" | "unknown" | "not_applicable",
+     "evidence": "concrete evidence from the diff or test output"}
+  ],
+  "required_next_steps": ["concrete step the builder must take next"],
+  "plan_refinements": ["adjustment to the plan justified by repo facts"],
+  "tests_to_run_next": ["exact test command worth running next"],
+  "risk_flags": ["anything risky the human should know"],
+  "should_open_pr": true | false
+}"""
+
+STATUS_SEMANTICS = """Status semantics:
+- "pass": EVERY criterion is met or not_applicable, tests that ran are
+  green, and there are no risk flags. Do not pass on partial work.
+- "continue": progress is real but criteria remain unmet and another
+  bounded iteration can plausibly close them.
+- "blocked": the plan cannot proceed without information or decisions the
+  relay does not have. Explain the blocker in summary.
+- "risk_escalation": the diff touches something a human must approve
+  (auth/security, schema, workflows, destructive behavior, scope break).
+"""
+
+
+def reviewer_prompt(
+    plan_text: str,
+    criteria: AcceptanceCriteria,
+    iteration: int,
+    bundle_summary: str,
+) -> str:
+    return (
+        "You are the REVIEWER in a bounded build/review relay. You are "
+        "read-only: you never edit files, and you review only the artifact "
+        "bundle below (you have no repository access).\n\n"
+        f"This is review iteration {iteration}.\n\n"
+        "## Plan\n\n"
+        f"{plan_text.rstrip()}\n\n"
+        "## Acceptance criteria (judge every id)\n\n"
+        f"{criteria.to_markdown().rstrip()}\n\n"
+        "## Review bundle (diff, changed files, tests, builder summary)\n\n"
+        f"{bundle_summary.rstrip()}\n\n"
+        f"{STATUS_SEMANTICS}\n"
+        "Judge honestly. Evidence must come from the bundle; if you cannot "
+        'verify a criterion, mark it "unknown", never "met".\n\n'
+        "Respond with EXACTLY ONE JSON object and nothing else (no prose, no "
+        "markdown fences) matching this schema:\n\n"
+        f"{REVIEWER_SCHEMA}\n"
+    )

--- a/orchestration/coding_relay/providers/__init__.py
+++ b/orchestration/coding_relay/providers/__init__.py
@@ -1,0 +1,172 @@
+"""Provider adapter core for the Coding Relay.
+
+Derived from skills/winston-plan-relay/scripts/adapters/__init__.py
+(the plan-relay Ticket 2 adapter core). Copied rather than imported: the
+skill directory is not an importable package and stays self-contained.
+Keep run_cli/AdapterResult behavior-compatible; sync changes manually.
+
+Additions over the original:
+- probe(): one --help call per run, cached to the run folder, so command
+  builders can gate optional flags (like model selection) on what the
+  installed CLI actually supports instead of hard-coding.
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+class AdapterUnavailable(Exception):
+    """Raised when a provider CLI is not installed or not on PATH."""
+
+    def __init__(self, agent: str, command: str, detail: str = ""):
+        self.agent = agent
+        self.command = command
+        self.detail = detail
+        msg = (
+            f"provider CLI for {agent} is unavailable.\n"
+            f"  attempted command: {command}\n"
+        )
+        if detail:
+            msg += f"  detail: {detail}\n"
+        msg += "  fallback: re-run with --fixture to exercise the loop without CLIs."
+        super().__init__(msg)
+
+
+@dataclass
+class AdapterResult:
+    """Outcome of one provider invocation. The relay turns this into files."""
+
+    agent: str
+    adapter: str
+    command: list[str]
+    exit_code: int
+    duration_ms: int
+    stdout: str
+    stderr: str
+    ok: bool = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.ok = self.exit_code == 0
+
+    @property
+    def command_str(self) -> str:
+        return " ".join(self.command)
+
+    def meta(self) -> dict:
+        return {
+            "agent": self.agent,
+            "adapter": self.adapter,
+            "command": self.command,
+            "exit_code": self.exit_code,
+            "duration_ms": self.duration_ms,
+        }
+
+
+def resolve_executable(names: list[str]) -> Optional[str]:
+    """Return the first CLI name on PATH, or None."""
+    for name in names:
+        path = shutil.which(name)
+        if path:
+            return path
+    return None
+
+
+def run_cli(
+    agent: str,
+    adapter: str,
+    command: list[str],
+    stdin_text: str,
+    timeout_s: int = 600,
+    cwd: Optional[str] = None,
+    env: Optional[dict] = None,
+) -> AdapterResult:
+    """Run `command` feeding `stdin_text` on stdin. Captures both streams.
+    Never raises on a non-zero exit; timeouts become exit code 124.
+
+    `cwd` matters: `claude -p` and `codex exec` operate on their CWD, so a
+    coding agent launched from the wrong directory reasons but edits nothing.
+    """
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(
+            command,
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            # Force UTF-8 on all pipes; the Windows default cp1252 cannot
+            # encode characters providers routinely emit.
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_s,
+            cwd=cwd,
+            env=env,
+        )
+    except FileNotFoundError as exc:
+        raise AdapterUnavailable(agent, " ".join(command), str(exc)) from exc
+    except subprocess.TimeoutExpired as exc:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return AdapterResult(
+            agent=agent,
+            adapter=adapter,
+            command=command,
+            exit_code=124,
+            duration_ms=duration_ms,
+            stdout=(exc.stdout or "") if isinstance(exc.stdout, str) else "",
+            stderr=((exc.stderr or "") if isinstance(exc.stderr, str) else "")
+            + f"\n[adapter] timed out after {timeout_s}s",
+        )
+    duration_ms = int((time.monotonic() - start) * 1000)
+    return AdapterResult(
+        agent=agent,
+        adapter=adapter,
+        command=command,
+        exit_code=proc.returncode,
+        duration_ms=duration_ms,
+        stdout=proc.stdout or "",
+        stderr=proc.stderr or "",
+    )
+
+
+@dataclass
+class CliCapabilities:
+    exe: str
+    help_text: str
+    flags: set = field(default_factory=set)
+
+
+FLAG_RE = re.compile(r"(?<![\w-])(--[a-z][a-z0-9-]+|-[a-zA-Z])(?![\w-])")
+
+
+def probe(exe: str, cache_file: Optional[Path] = None, timeout_s: int = 60) -> CliCapabilities:
+    """Run `<exe> --help` once and extract the flags it advertises.
+
+    Command builders use this to gate optional flags (e.g. model selection)
+    on the installed CLI instead of assuming. A failed probe returns empty
+    capabilities; builders then emit only their required flags.
+    """
+    try:
+        proc = subprocess.run(
+            [exe, "--help"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_s,
+        )
+        help_text = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        help_text = f"[probe failed: {exc}]"
+    caps = CliCapabilities(exe=exe, help_text=help_text, flags=set(FLAG_RE.findall(help_text)))
+    if cache_file is not None:
+        try:
+            cache_file.parent.mkdir(parents=True, exist_ok=True)
+            cache_file.write_text(help_text, encoding="utf-8")
+        except OSError:
+            pass
+    return caps

--- a/orchestration/coding_relay/providers/claude.py
+++ b/orchestration/coding_relay/providers/claude.py
@@ -1,0 +1,78 @@
+"""Claude CLI adapter: the BUILDER.
+
+Invocation matches the proven pattern from
+skills/winston-plan-relay/scripts/build_review_loop.py: non-interactive
+coding agent scoped to the worktree, prompt on stdin, cwd = worktree.
+
+    claude -p --permission-mode acceptEdits --add-dir <worktree>
+
+Model selection is passed through only when the installed CLI's --help
+advertises --model; otherwise the CLI default is used and the run metadata
+records that fact.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from orchestration.coding_relay.providers import (
+    AdapterResult,
+    CliCapabilities,
+    run_cli,
+)
+
+
+def scrubbed_env(keep: bool = False) -> Optional[dict]:
+    """Drop CLAUDE* variables from the child env by default.
+
+    The relay is frequently launched from inside a Claude Code session;
+    inherited CLAUDE* variables can confuse the nested CLI. --keep-env
+    disables the scrub.
+    """
+    if keep:
+        return None
+    return {k: v for k, v in os.environ.items() if not k.upper().startswith("CLAUDE")}
+
+
+def build_coding_command(
+    exe: str,
+    worktree: Path,
+    permission_mode: str = "acceptEdits",
+    model: Optional[str] = None,
+    caps: Optional[CliCapabilities] = None,
+) -> tuple[list[str], Optional[str]]:
+    """Return (command, note). note explains a dropped flag, if any."""
+    cmd = [exe, "-p", "--permission-mode", permission_mode, "--add-dir", str(worktree)]
+    note = None
+    if model:
+        if caps is not None and "--model" in caps.flags:
+            cmd += ["--model", model]
+        else:
+            note = (
+                f"--claude-model {model} requested but the installed CLI help "
+                "does not advertise --model; using the CLI default."
+            )
+    return cmd, note
+
+
+def invoke_builder(
+    prompt: str,
+    worktree: Path,
+    exe: str,
+    permission_mode: str = "acceptEdits",
+    model: Optional[str] = None,
+    caps: Optional[CliCapabilities] = None,
+    timeout_s: int = 1800,
+    keep_env: bool = False,
+) -> AdapterResult:
+    cmd, _ = build_coding_command(exe, worktree, permission_mode, model, caps)
+    return run_cli(
+        agent="claude-code",
+        adapter="relay_builder",
+        command=cmd,
+        stdin_text=prompt,
+        timeout_s=timeout_s,
+        cwd=str(worktree),
+        env=scrubbed_env(keep_env),
+    )

--- a/orchestration/coding_relay/providers/codex.py
+++ b/orchestration/coding_relay/providers/codex.py
@@ -1,0 +1,109 @@
+"""Codex CLI adapter: the REVIEWER, artifact-review posture by default.
+
+Codex never gets repo or worktree access in the default mode. The relay
+assembles a review bundle (diff, changed files, test outputs, builder
+summary) in a neutral directory under the run folder, embeds the bundle in
+the prompt, and runs:
+
+    codex exec --cd <review-bundle-dir> --skip-git-repo-check \
+        [-m <model>] -c model_reasoning_effort=<effort> -
+
+Windows caveat inherited from the prototype: Codex's sandbox can fail to
+spawn subprocesses (CreateProcessAsUserW error 1312). If the default
+invocation fails with a sandbox-shaped error, we retry ONCE with
+--dangerously-bypass-approvals-and-sandbox, still pointed only at the
+bundle directory, which contains nothing but run artifacts. The retry is
+recorded in the result metadata.
+
+--codex-repo-access switches to the prototype's full-worktree invocation
+(--cd <worktree> + bypass). The loop records that as a risk escalation.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from orchestration.coding_relay.providers import (
+    AdapterResult,
+    CliCapabilities,
+    run_cli,
+)
+
+BYPASS_FLAG = "--dangerously-bypass-approvals-and-sandbox"
+# Matched against STDERR only, and kept to the actual Windows failure
+# signature: codex banners routinely print the word "sandbox" to stdout,
+# which must not trigger a bypass retry.
+SANDBOX_ERROR_MARKERS = ("error 1312", "1312", "CreateProcessAsUserW")
+
+EFFORT_LADDER = ("minimal", "low", "medium", "high")
+
+
+def build_review_command(
+    exe: str,
+    review_dir: Path,
+    model: Optional[str] = "gpt-5.4",
+    effort: str = "low",
+    caps: Optional[CliCapabilities] = None,
+    bypass_sandbox: bool = False,
+) -> tuple[list[str], Optional[str]]:
+    """Return (command, note). `review_dir` is the bundle dir by default, or
+    the worktree only under --codex-repo-access."""
+    cmd = [exe, "exec", "--cd", str(review_dir)]
+    if bypass_sandbox:
+        cmd.append(BYPASS_FLAG)
+    cmd.append("--skip-git-repo-check")
+    note = None
+    if model:
+        if caps is None or "-m" in caps.flags or "--model" in caps.flags:
+            cmd += ["-m", model]
+        else:
+            note = (
+                f"codex model {model} requested but the installed CLI help does "
+                "not advertise -m/--model; using the CLI default."
+            )
+    cmd += ["-c", f"model_reasoning_effort={effort}", "-"]
+    return cmd, note
+
+
+def _looks_like_sandbox_failure(result: AdapterResult) -> bool:
+    stderr = result.stderr or ""
+    return not result.ok and any(marker in stderr for marker in SANDBOX_ERROR_MARKERS)
+
+
+def invoke_reviewer(
+    prompt: str,
+    review_dir: Path,
+    exe: str,
+    model: Optional[str] = "gpt-5.4",
+    effort: str = "low",
+    caps: Optional[CliCapabilities] = None,
+    timeout_s: int = 900,
+    repo_access: bool = False,
+) -> AdapterResult:
+    """Invoke Codex on the review bundle. Sandboxed first; one bypass retry
+    on a sandbox-shaped failure (Windows 1312). With repo_access=True the
+    bypass flag is required from the start (prototype behavior)."""
+    cmd, _ = build_review_command(
+        exe, review_dir, model, effort, caps, bypass_sandbox=repo_access
+    )
+    result = run_cli(
+        agent="codex",
+        adapter="relay_reviewer",
+        command=cmd,
+        stdin_text=prompt,
+        timeout_s=timeout_s,
+        cwd=str(review_dir),
+    )
+    if not repo_access and _looks_like_sandbox_failure(result):
+        retry_cmd, _ = build_review_command(
+            exe, review_dir, model, effort, caps, bypass_sandbox=True
+        )
+        result = run_cli(
+            agent="codex",
+            adapter="relay_reviewer_bypass_retry",
+            command=retry_cmd,
+            stdin_text=prompt,
+            timeout_s=timeout_s,
+            cwd=str(review_dir),
+        )
+    return result

--- a/orchestration/coding_relay/redact.py
+++ b/orchestration/coding_relay/redact.py
@@ -1,0 +1,89 @@
+"""Secret redaction for every artifact the relay writes.
+
+All run-folder writes go through runs.RunPaths.write(), which calls
+redact() on the text first. The goal is to keep tokens that leak into CLI
+output (builder logs, test output, diffs) out of the receipts on disk.
+Redaction is best-effort pattern matching, not a guarantee; the relay also
+never prints environment variables anywhere.
+
+Two pattern tiers:
+- SECRET_PATTERNS: aggressive, used for redaction. Over-matching only
+  costs a mangled line in a receipt.
+- STOP_PATTERNS: high-confidence literal-secret shapes, used by
+  safety.secrets_in_diff to terminate a run. Kept narrower so ordinary
+  code like `token = create_access_token(user)` does not kill a run.
+"""
+from __future__ import annotations
+
+import re
+
+# High-confidence literal secret shapes (also all redacted).
+STOP_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("github-pat", re.compile(r"github_pat_[A-Za-z0-9_]{20,}")),
+    ("github-token", re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}")),
+    ("openai-key", re.compile(r"sk-[A-Za-z0-9_-]{20,}")),
+    ("aws-key", re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("slack-token", re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}")),
+    ("gcp-api-key", re.compile(r"AIza[0-9A-Za-z_-]{35}")),
+    ("databricks-token", re.compile(r"dapi[0-9a-f]{30,}")),
+    ("jwt", re.compile(r"eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}")),
+    ("private-key", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+    ("bearer-token", re.compile(r"(?i)\bbearer\s+[A-Za-z0-9_\-.=]{20,}")),
+    (
+        "db-url-credential",
+        re.compile(r"(postgres(?:ql)?|mysql|mongodb(?:\+srv)?)://[^:/\s]+:[^@\s]+@"),
+    ),
+    # Quoted literal assigned to a secret-named key (FOO_TOKEN = "abc...").
+    (
+        "literal-assignment",
+        re.compile(
+            r"(?i)\b([a-z0-9_-]*(?:api[_-]?key|apikey|access[_-]?key|client[_-]?secret|"
+            r"private[_-]?key|secret|token|password|passwd))\b(\s*[=:]\s*)"
+            r"['\"]([A-Za-z0-9_\-./+]{12,})['\"]"
+        ),
+    ),
+]
+
+# Redaction-only additions (aggressive; may match non-secrets).
+_REDACT_EXTRA: list[tuple[str, re.Pattern[str]]] = [
+    # PEM block bodies (multi-line).
+    (
+        "private-key-block",
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]{0,20000}?-----END [A-Z ]*PRIVATE KEY-----"
+        ),
+    ),
+    # Unquoted assignment to a secret-named key (covers DATABRICKS_TOKEN=dapi...,
+    # DB_PASSWORD=..., MY_SECRET=...). The trailing lookahead rejects values
+    # followed by "(" so ordinary code like `token = create_access_token(user)`
+    # is left intact in receipts.
+    (
+        "generic-assignment",
+        re.compile(
+            r"(?i)\b([a-z0-9_-]*(?:api[_-]?key|apikey|access[_-]?key|client[_-]?secret|"
+            r"private[_-]?key|secret|token|password|passwd))\b(\s*[=:]\s*)"
+            r"['\"]?([A-Za-z0-9_\-./+]{12,})['\"]?(?=[\s'\",;)\]}]|$)"
+        ),
+    ),
+]
+
+# Order matters: the multi-line PEM block must run before the single-line
+# BEGIN pattern, or the block body would survive with only its header gone.
+SECRET_PATTERNS: list[tuple[str, re.Pattern[str]]] = (
+    _REDACT_EXTRA[:1] + STOP_PATTERNS + _REDACT_EXTRA[1:]
+)
+
+
+def redact(text: str) -> str:
+    """Replace anything secret-shaped with a [REDACTED:<label>] marker."""
+    if not text:
+        return text
+    out = text
+    for label, pattern in SECRET_PATTERNS:
+        if label in ("generic-assignment", "literal-assignment"):
+            out = pattern.sub(lambda m: f"{m.group(1)}{m.group(2)}[REDACTED:{label}]", out)
+        elif label == "db-url-credential":
+            out = pattern.sub(lambda m: f"{m.group(1)}://[REDACTED:{label}]@", out)
+        else:
+            out = pattern.sub(f"[REDACTED:{label}]", out)
+    return out

--- a/orchestration/coding_relay/report.py
+++ b/orchestration/coding_relay/report.py
@@ -1,0 +1,168 @@
+"""Final report and PR body generation.
+
+Both documents are receipts: they state what actually happened, including
+skipped tests and unmet criteria. Prose follows docs/anti-ai-style.md; the
+strip pass removes em-dashes from any text we assemble from model output.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+def strip_style(text: str) -> str:
+    """Minimal anti-ai-style pass on assembled prose: no em/en dashes."""
+    return text.replace("—", " - ").replace("–", "-")
+
+
+@dataclass
+class RunSummary:
+    """Everything the report needs, collected by the loop/__main__."""
+
+    run_id: str
+    state: str
+    exit_code: int
+    title: str
+    plan_path: str
+    branch: str = ""
+    worktree_path: str = ""
+    base_ref: str = ""
+    base_sha: str = ""
+    iterations_run: int = 0
+    max_iterations: int = 0
+    criteria_checklist: list = field(default_factory=list)  # (id, section, text)
+    final_criteria_status: list = field(default_factory=list)  # verdict dicts
+    verdict_history: list = field(default_factory=list)  # (iteration, status, summary)
+    test_results: list = field(default_factory=list)  # SuiteResult payload dicts
+    violations: list = field(default_factory=list)  # Violation dicts
+    files_changed: list = field(default_factory=list)  # numstat strings
+    risk_notes: list = field(default_factory=list)
+    removal_instructions: str = ""
+    codex_summary: str = ""
+    escalation_flags: list = field(default_factory=list)  # e.g. codex-repo-access
+
+
+def _criteria_lines(s: RunSummary) -> list:
+    status_by_id = {c.get("id"): c for c in s.final_criteria_status}
+    lines = []
+    for cid, section, text in s.criteria_checklist:
+        entry = status_by_id.get(cid)
+        # Only "met" earns a check; not_applicable stays visibly distinct
+        # via its status text so a reviewer never mistakes it for proven.
+        mark = "x" if (entry and entry.get("status") == "met") else " "
+        status = entry.get("status") if entry else "not reviewed"
+        evidence = (entry.get("evidence", "") if entry else "").strip()
+        line = f"- [{mark}] {cid} ({section}): {text} -- {status}"
+        if evidence:
+            line += f"; evidence: {evidence}"
+        lines.append(line)
+    return lines or ["- (no criteria recorded)"]
+
+
+def _test_lines(s: RunSummary) -> list:
+    if not s.test_results:
+        return ["- No test suites were run (no matching changed paths, or --no-tests)."]
+    lines = []
+    for t in s.test_results:
+        if t.get("skipped"):
+            lines.append(f"- {t['name']}: SKIPPED. {t.get('reason', '')}")
+        else:
+            state = "PASS" if t.get("exit_code") == 0 else f"FAIL (exit {t.get('exit_code')})"
+            lines.append(f"- {t['name']}: {state} ({t.get('duration_s', 0)}s), log: {t.get('log', '')}")
+    return lines
+
+
+def final_report(s: RunSummary) -> str:
+    lines = [
+        f"# Coding Relay run {s.run_id}",
+        "",
+        f"- Outcome: {s.state} (exit {s.exit_code})",
+        f"- Plan: {s.title} ({s.plan_path})",
+        f"- Branch: {s.branch or '(none created)'}",
+        f"- Worktree: {s.worktree_path or '(none created)'}",
+        f"- Base: {s.base_ref} @ {s.base_sha[:12]}",
+        f"- Iterations: {s.iterations_run}/{s.max_iterations}",
+        "",
+        "## Verdict history",
+    ]
+    for it, status, summary in s.verdict_history:
+        lines.append(f"- iteration {it}: {status}. {summary}")
+    if not s.verdict_history:
+        lines.append("- No reviewer verdicts were produced.")
+    lines += ["", "## Acceptance criteria"]
+    lines += _criteria_lines(s)
+    lines += ["", "## Tests"]
+    lines += _test_lines(s)
+    if s.violations:
+        lines += ["", "## Safety violations"]
+        for v in s.violations:
+            lines.append(f"- [{v['severity']}] {v['rule']}: {v['detail']}")
+            for p in v.get("paths", [])[:10]:
+                lines.append(f"    - {p}")
+    if s.escalation_flags:
+        lines += ["", "## Recorded escalations"]
+        lines += [f"- {flag}" for flag in s.escalation_flags]
+    lines += ["", "## Files changed (numstat)"]
+    lines += [f"- {n}" for n in s.files_changed] or ["- (none)"]
+    if s.risk_notes:
+        lines += ["", "## Risks and notes"]
+        lines += [f"- {n}" for n in s.risk_notes]
+    if s.removal_instructions:
+        lines += ["", "## Rollback / cleanup", "", s.removal_instructions]
+    return strip_style("\n".join(lines) + "\n")
+
+
+def pr_body(s: RunSummary, tips_note: str = "") -> str:
+    lines = [
+        "## Plan",
+        "",
+        f"{s.title} ({s.plan_path})",
+        "",
+        "## Acceptance criteria",
+        "",
+    ]
+    lines += _criteria_lines(s)
+    lines += [
+        "",
+        "## Implementation summary",
+        "",
+        s.codex_summary or "(see verdict history in the run folder)",
+        "",
+        "## Files changed",
+        "",
+    ]
+    lines += [f"- {n}" for n in s.files_changed] or ["- (none)"]
+    lines += ["", "## Tests", ""]
+    lines += _test_lines(s)
+    lines += [
+        "",
+        "## Evidence",
+        "",
+        f"- Run folder (local, untracked): .orchestration/runs/{s.run_id}/",
+        f"- Iterations run: {s.iterations_run}/{s.max_iterations}",
+        "",
+        "## Reviewer verdicts",
+        "",
+    ]
+    for it, status, summary in s.verdict_history:
+        lines.append(f"- iteration {it}: {status}. {summary}")
+    lines += ["", "## Risks and unknowns", ""]
+    lines += [f"- {n}" for n in s.risk_notes] or ["- None recorded."]
+    if s.escalation_flags:
+        lines += [f"- Escalation: {flag}" for flag in s.escalation_flags]
+    lines += [
+        "",
+        "## Follow-ups",
+        "",
+        "- Review the run folder receipts before merging.",
+        "",
+        "## tips.md",
+        "",
+        tips_note or "- No reusable lesson recorded this run.",
+        "",
+        "## Rollback",
+        "",
+        "Close this PR and delete the branch; the relay never merges.",
+        "",
+        "Draft PR opened by the Coding Relay (docs/reference/CODING_RELAY.md).",
+    ]
+    return strip_style("\n".join(lines) + "\n")

--- a/orchestration/coding_relay/runs.py
+++ b/orchestration/coding_relay/runs.py
@@ -1,0 +1,96 @@
+"""Run identity and the run-folder write choke point.
+
+A relay run owns one folder under <repo-root>/.orchestration/runs/<run_id>/.
+Every artifact write goes through RunPaths.write(), which applies secret
+redaction. Nothing else in the relay writes into the run folder directly.
+
+Manifest (see docs/reference/CODING_RELAY.md):
+    run.json
+    plan/original-plan.md          plan/normalized-criteria.md
+    env/preflight.json             env/<cli>-help.txt
+    iterations/NN/...              (prompts, outputs, diff, safety, tests, verdict)
+    report/final-report.md         report/PR_BODY.md   report/pr.json | MANUAL_PR.md
+"""
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from orchestration.coding_relay.redact import redact
+
+RUNS_DIRNAME = ".orchestration/runs"
+
+
+def safe_slug(title: str, max_len: int = 24) -> str:
+    """Lowercase [a-z0-9-] slug for branch and folder names."""
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    slug = re.sub(r"-{2,}", "-", slug)
+    return slug[:max_len].rstrip("-") or "task"
+
+
+def new_run_id(slug: str, now: datetime | None = None) -> str:
+    # Seconds in the stamp: a fast-failing run followed by an immediate
+    # rerun must never reuse (and corrupt) the previous run's receipts.
+    stamp = (now or datetime.now()).strftime("%Y%m%d-%H%M%S")
+    return f"{stamp}-{slug}"
+
+
+class RunPaths:
+    """All paths for one run, plus the redacting write choke point."""
+
+    def __init__(self, repo_root: Path, run_id: str):
+        self.repo_root = repo_root
+        self.run_id = run_id
+        self.root = repo_root / RUNS_DIRNAME / run_id
+
+    # -- layout ----------------------------------------------------------
+    @property
+    def plan_dir(self) -> Path:
+        return self.root / "plan"
+
+    @property
+    def env_dir(self) -> Path:
+        return self.root / "env"
+
+    @property
+    def report_dir(self) -> Path:
+        return self.root / "report"
+
+    def iteration_dir(self, n: int) -> Path:
+        return self.root / "iterations" / f"{n:02d}"
+
+    def review_bundle_dir(self, n: int) -> Path:
+        return self.iteration_dir(n) / "review-bundle"
+
+    def tests_dir(self, n: int) -> Path:
+        return self.iteration_dir(n) / "tests"
+
+    @property
+    def run_json(self) -> Path:
+        return self.root / "run.json"
+
+    # -- writes ----------------------------------------------------------
+    def write(self, relpath: str, text: str) -> Path:
+        """Write one artifact, redacted, UTF-8. relpath is run-folder relative."""
+        target = self.root / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(redact(text), encoding="utf-8")
+        return target
+
+    def write_json(self, relpath: str, payload: Any) -> Path:
+        return self.write(relpath, json.dumps(payload, indent=2, default=str) + "\n")
+
+    def update_run_json(self, **fields: Any) -> dict[str, Any]:
+        """Merge fields into run.json (read-modify-write; single process)."""
+        data: dict[str, Any] = {}
+        if self.run_json.is_file():
+            try:
+                data = json.loads(self.run_json.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                data = {}
+        data.update(fields)
+        self.write_json("run.json", data)
+        return data

--- a/orchestration/coding_relay/safety.py
+++ b/orchestration/coding_relay/safety.py
@@ -1,0 +1,203 @@
+"""Hard-stop safety scanner, run after every build pass and before review.
+
+Two severities:
+- "stop": the run terminates immediately (exit 4). No review, no PR.
+- "escalate": the run terminates with a risk report (exit 5); a human
+  decides how to proceed (inspect the worktree, adjust the plan, re-run).
+
+Structural never-dos live in code shape, not scanning: no relay code path
+invokes `gh pr merge`, `git push --force`, deploy commands, or
+`git worktree remove`; PR creation always passes --draft.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from orchestration.coding_relay.redact import STOP_PATTERNS
+
+STOP = "stop"
+ESCALATE = "escalate"
+
+# Mirrors .githooks/pre-commit: >100 files staged for deletion blocks.
+# The snapshot counts deletions with rename detection disabled, so a mass
+# move/rename counts as deletions too (the hook itself has that blind spot).
+MASS_DELETION_FILES = 100
+
+DB_MIGRATION_PREFIXES = ("supabase/", "repo-b/db/schema/", "migrations/")
+# Files that execute on developer or CI machines.
+WORKFLOW_PREFIXES = (".github/", ".githooks/")
+HOST_EXEC_FILES = ("Makefile", "dev.sh")
+AUTH_PATH_RE = re.compile(r"(^|/)(auth|security|permission|session)[^/]*(/|\.|$)", re.IGNORECASE)
+AUTH_SURFACE_PREFIXES = ("backend/", "repo-b/")
+SELF_PREFIX = "orchestration/coding_relay/"
+SYMLINK_DIFF_RE = re.compile(r"^(?:new|old) file mode 120000", re.MULTILINE)
+
+
+@dataclass
+class Violation:
+    rule: str
+    severity: str  # stop | escalate
+    detail: str
+    paths: list = field(default_factory=list)
+
+
+@dataclass
+class DiffSnapshot:
+    """What one build pass changed, gathered by the loop via git."""
+
+    diff_text: str
+    changed_paths: list
+    deleted_paths: list
+    numstat: list  # (added, deleted, path) strings
+
+
+def added_lines(diff_text: str) -> list:
+    return [
+        line[1:]
+        for line in diff_text.splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    ]
+
+
+def scan(
+    worktree: Path,
+    snapshot: DiffSnapshot,
+    plan_text: str,
+    allow_migrations: bool = False,
+    allow_relay_self_edit: bool = False,
+) -> list:
+    violations: list = []
+    paths = [p.replace("\\", "/") for p in snapshot.changed_paths]
+
+    # mass_deletion (stop) — same metric as .githooks/pre-commit.
+    if len(snapshot.deleted_paths) > MASS_DELETION_FILES:
+        violations.append(
+            Violation(
+                "mass_deletion", STOP,
+                f"{len(snapshot.deleted_paths)} files deleted "
+                f"(limit {MASS_DELETION_FILES}, mirroring .githooks/pre-commit).",
+                snapshot.deleted_paths[:20],
+            )
+        )
+
+    # outside_worktree_write (stop) — traversal, absolute, or resolve-escape.
+    wt = worktree.resolve()
+    escapes: list = []
+    for rel in paths:
+        p = Path(rel)
+        if p.is_absolute() or ".." in p.parts:
+            escapes.append(rel)
+            continue
+        try:
+            real = (wt / p).resolve()
+        except OSError:
+            escapes.append(rel)
+            continue
+        try:
+            real.relative_to(wt)
+        except ValueError:
+            escapes.append(rel)
+    if escapes:
+        violations.append(
+            Violation(
+                "outside_worktree_write", STOP,
+                "Changed paths resolve outside the relay worktree "
+                "(path traversal or a link escape).",
+                escapes[:20],
+            )
+        )
+    if SYMLINK_DIFF_RE.search(snapshot.diff_text):
+        violations.append(
+            Violation(
+                "outside_worktree_write", STOP,
+                "The diff creates or modifies a symlink (mode 120000). "
+                "Links are forbidden inside the relay sandbox.",
+            )
+        )
+
+    # db_migration (stop unless --allow-migrations).
+    db_paths = [p for p in paths if p.startswith(DB_MIGRATION_PREFIXES) or "/migrations/" in p]
+    if db_paths and not allow_migrations:
+        violations.append(
+            Violation(
+                "db_migration", STOP,
+                "DB schema/migration paths changed without --allow-migrations.",
+                db_paths[:20],
+            )
+        )
+
+    # secrets_in_diff (stop). Uses the high-confidence STOP_PATTERNS tier
+    # only, so ordinary code like `token = create_access_token(user)` does
+    # not kill a run; redaction of receipts stays aggressive separately.
+    secret_hits = []
+    for line in added_lines(snapshot.diff_text):
+        for label, pattern in STOP_PATTERNS:
+            if pattern.search(line):
+                secret_hits.append(label)
+                break
+    if secret_hits:
+        violations.append(
+            Violation(
+                "secrets_in_diff", STOP,
+                f"Secret-shaped content in added lines: {sorted(set(secret_hits))}. "
+                "The diff itself is redacted in the run artifacts.",
+            )
+        )
+
+    # workflow_hooks (escalate): CI config, git hooks, and root files that
+    # execute commands on developer/CI machines.
+    wf = [
+        p for p in paths
+        if p.startswith(WORKFLOW_PREFIXES) or p in HOST_EXEC_FILES
+    ]
+    if wf:
+        violations.append(
+            Violation(
+                "workflow_hooks", ESCALATE,
+                "CI workflow, git hook, or host-executable files changed; "
+                "a human must approve.",
+                wf[:20],
+            )
+        )
+
+    # auth_security (escalate).
+    auth = [
+        p for p in paths
+        if p.startswith(AUTH_SURFACE_PREFIXES) and AUTH_PATH_RE.search(p)
+    ]
+    if auth:
+        violations.append(
+            Violation(
+                "auth_security", ESCALATE,
+                "Auth/security-surface paths changed; a human must approve.",
+                auth[:20],
+            )
+        )
+
+    # orchestration_self_edit (escalate) — the builder rewriting its own
+    # harness. Always escalates: plan text is author-controlled, so a
+    # substring carve-out would let any plan that merely mentions the relay
+    # weaken the scanner. --allow-relay-self-edit is the recorded override.
+    self_edits = [p for p in paths if p.startswith(SELF_PREFIX)]
+    if self_edits and not allow_relay_self_edit:
+        violations.append(
+            Violation(
+                "orchestration_self_edit", ESCALATE,
+                "The builder edited the relay's own code. Re-run with "
+                "--allow-relay-self-edit (recorded) if the plan legitimately "
+                "targets the relay.",
+                self_edits[:20],
+            )
+        )
+
+    return violations
+
+
+def stops(violations: list) -> list:
+    return [v for v in violations if v.severity == STOP]
+
+
+def escalations(violations: list) -> list:
+    return [v for v in violations if v.severity == ESCALATE]

--- a/orchestration/coding_relay/test_runner.py
+++ b/orchestration/coding_relay/test_runner.py
@@ -1,0 +1,193 @@
+"""Minimal test-suite inference and execution (PR 1 scope).
+
+Maps changed paths to the portable, CI-matching commands and runs them
+inside the relay worktree. When a prerequisite is missing (no interpreter,
+no node_modules), the suite is SKIPPED with the exact manual command; the
+relay never fabricates a test result.
+
+Broader inference (Playwright/e2e, AI evals, migration verification) is a
+documented follow-up, not silently absent: infer_suites() only claims the
+four basic suites below.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Suite:
+    name: str
+    cwd_rel: str  # relative to the worktree
+    command: list
+    timeout_s: int
+    requires: str  # "python" | "npm" | ""
+
+
+@dataclass
+class SuiteResult:
+    name: str
+    command: list
+    skipped: bool = False
+    reason: str = ""
+    exit_code: int | None = None
+    duration_s: float = 0.0
+    log_relpath: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return not self.skipped and self.exit_code == 0
+
+    def summary_line(self) -> str:
+        if self.skipped:
+            return f"{self.name}: SKIPPED ({self.reason})"
+        state = "PASS" if self.exit_code == 0 else f"FAIL (exit {self.exit_code})"
+        return f"{self.name}: {state} in {self.duration_s:.0f}s"
+
+    def to_payload(self) -> dict:
+        return {
+            "name": self.name,
+            "command": self.command,
+            "skipped": self.skipped,
+            "reason": self.reason,
+            "exit_code": self.exit_code,
+            "duration_s": round(self.duration_s, 1),
+            "log": self.log_relpath,
+        }
+
+
+def resolve_python(worktree: Path, primary_root: Path | None) -> tuple[str | None, str]:
+    """Prefer a backend venv (worktree, then primary checkout), else PATH.
+    Returns (interpreter or None, description)."""
+    candidates = []
+    for root in (worktree, primary_root):
+        if root is None:
+            continue
+        venv = root / "backend" / ".venv"
+        candidates.append(venv / "Scripts" / "python.exe")
+        candidates.append(venv / "bin" / "python")
+    for c in candidates:
+        if c.is_file():
+            return str(c), f"backend venv: {c}"
+    path_python = shutil.which("python") or shutil.which("python3")
+    if path_python:
+        return path_python, f"PATH interpreter: {path_python} (no backend venv found)"
+    return None, "no python interpreter available"
+
+
+def infer_suites(changed_paths: list, python_exe: str | None) -> list:
+    """Changed paths -> suites, matching CI's canonical commands.
+
+    When no interpreter was resolved, python suites keep an empty command[0]
+    so run_suites SKIPS them honestly instead of failing with a bogus 127.
+    """
+    paths = [p.replace("\\", "/") for p in changed_paths]
+    py = python_exe or ""
+    suites: list = []
+
+    def touched(prefix: str) -> bool:
+        return any(p.startswith(prefix) for p in paths)
+
+    if touched("backend/"):
+        suites.append(Suite("backend-ruff", "backend", [py, "-m", "ruff", "check", "app", "tests"], 600, "python"))
+        suites.append(Suite("backend-pytest", "backend", [py, "-m", "pytest", "tests", "-q"], 1800, "python"))
+    if touched("repo-b/"):
+        for name, script in (("frontend-lint", "lint"), ("frontend-typecheck", "typecheck"), ("frontend-unit", "test:unit")):
+            suites.append(Suite(name, "repo-b", ["npm", "run", script], 900, "npm"))
+    if touched("rs_factory_seed/"):
+        suites.append(Suite("rs-factory-pytest", "rs_factory_seed", [py, "-m", "pytest", "tests", "-q"], 900, "python"))
+    if touched("backend/") or touched("repo-b/") or touched("verification/"):
+        suites.append(Suite("repe-lint", ".", [py, "-m", "verification.lint.no_legacy_repe_reads", "--json"], 300, "python"))
+    return suites
+
+
+def run_suites(
+    worktree: Path,
+    suites: list,
+    tests_rel: str,
+    python_desc: str = "",
+    write=None,
+) -> list:
+    """Execute suites in the worktree. `write(relpath, text)` is the run
+    folder's redacting writer; log_relpath values are run-folder relative
+    with forward slashes."""
+    results: list = []
+    for suite in suites:
+        cwd = worktree / suite.cwd_rel
+        log_rel = f"{tests_rel}/{suite.name}.log"
+        display_cmd = " ".join(c or "python" for c in suite.command)
+        manual = f"run manually: cd {cwd} && {display_cmd}"
+        skip_reason = None
+        if not cwd.is_dir():
+            skip_reason = f"missing directory {suite.cwd_rel}; {manual}"
+        elif suite.requires == "npm":
+            if shutil.which("npm") is None:
+                skip_reason = f"npm not on PATH; {manual}"
+            elif not (cwd / "node_modules").exists():
+                skip_reason = (
+                    "node_modules missing in the worktree (junction failed); "
+                    f"run manually: cd {cwd} && npm ci && {display_cmd}"
+                )
+        elif suite.requires == "python" and not suite.command[0]:
+            skip_reason = f"no python interpreter available; {manual}"
+        if skip_reason:
+            results.append(SuiteResult(suite.name, suite.command, skipped=True, reason=skip_reason))
+            continue
+
+        exe = suite.command[0]
+        cmd = list(suite.command)
+        if exe == "npm":
+            cmd[0] = shutil.which("npm") or "npm"
+        start = time.monotonic()
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                cwd=str(cwd),
+                timeout=suite.timeout_s,
+                env={**os.environ, "CI": "1"},
+            )
+            exit_code = proc.returncode
+            output = (proc.stdout or "") + "\n--- stderr ---\n" + (proc.stderr or "")
+        except subprocess.TimeoutExpired as exc:
+            exit_code = 124
+            output = (
+                ((exc.stdout or "") if isinstance(exc.stdout, str) else "")
+                + f"\n[test-runner] timed out after {suite.timeout_s}s"
+            )
+        except OSError as exc:
+            exit_code = 127
+            output = f"[test-runner] could not launch: {exc}"
+        duration = time.monotonic() - start
+        if write is not None:
+            header = f"$ {' '.join(cmd)}\n(cwd {cwd}, interpreter: {python_desc})\n\n"
+            write(log_rel, header + output)
+        results.append(
+            SuiteResult(
+                suite.name, cmd, skipped=False, exit_code=exit_code,
+                duration_s=duration, log_relpath=log_rel,
+            )
+        )
+    return results
+
+
+def failing_excerpt(results: list, run_root: Path, limit: int = 4000) -> str:
+    """Tail of each failing suite's log, for the next builder prompt."""
+    chunks: list = []
+    for r in results:
+        if r.skipped or r.ok:
+            continue
+        log = run_root / r.log_relpath
+        tail = ""
+        if log.is_file():
+            text = log.read_text(encoding="utf-8", errors="replace")
+            tail = text[-(limit // max(1, len([x for x in results if not x.skipped and not x.ok]))):]
+        chunks.append(f"### {r.name} (exit {r.exit_code})\n{tail}")
+    return "\n\n".join(chunks)[:limit]

--- a/orchestration/coding_relay/verdict.py
+++ b/orchestration/coding_relay/verdict.py
@@ -1,0 +1,154 @@
+"""Structured reviewer verdict: extraction and hand validation.
+
+The reviewer must answer with exactly one JSON object:
+
+    {
+      "status": "pass" | "continue" | "blocked" | "risk_escalation",
+      "summary": "...",
+      "criteria_status": [
+        {"id": "S1", "section": "Screen", "text": "...",
+         "status": "met" | "unmet" | "unknown" | "not_applicable",
+         "evidence": "..."}
+      ],
+      "required_next_steps": ["..."],
+      "plan_refinements": ["..."],
+      "tests_to_run_next": ["..."],
+      "risk_flags": ["..."],
+      "should_open_pr": true
+    }
+
+Validation is hand-rolled (stdlib only; jsonschema lives in the backend
+venv, which the relay must not depend on). Parse failure is never treated
+as success: the loop retries once with a return-only-JSON nudge, then
+treats the review as blocked.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+
+STATUSES = ("pass", "continue", "blocked", "risk_escalation")
+CRITERION_STATUSES = ("met", "unmet", "unknown", "not_applicable")
+
+FENCED_JSON_RE = re.compile(r"```(?:json)?\s*\n(.*?)```", re.DOTALL)
+
+
+@dataclass
+class Verdict:
+    status: str
+    summary: str
+    criteria_status: list = field(default_factory=list)
+    required_next_steps: list = field(default_factory=list)
+    plan_refinements: list = field(default_factory=list)
+    tests_to_run_next: list = field(default_factory=list)
+    risk_flags: list = field(default_factory=list)
+    should_open_pr: bool = False
+    raw_text: str = ""
+
+    def to_payload(self) -> dict:
+        d = dict(self.__dict__)
+        d.pop("raw_text", None)
+        return d
+
+
+REQUIRED_KEYS = (
+    "status", "summary", "criteria_status", "required_next_steps",
+    "plan_refinements", "tests_to_run_next", "risk_flags", "should_open_pr",
+)
+
+
+def _full_shape(obj: dict) -> bool:
+    return all(k in obj for k in REQUIRED_KEYS)
+
+
+def extract_json_object(text: str) -> dict | None:
+    """Extract the verdict object, hardened against decoys.
+
+    1. If the whole output is one JSON object, take it (the contract).
+    2. Otherwise scan fenced blocks and raw candidates, but accept only
+       objects carrying EVERY required schema key, and take the LAST one.
+       A quoted example like {"status": "pass", "summary": "ok"} embedded
+       in prose lacks the other keys and can never win.
+    """
+    try:
+        obj = json.loads(text.strip())
+        if isinstance(obj, dict):
+            return obj
+    except json.JSONDecodeError:
+        pass
+    last: dict | None = None
+    for block in FENCED_JSON_RE.findall(text):
+        try:
+            obj = json.loads(block)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and _full_shape(obj):
+            last = obj
+    decoder = json.JSONDecoder()
+    idx = text.find("{")
+    while idx != -1:
+        try:
+            obj, _ = decoder.raw_decode(text, idx)
+        except json.JSONDecodeError:
+            obj = None
+        if isinstance(obj, dict) and _full_shape(obj):
+            last = obj
+        idx = text.find("{", idx + 1)
+    return last
+
+
+def _str_list(value) -> list:
+    if not isinstance(value, list):
+        return []
+    return [str(v) for v in value if isinstance(v, (str, int, float))]
+
+
+def parse_verdict(text: str) -> Verdict | None:
+    """Validate the reviewer output into a Verdict, or None on any
+    structural failure. None must be handled as not-approved."""
+    obj = extract_json_object(text)
+    if obj is None:
+        return None
+    status = obj.get("status")
+    if status not in STATUSES:
+        return None
+    summary = obj.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        return None
+    criteria: list = []
+    raw_criteria = obj.get("criteria_status")
+    if isinstance(raw_criteria, list):
+        for entry in raw_criteria:
+            if not isinstance(entry, dict):
+                continue
+            c_status = entry.get("status")
+            if c_status not in CRITERION_STATUSES:
+                c_status = "unknown"
+            criteria.append(
+                {
+                    "id": str(entry.get("id", "?")),
+                    "section": str(entry.get("section", "")),
+                    "text": str(entry.get("text", "")),
+                    "status": c_status,
+                    "evidence": str(entry.get("evidence", "")),
+                }
+            )
+    return Verdict(
+        status=status,
+        summary=summary.strip(),
+        criteria_status=criteria,
+        required_next_steps=_str_list(obj.get("required_next_steps")),
+        plan_refinements=_str_list(obj.get("plan_refinements")),
+        tests_to_run_next=_str_list(obj.get("tests_to_run_next")),
+        risk_flags=_str_list(obj.get("risk_flags")),
+        should_open_pr=bool(obj.get("should_open_pr", False)),
+        raw_text=text,
+    )
+
+
+RETRY_NUDGE = (
+    "\n\nYour previous response was not a single valid JSON object matching "
+    "the required schema. Return ONLY the JSON object now. No prose, no "
+    "markdown fences, no text before or after it."
+)

--- a/orchestration/coding_relay/worktree.py
+++ b/orchestration/coding_relay/worktree.py
@@ -1,0 +1,121 @@
+"""Relay worktree management.
+
+Each run gets a throwaway git worktree on its own branch:
+
+    branch   relay/<slug>-YYYYMMDD-HHMM
+    path     <worktree-root>/r-<slug8>-<HHMM>   (short: Windows MAX_PATH)
+
+The default worktree root is a sibling of the repo (<parent>/Consulting_app_relay
+style: "<repo-name>_relay") so deep repo paths do not overflow MAX_PATH.
+The relay NEVER removes a worktree; the final report carries the exact
+removal commands instead.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+def git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+@dataclass
+class RelayWorktree:
+    path: Path
+    branch: str
+    base_ref: str
+    base_sha: str
+
+
+def default_worktree_root(repo_root: Path) -> Path:
+    return repo_root.parent / f"{repo_root.name}_relay"
+
+
+def create_worktree(
+    repo_root: Path,
+    slug: str,
+    base_ref: str,
+    worktree_root: Path | None = None,
+    now: datetime | None = None,
+) -> RelayWorktree:
+    now = now or datetime.now()
+    branch = f"relay/{slug}-{now.strftime('%Y%m%d-%H%M%S')}"
+    root = worktree_root or default_worktree_root(repo_root)
+    root.mkdir(parents=True, exist_ok=True)
+    wt_path = root / f"r-{slug[:8]}-{now.strftime('%H%M%S')}"
+    if wt_path.exists():
+        raise RuntimeError(
+            f"worktree path already exists: {wt_path}. Remove it or wait a second and retry."
+        )
+    sha = git(repo_root, "rev-parse", base_ref)
+    if sha.returncode != 0:
+        raise RuntimeError(f"base ref {base_ref} does not resolve: {sha.stderr.strip()}")
+    res = git(
+        repo_root,
+        "-c", "core.longpaths=true",
+        "worktree", "add", str(wt_path), "-b", branch, base_ref,
+    )
+    if res.returncode != 0:
+        raise RuntimeError(
+            f"git worktree add failed (branch {branch} may exist):\n{res.stderr.strip()}"
+        )
+    return RelayWorktree(
+        path=wt_path.resolve(), branch=branch, base_ref=base_ref,
+        base_sha=sha.stdout.strip(),
+    )
+
+
+def link_junction(target: Path, link: Path) -> tuple[bool, str]:
+    """Junction (Windows) or symlink (POSIX) `link` -> `target`.
+
+    Never raises: dependency links are best-effort, and a failure only means
+    the matching test suite is skipped with an honest reason.
+    """
+    try:
+        if link.exists():
+            return True, f"already present: {link}"
+        if not target.is_dir():
+            return False, f"target missing: {target}"
+        link.parent.mkdir(parents=True, exist_ok=True)
+        if os.name == "nt":
+            res = subprocess.run(
+                ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+                capture_output=True, text=True, encoding="utf-8", errors="replace",
+            )
+            if res.returncode != 0:
+                return False, f"mklink failed: {(res.stderr or res.stdout).strip()[:200]}"
+        else:
+            os.symlink(target, link, target_is_directory=True)
+        return True, f"{link} -> {target}"
+    except OSError as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+
+def ensure_deps_links(repo_root: Path, wt: RelayWorktree) -> dict[str, str]:
+    """Junction heavyweight dependency dirs from the primary checkout into the
+    worktree so test suites can run there. Returns {name: detail}."""
+    results: dict[str, str] = {}
+    for rel in ("repo-b/node_modules", "backend/.venv"):
+        target = repo_root / rel
+        link = wt.path / rel
+        ok, detail = link_junction(target, link)
+        results[rel] = ("linked: " if ok else "unavailable: ") + detail
+    return results
+
+
+def removal_instructions(repo_root: Path, wt: RelayWorktree) -> str:
+    return (
+        "To remove the relay worktree and branch when you are done:\n"
+        f"    git -C {repo_root} worktree remove --force {wt.path}\n"
+        f"    git -C {repo_root} branch -D {wt.branch}\n"
+    )

--- a/scripts/coding_relay.py
+++ b/scripts/coding_relay.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Anywhere-entry wrapper for the Coding Relay.
+
+`python -m orchestration.coding_relay` needs cwd = repo root (orchestration/
+is a namespace package). This wrapper works from any directory.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestration.coding_relay.__main__ import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What this is

A local coding cockpit at `orchestration/coding_relay/`: give it a plan with explicit success criteria and it validates the plan, preflights the environment, isolates work in a throwaway worktree on a `relay/<slug>-<timestamp>` branch off fresh `origin/main`, then runs a bounded loop: Claude CLI implements, a safety scanner checks the diff against the recorded base, CI-matching tests run with honest skips, and Codex CLI audits each pass from an artifact bundle (never the repo) with a structured JSON verdict per criterion. Receipts land under `.orchestration/runs/<run_id>/` through a secret-redaction choke point. On pass it opens a draft PR; it never merges, never force-pushes, never deploys.

Runnable spine per the approved plan (2026-07-07); guided interactive flow, cockpit UI, and broader test inference are follow-up tickets in plan 0016. ADO: Story #765 / Feature #764 / Epic #359.

## Key safety decisions

- Codex reviewer is artifact-review by default; `--codex-repo-access` is a recorded escalation.
- `git fetch origin main` failure is a hard stop; `--allow-stale-base` is the recorded override.
- Strict `--dry-run`: no worktree, no writes, no provider calls (probes gated on `--probe-clis`), mirrors real exit codes.
- Diff is taken against the base sha, so builder-made commits cannot bypass the scanner (and are themselves a stop).
- `--draft-pr` only extends PR creation to MAX_ITER; nothing is committed or pushed after a safety stop or block.
- Verdict parsing is decoy-hardened: embedded JSON candidates must carry the full schema; parse failure is never approval.
- Two-tier secret patterns: aggressive redaction of receipts, high-confidence stop gate (`token = mint_token(user)` does not kill a run; a quoted literal or known token shape does).

## Adversarial review

A multi-agent review over the finished diff produced 48 raw findings; confirmed ones were fixed before this PR (full list in the plan file 0016, 'Adversarial review round'). The verify phase was cut short by a session usage limit, so triage was manual against the code.

## Tests

- 78 relay tests green locally (61 unit + 17 fixture E2E, no CLIs, no tokens): `cd backend && python -m pytest tests/test_orchestration_relay_*.py -q`
- `ruff check orchestration/coding_relay scripts/coding_relay.py` clean; backend `ruff check app tests` clean.
- Manual: strict dry-run on this repo writes nothing; no-args prints the active-plan list.
- Not done: a real token-spending run with live claude/codex CLIs (documented caveat in 0016).

## Docs

`docs/reference/CODING_RELAY.md` (usage, plan format, exit codes, hard stops, failure recovery), `orchestration/README.md` section, plan `0016-coding-relay-agent.md`, tips.md lessons, `make relay` target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)