### PR TITLE
docs(relay): guided live smoke evidence + Guided live smoke checklist

### DIFF
--- a/docs/plans/03-implementation-plans/active/0017-relay-guided-live-smoke.md
+++ b/docs/plans/03-implementation-plans/active/0017-relay-guided-live-smoke.md
@@ -1,0 +1,60 @@
+# Relay Guided Live Smoke
+
+- Status: Done (live guided run, 2026-07-08)
+- Environment: Orchestration
+- Risk: Low
+
+## Live guided run - evidence
+
+- **Command:** `python scripts/coding_relay.py` (guided mode, real prompts, no `--yes`), max 2 iterations. Driven with the exact operator answer sequence (select plan 24, confirm criteria Y, confirm warnings y, start Y, continue after iter 1 Y, PR offer N). Invoked via a thin runner that injects only `input_fn`; `print_fn` uses the relay's own `safe_print` default, matching `main() -> run_guided(args)`.
+- **Selected plan:** `docs/plans/03-implementation-plans/active/0017-relay-guided-live-smoke.md` (menu entry 24).
+- **Result status:** MAX_ITER (exit 1). Correct, honest outcome: not a pass, worktree preserved.
+- **Worktree path:** `C:/Projects/cons_wt_relay_relay/r-relay-gu-090916` (branch `relay/relay-guided-live-smoke-20260708-090916`, base `1161fdcb`).
+- **Run folder:** `.orchestration/runs/20260708-090916-relay-guided-live-smoke/`.
+- **Codex artifact-only:** Yes, both iterations. `review-meta.json` shows `codex exec --cd <run>/iterations/NN/review-bundle`, adapter `relay_reviewer`, exit 0, no `--dangerously-bypass-approvals-and-sandbox` retry.
+- **Safety before PR:** Yes. `iterations/01,02/safety.json` present (`[]` violations), written before any PR step.
+- **Guided prompts:** All fired in order and behaved correctly. Menu selection, criteria preview, warnings confirmation (surfaced the real `backend-venv` WARN, default N, accepted with `y`), start approval (default Y), continue prompt after iteration 1 (default Y), and the MAX_ITER operator-override PR prompt (default N).
+- **Tests run/skipped:** None run (docs-only change, no matching changed paths). Reported honestly as `No suites were run.` in `tests-summary.md` and the report.
+- **PR URL:** None opened by the relay. Operator declined the MAX_ITER override at the prompt.
+- **Manual operator override:** The relay's docs diff was correct in substance but claimed the review bundle "includes a primary-checkout `git status` snapshot", a bundle feature that does not exist yet (which is itself why the reviewer left R3 `unknown`). Rather than ship a relay-authored PR containing that slightly-wrong sentence, the operator adopted the diff by hand with a one-line correction (reframing the snapshot as a planned improvement, not a current bundle artifact) and shipped it through the normal PR flow with this evidence. This is the intended operator-judgment path for MAX_ITER.
+- **Reviewer verdict (iteration 2):** 6 of 10 criteria met (T1-T4, R1-R2, each cited to a named bundle artifact: `run-meta.json`, `manifest.txt`, `tests-summary.json`, `files.txt`, `safety.json`, `diff.patch`), 4 unknown (B1-B3 AI-role provenance not verifiable from the bundle; R3 checkout-cleanliness snapshot not in the bundle). The PR 2 bundle improvements demonstrably worked: run-level criteria that were `unknown` in the first live run (2026-07-07, plan `0017-relay-smoke-docs-tweak`) are now `met` from named artifacts.
+- **Bug NOT found:** the first test-harness attempt crashed on a cp1252 `UnicodeEncodeError` printing a plan title containing an emoji, but only because the harness passed the builtin `print`; the relay's real no-args path uses `safe_print` and is crash-safe (verified: `main() -> run_guided(args)` with the `safe_print` default). No relay defect.
+- **Cleanup:** `git -C C:/Projects/cons_wt_relay worktree remove --force C:/Projects/cons_wt_relay_relay/r-relay-gu-090916` and `git -C C:/Projects/cons_wt_relay branch -D relay/relay-guided-live-smoke-20260708-090916` (run after adopting the diff).
+
+## Requested work
+
+Add a short "Guided live smoke checklist" section to `docs/reference/CODING_RELAY.md`.
+
+The section should explain the safest first live run after installing the relay:
+- start with a docs-only plan,
+- inspect the normalized criteria,
+- confirm preflight warnings,
+- review the run folder,
+- only open a draft PR if the result is PASS or the operator intentionally overrides MAX_ITER.
+
+## Acceptance Criteria
+
+### Screen
+- Not applicable.
+
+### API
+- Not applicable.
+
+### DB/Data
+- Not applicable.
+
+### AI behavior
+- Claude is used as the builder.
+- Codex is used as artifact-only reviewer.
+- Codex returns structured per-criterion review JSON.
+
+### Evals/tests
+- The relay creates a run folder under `.orchestration/runs/`.
+- The run folder includes plan, normalized criteria, safety output, review bundle, verdict, final report, and PR body or PR receipt.
+- Any skipped tests are reported honestly.
+- The docs change is visible in `docs/reference/CODING_RELAY.md`.
+
+### Regression guard
+- No non-doc source files are changed unless the relay explicitly documents why.
+- No DB migrations, workflow edits, auth/security edits, deploys, force pushes, or merges occur.
+- Primary checkout remains clean except for intentionally adopted evidence updates.

--- a/docs/reference/CODING_RELAY.md
+++ b/docs/reference/CODING_RELAY.md
@@ -280,6 +280,36 @@ Five things to verify by hand on your first live relay run:
 5. The run folder tells the whole story: plan, prompts, diff, tests, safety,
    verdict, final report, PR body.
 
+## Guided live smoke checklist
+
+The safest first live run after installing the relay. It exercises every
+checkpoint without risking a real diff.
+
+1. Pick a docs-only plan (a small `docs/**` change with concrete acceptance
+   criteria). Nothing under `backend/`, `repo-b/`, `.github/`, or DB schema.
+2. Launch guided mode (`python scripts/coding_relay.py`) and inspect the
+   normalized criteria preview. Every criterion should have a stable id
+   (S/A/D/B/T/R/G) and read the way you would judge it by hand. If anything
+   is vague, edit before accepting.
+3. Confirm the preflight table. Read every `WARN` line before answering
+   `Continue with warnings?`. A `FAIL` stops before the worktree exists;
+   fix the environment, do not paper over it.
+4. Watch the run folder fill in under `.orchestration/runs/<run_id>/`.
+   Pre-review artifacts: `plan/normalized-criteria.md`,
+   `iterations/01/safety.json`, `iterations/01/tests/summary.json`, and the
+   review bundle (`run-meta.json`, `safety.json`, `tests-summary.json`,
+   `manifest.txt`, `availability.md`). Post-review artifacts land after the
+   reviewer returns: `iterations/01/verdict.json`, `report/final-report.md`,
+   and `report/PR_BODY.md` (or `MANUAL_PR.md`) - this ordering matches the
+   bundle's `availability.md`. Any skipped suite is honestly recorded as
+   SKIPPED with the manual command, not silently dropped.
+5. Only accept the draft PR offer when the verdict is `pass`, or when you
+   are intentionally exercising the MAX_ITER operator override
+   (`--draft-pr`). On any safety stop, block, or error, decline the PR and
+   read the receipts by hand. Write acceptance criteria the reviewer can
+   judge from the diff and bundle; run-level or provenance criteria the
+   bundle cannot evidence come back `unknown` and hold the run at MAX_ITER.
+
 ## Known limitations (PR 1)
 
 - Test inference covers the four basic suite groups only.

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4970,3 +4970,27 @@ Redesign of `/lab/env/[envId]/telemetry/calibration` into an inspectable evidenc
   PR 1's stderr diagnostics to stdout. Keep a distinct error channel
   (stderr) for failures so wrappers that separate the streams keep working;
   add a byte-parity check against the prior version when a contract binds it.
+
+## Relay guided-flow live smoke (2026-07-08)
+
+- **The PR 2 review bundle closed the run-level `unknown` gap.** In the first
+  live run (pre-bundle-improvement) the reviewer marked run-folder-exists /
+  final-report-written criteria `unknown` and forced MAX_ITER. After adding
+  `run-meta.json`/`safety.json`/`tests-summary.json`/`manifest.txt` to the
+  bundle, the reviewer now marks those `met` and cites the artifact by name.
+  Provenance criteria ("Claude built it", "Codex reviewed it") still come
+  back `unknown` - the bundle proves `providers: cli` but not which model
+  played which role - so avoid AI-role-provenance bullets in relay plans, or
+  expect a permanent unknown.
+- **The relay builder will happily write docs describing features that don't
+  exist yet.** On a docs task it drafted a checklist asserting the bundle
+  "includes a primary-checkout git status snapshot" - a plausible but
+  unbuilt artifact. The artifact-only reviewer caught it (marked the matching
+  criterion unknown because the snapshot wasn't in the bundle). Lesson: on
+  MAX_ITER, read the diff before adopting; a correct-looking docs change can
+  still assert a non-existent capability.
+- **Guided mode needs a real TTY** (`stdin.isatty()`); to smoke it
+  programmatically, call `guided.run_guided(args, input_fn)` directly with a
+  scripted `input_fn` and let `print_fn` default to `safe_print`. Passing the
+  builtin `print` reintroduces the cp1252 `UnicodeEncodeError` that
+  `safe_print` exists to prevent - that is a harness bug, not a relay bug.


### PR DESCRIPTION
## What this is

Evidence from the first **live guided run** of the Coding Relay terminal flow, plus the docs it produced (operator-adopted with one correction).

Ran `python scripts/coding_relay.py` in guided mode (real prompts, no `--yes`, max 2 iterations) against a docs-only plan (0017). Every guided prompt fired and behaved correctly: plan menu selection, criteria preview, warnings confirmation (surfaced the real backend-venv WARN), start approval, per-iteration continue prompt, and the MAX_ITER operator-override PR prompt.

## Result: MAX_ITER (exit 1), honest

The reviewer marked **6 of 10 criteria met**, each cited to a named bundle artifact (`run-meta.json`, `manifest.txt`, `tests-summary.json`, `files.txt`, `safety.json`, `diff.patch`) - the PR 2 bundle improvement demonstrably closed the run-level `unknown` gap that forced the first live run to MAX_ITER back on 2026-07-07. The 4 remaining unknowns are correct fail-closed behavior: B1-B3 (the bundle proves `providers: cli` but not which model was builder vs reviewer) and R3 (checkout-cleanliness snapshot not in the bundle).

## Operator judgment

The relay's docs diff was substantively good but claimed the review bundle "includes a primary-checkout git status snapshot" - a plausible but unbuilt artifact (which is itself why the reviewer left R3 unknown). Per the task's operator-judgment rule for MAX_ITER, I declined the relay's own PR and adopted the diff by hand with that one sentence corrected, shipping it through the normal PR flow with full evidence.

## Watch-points (all pass)

- guided menu: selection worked (entry 24)
- criteria confirm/edit: preview shown, accepted
- preflight display: readable OK/WARN table, warning confirmed
- iteration summary: safety / tests / verdict / unmet-count / next steps / risk flags all rendered
- Codex artifact-only: `--cd <run>/iterations/NN/review-bundle`, adapter relay_reviewer, exit 0, no bypass retry, both iterations
- safety before PR: `safety.json` present each iteration ([] violations)
- run-folder completeness: plan, criteria, safety, review bundle, verdict, final report, PR body all present
- primary checkout containment: only the 0017 plan (baseline) - the relay's docs edit stayed entirely in its worktree

## Files changed

- `docs/reference/CODING_RELAY.md` - Guided live smoke checklist section (relay-authored, one sentence corrected)
- `docs/plans/03-implementation-plans/active/0017-relay-guided-live-smoke.md` - plan + evidence (Done)
- `docs/tips.md` - three reusable lessons (bundle closed the unknown gap; relay writes docs about unbuilt features; guided-mode smoke harness)

Docs-only. No source, no tests, no schema, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)