### PR TITLE
relay: Relay Smoke Docs Tweak

### DIFF
--- a/docs/plans/03-implementation-plans/active/0016-coding-relay-agent.md
+++ b/docs/plans/03-implementation-plans/active/0016-coding-relay-agent.md
@@ -113,6 +113,9 @@ confirmed ones were fixed before the PR:
   data contract.
 - Broader test inference: Playwright/e2e, AI-eval suites, migration/schema
   verification classes.
+- Review-bundle completeness (reviewer-suggested, plan 0017): include
+  `run.json` and the iteration's `safety.json` in the bundle so run-level
+  criteria are judgeable.
 - PR polish: `scripts/winston/merge_gate.ps1` integration, richer evidence
   linking, approve-and-continue flag for escalations.
 - Optional: routed skill wrapper so the relay is discoverable through the
@@ -121,13 +124,13 @@ confirmed ones were fixed before the PR:
 ## Honest caveats
 
 - PR 1 is non-interactive; `--yes` is a forward-compatibility no-op.
-- The reviewer's default sandbox behavior on Windows may require the bypass
-  retry (still pointed only at the bundle dir); first real CLI run should
-  confirm which path executes and record it in `review-meta.json`.
-- A real (token-spending) end-to-end run with live `claude`/`codex` CLIs was
-  not part of the test suite; the loop is proven by fixture providers and by
-  the CLIs' own `--help` probes. Run one small real task before relying on
-  it for daily work.
+- First live run completed 2026-07-07 (plan 0017, run
+  `20260707-214554-relay-smoke-docs-tweak`, draft PR #509): full loop worked
+  with real CLIs; Codex default sandbox succeeded on Windows from the bundle
+  dir (adapter `relay_reviewer`, no 1312 bypass retry). The run ended
+  MAX_ITER because the smoke plan's criteria described the run itself,
+  which the reviewer cannot verify from its bundle; that honesty is by
+  design. Write criteria the reviewer can judge from the diff.
 - Out-of-worktree containment is diff-based plus the Claude CLI's own
   edit scoping; `--claude-permission-mode bypassPermissions` weakens it and
   is recorded as an escalation, not blocked.

--- a/docs/plans/03-implementation-plans/active/0017-relay-smoke-docs-tweak.md
+++ b/docs/plans/03-implementation-plans/active/0017-relay-smoke-docs-tweak.md
@@ -1,0 +1,74 @@
+# Relay Smoke Docs Tweak
+
+- Status: Done (first live relay run, 2026-07-07; PR #509)
+- Environment: Orchestration
+- Risk: Low
+- Owner: relay smoke test
+
+## Outcome (live-run evidence)
+
+First real Coding Relay run with live claude/codex CLIs, run id
+`20260707-214554-relay-smoke-docs-tweak`. Result: MAX_ITER exit 1 with the
+docs change complete and draft PR #509 opened via `--draft-pr`.
+
+All five manual watch-points passed:
+
+| # | Watch-point | Result | Evidence |
+|---|---|---|---|
+| 1 | Builder edited only the worktree; primary checkout stayed clean | PASS | `git status --porcelain` unchanged vs pre-run baseline |
+| 2 | Reviewer stayed artifact-only | PASS | review-meta.json: `codex exec --cd <run>/iterations/01/review-bundle`, adapter `relay_reviewer`, exit 0; no bypass retry needed on Windows |
+| 3 | Safety scanner ran each iteration before any PR step | PASS | `iterations/01,02/safety.json` present, `[]` violations |
+| 4 | Verdict parsed from structured JSON only | PASS | `verdict.json` both iterations; per-criterion statuses with evidence |
+| 5 | Run folder tells the whole story | PASS | 41-file manifest: plan, prompts, diffs, bundles, safety, verdicts, report, PR body, pr.json |
+
+Why MAX_ITER instead of PASS: the reviewer marked every diff-verifiable
+criterion met (R1-R3, T5) and honestly refused to mark "met" the criteria
+that describe the run itself (run folder created, final report written,
+structured verdict returned): those artifacts are not in its bundle, so it
+returned `unknown` and `continue`. That is the fail-closed behavior working
+as designed. Lesson: write acceptance criteria the reviewer can judge from
+the diff and test outputs. Reviewer's own suggestion, now a 0016 follow-up:
+include `run.json` and `safety.json` in the review bundle.
+
+Also observed: `should_open_pr: false` in the verdict; the draft PR opened
+only because `--draft-pr` on MAX_ITER is the explicit operator override.
+
+## Requested work
+
+Make a small documentation-only improvement to `docs/reference/CODING_RELAY.md` by adding a short "First real run checklist" section near the end of the file (before "Known limitations"). The checklist should tell an operator the five things to verify manually on their first live relay run:
+
+1. The builder edited only the relay worktree; the primary checkout stayed clean.
+2. The reviewer stayed artifact-only (no repo access mode).
+3. The safety scanner ran on every iteration before any PR step.
+4. The verdict was parsed from the structured JSON, not from prose.
+5. The run folder tells the whole story: plan, prompts, diff, tests, safety, verdict, final report, PR body.
+
+Keep it terse and in the file's existing style. Do not change any other section.
+
+## Acceptance Criteria
+
+### Screen
+- Not applicable.
+
+### API
+- Not applicable.
+
+### DB/Data
+- Not applicable.
+
+### AI behavior
+- The relay must use Claude as builder and Codex as artifact reviewer.
+- Codex must return a structured verdict.
+- The run must not require repo-access mode for Codex.
+
+### Evals/tests
+- Relay run exits cleanly.
+- Run folder is created under `.orchestration/runs/`.
+- Final report is written.
+- PR body is written or draft PR is opened.
+- Any skipped tests are reported honestly.
+
+### Regression guard
+- No source code outside docs is changed.
+- No secrets, deploys, DB migrations, workflow edits, or auth/security changes.
+- Existing sections of CODING_RELAY.md are unchanged apart from the new checklist section.

--- a/docs/reference/CODING_RELAY.md
+++ b/docs/reference/CODING_RELAY.md
@@ -220,6 +220,21 @@ how the E2E tests exercise the loop.
 - Stale worktree path collision: remove the old worktree (command above) or
   pass a different `--worktree-root`.
 
+## First real run checklist
+
+Five things to verify by hand on your first live relay run:
+
+1. The builder edited only the relay worktree; the primary checkout stayed
+   clean (`git status` in both).
+2. The reviewer stayed artifact-only: no `--codex-repo-access`, no repo-access
+   escalation in `run.json`.
+3. The safety scanner ran on every iteration before any PR step
+   (`iterations/NN/safety.json` exists for each pass).
+4. The verdict came from the structured JSON (`iterations/NN/verdict.json`),
+   not from prose in the review output.
+5. The run folder tells the whole story: plan, prompts, diff, tests, safety,
+   verdict, final report, PR body.
+
 ## Known limitations (PR 1)
 
 - Non-interactive: no guided menu flow yet; `--yes` is accepted as a no-op

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4936,3 +4936,17 @@ Redesign of `/lab/env/[envId]/telemetry/calibration` into an inspectable evidenc
   hand-edit the table. Register new routed surfaces in the JSON, or skip the
   registry when the thing is a tool with a reference doc rather than a
   skill/agent.
+
+## Coding Relay first live run (2026-07-07)
+
+- **Codex default sandbox works on Windows from a plain directory.** The
+  relay's artifact-review invocation (`codex exec --cd <bundle-dir>
+  --skip-git-repo-check ... -`) ran clean (exit 0) with NO
+  `--dangerously-bypass-approvals-and-sandbox`; the 1312 bypass retry never
+  fired. The prototype's bypass flag was only ever needed for repo-rooted
+  review with file exploration. Prefer the sandboxed artifact posture.
+- **Write relay acceptance criteria the reviewer can judge from the diff.**
+  Criteria that describe the run itself ("run folder is created", "final
+  report is written") come back `unknown` from an honest artifact-only
+  reviewer and force MAX_ITER instead of pass. Criteria belong to the
+  change, not the harness; harness assertions live in the relay's own tests.


### PR DESCRIPTION
## Plan

Relay Smoke Docs Tweak (C:\Projects\cons_wt_relay\docs\plans\03-implementation-plans\active\0017-relay-smoke-docs-tweak.md)

## Acceptance criteria

- [x] R1 (Regression guard): No source code outside docs is changed. -- met; evidence: `files.txt`/changed-files summary lists only `docs/reference/CODING_RELAY.md`, and `diff-stat.txt` shows one changed file with 15 insertions.
- [x] R2 (Regression guard): No secrets, deploys, DB migrations, workflow edits, or auth/security changes. -- met; evidence: The only changed file is `docs/reference/CODING_RELAY.md`, and the diff is prose-only documentation text.
- [x] R3 (Regression guard): Existing sections of CODING_RELAY.md are unchanged apart from the new checklist section. -- met; evidence: The diff is a single additive hunk inserting `## First real run checklist` immediately before `## Known limitations (PR 1)` with no deleted or modified existing lines.
- [ ] T1 (Evals-tests): Relay run exits cleanly. -- unknown; evidence: `tests-summary.md` says 'No suites were run.' and the bundle includes no relay exit/status artifact.
- [ ] T2 (Evals-tests): Run folder is created under `.orchestration/runs/`. -- unknown; evidence: The review bundle is presented as extracted artifacts, but no explicit run-manifest artifact in the bundle proves the run-folder creation criterion.
- [ ] T3 (Evals-tests): Final report is written. -- unknown; evidence: No final report file is included in the bundle.
- [ ] T4 (Evals-tests): PR body is written or draft PR is opened. -- unknown; evidence: No PR body artifact or draft-PR evidence is included in the bundle.
- [x] T5 (Evals-tests): Any skipped tests are reported honestly. -- met; evidence: The bundle states 'Tests: No suites were run.' and the builder summary also says 'none exist for prose in this file and none were run'.
- [ ] B1 (AI behavior): The relay must use Claude as builder and Codex as artifact reviewer. -- unknown; evidence: The bundle contains only a docs diff plus summaries; no run artifact such as `run.json` is included to prove the builder/reviewer identities used in this run.
- [ ] B2 (AI behavior): Codex must return a structured verdict. -- unknown; evidence: No `iterations/NN/verdict.json` or equivalent structured verdict artifact is present in the bundle.
- [ ] B3 (AI behavior): The run must not require repo-access mode for Codex. -- unknown; evidence: The new checklist mentions 'no `--codex-repo-access`' and 'no repo-access escalation in `run.json`', but the bundle does not include `run.json` or other run metadata for this iteration.

## Implementation summary

The documentation change itself is narrowly scoped and matches the request: the diff adds a terse five-item "First real run checklist" immediately before "Known limitations" in `docs/reference/CODING_RELAY.md`, with no other file changes. However, the bundle still does not include the run artifacts needed to verify the AI-behavior and run-output criteria for this live relay run, so those items remain unknown rather than met.

## Files changed

- 15	0	docs/reference/CODING_RELAY.md

## Tests

- No test suites were run (no matching changed paths, or --no-tests).

## Evidence

- Run folder (local, untracked): .orchestration/runs/20260707-214554-relay-smoke-docs-tweak/
- Iterations run: 2/2

## Reviewer verdicts

- iteration 1: continue. The documentation change itself appears narrowly scoped and matches the requested placement and content, but this bundle does not contain enough evidence to pass the relay acceptance criteria. The diff shows a single additive section in `docs/reference/CODING_RELAY.md`, and the test summary honestly states that no suites were run, but the bundle does not prove the live relay behavior claims about Claude/Codex roles, artifact-only review mode, safety scanning on every iteration, clean exit, run-folder outputs, or PR creation.
- iteration 2: continue. The documentation change itself is narrowly scoped and matches the request: the diff adds a terse five-item "First real run checklist" immediately before "Known limitations" in `docs/reference/CODING_RELAY.md`, with no other file changes. However, the bundle still does not include the run artifacts needed to verify the AI-behavior and run-output criteria for this live relay run, so those items remain unknown rather than met.

## Risks and unknowns

- Current bundle cannot substantiate B1-B3 or T1-T4, so passing now would rely on prose claims instead of run artifacts.
- The builder summary references harness behavior and file names, but those claims are not backed by the corresponding generated artifacts in this bundle.
- max iterations (2) reached; last verdict was 'continue'. The worktree is preserved for inspection or a re-run.

## Follow-ups

- Review the run folder receipts before merging.

## tips.md

- No reusable lesson recorded this run.

## Rollback

Close this PR and delete the branch; the relay never merges.

Draft PR opened by the Coding Relay (docs/reference/CODING_RELAY.md).
