### PR TITLE
feat(orchestration): Coding Relay PR 2 - guided terminal flow + review-bundle run artifacts

### DIFF
--- a/backend/tests/test_orchestration_relay_guided.py
+++ b/backend/tests/test_orchestration_relay_guided.py
@@ -1,0 +1,491 @@
+"""Guided operator flow: menu, criteria confirm/edit, preflight display,
+prompts, PR-offer policy, and no-mutation-on-abort. All I/O is injected;
+no TTY, no CLIs, no tokens.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestration.coding_relay import guided  # noqa: E402
+from orchestration.coding_relay.__main__ import build_parser  # noqa: E402
+from orchestration.coding_relay.guided import (  # noqa: E402
+    AutoUI,
+    TerminalUI,
+    confirm_criteria,
+    plan_menu_entries,
+    reload_criteria,
+    render_preflight,
+    select_plan,
+    strip_id_markers,
+)
+from orchestration.coding_relay.intake import IntakeError, load_plan  # noqa: E402
+from orchestration.coding_relay.preflight import Check, PreflightResult  # noqa: E402
+
+FIXTURE = ROOT / "orchestration" / "coding_relay" / "fixtures" / "demo"
+
+PLAN_TEXT = (FIXTURE / "plan.md").read_text(encoding="utf-8")
+
+
+class Script:
+    """Deterministic input_fn: pops scripted answers, records prompts."""
+
+    def __init__(self, answers):
+        self.answers = list(answers)
+        self.prompts = []
+
+    def __call__(self, prompt=""):
+        self.prompts.append(prompt)
+        if not self.answers:
+            raise AssertionError(f"input exhausted at prompt: {prompt!r}")
+        return self.answers.pop(0)
+
+
+class Sink:
+    def __init__(self):
+        self.lines = []
+
+    def __call__(self, text=""):
+        self.lines.append(str(text))
+
+    @property
+    def text(self):
+        return "\n".join(self.lines)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_git_config(monkeypatch):
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+
+
+@pytest.fixture()
+def repo_with_active_plan(tmp_path):
+    repo = tmp_path / "repo"
+    active = repo / "docs" / "plans" / "03-implementation-plans" / "active"
+    active.mkdir(parents=True)
+    subprocess.run(["git", "init"], cwd=str(repo), capture_output=True, text=True)
+    for cmd in (
+        ["config", "user.email", "t@example.com"],
+        ["config", "user.name", "T"],
+        ["config", "commit.gpgsign", "false"],
+    ):
+        subprocess.run(["git", "-C", str(repo), *cmd], capture_output=True, text=True)
+    (active / "0001-demo-plan.md").write_text(PLAN_TEXT, encoding="utf-8")
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "seed"], capture_output=True, text=True)
+    return repo
+
+
+# ------------------------------------------------------------------- menu
+
+def test_plan_menu_entries_parse_title_and_status(repo_with_active_plan):
+    entries = plan_menu_entries(repo_with_active_plan)
+    assert len(entries) == 1
+    path, title, status = entries[0]
+    assert path.name == "0001-demo-plan.md"
+    assert title.startswith("Demo fixture plan")
+    # The demo plan has no Status line; robustness means empty, not crash.
+    assert status == ""
+
+
+def test_plan_menu_robust_to_garbage_file(repo_with_active_plan):
+    active = repo_with_active_plan / "docs" / "plans" / "03-implementation-plans" / "active"
+    (active / "0002-garbage.md").write_bytes(b"\xff\xfe\x00garbage")
+    entries = plan_menu_entries(repo_with_active_plan)
+    assert len(entries) == 2  # no crash
+
+
+def test_select_plan_by_number(repo_with_active_plan):
+    script = Script(["1"])
+    sel = select_plan(repo_with_active_plan, script, Sink())
+    assert sel and sel["plan"].endswith("0001-demo-plan.md")
+
+
+def test_select_plan_quit_and_empty(repo_with_active_plan):
+    assert select_plan(repo_with_active_plan, Script(["q"]), Sink()) is None
+    assert select_plan(repo_with_active_plan, Script([""]), Sink()) is None
+
+
+def test_select_plan_file_path(repo_with_active_plan, tmp_path):
+    plan = tmp_path / "somewhere.md"
+    plan.write_text(PLAN_TEXT, encoding="utf-8")
+    sel = select_plan(repo_with_active_plan, Script(["f", str(plan)]), Sink())
+    assert sel == {"plan": str(plan)}
+    # Bad path re-prompts, then quit.
+    out = Sink()
+    sel = select_plan(repo_with_active_plan, Script(["f", "no-such.md", "q"]), out)
+    assert sel is None
+    assert "Not a file" in out.text
+
+
+def test_select_plan_paste(repo_with_active_plan):
+    lines = PLAN_TEXT.splitlines()
+    script = Script(["p", *lines, "END"])
+    sel = select_plan(repo_with_active_plan, script, Sink())
+    assert sel and "paste_file" in sel
+    pasted = Path(sel["paste_file"]).read_text(encoding="utf-8")
+    assert "Acceptance Criteria" in pasted
+
+
+def test_select_plan_unrecognized_reprompts(repo_with_active_plan):
+    out = Sink()
+    sel = select_plan(repo_with_active_plan, Script(["zz", "99", "1"]), out)
+    assert sel and sel["plan"].endswith("0001-demo-plan.md")
+    assert "Unrecognized" in out.text
+
+
+# --------------------------------------------------------------- criteria
+
+def _demo_result(repo_root):
+    return load_plan(repo_root, str(FIXTURE / "plan.md"), None)
+
+
+def test_strip_id_markers():
+    assert strip_id_markers("- [T1] tests pass") == "- tests pass"
+    assert strip_id_markers("  - [R12] no break") == "  - no break"
+    assert strip_id_markers("- plain bullet") == "- plain bullet"
+
+
+def test_reload_criteria_roundtrip(tmp_path):
+    result = _demo_result(tmp_path)
+    md = result.criteria.to_markdown()
+    criteria = reload_criteria(md)
+    assert [c[2] for c in criteria.checklist()] == [c[2] for c in result.criteria.checklist()]
+
+
+def test_reload_criteria_invalid_raises():
+    with pytest.raises(IntakeError):
+        reload_criteria("no heading, no bullets")
+    with pytest.raises(IntakeError):
+        reload_criteria("## Acceptance Criteria\n\n(prose only, no bullets)\n")
+
+
+def test_confirm_criteria_accept_and_abort(tmp_path):
+    result = _demo_result(tmp_path)
+    assert confirm_criteria(result, Script(["y"]), Sink()) is result
+    assert confirm_criteria(result, Script([""]), Sink()) is result
+    assert confirm_criteria(_demo_result(tmp_path), Script(["n"]), Sink()) is None
+
+
+def test_confirm_criteria_edit_reloads(tmp_path):
+    result = _demo_result(tmp_path)
+
+    def editor(path: Path):
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text + "- the new edited criterion runs a pytest check\n", encoding="utf-8"
+        )
+
+    out = Sink()
+    confirmed = confirm_criteria(result, Script(["e", "y"]), out, editor_fn=editor)
+    assert confirmed is not None
+    texts = [t for _, _, t in confirmed.criteria.checklist()]
+    assert any("new edited criterion" in t for t in texts)
+
+
+def test_confirm_criteria_edit_propagates_into_plan_text(tmp_path):
+    """The edited criteria must replace the plan's original criteria section
+    in plan_text, so the builder/reviewer prompts do not carry stale,
+    contradicting criteria."""
+    result = _demo_result(tmp_path)
+    original_criterion = "The fixture loop runs to completion"
+    assert original_criterion in result.plan_text
+
+    def editor(path: Path):
+        # Replace all criteria with a single fresh one.
+        path.write_text(
+            "## Acceptance Criteria\n\n### Evals/tests\n"
+            "- only the freshly edited criterion survives\n",
+            encoding="utf-8",
+        )
+
+    confirmed = confirm_criteria(result, Script(["e", "y"]), Sink(), editor_fn=editor)
+    assert confirmed is not None
+    # The stale original criterion is gone from plan_text; the edit is present.
+    assert original_criterion not in confirmed.plan_text
+    assert "only the freshly edited criterion survives" in confirmed.plan_text
+    # And the plan's non-criteria content is preserved.
+    assert "RELAY_NOTE.md" in confirmed.plan_text
+
+
+def test_confirm_criteria_edit_to_invalid_raises(tmp_path):
+    result = _demo_result(tmp_path)
+
+    def editor(path: Path):
+        path.write_text("wrecked\n", encoding="utf-8")
+
+    with pytest.raises(IntakeError):
+        confirm_criteria(result, Script(["e"]), Sink(), editor_fn=editor)
+
+
+def test_confirm_criteria_assume_yes_skips_prompt(tmp_path):
+    result = _demo_result(tmp_path)
+    script = Script([])  # any prompt would raise
+    assert confirm_criteria(result, script, Sink(), assume_yes=True) is result
+
+
+# -------------------------------------------------------------- preflight
+
+def test_render_preflight_table():
+    checks = PreflightResult()
+    checks.add("git-repo", "ok", "C:/x")
+    checks.add("gh-cli", "warn", "gh unauthenticated\nsecond warn line dropped")
+    checks.add("base-fetch", "fail", "network down\nre-run with --allow-stale-base")
+    out = Sink()
+    render_preflight(checks, out)
+    assert "OK    git-repo" in out.text
+    assert "WARN  gh-cli" in out.text
+    assert "FAIL  base-fetch" in out.text
+    # WARN/OK rows are truncated to one line; FAIL rows keep the remediation.
+    assert "second warn line dropped" not in out.text
+    assert "re-run with --allow-stale-base" in out.text
+
+
+def _args(extra=None):
+    return build_parser().parse_args(extra or [])
+
+
+def test_confirm_warnings_default_no():
+    ui = TerminalUI(_args(), Script([""]), Sink())
+    assert ui.confirm_warnings([Check("gh-cli", "warn", "x")]) is False
+    ui = TerminalUI(_args(), Script(["y"]), Sink())
+    assert ui.confirm_warnings([Check("gh-cli", "warn", "x")]) is True
+
+
+def test_yes_flag_accepts_warnings_without_prompt():
+    ui = TerminalUI(_args(["--yes"]), Script([]), Sink())
+    assert ui.confirm_warnings([Check("gh-cli", "warn", "x")]) is True
+
+
+# ----------------------------------------------------------- PR decisions
+
+class FakeVerdict:
+    def __init__(self, should_open_pr=True, criteria_status=None,
+                 required_next_steps=None, risk_flags=None,
+                 status="continue", summary="s"):
+        self.should_open_pr = should_open_pr
+        self.criteria_status = criteria_status or []
+        self.required_next_steps = required_next_steps or []
+        self.risk_flags = risk_flags or []
+        self.status = status
+        self.summary = summary
+
+
+def test_terminal_pr_offer_pass_default_yes():
+    ui = TerminalUI(_args(), Script([""]), Sink())
+    assert ui.decide_pr("PASS", FakeVerdict()) is True
+    ui = TerminalUI(_args(), Script(["n"]), Sink())
+    assert ui.decide_pr("PASS", FakeVerdict()) is False
+
+
+def test_terminal_pr_offer_pass_reviewer_veto_defaults_no():
+    ui = TerminalUI(_args(), Script([""]), Sink())
+    assert ui.decide_pr("PASS", FakeVerdict(should_open_pr=False)) is False
+
+
+def test_terminal_pr_offer_max_iter_default_no():
+    ui = TerminalUI(_args(), Script([""]), Sink())
+    assert ui.decide_pr("MAX_ITER", FakeVerdict()) is False
+    ui = TerminalUI(_args(), Script(["y"]), Sink())
+    assert ui.decide_pr("MAX_ITER", FakeVerdict()) is True
+
+
+def test_terminal_pr_never_offered_after_stop_states():
+    for state in ("SAFETY_STOP", "BLOCKED", "ERROR"):
+        ui = TerminalUI(_args(), Script([]), Sink())  # a prompt would raise
+        assert ui.decide_pr(state, FakeVerdict()) is False
+        # Even --draft-pr cannot reach these states.
+        ui = TerminalUI(_args(["--draft-pr"]), Script([]), Sink())
+        assert ui.decide_pr(state, FakeVerdict()) is False
+
+
+def test_terminal_pr_flag_matrix_no_prompt():
+    """--yes and --draft-pr resolve the PR decision without prompting; a
+    stray prompt would raise via the empty Script."""
+    # --yes at MAX_ITER: no PR for failing work without --draft-pr.
+    assert TerminalUI(_args(["--yes"]), Script([]), Sink()).decide_pr("MAX_ITER", FakeVerdict()) is False
+    # --yes at PASS: PR (delegates to AutoUI policy).
+    assert TerminalUI(_args(["--yes"]), Script([]), Sink()).decide_pr("PASS", FakeVerdict()) is True
+    # --draft-pr at MAX_ITER: operator override, no prompt.
+    assert TerminalUI(_args(["--draft-pr"]), Script([]), Sink()).decide_pr("MAX_ITER", FakeVerdict()) is True
+    # --yes at PASS with reviewer veto and no --draft-pr: veto honored.
+    assert TerminalUI(_args(["--yes"]), Script([]), Sink()).decide_pr(
+        "PASS", FakeVerdict(should_open_pr=False)
+    ) is False
+
+
+def test_eof_at_prompt_is_treated_as_decline():
+    def eof(_prompt=""):
+        raise EOFError
+
+    ui = TerminalUI(_args(), eof, Sink())
+    # PASS default-yes prompt: EOF must decline, not crash or accept.
+    assert ui.decide_pr("PASS", FakeVerdict()) is False
+    # continue prompt: EOF declines -> operator stop.
+    assert ui.on_continue(1, FakeVerdict(), [], []) is False
+
+
+def test_no_pr_wins_everywhere():
+    for state in ("PASS", "MAX_ITER"):
+        ui = TerminalUI(_args(["--no-pr"]), Script([]), Sink())
+        assert ui.decide_pr(state, FakeVerdict()) is False
+
+
+def test_auto_ui_matches_flag_policy():
+    assert AutoUI(_args()).decide_pr("PASS", FakeVerdict()) is True
+    assert AutoUI(_args()).decide_pr("MAX_ITER", FakeVerdict()) is False
+    assert AutoUI(_args(["--draft-pr"])).decide_pr("MAX_ITER", FakeVerdict()) is True
+    assert AutoUI(_args(["--no-pr"])).decide_pr("PASS", FakeVerdict()) is False
+    assert AutoUI(_args()).decide_pr("PASS", FakeVerdict(should_open_pr=False)) is False
+    # --draft-pr overrides the reviewer veto (PR 1 byte-compat behavior).
+    assert AutoUI(_args(["--draft-pr"])).decide_pr("PASS", FakeVerdict(should_open_pr=False)) is True
+    assert AutoUI(_args()).decide_pr("SAFETY_STOP", FakeVerdict()) is False
+
+
+# --------------------------------------------------- guided E2E (fixture)
+
+def guided_args(repo, tmp_path, extra=None):
+    return build_parser().parse_args([
+        "--repo-root", str(repo),
+        "--fixture", str(FIXTURE),
+        "--base", "HEAD",
+        "--worktree-root", str(tmp_path / "wts"),
+        "--max-iterations", "2",
+        *(extra or []),
+    ])
+
+
+def test_guided_quit_makes_no_mutation(repo_with_active_plan, tmp_path):
+    args = guided_args(repo_with_active_plan, tmp_path)
+    code = guided.run_guided(args, Script(["q"]), Sink())
+    assert code == 2
+    assert not (repo_with_active_plan / ".orchestration").exists()
+    assert not (tmp_path / "wts").exists()
+
+
+def test_guided_criteria_abort_makes_no_mutation(repo_with_active_plan, tmp_path):
+    args = guided_args(repo_with_active_plan, tmp_path)
+    code = guided.run_guided(args, Script(["1", "n"]), Sink())
+    assert code == 2
+    assert not (repo_with_active_plan / ".orchestration").exists()
+    assert not (tmp_path / "wts").exists()
+
+
+def test_guided_start_decline_stops_before_worktree(repo_with_active_plan, tmp_path):
+    args = guided_args(repo_with_active_plan, tmp_path)
+    # menu 1, criteria yes, warnings yes (tmp repo always warns on venv/base),
+    # start: decline.
+    code = guided.run_guided(args, Script(["1", "y", "y", "n"]), Sink())
+    assert code == 2
+    # The preflight writability probe may create the empty root dirs, but no
+    # worktree and no run receipts exist.
+    assert not list((tmp_path / "wts").glob("*")) if (tmp_path / "wts").exists() else True
+    runs = repo_with_active_plan / ".orchestration" / "runs"
+    assert not runs.exists() or not list(runs.glob("*"))
+
+
+def test_guided_happy_path_full_loop(repo_with_active_plan, tmp_path):
+    args = guided_args(repo_with_active_plan, tmp_path, ["--no-pr"])
+    out = Sink()
+    # menu 1, criteria yes, warnings yes, start yes, continue after iter 1 yes.
+    code = guided.run_guided(args, Script(["1", "y", "y", "y", "y"]), out)
+    assert code == 0
+    runs = list((repo_with_active_plan / ".orchestration" / "runs").iterdir())
+    assert len(runs) == 1
+    assert (runs[0] / "report" / "final-report.md").is_file()
+    assert "iteration 1 summary" in out.text
+    assert "verdict:  continue" in out.text
+    assert "[done] PASS" in out.text
+
+
+def test_guided_operator_stop_on_continue(repo_with_active_plan, tmp_path):
+    args = guided_args(repo_with_active_plan, tmp_path, ["--no-pr"])
+    out = Sink()
+    # Decline the continue prompt after iteration 1.
+    script = Script(["1", "y", "y", "y", "n"])
+    code = guided.run_guided(args, script, out)
+    assert code == 1
+    assert script.answers == []  # exact prompt sequence, no drift
+    runs = list((repo_with_active_plan / ".orchestration" / "runs").iterdir())
+    meta = json.loads((runs[0] / "run.json").read_text(encoding="utf-8"))
+    assert meta["state"] == "MAX_ITER"
+    assert "operator stopped" in meta["detail"]
+    assert (runs[0] / "report" / "final-report.md").is_file()
+    # Contract point 4: the worktree is kept for inspection or a re-run.
+    wts = list((tmp_path / "wts").iterdir())
+    assert len(wts) == 1 and (wts[0] / "RELAY_NOTE.md").is_file()
+
+
+def test_guided_warn_decline_stops_before_worktree(repo_with_active_plan, tmp_path):
+    """Answering No at the warnings prompt aborts: no worktree, no receipts."""
+    args = guided_args(repo_with_active_plan, tmp_path)
+    out = Sink()
+    code = guided.run_guided(args, Script(["1", "y", "n"]), out)
+    assert code == 2
+    assert "Stopped at preflight warnings" in out.text
+    assert not (tmp_path / "wts").exists() or not list((tmp_path / "wts").glob("*"))
+    runs = repo_with_active_plan / ".orchestration" / "runs"
+    assert not runs.exists() or not list(runs.glob("*"))
+
+
+def test_guided_eof_at_continue_is_operator_stop(repo_with_active_plan, tmp_path):
+    """EOF (closed stdin) at the continue prompt is a clean operator stop
+    (exit 1, report written), never an internal ERROR (exit 6)."""
+    args = guided_args(repo_with_active_plan, tmp_path, ["--no-pr"])
+
+    answers = iter(["1", "y", "y", "y"])
+
+    def input_fn(_prompt=""):
+        try:
+            return next(answers)
+        except StopIteration:
+            raise EOFError  # stdin closes right at the continue prompt
+
+    code = guided.run_guided(args, input_fn, Sink())
+    assert code == 1
+    runs = list((repo_with_active_plan / ".orchestration" / "runs").iterdir())
+    meta = json.loads((runs[0] / "run.json").read_text(encoding="utf-8"))
+    assert meta["state"] == "MAX_ITER"
+    assert meta["exit_code"] == 1
+    assert (runs[0] / "report" / "final-report.md").is_file()
+
+
+def test_guided_yes_is_nonblocking(repo_with_active_plan, tmp_path):
+    """--yes drives the whole guided run with only the plan selection; any
+    later prompt would raise via input exhaustion."""
+    args = guided_args(repo_with_active_plan, tmp_path, ["--no-pr", "--yes"])
+    script = Script(["1"])  # menu selection only
+    code = guided.run_guided(args, script, Sink())
+    assert code == 0
+    assert script.answers == []
+    runs = list((repo_with_active_plan / ".orchestration" / "runs").iterdir())
+    assert (runs[0] / "report" / "final-report.md").is_file()
+
+
+def test_guided_yes_never_bypasses_hard_preflight_failure(repo_with_active_plan, tmp_path):
+    """--yes with a bad --fixture dir: the hard preflight failure stops
+    before any prompt or mutation, exit 2."""
+    args = build_parser().parse_args([
+        "--repo-root", str(repo_with_active_plan),
+        "--fixture", str(tmp_path / "does-not-exist"),
+        "--base", "HEAD",
+        "--worktree-root", str(tmp_path / "wts"),
+        "--no-pr", "--yes",
+    ])
+    script = Script(["1"])  # only the menu; no prompt should follow a hard fail
+    code = guided.run_guided(args, script, Sink())
+    assert code == 2
+    assert not (tmp_path / "wts").exists() or not list((tmp_path / "wts").glob("*"))
+    runs = repo_with_active_plan / ".orchestration" / "runs"
+    assert not runs.exists() or not list(runs.glob("*"))

--- a/backend/tests/test_orchestration_relay_intake.py
+++ b/backend/tests/test_orchestration_relay_intake.py
@@ -128,3 +128,27 @@ def test_safe_slug():
     assert safe_slug("Add Widget Counter!") == "add-widget-counter"
     assert safe_slug("///") == "task"
     assert len(safe_slug("a" * 100)) <= 24
+
+
+def test_replace_criteria_block_swaps_section_preserving_rest():
+    plan = (
+        "# Title\n\n## Requested work\n\nBuild the thing.\n\n"
+        "## Acceptance Criteria\n\n### Screen\n- old bullet\n\n"
+        "## Out of scope\n\n- nothing else\n"
+    )
+    new = "## Acceptance Criteria\n\n### API\n- fresh bullet\n"
+    out = intake.replace_criteria_block(plan, new)
+    assert "old bullet" not in out
+    assert "fresh bullet" in out
+    # Surrounding sections survive.
+    assert "## Requested work" in out
+    assert "Build the thing." in out
+    assert "## Out of scope" in out
+    assert "nothing else" in out
+
+
+def test_replace_criteria_block_appends_when_absent():
+    plan = "# Title\n\nNo criteria heading here.\n"
+    out = intake.replace_criteria_block(plan, "## Acceptance Criteria\n\n### API\n- x\n")
+    assert "No criteria heading here." in out
+    assert "### API" in out

--- a/backend/tests/test_orchestration_relay_loop_fixture.py
+++ b/backend/tests/test_orchestration_relay_loop_fixture.py
@@ -161,6 +161,52 @@ def test_fixture_loop_passes_end_to_end(tmp_repo: Path, tmp_path: Path):
     assert "RELAY_NOTE.md" in report
 
 
+def test_review_bundle_contains_run_artifacts(tmp_repo: Path, tmp_path: Path):
+    """The reviewer can verify run-level criteria: the bundle carries a
+    redacted run.json excerpt, this iteration's safety scan, the tests
+    summary, an artifact manifest, and an availability note."""
+    exit_code = run_relay(tmp_repo, tmp_path, ["--max-iterations", "2"])
+    assert exit_code == 0
+    run_dir = find_run_dir(tmp_repo)
+    bundle = run_dir / "iterations" / "01" / "review-bundle"
+    for name in (
+        "run-meta.json", "safety.json", "tests-summary.json",
+        "manifest.txt", "availability.md",
+    ):
+        assert (bundle / name).is_file(), f"missing bundle file {name}"
+
+    meta = json.loads((bundle / "run-meta.json").read_text(encoding="utf-8"))
+    assert meta["run_id"] == run_dir.name
+    assert meta["branch"].startswith("relay/")
+    assert "state" in meta
+    # Contract: run-meta is a whitelist EXCERPT, never a full run.json dump.
+    # run.json carries plan_path (absolute) and fixture at this point; a
+    # regression to a blind dump would leak them into the reviewer bundle.
+    full = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    assert "plan_path" in full and "plan_path" not in meta
+    assert "fixture" in full and "fixture" not in meta
+    ALLOWED = {
+        "run_id", "relay_version", "title", "base_ref", "base_sha", "branch",
+        "worktree", "max_iterations", "escalations", "providers",
+        "codex_model", "state",
+    }
+    assert set(meta) <= ALLOWED
+
+    assert json.loads((bundle / "safety.json").read_text(encoding="utf-8")) == []
+
+    manifest = (bundle / "manifest.txt").read_text(encoding="utf-8")
+    assert "run.json" in manifest
+    assert "plan/original-plan.md" in manifest
+    assert "iterations/01/safety.json" in manifest
+
+    prompt = (run_dir / "iterations" / "01" / "review-prompt.md").read_text(encoding="utf-8")
+    assert "Run metadata" in prompt
+    assert run_dir.name in prompt
+    assert "Artifact availability" in prompt
+    assert "final-report.md" in prompt  # availability note names post-review artifacts
+    assert "AFTER this review" in prompt
+
+
 def test_fixture_loop_max_iterations_exit_1(tmp_repo: Path, tmp_path: Path):
     # Only one iteration allowed; fixture iteration 1 says "continue".
     exit_code = run_relay(tmp_repo, tmp_path, ["--max-iterations", "1"])
@@ -338,6 +384,29 @@ def test_draft_pr_never_fires_after_safety_stop(tmp_repo: Path, tmp_path: Path):
     wt = next((tmp_path / "w7").iterdir())
     log = _git(wt, "log", "--oneline")
     assert len(log.stdout.strip().splitlines()) == 1  # seed commit only
+
+
+def test_pass_with_no_changes_prints_skip_message(tmp_repo: Path, tmp_path: Path, capsys):
+    """A PASS whose builder changed nothing still explains why no PR opened,
+    restoring the PR 1 '[pr] skipped: no changes to commit' line."""
+    # Fixture: builder writes no files, reviewer passes on iteration 1.
+    fx = tmp_path / "fx-empty"
+    (fx / "iterations" / "1").mkdir(parents=True)
+    fx.joinpath("plan.md").write_text(
+        (FIXTURE / "plan.md").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (fx / "iterations" / "1" / "review.json").write_text(verdict_json("pass"), encoding="utf-8")
+    code = main([
+        "--repo-root", str(tmp_repo), "--plan", str(fx / "plan.md"),
+        "--fixture", str(fx), "--base", "HEAD", "--draft-pr",
+        "--worktree-root", str(tmp_path / "we"), "--max-iterations", "1",
+    ])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "no changes to commit" in out
+    run_dir = find_run_dir(tmp_repo)
+    assert not (run_dir / "report" / "pr.json").exists()
+    assert not (run_dir / "report" / "MANUAL_PR.md").exists()
 
 
 def test_missing_clis_exit_3(tmp_repo: Path, tmp_path: Path, monkeypatch):

--- a/backend/tests/test_orchestration_relay_providers.py
+++ b/backend/tests/test_orchestration_relay_providers.py
@@ -1,0 +1,82 @@
+"""Provider command construction: the artifact-only contract in unit form."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestration.coding_relay.providers import AdapterResult, CliCapabilities  # noqa: E402
+from orchestration.coding_relay.providers.claude import (  # noqa: E402
+    build_coding_command,
+    scrubbed_env,
+)
+from orchestration.coding_relay.providers.codex import (  # noqa: E402
+    BYPASS_FLAG,
+    _looks_like_sandbox_failure,
+    build_review_command,
+)
+
+
+def test_default_review_command_is_artifact_only(tmp_path):
+    bundle = tmp_path / "review-bundle"
+    cmd, note = build_review_command("codex", bundle)
+    assert cmd[:4] == ["codex", "exec", "--cd", str(bundle)]
+    assert BYPASS_FLAG not in cmd
+    assert "--skip-git-repo-check" in cmd
+    assert cmd[-1] == "-"
+    assert note is None
+
+
+def test_repo_access_adds_bypass_from_the_start(tmp_path):
+    cmd, _ = build_review_command("codex", tmp_path, bypass_sandbox=True)
+    assert BYPASS_FLAG in cmd
+
+
+def test_model_flag_gated_on_capabilities(tmp_path):
+    caps_without = CliCapabilities(exe="codex", help_text="", flags={"--cd"})
+    cmd, note = build_review_command("codex", tmp_path, model="gpt-5.4", caps=caps_without)
+    assert "-m" not in cmd
+    assert note and "does not advertise" in note
+    caps_with = CliCapabilities(exe="codex", help_text="", flags={"-m"})
+    cmd, note = build_review_command("codex", tmp_path, model="gpt-5.4", caps=caps_with)
+    assert cmd[cmd.index("-m") + 1] == "gpt-5.4"
+    assert note is None
+
+
+def test_sandbox_failure_detection_is_stderr_only():
+    def res(exit_code, stdout="", stderr=""):
+        return AdapterResult(
+            agent="codex", adapter="x", command=["codex"],
+            exit_code=exit_code, duration_ms=1, stdout=stdout, stderr=stderr,
+        )
+
+    # The stdout banner "sandbox: read-only" must never trigger the bypass.
+    assert not _looks_like_sandbox_failure(res(1, stdout="sandbox: read-only\nauth error"))
+    assert not _looks_like_sandbox_failure(res(0, stderr="error 1312"))  # success: no retry
+    assert _looks_like_sandbox_failure(res(1, stderr="CreateProcessAsUserW failed"))
+    assert _looks_like_sandbox_failure(res(1, stderr="spawn failed: error 1312"))
+
+
+def test_claude_command_and_model_gating(tmp_path):
+    cmd, note = build_coding_command("claude", tmp_path)
+    assert cmd == ["claude", "-p", "--permission-mode", "acceptEdits", "--add-dir", str(tmp_path)]
+    caps = CliCapabilities(exe="claude", help_text="", flags={"--model"})
+    cmd, note = build_coding_command("claude", tmp_path, model="opus", caps=caps)
+    assert "--model" in cmd and note is None
+    cmd, note = build_coding_command("claude", tmp_path, model="opus", caps=CliCapabilities("claude", "", set()))
+    assert "--model" not in cmd and note is not None
+
+
+def test_scrubbed_env_drops_claude_vars(monkeypatch):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "cli")
+    monkeypatch.setenv("UNRELATED_VAR", "keep")
+    env = scrubbed_env(keep=False)
+    assert env is not None
+    assert "CLAUDECODE" not in env
+    assert "CLAUDE_CODE_ENTRYPOINT" not in env
+    assert env.get("UNRELATED_VAR") == "keep"
+    assert scrubbed_env(keep=True) is None

--- a/docs/plans/03-implementation-plans/active/0016-coding-relay-agent.md
+++ b/docs/plans/03-implementation-plans/active/0016-coding-relay-agent.md
@@ -1,6 +1,6 @@
 # 0016 - Coding Relay (Claude implements, Codex reviews, receipts + draft PR)
 
-- Status: PR 1 (runnable spine) implemented; follow-up tickets below are open
+- Status: PR 1 (runnable spine) and PR 2 (guided flow + review-bundle run artifacts) implemented; remaining follow-ups below
 - Date: 2026-07-07
 - ADO: Story #765 under Feature #764 (Coding Relay) under Epic #359 (Orchestration: Codex + Agent Workflows)
 - Risk: Medium (orchestration governance surface; no schema, auth, or prod changes)
@@ -104,18 +104,55 @@ confirmed ones were fixed before the PR:
 | 12 | Secrets redacted in every receipt; decoy verdicts rejected | PASS | planted `ghp_...` swept across the run folder; 4 decoy tests |
 | 13 | Ruff clean; all relay tests green | PASS | 78 passed locally (61 unit + 17 E2E); ruff clean on package + tests |
 
+## PR 2 (guided flow) - delivered
+
+- ADO Story #766 under Feature #764. Guided terminal flow in
+  `orchestration/coding_relay/guided.py`: active-plan menu (paste/file/quit),
+  criteria preview with confirm/edit/abort via `$EDITOR`, compact preflight
+  table with warnings confirmation (default No), start approval,
+  per-iteration summaries with continue prompts, and outcome-gated PR
+  offers (PASS default Yes, honoring a reviewer `should_open_pr` veto;
+  MAX_ITER operator override default No; never after stop/block/error).
+- Operator declining a continue prompt = MAX_ITER semantics (exit 1,
+  worktree kept, report written).
+- `AutoUI` reproduces the PR 1 non-interactive policy exactly; `--yes`
+  makes guided mode non-blocking and never bypasses hard failures.
+- Review bundle now carries `run-meta.json` (redacted run.json excerpt),
+  the iteration's `safety.json`, `tests-summary.json`, an artifact
+  manifest, and an availability note, so run-level criteria are judgeable
+  (closes the plan-0017 reviewer suggestion).
+- Tests: 113 relay tests total (28 guided, providers unit tests covering
+  the artifact-only command contract, bundle-content assertions).
+
+## PR 2 adversarial review (2026-07-08)
+
+A multi-agent review of the guided-flow diff confirmed 8 findings (3 real
+correctness bugs, 4 test-coverage gaps on contract points, 1 output-parity
+regression). All fixed before the PR:
+
+- EOF at a guided prompt (Ctrl+D, dropped stdin) was swallowed by the loop's
+  blanket except as an internal ERROR (exit 6, no report). Fixed: `_ask`
+  treats EOF as decline, so operator termination is the safe MAX_ITER path.
+- Criteria edited in guided mode were not propagated to `plan_text`, so the
+  builder/reviewer prompts carried the stale original criteria. Fixed:
+  `intake.replace_criteria_block` splices the edit over the plan section.
+- Output parity with PR 1: FAIL preflight rows now print full multi-line
+  detail (remediation hints), the `[pr] skipped: no changes to commit` line
+  is restored, and failure messages route through a `ui.error` stderr
+  channel. Policy and exit codes were already byte-identical.
+- Added coverage: warn-decline stop E2E, decide_pr flag matrix (--yes /
+  --draft-pr at PASS and MAX_ITER, veto override), --yes non-blocking E2E,
+  --yes-never-bypasses-hard-failure, worktree-kept on operator stop,
+  run-meta whitelist boundary (not a full run.json dump), EOF-at-continue
+  E2E, and answer-exhaustion assertions so prompt-sequence drift fails loud.
+
 ## Follow-up tickets (open)
 
-- Guided interactive flow: numbered plan menu, paste mode, criteria
-  confirm/edit screen, per-iteration continue prompts, final PR offer.
 - Cockpit UI: read-only viewer over `.orchestration/runs/` (self-contained
   HTML status page per run). The `run.json` state schema from PR 1 is the
   data contract.
 - Broader test inference: Playwright/e2e, AI-eval suites, migration/schema
   verification classes.
-- Review-bundle completeness (reviewer-suggested, plan 0017): include
-  `run.json` and the iteration's `safety.json` in the bundle so run-level
-  criteria are judgeable.
 - PR polish: `scripts/winston/merge_gate.ps1` integration, richer evidence
   linking, approve-and-continue flag for escalations.
 - Optional: routed skill wrapper so the relay is discoverable through the

--- a/docs/reference/CODING_RELAY.md
+++ b/docs/reference/CODING_RELAY.md
@@ -12,13 +12,15 @@ deploys.
 ## Launch
 
 ```
+python scripts/coding_relay.py                            # guided mode (TTY)
 python -m orchestration.coding_relay --plan <path|NNNN>   # from repo root
 python scripts/coding_relay.py --plan <path|NNNN>         # from anywhere
 make relay ARGS="--plan 0016"                             # POSIX shells
 ```
 
-Run with no arguments to get usage plus a numbered list of the active plans
-in `docs/plans/03-implementation-plans/active/`.
+With no arguments on a terminal the relay enters guided mode (next
+section). Without a TTY it prints usage plus the numbered active-plan
+list.
 
 ## Required CLIs
 
@@ -59,6 +61,45 @@ Provide the plan by path (`--plan docs/plans/.../0016-foo.md`), by active-dir
 prefix (`--plan 0016`), or as pasted text saved to a file
 (`--paste-file my-task.md`).
 
+## Guided mode
+
+Launch with no arguments on a TTY and the relay walks you through the whole
+run:
+
+1. Pick a plan from the numbered active-plan menu, or `[p]` paste plan text
+   (finish with a line containing only `END`), `[f]` give a file path,
+   `[q]` quit.
+2. Preview the normalized acceptance criteria, then answer
+   `Use these criteria? [Y/e/n]`. `e` writes the criteria to a temp file and
+   opens `$EDITOR` (or waits for you to edit the printed path); the edited
+   file is re-parsed and previewed again. An edit that produces no valid
+   criteria aborts with the fill-in template.
+3. Read the compact preflight table (`OK/WARN/FAIL name detail`). Hard
+   failures stop before anything is created, always. Warnings ask
+   `Continue with warnings? [y/N]`.
+4. Approve worktree creation, then watch each iteration: safety status,
+   test results, verdict, unmet-criteria count, required next steps, risk
+   flags. On a `continue` verdict you choose
+   `Continue to next iteration? [Y/n]`; declining preserves the worktree
+   and exits 1, same as hitting max iterations.
+5. On the final outcome the PR offer follows the safety policy below.
+
+`--yes` makes guided mode non-blocking: criteria accepted, warnings
+proceeded past (matching the non-interactive path), iterations continue,
+and the PR decision falls back to the flag policy. It never bypasses hard
+preflight failures; those stop before any prompt exists.
+
+## PR offers by outcome
+
+| Outcome | Guided prompt | Non-interactive |
+|---|---|---|
+| PASS | `Open draft PR now? [Y/n]` (default No when the reviewer set `should_open_pr: false`) | PR unless `--no-pr` or reviewer veto (`--draft-pr` overrides the veto) |
+| MAX_ITER / operator stop | `Open draft PR anyway as operator override? [y/N]` (`--draft-pr` answers yes) | PR only with `--draft-pr` |
+| SAFETY_STOP, BLOCKED, RISK, ERROR | never offered | never created |
+
+`--no-pr` wins everywhere. The MANUAL_PR.md fallback covers gh/push
+failures in every case that reaches the PR step.
+
 ## How Claude and Codex divide the work
 
 Claude is the only writer. Each iteration it runs as
@@ -67,9 +108,13 @@ pinned to the worktree, receives the plan, the normalized criteria, prior
 reviewer feedback, and failing-test excerpts, and edits files.
 
 Codex never edits and, by default, never sees the repo. After each build
-pass the relay assembles a review bundle (diff, changed-file list, test
-summary, builder summary) under
-`iterations/NN/review-bundle/` and runs
+pass the relay assembles a review bundle under `iterations/NN/review-bundle/`
+(diff, changed-file list, test summaries, builder summary, a redacted
+`run-meta.json` excerpt of run.json, this iteration's `safety.json`, a
+manifest of every run-folder artifact existing at review time, and an
+availability note naming the artifacts that can only exist after the
+review, like the final report and PR body). That lets the reviewer verify
+run-level criteria honestly instead of returning `unknown`. It then runs
 `codex exec --cd <bundle-dir> --skip-git-repo-check -m <model>
 -c model_reasoning_effort=<effort> -`. Codex must answer with one JSON
 verdict: `pass`, `continue`, `blocked`, or `risk_escalation`, plus
@@ -92,7 +137,7 @@ is never treated as approval.
 | Exit | Meaning |
 |---|---|
 | 0 | PASS: every criterion met or not applicable, no risk flags |
-| 1 | Max iterations reached (default 3, `--max-iterations`); worktree kept |
+| 1 | Stopped on a continue verdict: max iterations (default 3) reached, or the operator declined to continue; worktree kept |
 | 2 | Intake or preflight refusal (missing criteria, bad plan, failed fetch) |
 | 3 | `claude` or `codex` CLI missing |
 | 4 | Safety stop (see hard stops below) |
@@ -237,8 +282,6 @@ Five things to verify by hand on your first live relay run:
 
 ## Known limitations (PR 1)
 
-- Non-interactive: no guided menu flow yet; `--yes` is accepted as a no-op
-  for forward compatibility. Run with no args to see the plan list.
 - Test inference covers the four basic suite groups only.
 - Escalations (exit 5) have no generic approve-and-continue flag; a human
   finishes by hand or re-runs (`--allow-relay-self-edit` and

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4950,3 +4950,23 @@ Redesign of `/lab/env/[envId]/telemetry/calibration` into an inspectable evidenc
   report is written") come back `unknown` from an honest artifact-only
   reviewer and force MAX_ITER instead of pass. Criteria belong to the
   change, not the harness; harness assertions live in the relay's own tests.
+
+## Relay guided-flow lessons (2026-07-08)
+
+- **A blanket `except Exception` around an interactive loop turns operator
+  stdin actions into fake crashes.** The relay's `run_loop` is wrapped in
+  `except Exception -> exit 6 ERROR`; an `EOFError` from `input()` at a
+  guided prompt (Ctrl+D, dropped SSH) got swallowed as an internal error
+  with no final report. Interactive prompt helpers must catch `EOFError`
+  themselves and map it to the safe default (decline), so the exception
+  never reaches a catch-all that misclassifies it. Test EOF paths.
+- **Editing a normalized view is not editing the source.** The relay let
+  operators edit normalized criteria, but the builder/reviewer prompts
+  embed the raw `plan_text`, which still held the original criteria section.
+  When you offer an edit of a derived artifact, propagate the edit back into
+  whatever the downstream actually consumes, or the two silently diverge.
+- **Refactors that unify output through one channel break stream
+  separation.** Routing every message through a single `notify()` moved
+  PR 1's stderr diagnostics to stdout. Keep a distinct error channel
+  (stderr) for failures so wrappers that separate the streams keep working;
+  add a byte-parity check against the prior version when a contract binds it.

--- a/orchestration/coding_relay/__main__.py
+++ b/orchestration/coding_relay/__main__.py
@@ -2,10 +2,13 @@
 
     python -m orchestration.coding_relay --plan docs/plans/.../0016-foo.md
     python scripts/coding_relay.py --plan 0016 --max-iterations 3
+    python scripts/coding_relay.py            # guided mode on a TTY
 
-Run with no arguments for usage plus the numbered list of active plans.
-Exit codes: 0 pass, 1 max-iterations, 2 intake/preflight, 3 missing CLI,
-4 safety stop, 5 blocked/risk escalation, 6 provider/internal error.
+Run with no arguments on a TTY for the guided operator flow; without a TTY
+it prints usage plus the numbered list of active plans.
+Exit codes: 0 pass, 1 stopped on continue (max iterations or operator), 2
+intake/preflight, 3 missing CLI, 4 safety stop, 5 blocked/risk escalation,
+6 provider/internal error.
 """
 from __future__ import annotations
 
@@ -18,8 +21,6 @@ from orchestration.coding_relay import RELAY_VERSION, intake as intake_mod
 from orchestration.coding_relay.intake import IntakeError
 from orchestration.coding_relay.loop import (
     LoopConfig,
-    MAX_ITER,
-    PASS,
     collect_snapshot,
     run_loop,
 )
@@ -51,7 +52,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--plan", help="Plan file path, or a filename prefix (e.g. 0016) in docs/plans/03-implementation-plans/active/")
     p.add_argument("--paste-file", help="Read the plan text from this file instead of --plan")
     p.add_argument("--repo-root", type=Path, default=DEFAULT_REPO_ROOT, help=argparse.SUPPRESS)
-    p.add_argument("--yes", action="store_true", help="Accepted for forward compatibility (PR 1 is non-interactive)")
+    p.add_argument("--yes", action="store_true",
+                   help="Guided mode: accept prompts non-interactively (never bypasses hard failures)")
     p.add_argument("--max-iterations", type=int, default=3, help="Build/review iterations cap (default 3)")
     p.add_argument("--base", default="origin/main", help="Base ref for the relay worktree (default origin/main)")
     p.add_argument("--allow-stale-base", action="store_true", help="Proceed on the local base ref if git fetch fails (recorded)")
@@ -86,7 +88,8 @@ def build_parser() -> argparse.ArgumentParser:
 def print_no_args_help(repo_root: Path) -> int:
     print("Coding Relay: give it a plan with explicit success criteria.\n")
     print("Usage:  python -m orchestration.coding_relay --plan <path|NNNN>")
-    print("        python scripts/coding_relay.py --plan <path|NNNN>\n")
+    print("        python scripts/coding_relay.py --plan <path|NNNN>")
+    print("        python scripts/coding_relay.py          (guided mode, TTY)\n")
     plans = intake_mod.list_active_plans(repo_root)
     if plans:
         print("Active plans (docs/plans/03-implementation-plans/active/):")
@@ -102,14 +105,9 @@ def print_no_args_help(repo_root: Path) -> int:
     return 2
 
 
-def do_dry_run(args, result) -> int:
-    """Strict dry run: nothing written, no worktree, no providers.
-    Capability probes only with --probe-clis."""
-    print(f"[dry-run] plan accepted: {result.title} (slug {result.slug})")
-    print("[dry-run] normalized acceptance criteria:\n")
-    print(result.criteria.to_markdown())
-    cfg = PreflightConfig(
-        repo_root=args.repo_root,
+def _preflight_config(args, result, read_only: bool = False) -> PreflightConfig:
+    return PreflightConfig(
+        repo_root=args.repo_root.resolve(),
         base_ref=args.base,
         allow_stale_base=args.allow_stale_base,
         pr_requested=not args.no_pr,
@@ -117,9 +115,22 @@ def do_dry_run(args, result) -> int:
         worktree_root=args.worktree_root,
         fixture_mode=args.fixture is not None,
         fixture_dir=args.fixture,
-        read_only=True,
+        read_only=read_only,
     )
-    checks = run_preflight(cfg)
+
+
+def _preflight_exit_code(checks) -> int:
+    failed_names = {c.name for c in checks.failures()}
+    return 3 if {"claude-cli", "codex-cli"} & failed_names else 2
+
+
+def do_dry_run(args, result) -> int:
+    """Strict dry run: nothing written, no worktree, no providers.
+    Capability probes only with --probe-clis."""
+    print(f"[dry-run] plan accepted: {result.title} (slug {result.slug})")
+    print("[dry-run] normalized acceptance criteria:\n")
+    print(result.criteria.to_markdown())
+    checks = run_preflight(_preflight_config(args, result, read_only=True))
     for c in checks.checks:
         print(f"[preflight] {c.name}: {c.status} - {c.detail}")
     wt_root = args.worktree_root or default_worktree_root(args.repo_root)
@@ -146,56 +157,30 @@ def do_dry_run(args, result) -> int:
                 print(f"[probe] {name}: not on PATH")
     # A dry run is a validation gate: mirror the real exit codes.
     if checks.failed:
-        failed_names = {c.name for c in checks.failures()}
-        code = 3 if {"claude-cli", "codex-cli"} & failed_names else 2
+        code = _preflight_exit_code(checks)
         print(f"\n[dry-run] wrote nothing, changed nothing. Preflight FAILED; a real run would exit {code}.")
         return code
     print("\n[dry-run] wrote nothing, changed nothing. Exit 0.")
     return 0
 
 
-def main(argv: list | None = None) -> int:
-    argv = sys.argv[1:] if argv is None else argv
-    parser = build_parser()
-    args = parser.parse_args(argv)
+def execute_run(args, result, ui) -> int:
+    """The shared pipeline after intake: preflight -> receipts -> worktree ->
+    loop -> finalize. `ui` supplies the operator decision points; AutoUI
+    reproduces the non-interactive policy exactly."""
     repo_root: Path = args.repo_root.resolve()
 
-    if not args.plan and not args.paste_file:
-        return print_no_args_help(repo_root)
+    # ---- PREFLIGHT (hard failures stop before any mutation, always)
+    checks = run_preflight(_preflight_config(args, result))
+    from orchestration.coding_relay.guided import render_preflight
 
-    # ---- INTAKE (exit 2 on refusal)
-    try:
-        result = intake_mod.load_plan(repo_root, args.plan, args.paste_file)
-    except IntakeError as exc:
-        print(f"[intake] REFUSED: {exc}", file=sys.stderr)
-        return 2
-    print(f"[intake] plan: {result.title}")
-    print(f"[intake] criteria: {len(result.criteria.checklist())} normalized "
-          f"(sections with content: "
-          f"{sum(1 for _, v in result.criteria.sections.items() if v) + (1 if result.criteria.general else 0)})")
-
-    if args.dry_run:
-        return do_dry_run(args, result)
-
-    # ---- PREFLIGHT
-    pf_cfg = PreflightConfig(
-        repo_root=repo_root,
-        base_ref=args.base,
-        allow_stale_base=args.allow_stale_base,
-        pr_requested=not args.no_pr,
-        plan_path=result.plan_path,
-        worktree_root=args.worktree_root,
-        fixture_mode=args.fixture is not None,
-        fixture_dir=args.fixture,
-    )
-    checks = run_preflight(pf_cfg)
-    for c in checks.checks:
-        print(f"[preflight] {c.name}: {c.status} - {c.detail}")
+    render_preflight(checks, ui.notify)
     if checks.failed:
-        failed_names = {c.name for c in checks.failures()}
-        if {"claude-cli", "codex-cli"} & failed_names:
-            return 3
-        print("[preflight] FAILED; nothing was created.", file=sys.stderr)
+        ui.error("[preflight] FAILED; nothing was created.")
+        return _preflight_exit_code(checks)
+    warns = [c for c in checks.checks if c.status == "warn"]
+    if warns and not ui.confirm_warnings(warns):
+        ui.notify("Stopped at preflight warnings. Nothing was created.")
         return 2
 
     # ---- RUN FOLDER (refuse to reuse an existing run's receipts)
@@ -205,6 +190,12 @@ def main(argv: list | None = None) -> int:
         suffix += 1
         run_id = f"{new_run_id(result.slug)}-{suffix}"
     run_paths = RunPaths(repo_root, run_id)
+
+    wt_root = args.worktree_root or default_worktree_root(repo_root)
+    if not ui.confirm_start(f"a relay worktree under {wt_root}"):
+        ui.notify("Stopped before worktree creation. Nothing was created.")
+        return 2
+
     run_paths.write("plan/original-plan.md", result.plan_text)
     run_paths.write("plan/normalized-criteria.md", result.criteria.to_markdown())
     run_paths.write_json("env/preflight.json", checks.to_payload())
@@ -232,19 +223,19 @@ def main(argv: list | None = None) -> int:
         max_iterations=args.max_iterations, escalations=escalation_flags,
         codex_model=args.codex_model, state="STARTED",
     )
-    print(f"[run] receipts: {run_paths.root}")
+    ui.notify(f"[run] receipts: {run_paths.root}")
 
     # ---- WORKTREE
     try:
         wt = create_worktree(repo_root, result.slug, args.base, args.worktree_root)
     except RuntimeError as exc:
-        print(f"[worktree] FAILED: {exc}", file=sys.stderr)
+        ui.error(f"[worktree] FAILED: {exc}")
         run_paths.update_run_json(state="ERROR", detail=str(exc), exit_code=6)
         return 6
-    print(f"[worktree] {wt.path} (branch {wt.branch}, base {wt.base_sha[:12]})")
+    ui.notify(f"[worktree] {wt.path} (branch {wt.branch}, base {wt.base_sha[:12]})")
     links = ensure_deps_links(repo_root, wt)
     for name, detail in links.items():
-        print(f"[worktree] deps {name}: {detail}")
+        ui.notify(f"[worktree] deps {name}: {detail}")
     run_paths.update_run_json(branch=wt.branch, worktree=str(wt.path), base_sha=wt.base_sha)
 
     # ---- PROVIDERS
@@ -268,7 +259,7 @@ def main(argv: list | None = None) -> int:
             claude_exe, wt.path, args.claude_permission_mode, args.claude_model, claude_caps,
         )
         if model_note:
-            print(f"[providers] {model_note}")
+            ui.notify(f"[providers] {model_note}")
         run_paths.update_run_json(
             providers="cli",
             claude_model=args.claude_model or "(cli default)",
@@ -304,21 +295,22 @@ def main(argv: list | None = None) -> int:
         primary_root=repo_root,
     )
     try:
-        outcome = run_loop(loop_cfg, result, wt, run_paths, build_fn, review_fn)
+        outcome = run_loop(
+            loop_cfg, result, wt, run_paths, build_fn, review_fn,
+            log=ui.notify, on_continue=ui.on_continue,
+        )
     except AdapterUnavailable as exc:
-        print(f"[loop] provider CLI vanished mid-run: {exc}", file=sys.stderr)
+        ui.error(f"[loop] provider CLI vanished mid-run: {exc}")
         run_paths.update_run_json(state="ERROR", exit_code=3, detail=str(exc))
         return 3
     except Exception as exc:  # noqa: BLE001 - exit-code table integrity
-        print(f"[loop] internal error: {type(exc).__name__}: {exc}", file=sys.stderr)
+        ui.error(f"[loop] internal error: {type(exc).__name__}: {exc}")
         run_paths.update_run_json(state="ERROR", exit_code=6, detail=f"{type(exc).__name__}: {exc}")
-        print(removal_instructions(repo_root, wt))
+        ui.notify(removal_instructions(repo_root, wt))
         return 6
 
-    # ---- FINALIZE: report + PR body always. PR only on PASS, or on
-    # MAX_ITER with --draft-pr. Never after a safety stop, block, or error:
-    # pushing a diff the scanner flagged (e.g. secrets) would defeat the
-    # whole safety layer, and --no-pr always wins.
+    # ---- FINALIZE: report + PR body always. The PR decision belongs to the
+    # ui policy, which can never allow it after SAFETY_STOP/BLOCKED/ERROR.
     snapshot = collect_snapshot(wt.path, wt.base_sha)
     last_verdict = outcome.verdicts[-1] if outcome.verdicts else None
     summary = RunSummary(
@@ -353,26 +345,33 @@ def main(argv: list | None = None) -> int:
         iterations_run=outcome.iterations_run,
     )
 
-    do_pr = (not args.no_pr) and (
-        outcome.state == PASS or (args.draft_pr and outcome.state == MAX_ITER)
-    )
-    if do_pr and outcome.state == PASS and last_verdict and not last_verdict.should_open_pr:
-        # The reviewer passed the work but explicitly voted against a PR
-        # (e.g. needs a human sign-off first). Honor it unless forced.
-        if not args.draft_pr:
-            do_pr = False
-            print("[pr] skipped: reviewer set should_open_pr=false (pass --draft-pr to override)")
-    if do_pr and snapshot.changed_paths:
+    # Compact outcome block (all modes).
+    if last_verdict:
+        counts = {"met": 0, "unmet": 0, "unknown": 0, "not_applicable": 0}
+        for c in last_verdict.criteria_status:
+            counts[c.get("status", "unknown")] = counts.get(c.get("status", "unknown"), 0) + 1
+        ui.notify(
+            f"[outcome] criteria: {counts['met']} met / {counts['unmet']} unmet / "
+            f"{counts['unknown']} unknown / {counts['not_applicable']} n/a "
+            f"(of {len(result.criteria.checklist())} normalized)"
+        )
+        for flag in last_verdict.risk_flags[:5]:
+            ui.notify(f"[outcome] risk flag: {flag[:160]}")
+
+    want_pr = ui.decide_pr(outcome.state, last_verdict)
+    if want_pr and not snapshot.changed_paths:
+        ui.notify("[pr] skipped: no changes to commit")
+    if want_pr and snapshot.changed_paths:
         committed, commit_detail = pr_mod.commit_all(wt.path, result.slug, run_id, result.title)
         if committed:
             pushed, push_detail = pr_mod.push(wt.path, wt.branch)
-            print(f"[pr] {push_detail}")
+            ui.notify(f"[pr] {push_detail}")
             if pushed:
                 ok, pr_detail = pr_mod.create_draft_pr(
                     wt.path, wt.branch, result.title, run_paths.report_dir / "PR_BODY.md",
                 )
                 if ok:
-                    print(f"[pr] draft PR: {pr_detail}")
+                    ui.notify(f"[pr] draft PR: {pr_detail}")
                     run_paths.write_json("report/pr.json", {"url": pr_detail, "draft": True})
                 else:
                     run_paths.write(
@@ -382,7 +381,7 @@ def main(argv: list | None = None) -> int:
                             run_paths.report_dir / "PR_BODY.md", pr_detail,
                         ),
                     )
-                    print(f"[pr] fell back to MANUAL_PR.md: {pr_detail}")
+                    ui.notify(f"[pr] fell back to MANUAL_PR.md: {pr_detail}")
             else:
                 run_paths.write(
                     "report/MANUAL_PR.md",
@@ -391,16 +390,46 @@ def main(argv: list | None = None) -> int:
                         run_paths.report_dir / "PR_BODY.md", push_detail,
                     ),
                 )
-                print(f"[pr] fell back to MANUAL_PR.md: {push_detail}")
+                ui.notify(f"[pr] fell back to MANUAL_PR.md: {push_detail}")
         else:
-            print(f"[pr] skipped: {commit_detail}")
-    elif do_pr:
-        print("[pr] skipped: no changes to commit")
+            ui.notify(f"[pr] skipped: {commit_detail}")
 
-    print(f"\n[done] {outcome.state} (exit {outcome.exit_code}). {outcome.detail}")
-    print(f"[done] final report: {run_paths.report_dir / 'final-report.md'}")
-    print(removal_instructions(repo_root, wt))
+    ui.notify(f"\n[done] {outcome.state} (exit {outcome.exit_code}). {outcome.detail}")
+    ui.notify(f"[done] final report: {run_paths.report_dir / 'final-report.md'}")
+    ui.notify(removal_instructions(repo_root, wt))
     return outcome.exit_code
+
+
+def main(argv: list | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    repo_root: Path = args.repo_root.resolve()
+
+    from orchestration.coding_relay import guided
+
+    if not args.plan and not args.paste_file:
+        if guided.stdin_is_tty() and not args.dry_run:
+            return guided.run_guided(args)
+        return print_no_args_help(repo_root)
+
+    # ---- INTAKE (exit 2 on refusal)
+    try:
+        result = intake_mod.load_plan(repo_root, args.plan, args.paste_file)
+    except IntakeError as exc:
+        print(f"[intake] REFUSED: {exc}", file=sys.stderr)
+        return 2
+    print(f"[intake] plan: {result.title}")
+    print(f"[intake] criteria: {len(result.criteria.checklist())} normalized "
+          f"(sections with content: "
+          f"{sum(1 for _, v in result.criteria.sections.items() if v) + (1 if result.criteria.general else 0)})")
+
+    if args.dry_run:
+        return do_dry_run(args, result)
+
+    from orchestration.coding_relay.guided import AutoUI
+
+    return execute_run(args, result, AutoUI(args))
 
 
 if __name__ == "__main__":

--- a/orchestration/coding_relay/guided.py
+++ b/orchestration/coding_relay/guided.py
@@ -1,0 +1,399 @@
+"""Guided terminal operator flow for the Coding Relay (stdlib only).
+
+Entered when the relay is launched with no plan arguments on a TTY:
+
+    select plan -> preview/confirm/edit criteria -> preflight table ->
+    approve start -> per-iteration summaries with continue prompts ->
+    final outcome -> safe draft-PR offer.
+
+Design rules:
+- No new bypasses: hard preflight failures stop before any prompt, and
+  nothing here can reach a PR after a safety stop, block, or error.
+- `--yes` makes the guided flow non-blocking (accept criteria, proceed on
+  warnings like the non-interactive path, keep iterating, auto PR policy).
+  It never bypasses hard failures; those stop before prompts exist.
+- All prompt I/O is injectable (input_fn/print_fn/editor_fn) so the flow is
+  testable without a real terminal.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Callable, Optional
+
+from orchestration.coding_relay import intake as intake_mod
+from orchestration.coding_relay.intake import (
+    AcceptanceCriteria,
+    IntakeError,
+    IntakeResult,
+    TEMPLATE,
+    extract_criteria,
+    normalize_criteria,
+)
+
+HEADING_RE = re.compile(r"^#\s+(.*)")
+STATUS_RE = re.compile(r"^[-*]?\s*(?:\*\*)?Status(?:\*\*)?\s*:\s*(.*)", re.IGNORECASE)
+ID_MARKER_RE = re.compile(r"^(\s*[-*+]\s+)\[[A-Z]+\d+\]\s+")
+
+
+def stdin_is_tty() -> bool:
+    try:
+        return sys.stdin.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def safe_print(text: str = "") -> None:
+    """print() that survives narrow consoles. Windows terminals often run
+    cp1252, and active-plan titles legitimately contain characters it
+    cannot encode; a crash here would exit 1 and collide with the MAX_ITER
+    exit code. Lossy replacement beats a dead menu."""
+    enc = getattr(sys.stdout, "encoding", None) or "utf-8"
+    sys.stdout.write(str(text).encode(enc, "replace").decode(enc, "replace") + "\n")
+    sys.stdout.flush()
+
+
+# ---------------------------------------------------------------- plan menu
+
+def plan_menu_entries(repo_root: Path) -> list:
+    """(path, title, status) per active plan; robust to unparseable files."""
+    entries = []
+    for path in intake_mod.list_active_plans(repo_root):
+        title, status = "", ""
+        try:
+            for line in path.read_text(encoding="utf-8", errors="replace").splitlines()[:40]:
+                line = line.strip()
+                if not title:
+                    m = HEADING_RE.match(line)
+                    if m:
+                        title = m.group(1).strip()
+                        continue
+                if not status:
+                    m = STATUS_RE.match(line)
+                    if m:
+                        status = m.group(1).strip()
+                if title and status:
+                    break
+        except OSError:
+            pass
+        entries.append((path, title, status))
+    return entries
+
+
+def render_menu(entries: list, print_fn: Callable = safe_print) -> None:
+    print_fn("Active plans (docs/plans/03-implementation-plans/active/):")
+    for i, (path, title, status) in enumerate(entries, 1):
+        label = title or "(no title parsed)"
+        suffix = f"  [{status[:40]}]" if status else ""
+        print_fn(f"  {i:2d}. {path.name}")
+        print_fn(f"      {label[:76]}{suffix}")
+    print_fn("")
+    print_fn("  [p] paste a plan   [f] enter a file path   [q] quit")
+
+
+def _read_paste(input_fn: Callable, print_fn: Callable) -> Optional[str]:
+    print_fn("Paste the plan text. Finish with a single line containing only END")
+    lines = []
+    while True:
+        try:
+            line = input_fn("")
+        except EOFError:
+            break
+        if line.strip() == "END":
+            break
+        lines.append(line)
+    text = "\n".join(lines).strip()
+    if not text:
+        print_fn("Nothing pasted.")
+        return None
+    tmp = tempfile.NamedTemporaryFile(
+        "w", suffix=".md", prefix="relay-paste-", delete=False, encoding="utf-8"
+    )
+    tmp.write(text + "\n")
+    tmp.close()
+    return tmp.name
+
+
+def select_plan(
+    repo_root: Path,
+    input_fn: Callable = input,
+    print_fn: Callable = safe_print,
+) -> Optional[dict]:
+    """Menu loop. Returns {'plan': str} or {'paste_file': str}, or None on quit."""
+    entries = plan_menu_entries(repo_root)
+    render_menu(entries, print_fn)
+    while True:
+        try:
+            choice = input_fn("Select a plan number, [p]aste, [f]ile path, or [q]uit: ").strip().lower()
+        except EOFError:
+            return None
+        if choice in ("q", "quit", ""):
+            return None
+        if choice == "p":
+            paste = _read_paste(input_fn, print_fn)
+            if paste:
+                return {"paste_file": paste}
+            continue
+        if choice == "f":
+            raw = input_fn("Plan file path: ").strip().strip('"')
+            if raw and Path(raw).is_file():
+                return {"plan": raw}
+            print_fn(f"Not a file: {raw}")
+            continue
+        if choice.isdigit() and 1 <= int(choice) <= len(entries):
+            return {"plan": str(entries[int(choice) - 1][0])}
+        print_fn("Unrecognized choice.")
+
+
+# ------------------------------------------------- criteria confirm / edit
+
+def strip_id_markers(text: str) -> str:
+    return "\n".join(ID_MARKER_RE.sub(r"\1", line) for line in text.splitlines())
+
+
+def reload_criteria(text: str) -> AcceptanceCriteria:
+    """Re-parse an edited normalized-criteria file. Raises IntakeError."""
+    cleaned = strip_id_markers(text)
+    block = extract_criteria(cleaned)
+    if block is None:
+        raise IntakeError(
+            "The edited file no longer contains an 'Acceptance Criteria' "
+            "heading. Restore the shape:\n\n" + TEMPLATE
+        )
+    return normalize_criteria(block)
+
+
+def default_editor(path: Path, input_fn: Callable = input, print_fn: Callable = safe_print) -> None:
+    """Open $EDITOR on the file, or wait for a manual edit."""
+    editor = os.environ.get("EDITOR", "").strip()
+    if editor:
+        try:
+            subprocess.run([*shlex.split(editor), str(path)], check=False)
+            return
+        except OSError as exc:
+            print_fn(f"Could not launch $EDITOR ({exc}); edit the file manually.")
+    print_fn(f"Edit this file, then come back:\n  {path}")
+    input_fn("Press Enter when you are done editing... ")
+
+
+def confirm_criteria(
+    result: IntakeResult,
+    input_fn: Callable = input,
+    print_fn: Callable = safe_print,
+    editor_fn: Optional[Callable] = None,
+    assume_yes: bool = False,
+) -> Optional[IntakeResult]:
+    """Preview loop: accept (Y), edit (e), or abort (n). None on abort.
+    Raises IntakeError if an edit produces invalid criteria."""
+    editor_fn = editor_fn or (lambda p: default_editor(p, input_fn, print_fn))
+    while True:
+        print_fn("")
+        print_fn(result.criteria.to_markdown())
+        if assume_yes:
+            return result
+        answer = input_fn("Use these criteria? [Y/e/n] ").strip().lower()
+        if answer in ("", "y", "yes"):
+            return result
+        if answer in ("n", "no"):
+            print_fn("Aborted before any work started.")
+            return None
+        if answer == "e":
+            tmp = Path(tempfile.mkstemp(suffix=".md", prefix="relay-criteria-")[1])
+            tmp.write_text(result.criteria.to_markdown(), encoding="utf-8")
+            editor_fn(tmp)
+            edited = tmp.read_text(encoding="utf-8", errors="replace")
+            result.criteria = reload_criteria(edited)  # IntakeError propagates
+            # Splice the edited criteria over the plan's original section so
+            # the builder/reviewer prompts (which embed plan_text) do not
+            # carry the stale, now-contradicting criteria.
+            result.plan_text = intake_mod.replace_criteria_block(
+                result.plan_text, result.criteria.to_markdown()
+            )
+            continue
+        print_fn("Answer Y (accept), e (edit), or n (abort).")
+
+
+# ----------------------------------------------------------- preflight view
+
+def render_preflight(checks, print_fn: Callable = safe_print) -> None:
+    for c in checks.checks:
+        lines = c.detail.splitlines() or [""]
+        # FAIL rows keep their full multi-line detail: it carries the
+        # remediation hint (e.g. 're-run with --allow-stale-base'), which
+        # must not be truncated away.
+        if c.status == "fail":
+            print_fn(f"{c.status.upper():<5} {c.name:<16} {lines[0]}")
+            for extra in lines[1:]:
+                print_fn(f"{'':<22}{extra}")
+        else:
+            print_fn(f"{c.status.upper():<5} {c.name:<16} {lines[0][:90]}")
+
+
+# ------------------------------------------------------------- operator UI
+
+class AutoUI:
+    """Non-interactive policy: byte-identical to the pre-guided behavior."""
+
+    def __init__(self, args):
+        self.args = args
+
+    def notify(self, text: str) -> None:
+        safe_print(text)
+
+    def error(self, text: str) -> None:
+        """Failure/diagnostic channel. PR 1 wrote these to stderr; keep that
+        so wrappers separating the streams still work."""
+        sys.stderr.write(str(text) + "\n")
+
+    def confirm_warnings(self, warn_checks) -> bool:
+        return True  # non-interactive runs always proceeded on warnings
+
+    def confirm_start(self, description: str) -> bool:
+        return True
+
+    def on_continue(self, iteration: int, verdict, test_results, violations) -> bool:
+        return True
+
+    def decide_pr(self, state: str, last_verdict) -> bool:
+        from orchestration.coding_relay.loop import MAX_ITER, PASS
+
+        if self.args.no_pr:
+            return False
+        if state == PASS:
+            if last_verdict and not last_verdict.should_open_pr and not self.args.draft_pr:
+                self.notify(
+                    "[pr] skipped: reviewer set should_open_pr=false "
+                    "(pass --draft-pr to override)"
+                )
+                return False
+            return True
+        if state == MAX_ITER:
+            return self.args.draft_pr
+        return False
+
+
+class TerminalUI(AutoUI):
+    """Interactive prompts layered on the same safe policy boundaries."""
+
+    def __init__(self, args, input_fn: Callable = input, print_fn: Callable = safe_print):
+        super().__init__(args)
+        self.input_fn = input_fn
+        self.print_fn = print_fn
+
+    def notify(self, text: str) -> None:
+        self.print_fn(text)
+
+    def error(self, text: str) -> None:
+        # Interactive operator sees failures inline; still mirror to stderr
+        # so piped invocations keep the stream separation.
+        self.print_fn(text)
+        sys.stderr.write(str(text) + "\n")
+
+    def _ask(self, question: str, default_yes: bool) -> bool:
+        suffix = "[Y/n] " if default_yes else "[y/N] "
+        try:
+            answer = self.input_fn(f"{question} {suffix}").strip().lower()
+        except EOFError:
+            # A closed stdin (Ctrl+D, dropped SSH) is a decline, not a crash.
+            # This keeps operator termination on the safe path: No answers
+            # never open a PR or continue, and the loop's on_continue stop is
+            # MAX_ITER semantics, not an internal ERROR.
+            self.print_fn("")
+            return False
+        if not answer:
+            return default_yes
+        return answer in ("y", "yes")
+
+    def confirm_warnings(self, warn_checks) -> bool:
+        if self.args.yes:
+            return True  # matches non-interactive behavior; never hides FAILs
+        names = ", ".join(c.name for c in warn_checks)
+        return self._ask(f"Preflight warnings ({names}). Continue with warnings?", default_yes=False)
+
+    def confirm_start(self, description: str) -> bool:
+        if self.args.yes:
+            return True
+        return self._ask(f"Create {description} and start the relay?", default_yes=True)
+
+    def on_continue(self, iteration: int, verdict, test_results, violations) -> bool:
+        unmet = sum(1 for c in verdict.criteria_status if c.get("status") in ("unmet", "unknown"))
+        self.print_fn("")
+        self.print_fn(f"--- iteration {iteration} summary ---")
+        self.print_fn(f"safety:   {len(violations)} violation(s) this run")
+        if test_results:
+            for r in test_results:
+                self.print_fn(f"tests:    {r.summary_line()}")
+        else:
+            self.print_fn("tests:    none run (no matching changed paths)")
+        self.print_fn(f"verdict:  {verdict.status} - {verdict.summary[:160]}")
+        self.print_fn(f"criteria: {unmet} unmet/unknown of {len(verdict.criteria_status)} judged")
+        for step in verdict.required_next_steps[:5]:
+            self.print_fn(f"next:     {step[:160]}")
+        for flag in verdict.risk_flags[:5]:
+            self.print_fn(f"risk:     {flag[:160]}")
+        if self.args.yes:
+            return True
+        return self._ask("Continue to next iteration?", default_yes=True)
+
+    def decide_pr(self, state: str, last_verdict) -> bool:
+        from orchestration.coding_relay.loop import MAX_ITER, PASS
+
+        if self.args.no_pr:
+            return False
+        if state == PASS:
+            if self.args.yes or self.args.draft_pr:
+                return super().decide_pr(state, last_verdict)
+            default_yes = True
+            note = ""
+            if last_verdict and not last_verdict.should_open_pr:
+                default_yes = False
+                note = " (reviewer set should_open_pr=false)"
+            return self._ask(f"Open draft PR now?{note}", default_yes=default_yes)
+        if state == MAX_ITER:
+            if self.args.draft_pr:
+                return True  # explicit flag is the operator override
+            if self.args.yes:
+                return False
+            return self._ask(
+                "Relay did not pass. Open draft PR anyway as operator override?",
+                default_yes=False,
+            )
+        return False  # never after SAFETY_STOP / BLOCKED / ERROR
+
+
+# ----------------------------------------------------------------- guided
+
+def run_guided(args, input_fn: Callable = input, print_fn: Callable = safe_print) -> int:
+    """Full guided flow. Returns the process exit code."""
+    from orchestration.coding_relay.__main__ import execute_run
+
+    repo_root: Path = args.repo_root.resolve()
+    print_fn("Coding Relay - guided mode (docs/reference/CODING_RELAY.md)")
+    selection = select_plan(repo_root, input_fn, print_fn)
+    if selection is None:
+        print_fn("Quit. Nothing was created.")
+        return 2
+    try:
+        result = intake_mod.load_plan(
+            repo_root, selection.get("plan"), selection.get("paste_file")
+        )
+    except IntakeError as exc:
+        print_fn(f"[intake] REFUSED: {exc}")
+        return 2
+    print_fn(f"[intake] plan: {result.title}")
+    try:
+        confirmed = confirm_criteria(
+            result, input_fn, print_fn, assume_yes=args.yes
+        )
+    except IntakeError as exc:
+        print_fn(f"[criteria] invalid after edit: {exc}")
+        return 2
+    if confirmed is None:
+        return 2
+    ui = TerminalUI(args, input_fn, print_fn)
+    return execute_run(args, confirmed, ui)

--- a/orchestration/coding_relay/intake.py
+++ b/orchestration/coding_relay/intake.py
@@ -218,6 +218,32 @@ def extract_criteria(plan_text: str) -> str | None:
     return "\n".join(lines[start:end]).strip()
 
 
+def replace_criteria_block(plan_text: str, new_block: str) -> str:
+    """Return plan_text with its criteria section replaced by `new_block`.
+
+    Used when the operator edits normalized criteria in guided mode: the
+    builder and reviewer prompts embed plan_text, so the original criteria
+    section must not linger and contradict the edit. If no criteria heading
+    is found, appends the block (should not happen post-intake)."""
+    lines = plan_text.splitlines()
+    start: int | None = None
+    level = 0
+    for i, line in enumerate(lines):
+        if CRITERIA_HEADING_RE.match(line.strip()):
+            start = i
+            level = len(HEADING_RE.match(line.strip()).group(1))  # type: ignore[union-attr]
+            break
+    if start is None:
+        return plan_text.rstrip() + "\n\n" + new_block.rstrip() + "\n"
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        m = HEADING_RE.match(lines[j].strip())
+        if m and len(m.group(1)) <= level:
+            end = j
+            break
+    return "\n".join(lines[:start] + [new_block.rstrip(), ""] + lines[end:]).rstrip() + "\n"
+
+
 def _kw_hit(kw: str, text: str) -> bool:
     """Multi-word keywords match as phrases. Short tokens need full word
     boundaries so 'ci' never fires inside 'decision' or 'db' inside

--- a/orchestration/coding_relay/loop.py
+++ b/orchestration/coding_relay/loop.py
@@ -110,6 +110,45 @@ def head_moved(worktree: Path, base_sha: str) -> bool:
     return bool(head) and head != base_sha
 
 
+def _run_meta_excerpt(run_paths: RunPaths) -> dict:
+    """Redacted, reviewer-relevant excerpt of run.json (never the full file)."""
+    import json as _json
+
+    keys = (
+        "run_id", "relay_version", "title", "base_ref", "base_sha", "branch",
+        "worktree", "max_iterations", "escalations", "providers", "codex_model",
+        "state",
+    )
+    try:
+        data = _json.loads(run_paths.run_json.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        data = {}
+    return {k: data[k] for k in keys if k in data}
+
+
+def _artifact_manifest(run_paths: RunPaths) -> list:
+    """Run-folder files existing at review time, run-root relative."""
+    files = []
+    for f in sorted(run_paths.root.rglob("*")):
+        if f.is_file():
+            files.append(f.relative_to(run_paths.root).as_posix())
+    return files
+
+
+def _availability_note(iteration: int) -> str:
+    return (
+        "Artifact availability at review time:\n"
+        "- Already written (see manifest): run.json, plan/, env/, this "
+        "iteration's diff, safety.json, tests, and this bundle.\n"
+        f"- Written AFTER this review, so they cannot appear yet: "
+        f"iterations/{iteration:02d}/verdict.json (built from YOUR response), "
+        "report/final-report.md, report/PR_BODY.md. The relay writes the "
+        "final report and PR body for every run that reaches the loop; "
+        "judge 'final report is written'-style criteria as met when the "
+        "manifest and run metadata show the run is on that path.\n"
+    )
+
+
 def _bundle_summary(
     run_paths: RunPaths,
     iteration: int,
@@ -117,11 +156,22 @@ def _bundle_summary(
     diff_stat: str,
     test_results: list,
     builder_tail: str,
+    violations: list,
     repo_access: bool = False,
 ) -> str:
     """Write the review bundle files and return the prompt-embedded summary."""
+    import json as _json
+
     n = iteration
     bundle_rel = f"iterations/{n:02d}/review-bundle"
+    run_meta = _run_meta_excerpt(run_paths)
+    run_paths.write_json(f"{bundle_rel}/run-meta.json", run_meta)
+    run_paths.write_json(f"{bundle_rel}/safety.json", [v.__dict__ for v in violations])
+    run_paths.write_json(f"{bundle_rel}/tests-summary.json", [r.to_payload() for r in test_results])
+    manifest = _artifact_manifest(run_paths)
+    run_paths.write(f"{bundle_rel}/manifest.txt", "\n".join(manifest) + "\n")
+    availability = _availability_note(n)
+    run_paths.write(f"{bundle_rel}/availability.md", availability)
     diff_for_artifact = snapshot.diff_text
     truncated_artifact = len(diff_for_artifact) > DIFF_ARTIFACT_CAP
     if truncated_artifact:
@@ -134,18 +184,19 @@ def _bundle_summary(
     run_paths.write(f"{bundle_rel}/builder-summary.md", builder_tail + "\n")
 
     bundle_abs = run_paths.review_bundle_dir(n)
+    bundle_files = (
+        "diff.patch, diff-stat.txt, files.txt, tests-summary.md, "
+        "tests-summary.json, builder-summary.md, run-meta.json, safety.json, "
+        "manifest.txt, availability.md"
+    )
     if repo_access:
         bundle_line = (
             f"You have repository access at your working directory; the review "
-            f"bundle files (diff.patch, diff-stat.txt, files.txt, "
-            f"tests-summary.md, builder-summary.md) live at {bundle_abs}"
+            f"bundle files ({bundle_files}) live at {bundle_abs}"
         )
         diff_location = f"the full diff is {bundle_abs / 'diff.patch'}"
     else:
-        bundle_line = (
-            "Bundle files in your working directory: diff.patch, "
-            "diff-stat.txt, files.txt, tests-summary.md, builder-summary.md"
-        )
+        bundle_line = f"Bundle files in your working directory: {bundle_files}"
         diff_location = "the full diff is diff.patch in your working directory"
     diff_for_prompt = snapshot.diff_text
     diff_note = ""
@@ -154,7 +205,14 @@ def _bundle_summary(
         diff_note = f"\n[diff truncated in this prompt; {diff_location}]\n"
     return (
         f"{bundle_line}\n\n"
-        f"### Changed files ({len(snapshot.changed_paths)})\n"
+        "### Run metadata (redacted excerpt of run.json)\n"
+        + _json.dumps(run_meta, indent=2, default=str)
+        + f"\n\n### Run-folder artifact manifest ({len(manifest)} files at review time)\n"
+        + "\n".join(manifest[:300])
+        + "\n\n### Artifact availability\n" + availability
+        + "\n### Safety scan (this iteration)\n"
+        + (_json.dumps([v.__dict__ for v in violations], default=str) if violations else "[] (no violations)")
+        + f"\n\n### Changed files ({len(snapshot.changed_paths)})\n"
         + "\n".join(snapshot.changed_paths[:200])
         + "\n\n### Diff stat\n" + diff_stat
         + "\n### Tests\n" + tests_md
@@ -192,7 +250,11 @@ def run_loop(
     build: Callable[[str], AdapterResult],
     review: Callable[[str, Path, str], AdapterResult],
     log: Callable[[str], None] = print,
+    on_continue: Optional[Callable] = None,
 ) -> LoopOutcome:
+    """on_continue(iteration, verdict, test_results, violations) -> bool is
+    called after a 'continue' verdict when another iteration remains; False
+    stops the run (MAX_ITER semantics: work preserved, exit 1)."""
     outcome = LoopOutcome(state=ERROR, exit_code=EXIT_CODES[ERROR])
     reviewer_feedback: Optional[str] = None
     test_failures: Optional[str] = None
@@ -281,7 +343,7 @@ def run_loop(
         builder_tail = b_res.stdout.strip()[-2000:]
         bundle_summary = _bundle_summary(
             run_paths, iteration, snapshot, diff_stat, test_results, builder_tail,
-            repo_access=cfg.codex_repo_access,
+            violations, repo_access=cfg.codex_repo_access,
         )
         r_prompt = prompts.reviewer_prompt(
             intake.plan_text, intake.criteria, iteration, bundle_summary,
@@ -336,7 +398,17 @@ def run_loop(
                 f"approve before this continues; inspect {wt.path}."
             )
             return outcome
-        # "continue": carry feedback into the next builder pass.
+        # "continue": carry feedback into the next builder pass; the
+        # operator may stop here in guided mode.
+        if on_continue is not None and iteration < cfg.max_iterations:
+            if not on_continue(iteration, v, test_results, violations):
+                outcome.state, outcome.exit_code = MAX_ITER, EXIT_CODES[MAX_ITER]
+                outcome.detail = (
+                    f"operator stopped after iteration {iteration} (last "
+                    "verdict 'continue'). The worktree is preserved for "
+                    "inspection or a re-run."
+                )
+                return outcome
         reviewer_feedback = _feedback_text(v)
 
     outcome.state, outcome.exit_code = MAX_ITER, EXIT_CODES[MAX_ITER]


### PR DESCRIPTION
## What this is

PR 2 of the Coding Relay: a polished terminal-guided operator flow (no web cockpit). Launch `python scripts/coding_relay.py` with no args on a TTY and the relay walks you through plan selection (menu / paste / file path), criteria preview with confirm/edit/abort via $EDITOR, a compact preflight table, warnings confirmation, per-iteration summaries with continue prompts, and outcome-gated draft-PR offers. Stdlib only; no rich/click/typer.

Also improves the Codex review bundle so the reviewer can honestly verify run-level criteria (the gap that made the first live run exit MAX_ITER): the bundle now carries a redacted `run-meta.json` excerpt, the iteration's `safety.json`, `tests-summary.json`, an artifact manifest, and an availability note naming the artifacts that only exist after the review.

ADO: Story #766 under Feature #764 / Epic #359.

## Safety boundaries preserved

- `AutoUI` reproduces the PR 1 non-interactive policy exactly (verified by tests + the flag matrix); the guided `TerminalUI` layers prompts on the same boundaries.
- No new broad bypass. `--yes` makes guided mode non-blocking but never bypasses hard preflight failures, which stop before any prompt or mutation.
- Warnings default No; MAX_ITER PR override default No; PR never offered after SAFETY_STOP/BLOCKED/ERROR; `--no-pr` wins everywhere.
- Declining a continue prompt (or EOF/closed stdin) = MAX_ITER semantics: exit 1, report written, worktree kept.

## Adversarial review

A multi-agent review of this diff confirmed 8 findings; all fixed before this PR (full list in plan 0016, 'PR 2 adversarial review'). The three real bugs: EOF at a guided prompt was swallowed by the loop's catch-all as an exit-6 internal ERROR (now a clean operator decline); criteria edited in guided mode did not propagate into the plan text the prompts embed (now spliced in); and FAIL preflight detail was truncated, dropping remediation hints (now kept, and failure messages route to stderr to match PR 1). The other five were test-coverage gaps on contract points, now locked. The verify phase was cut short by a session usage limit; every confirmed finding had a completed high-effort verifier before the cutoff, and I triaged the rest against the code.

## Tests

- 123 relay tests green locally (was 78): `cd backend && python -m pytest tests/test_orchestration_relay_*.py -q`
- `ruff check orchestration/coding_relay backend/tests` clean
- New: full guided E2E suite (quit/abort/warn-decline/start-decline/happy/continue-decline/EOF/--yes), provider command-contract units, bundle-content + run-meta-boundary assertions
- Manual: non-TTY no-args still prints the plan list; guided EOF exits 2 at the menu and 1 mid-loop

## Docs

`docs/reference/CODING_RELAY.md` (guided mode, PR-offer-by-outcome table, updated bundle description, exit-1 wording), plan `0016`, tips.md lessons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)