### PR TITLE
docs(sustainability): T2 fail-closed vocabulary (relay-authored)

### DIFF
--- a/docs/plans/01-shared-standards/ai-runtime/fail-closed-rules.md
+++ b/docs/plans/01-shared-standards/ai-runtime/fail-closed-rules.md
@@ -30,6 +30,13 @@ An invented answer that looks right is worse than an honest null. The user acts 
 ### 6. AI answer exceeds declared scope
 - If the environment's `ai-behavior.md` defines a scope limit (e.g. "fund-level only, not investor-level") → refuse investor-level questions with a clear scope declaration
 
+### 7. Sustainability metrics without a certified basis
+- If a computed emission (e.g. tCO2e) would require an emission factor and no approved factor exists for this activity, factor-set version, and reporting period → return null with `null_reason: "emission_factor_missing"`
+- If a metric key requested from the sustainability reader is not registered in the unified metric registry → return null with `null_reason: "metric_definition_missing"`
+- If the value or report would require an external assurance the platform does not hold (v1 is internal decision-support only, not an assured or published disclosure) → return null with `null_reason: "out_of_certified_scope"`
+- A missing source record for an (asset, period) already maps to the existing `data_not_ingested`; a missing released authoritative snapshot for a released (asset, period) already maps to the existing `snapshot_unavailable`. No new tokens are introduced for those two cases.
+- NEVER fabricate an emission factor, invent a metric definition, or claim an assured or published value
+
 ## Null reason vocabulary
 
 Standard null_reasons across all environments:
@@ -56,6 +63,9 @@ Standard null_reasons across all environments:
 | `privacy_forbidden` | Provider's max privacy is below the request's privacy (AI Provider Dispatch) |
 | `no_eligible_provider` | No provider can serve this mode/risk/privacy (AI Provider Dispatch) |
 | `fallback_disabled` | Chosen provider unavailable and per-request fallback was not enabled (AI Provider Dispatch) |
+| `emission_factor_missing` | No approved emission factor exists for this activity, factor-set version, and reporting period (Sustainability) |
+| `metric_definition_missing` | The requested metric key is not registered in the unified metric registry (Sustainability) |
+| `out_of_certified_scope` | The value or report would require an external assurance the platform does not hold; v1 is internal decision-support only (Sustainability) |
 
 ## Rule for eval coverage
 

--- a/docs/plans/03-implementation-plans/active/0020-sustainability-t2-fail-closed-vocab.md
+++ b/docs/plans/03-implementation-plans/active/0020-sustainability-t2-fail-closed-vocab.md
@@ -1,0 +1,52 @@
+# 0020 - Sustainability T2: Fail-Closed Vocabulary (Docs Only)
+
+- Status: Done (2026-07-10) - relay run 20260710-152523, PASS iter 1.
+- Environment: Business OS / Sustainability
+- Risk: Low (docs-only)
+- Scope: Add three sustainability null-reason tokens to the shared fail-closed vocabulary, and a sustainability mandatory-case entry. One ticket (T2 from plan 0018).
+- Master plan: `docs/plans/03-implementation-plans/active/0018-sustainability-tool-planning.md`
+- ADR: `docs/adr/sustainability/0001-brownfield-extension.md` (T1, merged) - decisions 6 and 7 require these tokens.
+
+Docs-only. No code, schema, route, or frontend change.
+
+## Background
+
+Plan 0018 ticket T2: "append `emission_factor_missing`, `metric_definition_missing`, `out_of_certified_scope` to `docs/plans/01-shared-standards/ai-runtime/fail-closed-rules.md`." The T1 ADR (decision 6) states the reader, UI, and AI copilot use these tokens with no local strings; decision 7 and Open Question 4 tie `out_of_certified_scope` to the internal-decision-support-only boundary. This ticket adds the tokens to the shared vocabulary so downstream code tickets (T4 reader, T6 registry, T10 AI) reference a single source.
+
+The target file `docs/plans/01-shared-standards/ai-runtime/fail-closed-rules.md` already has a "Null reason vocabulary" table and a "Mandatory fail-closed cases" section. This ticket extends both; it does not restructure the file.
+
+## Scope
+
+In scope:
+- Add three rows to the "Null reason vocabulary" table in `docs/plans/01-shared-standards/ai-runtime/fail-closed-rules.md`:
+  - `emission_factor_missing` - no approved emission factor exists for this activity, factor-set version, and reporting period (Sustainability).
+  - `metric_definition_missing` - the requested metric key is not registered in the unified metric registry (Sustainability).
+  - `out_of_certified_scope` - the value or report would require an external assurance the platform does not hold; v1 is internal decision-support only (Sustainability).
+- Add one "Mandatory fail-closed cases" entry for sustainability that names when each token is returned, consistent with the ADR (missing factor, unregistered metric key, out-of-certified-scope request), and states that a missing source record for an (asset, period) already maps to the existing `data_not_ingested`, and a missing released snapshot to the existing `snapshot_unavailable` (no new tokens for those two).
+
+Out of scope (explicitly):
+- Any change under `backend/`, `repo-b/`, or DB schema.
+- Editing existing null_reason rows or the file's other sections beyond the additive table rows and the one new mandatory-case entry.
+- Wiring these tokens into any reader, UI, or eval (those are T4/T7/T12).
+
+## Acceptance Criteria
+
+### Screen
+Not applicable.
+
+### API
+Not applicable.
+
+### DB/Data
+Not applicable.
+
+### AI behavior
+- The three new tokens are documented as fail-closed null_reasons (not error states) so downstream services return them with `value: null`, never a fabricated number. This is a documentation outcome, verifiable by reading the added rows and mandatory-case text.
+
+### Evals/tests
+- No test suite is required for a docs-only change with zero touched paths under `backend/**`, `repo-b/**`, `rs_factory_seed/**`, or `verification/**`. The diff must contain only the single file `docs/plans/01-shared-standards/ai-runtime/fail-closed-rules.md` (plus this plan file), verifiable from the review bundle `files.txt`.
+
+### Regression guard
+- The diff must not modify any file under `repo-b/`, `backend/`, or `repo-b/db/schema/`.
+- The diff must not remove or rename any existing row in the "Null reason vocabulary" table (the three additions are additive only).
+- After the change, `docs/plans/01-shared-standards/ai-runtime/fail-closed-rules.md` must contain the literal strings `emission_factor_missing`, `metric_definition_missing`, and `out_of_certified_scope`, each with a Sustainability-context meaning.


### PR DESCRIPTION
## Ticket
T2 from plan 0018. Adds the sustainability null-reason tokens the ADR (0001, decisions 6 & 7) requires, so downstream code tickets (T4 reader, T6 registry, T10 AI) reference one shared vocabulary.

## Change (docs-only)
`docs/plans/01-shared-standards/ai-runtime/fail-closed-rules.md`:
- New mandatory case §7 "Sustainability metrics without a certified basis".
- Three additive vocab rows: `emission_factor_missing`, `metric_definition_missing`, `out_of_certified_scope`.
- Reuses existing `data_not_ingested` / `snapshot_unavailable` for the two cases the plan says need no new token. No existing rows changed.

## Relay
`--no-pr`, max 3 iter, no `--yes`, artifact-only Codex. **PASS iteration 1**, 5/5 criteria met, `safety.json` empty, no escalations. Base `origin/main` `a90a136b` (on top of merged T1).

## Tests
None — docs-only, no matching suite paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)