### PR TITLE
feat(sustainability): T4 authoritative reader service

### DIFF
--- a/backend/app/services/re_sustainability_authoritative.py
+++ b/backend/app/services/re_sustainability_authoritative.py
@@ -1,0 +1,239 @@
+"""Sustainability authoritative-state reader (single fetch layer).
+
+Mirrors ``re_authoritative_snapshots.get_authoritative_state`` for the
+sustainability authoritative tables introduced by
+``repo-b/db/schema/618_sus_authoritative.sql`` (T3 of plan 0018):
+
+- ``sus_authoritative_snapshots`` — the snapshot header, keyed by
+  ``snapshot_version`` and scoped by
+  ``(business_id, env_id, entity_scope, period_key, metric_family)``.
+- ``sus_authoritative_metric_value`` — per-metric numeric values keyed by
+  ``(snapshot_version, metric_key)``. A row whose ``value_numeric`` is NULL
+  carries a stored ``null_reason``; the reader never substitutes zero.
+- ``sus_authoritative_evidence`` — per-metric provenance rows.
+
+Every sustainability read that surfaces a governed ESG metric MUST go through
+``get_authoritative_state`` / ``get_metric`` in this module. The reader is
+fail-closed: a missing released snapshot returns
+``null_reason="snapshot_unavailable"`` with empty metrics and no exception; a
+metric row with NULL value returns its stored ``null_reason`` (see T2 fail-closed
+vocabulary in ``docs/plans/03-implementation-plans/active/0018-...``).
+
+The reader is read-only: only SELECTs against ``sus_authoritative_*`` tables.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from app.db import get_cursor
+
+
+def _uuid_to_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+SNAPSHOT_UNAVAILABLE = "snapshot_unavailable"
+METRIC_DEFINITION_MISSING = "metric_definition_missing"
+
+
+def get_authoritative_state(
+    *,
+    business_id: UUID | str,
+    env_id: str,
+    entity_scope: str,
+    period_key: str,
+    metric_family: str,
+    snapshot_version: str | None = None,
+) -> dict[str, Any]:
+    """Return the authoritative sustainability state for a scope+period+family.
+
+    Selects the latest matching row from ``sus_authoritative_snapshots``,
+    defaulting to ``promotion_state = 'released'`` when no explicit
+    ``snapshot_version`` is supplied (mirroring the REPE reader). On a hit,
+    also loads the associated metric-value and evidence rows.
+
+    Fail-closed contract:
+      - No matching snapshot → ``null_reason="snapshot_unavailable"``,
+        ``trust_status="missing_source"``, empty ``metrics`` and ``evidence``.
+      - A metric row with NULL ``value_numeric`` → ``value=None`` plus its
+        stored ``null_reason``. Zero is never substituted.
+    """
+    filters = [
+        "business_id = %s::uuid",
+        "env_id = %s",
+        "entity_scope = %s",
+        "period_key = %s",
+        "metric_family = %s",
+    ]
+    params: list[Any] = [
+        str(business_id),
+        env_id,
+        entity_scope,
+        period_key,
+        metric_family,
+    ]
+    if snapshot_version:
+        filters.append("snapshot_version = %s")
+        params.append(snapshot_version)
+    else:
+        filters.append("promotion_state = 'released'")
+
+    where_sql = " AND ".join(filters)
+
+    with get_cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT snapshot_version, promotion_state, trust_status,
+                   period_key, entity_scope, metric_family
+            FROM sus_authoritative_snapshots
+            WHERE {where_sql}
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            params,
+        )
+        header = cur.fetchone()
+
+    if not header:
+        return {
+            "entity_scope": entity_scope,
+            "period_key": period_key,
+            "requested_period_key": period_key,
+            "period_exact": False,
+            "state_origin": "authoritative",
+            "snapshot_version": None,
+            "promotion_state": None,
+            "trust_status": "missing_source",
+            "null_reason": SNAPSHOT_UNAVAILABLE,
+            "metrics": [],
+            "evidence": [],
+        }
+
+    resolved_version = header["snapshot_version"]
+
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            SELECT metric_key, value_numeric, unit, null_reason, trust_status
+            FROM sus_authoritative_metric_value
+            WHERE snapshot_version = %s
+            ORDER BY metric_key ASC
+            """,
+            (resolved_version,),
+        )
+        metric_rows = cur.fetchall() or []
+
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            SELECT metric_key, source_table, source_row_ref,
+                   emission_factor_set_id, ingestion_run_id, formula_id
+            FROM sus_authoritative_evidence
+            WHERE snapshot_version = %s
+            ORDER BY metric_key ASC, created_at ASC
+            """,
+            (resolved_version,),
+        )
+        evidence_rows = cur.fetchall() or []
+
+    metrics = [
+        {
+            "metric_key": row["metric_key"],
+            "value": row.get("value_numeric"),
+            "unit": row.get("unit"),
+            "null_reason": row.get("null_reason"),
+            "trust_status": row.get("trust_status"),
+        }
+        for row in metric_rows
+    ]
+
+    evidence = [
+        {
+            "metric_key": row["metric_key"],
+            "source_table": row.get("source_table"),
+            "source_row_ref": row.get("source_row_ref"),
+            "emission_factor_set_id": _uuid_to_str(row.get("emission_factor_set_id")),
+            "ingestion_run_id": _uuid_to_str(row.get("ingestion_run_id")),
+            "formula_id": row.get("formula_id"),
+        }
+        for row in evidence_rows
+    ]
+
+    returned_period_key = str(header["period_key"])
+    return {
+        "entity_scope": header.get("entity_scope") or entity_scope,
+        "period_key": returned_period_key,
+        "requested_period_key": period_key,
+        "period_exact": returned_period_key == period_key,
+        "state_origin": "authoritative",
+        "snapshot_version": resolved_version,
+        "promotion_state": header["promotion_state"],
+        "trust_status": header["trust_status"],
+        "null_reason": None,
+        "metrics": metrics,
+        "evidence": evidence,
+    }
+
+
+def get_metric(
+    *,
+    business_id: UUID | str,
+    env_id: str,
+    entity_scope: str,
+    period_key: str,
+    metric_family: str,
+    metric_key: str,
+    snapshot_version: str | None = None,
+) -> dict[str, Any]:
+    """Return a single governed metric from the authoritative snapshot.
+
+    Contract:
+      - Snapshot missing → ``null_reason="snapshot_unavailable"``, ``value=None``,
+        ``trust_status="missing_source"``.
+      - ``metric_key`` not present in the snapshot's value rows →
+        ``null_reason="metric_definition_missing"``, ``value=None``.
+      - Metric row present with NULL ``value_numeric`` → ``value=None`` plus its
+        stored ``null_reason`` (never 0).
+    """
+    state = get_authoritative_state(
+        business_id=business_id,
+        env_id=env_id,
+        entity_scope=entity_scope,
+        period_key=period_key,
+        metric_family=metric_family,
+        snapshot_version=snapshot_version,
+    )
+
+    if state.get("null_reason") == SNAPSHOT_UNAVAILABLE:
+        return {
+            "value": None,
+            "unit": None,
+            "null_reason": SNAPSHOT_UNAVAILABLE,
+            "trust_status": "missing_source",
+            "snapshot_version": None,
+            "state_origin": "authoritative",
+        }
+
+    for metric in state.get("metrics", []):
+        if metric.get("metric_key") == metric_key:
+            return {
+                "value": metric.get("value"),
+                "unit": metric.get("unit"),
+                "null_reason": metric.get("null_reason"),
+                "trust_status": metric.get("trust_status"),
+                "snapshot_version": state.get("snapshot_version"),
+                "state_origin": "authoritative",
+            }
+
+    return {
+        "value": None,
+        "unit": None,
+        "null_reason": METRIC_DEFINITION_MISSING,
+        "trust_status": "missing_source",
+        "snapshot_version": state.get("snapshot_version"),
+        "state_origin": "authoritative",
+    }

--- a/backend/tests/test_re_sustainability_authoritative.py
+++ b/backend/tests/test_re_sustainability_authoritative.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from decimal import Decimal
+from unittest.mock import patch
+from uuid import uuid4
+
+from tests.conftest import FakeCursor
+
+
+def _make_fake_cursor(cur: FakeCursor):
+    @contextmanager
+    def _mock():
+        yield cur
+
+    return _mock
+
+
+def test_released_snapshot_returns_authoritative_state_with_metrics_and_evidence():
+    from app.services import re_sustainability_authoritative
+
+    business_id = uuid4()
+    emission_factor_set_id = uuid4()
+    ingestion_run_id = uuid4()
+
+    cur = FakeCursor()
+    # snapshot header
+    cur.push_result(
+        [
+            {
+                "snapshot_version": "sus-20260709T000000Z-abcd1234",
+                "promotion_state": "released",
+                "trust_status": "trusted",
+                "period_key": "2026Q2",
+                "entity_scope": "portfolio",
+                "metric_family": "emissions",
+            }
+        ]
+    )
+    # metric value rows
+    cur.push_result(
+        [
+            {
+                "metric_key": "scope_1_emissions_tco2e",
+                "value_numeric": Decimal("1234.567890000000"),
+                "unit": "tCO2e",
+                "null_reason": None,
+                "trust_status": "trusted",
+            },
+            {
+                "metric_key": "scope_2_emissions_tco2e",
+                "value_numeric": Decimal("789.100000000000"),
+                "unit": "tCO2e",
+                "null_reason": None,
+                "trust_status": "trusted",
+            },
+        ]
+    )
+    # evidence rows
+    cur.push_result(
+        [
+            {
+                "metric_key": "scope_1_emissions_tco2e",
+                "source_table": "sus_utility_monthly",
+                "source_row_ref": "utility_monthly_id=abc-123",
+                "emission_factor_set_id": emission_factor_set_id,
+                "ingestion_run_id": ingestion_run_id,
+                "formula_id": "sus.scope1.v1",
+            }
+        ]
+    )
+
+    with patch(
+        "app.services.re_sustainability_authoritative.get_cursor",
+        _make_fake_cursor(cur),
+    ):
+        payload = re_sustainability_authoritative.get_authoritative_state(
+            business_id=business_id,
+            env_id="env-demo",
+            entity_scope="portfolio",
+            period_key="2026Q2",
+            metric_family="emissions",
+        )
+
+    assert payload["state_origin"] == "authoritative"
+    assert payload["trust_status"] == "trusted"
+    assert payload["snapshot_version"] == "sus-20260709T000000Z-abcd1234"
+    assert payload["promotion_state"] == "released"
+    assert payload["null_reason"] is None
+    assert payload["period_exact"] is True
+    assert payload["requested_period_key"] == "2026Q2"
+    assert payload["period_key"] == "2026Q2"
+
+    assert len(payload["metrics"]) == 2
+    scope1 = payload["metrics"][0]
+    assert scope1["metric_key"] == "scope_1_emissions_tco2e"
+    assert scope1["value"] == Decimal("1234.567890000000")
+    assert scope1["unit"] == "tCO2e"
+    assert scope1["null_reason"] is None
+    assert scope1["trust_status"] == "trusted"
+
+    assert len(payload["evidence"]) == 1
+    ev = payload["evidence"][0]
+    assert ev["metric_key"] == "scope_1_emissions_tco2e"
+    assert ev["source_table"] == "sus_utility_monthly"
+    assert ev["emission_factor_set_id"] == str(emission_factor_set_id)
+    assert ev["ingestion_run_id"] == str(ingestion_run_id)
+    assert ev["formula_id"] == "sus.scope1.v1"
+
+
+def test_no_released_row_returns_snapshot_unavailable_and_empty_lists():
+    from app.services import re_sustainability_authoritative
+
+    cur = FakeCursor()
+    cur.push_result([])  # snapshot header lookup returns nothing
+
+    with patch(
+        "app.services.re_sustainability_authoritative.get_cursor",
+        _make_fake_cursor(cur),
+    ):
+        payload = re_sustainability_authoritative.get_authoritative_state(
+            business_id=uuid4(),
+            env_id="env-demo",
+            entity_scope="portfolio",
+            period_key="2026Q2",
+            metric_family="emissions",
+        )
+
+    assert payload["null_reason"] == "snapshot_unavailable"
+    assert payload["trust_status"] == "missing_source"
+    assert payload["state_origin"] == "authoritative"
+    assert payload["snapshot_version"] is None
+    assert payload["promotion_state"] is None
+    assert payload["period_exact"] is False
+    assert payload["metrics"] == []
+    assert payload["evidence"] == []
+
+
+def test_null_value_numeric_returns_none_and_stored_null_reason_never_zero():
+    from app.services import re_sustainability_authoritative
+
+    cur = FakeCursor()
+    cur.push_result(
+        [
+            {
+                "snapshot_version": "sus-null-1",
+                "promotion_state": "released",
+                "trust_status": "untrusted",
+                "period_key": "2026Q2",
+                "entity_scope": "portfolio",
+                "metric_family": "emissions",
+            }
+        ]
+    )
+    cur.push_result(
+        [
+            {
+                "metric_key": "scope_3_emissions_tco2e",
+                "value_numeric": None,
+                "unit": "tCO2e",
+                "null_reason": "emission_factor_missing",
+                "trust_status": "missing_source",
+            }
+        ]
+    )
+    cur.push_result([])  # no evidence rows
+
+    with patch(
+        "app.services.re_sustainability_authoritative.get_cursor",
+        _make_fake_cursor(cur),
+    ):
+        payload = re_sustainability_authoritative.get_authoritative_state(
+            business_id=uuid4(),
+            env_id="env-demo",
+            entity_scope="portfolio",
+            period_key="2026Q2",
+            metric_family="emissions",
+        )
+
+    assert len(payload["metrics"]) == 1
+    metric = payload["metrics"][0]
+    assert metric["value"] is None
+    assert metric["value"] != 0
+    assert metric["value"] != "0"
+    assert metric["null_reason"] == "emission_factor_missing"
+    assert metric["trust_status"] == "missing_source"
+
+
+def test_get_metric_unknown_key_returns_metric_definition_missing():
+    from app.services import re_sustainability_authoritative
+
+    cur = FakeCursor()
+    cur.push_result(
+        [
+            {
+                "snapshot_version": "sus-known-1",
+                "promotion_state": "released",
+                "trust_status": "trusted",
+                "period_key": "2026Q2",
+                "entity_scope": "portfolio",
+                "metric_family": "emissions",
+            }
+        ]
+    )
+    cur.push_result(
+        [
+            {
+                "metric_key": "scope_1_emissions_tco2e",
+                "value_numeric": Decimal("42.000000000000"),
+                "unit": "tCO2e",
+                "null_reason": None,
+                "trust_status": "trusted",
+            }
+        ]
+    )
+    cur.push_result([])  # no evidence rows
+
+    with patch(
+        "app.services.re_sustainability_authoritative.get_cursor",
+        _make_fake_cursor(cur),
+    ):
+        payload = re_sustainability_authoritative.get_metric(
+            business_id=uuid4(),
+            env_id="env-demo",
+            entity_scope="portfolio",
+            period_key="2026Q2",
+            metric_family="emissions",
+            metric_key="scope_3_emissions_tco2e",
+        )
+
+    assert payload["value"] is None
+    assert payload["null_reason"] == "metric_definition_missing"
+    assert payload["trust_status"] == "missing_source"
+    assert payload["state_origin"] == "authoritative"
+    assert payload["snapshot_version"] == "sus-known-1"

--- a/docs/plans/03-implementation-plans/active/0023-sustainability-t4-authoritative-reader.md
+++ b/docs/plans/03-implementation-plans/active/0023-sustainability-t4-authoritative-reader.md
@@ -1,0 +1,53 @@
+# 0023 - Sustainability T4: Authoritative Reader Service
+
+- Status: Done (2026-07-10) - relay authored service+test; MAX_ITER only because the relay ran the full backend suite which times out (1800s), not a code fault. Targeted test (4 passed) + ruff + repe-lint green; verified by hand. Stray run_checks.* removed.
+- Environment: Business OS / Sustainability
+- Risk: Medium (new backend service; read-only)
+- Scope: Add the single governed reader for sustainability authoritative metrics. One ticket (T4 from plan 0018).
+- Master plan: `docs/plans/03-implementation-plans/active/0018-sustainability-tool-planning.md`
+- Depends on: T3 (schema `618_sus_authoritative.sql`, merged + applied). ADR 0001 decision 5.
+
+## Background
+
+T4 from plan 0018: add `backend/app/services/re_sustainability_authoritative.py` mirroring `backend/app/services/re_authoritative_snapshots.py`, with a single `get_authoritative_state` entry point. Every sustainability metric read goes through this reader (the single-fetch-layer principle from the authoritative-state contract). It reads the T3 tables `sus_authoritative_snapshots` / `sus_authoritative_metric_value` / `sus_authoritative_evidence`.
+
+The contract to mirror is `re_authoritative_snapshots.get_authoritative_state`, whose released-read return dict carries: `entity_*`, `requested_*`, `period_exact`, `state_origin`, `snapshot_version`, `promotion_state`, `trust_status`, `null_reason` (None when found), a `state` block with `canonical_metrics`/`display_metrics`, plus `null_reasons`, `formulas`, `provenance`. When no released row exists it returns a missing-state dict with a `null_reason`.
+
+Fail-closed vocabulary is already defined (T2, merged): `snapshot_unavailable`, `data_not_ingested`, `emission_factor_missing`, `metric_definition_missing`, `out_of_certified_scope`.
+
+## Scope
+
+In scope: create `backend/app/services/re_sustainability_authoritative.py` with:
+- A single public entry point `get_authoritative_state(*, business_id, env_id, entity_scope, period_key, metric_family, snapshot_version=None) -> dict[str, Any]`.
+- It selects the latest matching row from `sus_authoritative_snapshots`, defaulting to `promotion_state = 'released'` when no explicit `snapshot_version` is given (mirroring the REPE reader's released-default behavior). It reads via `app.db.get_cursor` like the sibling sustainability services.
+- On a hit it returns a dict mirroring the REPE reader's shape: `entity_scope`, `period_key`, `requested_period_key`, `period_exact`, `state_origin: "authoritative"`, `snapshot_version`, `promotion_state`, `trust_status`, `null_reason: None`, a `metrics` list built from `sus_authoritative_metric_value` (each item: `metric_key`, `value` (numeric or None), `unit`, `null_reason`, `trust_status`), and an `evidence` list built from `sus_authoritative_evidence` (each: `metric_key`, `source_table`, `source_row_ref`, `emission_factor_set_id`, `ingestion_run_id`, `formula_id`).
+- On a miss it returns `{... null_reason: "snapshot_unavailable", metrics: [], evidence: [], state_origin: "authoritative", trust_status: "missing_source"}` - never raises, never fabricates.
+- Fail-closed rule: a metric value row whose `value_numeric` is NULL is returned with `value: None` and its stored `null_reason`; the reader never substitutes zero for a missing value.
+- A helper `get_metric(*, business_id, env_id, entity_scope, period_key, metric_family, metric_key, snapshot_version=None) -> dict` that returns a single metric's `{value, unit, null_reason, trust_status, snapshot_version, state_origin}`, returning `null_reason: "metric_definition_missing"` when the metric_key is absent from the released snapshot's value rows.
+
+Out of scope (explicit):
+- Any route/endpoint (T5), UI (T7), metric-registry entry (T6), AI wiring (T10), or intake/write path.
+- Any change to the schema, to `re_authoritative_snapshots.py`, or to any existing service.
+- Writing/releasing snapshots (a later ticket owns the write side).
+
+## Acceptance Criteria
+
+### Screen
+Not applicable.
+
+### API
+- Not applicable in this ticket (no route). The service is importable and callable: `from app.services import re_sustainability_authoritative` exposes `get_authoritative_state` and `get_metric`.
+
+### DB/Data
+- The reader queries `sus_authoritative_snapshots`, `sus_authoritative_metric_value`, and `sus_authoritative_evidence` and defaults to `promotion_state = 'released'` when no `snapshot_version` is supplied. It performs no writes (SELECT only).
+
+### AI behavior
+- Fail-closed is enforced in the reader: a missing released snapshot yields `null_reason: "snapshot_unavailable"`; a NULL metric value yields `value: None` plus its `null_reason` (never 0); an absent metric_key in `get_metric` yields `null_reason: "metric_definition_missing"`. No path returns a fabricated number.
+
+### Evals/tests
+- A new test file `backend/tests/test_re_sustainability_authoritative.py` covers, with `get_cursor` monkeypatched to a fake cursor returning canned rows (no real DB): (1) a released snapshot returns `state_origin: "authoritative"`, `trust_status`, and the metric list; (2) no released row returns `null_reason: "snapshot_unavailable"` with empty `metrics` and no exception; (3) a metric value row with NULL `value_numeric` returns `value: None` and its `null_reason`, never 0; (4) `get_metric` for an unknown key returns `null_reason: "metric_definition_missing"`.
+- `cd backend && python -m ruff check app tests` and `python -m pytest tests/test_re_sustainability_authoritative.py -q` pass.
+
+### Regression guard
+- Only `backend/app/services/re_sustainability_authoritative.py`, `backend/tests/test_re_sustainability_authoritative.py`, and this plan are added/changed. No existing service, route, schema, or frontend file is modified.
+- The reader is read-only: the diff contains no INSERT/UPDATE/DELETE against the `sus_authoritative_*` tables.


### PR DESCRIPTION
## Ticket
T4 from plan 0018 - the single governed reader every sustainability metric read goes through (single-fetch-layer principle), mirroring `re_authoritative_snapshots.get_authoritative_state` over the T3 tables.

## Change
New `backend/app/services/re_sustainability_authoritative.py`:
- `get_authoritative_state(*, business_id, env_id, entity_scope, period_key, metric_family, snapshot_version=None)` - selects the latest `sus_authoritative_snapshots` row (defaults to `promotion_state='released'`), joins `sus_authoritative_metric_value` + `sus_authoritative_evidence`. Returns the REPE-shaped contract (`state_origin`, `snapshot_version`, `promotion_state`, `trust_status`, `period_exact`, `null_reason`, `metrics[]`, `evidence[]`).
- `get_metric(...)` - single metric lookup.
- **Read-only** (SELECT only); no writes.

## Fail-closed (uses the T2 vocabulary)
- no released snapshot -> `null_reason: "snapshot_unavailable"`, `trust_status: "missing_source"`
- NULL metric value -> `value: None` + stored `null_reason` (never 0)
- unknown `metric_key` -> `null_reason: "metric_definition_missing"`

## Relay note (MAX_ITER was infra, not the code)
The relay ended at MAX_ITER because it runs the **entire** backend suite (`pytest tests`, ~5000 tests, many DB-bound) which **times out at 1800s** in the worktree - `exit 124` each iteration. Ruff + the REPE state-lock lint passed, Codex reviewed the diff as in-scope, and the **targeted test passes (4 passed in 0.82s)** covering: released->authoritative, no-snapshot->snapshot_unavailable, NULL value->None-not-0, unknown-key->metric_definition_missing. Verified by hand; two stray `run_checks.*` files the builder added to dodge the timeout were removed so the diff is service + test + plan only.

## Tests
`cd backend && python -m pytest tests/test_re_sustainability_authoritative.py -q` -> 4 passed. Ruff clean. (CI's Backend Lint runs the full suite properly, without the worktree timeout.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)