### PR TITLE
feat(orchestration): make the Coding Relay portable across repositories

### DIFF
--- a/backend/tests/test_orchestration_relay_config.py
+++ b/backend/tests/test_orchestration_relay_config.py
@@ -1,0 +1,182 @@
+"""Config layer for the Coding Relay: defaults, overrides, and portability.
+
+The relay ships defaults that reproduce THIS repo exactly, so a checkout with
+no relay.config.json behaves as it always has. A different repo drops in a
+relay.config.json to describe its own layout. These tests pin both halves: the
+defaults must not drift, and an override must actually take effect.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestration.coding_relay.config import (  # noqa: E402
+    CONFIG_FILENAME,
+    RelayConfig,
+    default_config,
+    load_config,
+    merge_config,
+    venv_rel_from,
+    write_starter_config,
+)
+from orchestration.coding_relay.test_runner import infer_suites  # noqa: E402
+
+
+# --- defaults must reproduce this repo -----------------------------------
+
+def test_defaults_reproduce_this_repo():
+    cfg = default_config()
+    assert cfg.plan_dir == "docs/plans/03-implementation-plans/active"
+    assert cfg.base_ref == "origin/main"
+    assert "repo-b/db/schema/" in cfg.migration_prefixes
+    assert "supabase/" in cfg.migration_prefixes
+    assert "backend/" in cfg.auth_prefixes
+    assert "repo-b/node_modules" in cfg.dep_links
+    assert "backend/.venv" in cfg.dep_links
+    assert cfg.test_suites, "default test_suites must not be empty"
+
+
+def test_venv_rel_picks_the_venv_dep_link():
+    assert venv_rel_from(default_config()) == "backend/.venv"
+    # A repo with no .venv dep link falls back to the supplied default.
+    cfg = RelayConfig(dep_links=["web/node_modules"])
+    assert venv_rel_from(cfg, default="x/.venv") == "x/.venv"
+
+
+# --- override behavior ----------------------------------------------------
+
+def test_partial_override_leaves_other_keys_at_default():
+    cfg = merge_config({"plan_dir": "docs/plans", "base_ref": "origin/trunk"})
+    assert cfg.plan_dir == "docs/plans"
+    assert cfg.base_ref == "origin/trunk"
+    # untouched keys keep their defaults
+    assert cfg.migration_prefixes == default_config().migration_prefixes
+    assert cfg.test_suites == default_config().test_suites
+
+
+def test_unknown_key_fails_loudly():
+    with pytest.raises(ValueError) as exc:
+        merge_config({"plan_directory": "docs/plans"})
+    assert "plan_directory" in str(exc.value)
+
+
+def test_load_config_returns_defaults_when_no_file(tmp_path):
+    assert load_config(tmp_path) == default_config()
+
+
+def test_load_config_reads_a_foreign_repo_config(tmp_path):
+    """A different repo describes its own layout and the relay honors it."""
+    (tmp_path / CONFIG_FILENAME).write_text(
+        json.dumps(
+            {
+                "plan_dir": "planning/tickets",
+                "base_ref": "origin/develop",
+                "migration_prefixes": ["db/migrate/"],
+                "dep_links": ["web/node_modules"],
+                "test_suites": [
+                    {
+                        "when_touched": "web/",
+                        "name": "web-test",
+                        "cwd": "web",
+                        "cmd": ["npm", "test"],
+                        "timeout": 600,
+                        "runner": "npm",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = load_config(tmp_path)
+    assert cfg.plan_dir == "planning/tickets"
+    assert cfg.base_ref == "origin/develop"
+    assert cfg.migration_prefixes == ["db/migrate/"]
+    assert cfg.dep_links == ["web/node_modules"]
+    assert len(cfg.test_suites) == 1
+    assert cfg.test_suites[0]["name"] == "web-test"
+    # keys the foreign config did not name stay at the defaults
+    assert cfg.auth_prefixes == default_config().auth_prefixes
+
+
+def test_malformed_config_raises_rather_than_silently_defaulting(tmp_path):
+    (tmp_path / CONFIG_FILENAME).write_text("{not json", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_config(tmp_path)
+
+
+# --- suite inference is driven by config, and defaults are unchanged ------
+
+def _names(touched: list[str], cfg: RelayConfig | None = None) -> set[str]:
+    # A real interpreter path so the `{py}` slot resolves and python suites are
+    # emitted rather than honestly skipped.
+    return {s.name for s in infer_suites(touched, sys.executable, config=cfg)}
+
+
+def test_default_suite_inference_matches_this_repo():
+    # backend change -> ruff + pytest + the repe state-lock lint
+    backend = _names(["backend/app/services/x.py"])
+    assert "backend-ruff" in backend
+    assert "backend-pytest" in backend
+    assert "repe-lint" in backend
+
+    # frontend change -> npm suites + the repe lint
+    frontend = _names(["repo-b/src/app/page.tsx"])
+    assert {"frontend-lint", "frontend-typecheck", "frontend-unit"} <= frontend
+    assert "repe-lint" in frontend
+
+    # rs_factory_seed -> its own pytest
+    assert "rs-factory-pytest" in _names(["rs_factory_seed/gen.py"])
+
+    # verification/ alone still triggers the repe lint
+    assert "repe-lint" in _names(["verification/lint/x.py"])
+
+
+def test_paths_outside_the_config_run_no_suites():
+    assert _names(["docs/plans/x.md"]) == set()
+
+
+def test_a_foreign_config_drives_its_own_suites():
+    cfg = RelayConfig(
+        test_suites=[
+            {
+                "when_touched": "web/",
+                "name": "web-test",
+                "cwd": "web",
+                "cmd": ["npm", "test"],
+                "timeout": 600,
+                "runner": "npm",
+            }
+        ]
+    )
+    assert _names(["web/src/index.ts"], cfg) == {"web-test"}
+    # this repo's paths mean nothing to a foreign config
+    assert _names(["backend/app/x.py"], cfg) == set()
+
+
+# --- init-config ----------------------------------------------------------
+
+def test_write_starter_config_writes_defaults_and_refuses_overwrite(tmp_path):
+    path = write_starter_config(tmp_path)
+    assert path.is_file()
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert written["plan_dir"] == default_config().plan_dir
+    assert written["test_suites"] == default_config().test_suites
+
+    with pytest.raises(FileExistsError):
+        write_starter_config(tmp_path)
+
+    # force overwrites
+    path2 = write_starter_config(tmp_path, force=True)
+    assert path2 == path
+
+
+def test_starter_config_round_trips_through_load(tmp_path):
+    write_starter_config(tmp_path)
+    assert load_config(tmp_path) == default_config()

--- a/docs/reference/CODING_RELAY.md
+++ b/docs/reference/CODING_RELAY.md
@@ -310,6 +310,55 @@ checkpoint without risking a real diff.
    judge from the diff and bundle; run-level or provenance criteria the
    bundle cannot evidence come back `unknown` and hold the run at MAX_ITER.
 
+## Using it in another repository
+
+The relay ships defaults that describe THIS repo. A checkout with no config
+file behaves exactly as it always has. To run it somewhere else, drop a
+`relay.config.json` at that repo's root and the relay reads its layout from
+there instead.
+
+```
+python -m orchestration.coding_relay --init-config    # writes a starter file
+python -m orchestration.coding_relay --init-config --force   # overwrite
+```
+
+Copy `orchestration/coding_relay/` into the target repo, run `--init-config`,
+then edit the six keys:
+
+| Key | What it names | Default (this repo) |
+|---|---|---|
+| `plan_dir` | Where active plans live, for `--plan NNNN` and the guided menu | `docs/plans/03-implementation-plans/active` |
+| `base_ref` | Branch the relay worktree is cut from | `origin/main` |
+| `test_suites` | Changed-path -> test-command rules (below) | repo-b npm suites, backend ruff+pytest, rs_factory_seed pytest, the repe lint |
+| `migration_prefixes` | Paths that require `--allow-migrations` | `supabase/`, `repo-b/db/schema/`, `migrations/` |
+| `auth_prefixes` | Paths whose edits escalate as an auth surface | `backend/`, `repo-b/` |
+| `dep_links` | Dirs junctioned into the worktree so suites can run | `repo-b/node_modules`, `backend/.venv` |
+
+A `test_suites` rule fires when any changed path starts with `when_touched`
+(or any prefix in `when_touched_any`). `{py}` in a command is replaced with
+the resolved interpreter; when none resolves, that suite is SKIPPED honestly
+rather than reported as passing.
+
+```json
+{
+  "plan_dir": "planning/tickets",
+  "base_ref": "origin/develop",
+  "test_suites": [
+    {"when_touched": "web/", "name": "web-test", "cwd": "web",
+     "cmd": ["npm", "test"], "timeout": 600, "runner": "npm"},
+    {"when_touched": "api/", "name": "api-pytest", "cwd": "api",
+     "cmd": ["{py}", "-m", "pytest", "-q"], "timeout": 900, "runner": "python"}
+  ],
+  "migration_prefixes": ["db/migrate/"],
+  "dep_links": ["web/node_modules"]
+}
+```
+
+An unknown key, or a malformed file, fails loudly with the offending name. A
+config that cannot be read is never silently ignored. The `claude` and `codex`
+CLIs still have to be installed and authenticated in that environment, and the
+plan still needs an acceptance-criteria heading.
+
 ## Known limitations (PR 1)
 
 - Test inference covers the four basic suite groups only.

--- a/orchestration/coding_relay/__main__.py
+++ b/orchestration/coding_relay/__main__.py
@@ -18,6 +18,12 @@ import sys
 from pathlib import Path
 
 from orchestration.coding_relay import RELAY_VERSION, intake as intake_mod
+from orchestration.coding_relay.config import (
+    CONFIG_FILENAME,
+    load_config,
+    venv_rel_from,
+    write_starter_config,
+)
 from orchestration.coding_relay.intake import IntakeError
 from orchestration.coding_relay.loop import (
     LoopConfig,
@@ -55,7 +61,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--yes", action="store_true",
                    help="Guided mode: accept prompts non-interactively (never bypasses hard failures)")
     p.add_argument("--max-iterations", type=int, default=3, help="Build/review iterations cap (default 3)")
-    p.add_argument("--base", default="origin/main", help="Base ref for the relay worktree (default origin/main)")
+    p.add_argument("--base", default=None,
+                   help="Base ref for the relay worktree (default: relay.config.json base_ref, else origin/main)")
+    p.add_argument("--init-config", action="store_true",
+                   help=f"Write a starter {CONFIG_FILENAME} (the defaults) to the repo root and exit")
+    p.add_argument("--force", action="store_true",
+                   help=f"With --init-config: overwrite an existing {CONFIG_FILENAME}")
     p.add_argument("--allow-stale-base", action="store_true", help="Proceed on the local base ref if git fetch fails (recorded)")
     p.add_argument("--worktree-root", type=Path, help="Directory for relay worktrees (default: sibling <repo>_relay)")
     p.add_argument("--claude-model", help="Builder model; passed only if the installed CLI advertises --model")
@@ -85,14 +96,14 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
-def print_no_args_help(repo_root: Path) -> int:
+def print_no_args_help(repo_root: Path, plan_dir: str = "docs/plans/03-implementation-plans/active") -> int:
     print("Coding Relay: give it a plan with explicit success criteria.\n")
     print("Usage:  python -m orchestration.coding_relay --plan <path|NNNN>")
     print("        python scripts/coding_relay.py --plan <path|NNNN>")
     print("        python scripts/coding_relay.py          (guided mode, TTY)\n")
-    plans = intake_mod.list_active_plans(repo_root)
+    plans = intake_mod.list_active_plans(repo_root, plan_dir)
     if plans:
-        print("Active plans (docs/plans/03-implementation-plans/active/):")
+        print(f"Active plans ({plan_dir}/):")
         for i, p in enumerate(plans, 1):
             print(f"  {i:2d}. {p.name}")
         print("\nExample:")
@@ -105,7 +116,21 @@ def print_no_args_help(repo_root: Path) -> int:
     return 2
 
 
+def _relay_config(args):
+    """The repo's RelayConfig. Present on args after main() loads it; this
+    fallback covers direct callers of execute_run/run_guided (the guided
+    tests build args with parse_args and skip main())."""
+    cfg = getattr(args, "relay_config", None)
+    if cfg is None:
+        cfg = load_config(args.repo_root.resolve())
+        args.relay_config = cfg
+    if getattr(args, "base", None) is None:
+        args.base = cfg.base_ref
+    return cfg
+
+
 def _preflight_config(args, result, read_only: bool = False) -> PreflightConfig:
+    cfg = _relay_config(args)
     return PreflightConfig(
         repo_root=args.repo_root.resolve(),
         base_ref=args.base,
@@ -116,6 +141,7 @@ def _preflight_config(args, result, read_only: bool = False) -> PreflightConfig:
         fixture_mode=args.fixture is not None,
         fixture_dir=args.fixture,
         read_only=read_only,
+        venv_rel=venv_rel_from(cfg),
     )
 
 
@@ -233,7 +259,7 @@ def execute_run(args, result, ui) -> int:
         run_paths.update_run_json(state="ERROR", detail=str(exc), exit_code=6)
         return 6
     ui.notify(f"[worktree] {wt.path} (branch {wt.branch}, base {wt.base_sha[:12]})")
-    links = ensure_deps_links(repo_root, wt)
+    links = ensure_deps_links(repo_root, wt, _relay_config(args).dep_links)
     for name, detail in links.items():
         ui.notify(f"[worktree] deps {name}: {detail}")
     run_paths.update_run_json(branch=wt.branch, worktree=str(wt.path), base_sha=wt.base_sha)
@@ -293,6 +319,7 @@ def execute_run(args, result, ui) -> int:
         codex_max_effort=args.codex_max_effort,
         codex_repo_access=args.codex_repo_access,
         primary_root=repo_root,
+        relay_config=_relay_config(args),
     )
     try:
         outcome = run_loop(
@@ -406,16 +433,37 @@ def main(argv: list | None = None) -> int:
     args = parser.parse_args(argv)
     repo_root: Path = args.repo_root.resolve()
 
+    if args.init_config:
+        try:
+            path = write_starter_config(repo_root, force=args.force)
+        except FileExistsError as exc:
+            print(f"[init-config] {exc}", file=sys.stderr)
+            return 2
+        print(f"[init-config] wrote {path}")
+        return 0
+
+    # Load the repo's config once. base_ref falls back to the config value
+    # (itself origin/main by default) when the operator did not pass --base.
+    try:
+        args.relay_config = load_config(repo_root)
+    except ValueError as exc:
+        print(f"[config] {exc}", file=sys.stderr)
+        return 2
+    if args.base is None:
+        args.base = args.relay_config.base_ref
+
     from orchestration.coding_relay import guided
 
     if not args.plan and not args.paste_file:
         if guided.stdin_is_tty() and not args.dry_run:
             return guided.run_guided(args)
-        return print_no_args_help(repo_root)
+        return print_no_args_help(repo_root, args.relay_config.plan_dir)
 
     # ---- INTAKE (exit 2 on refusal)
     try:
-        result = intake_mod.load_plan(repo_root, args.plan, args.paste_file)
+        result = intake_mod.load_plan(
+            repo_root, args.plan, args.paste_file, args.relay_config.plan_dir
+        )
     except IntakeError as exc:
         print(f"[intake] REFUSED: {exc}", file=sys.stderr)
         return 2

--- a/orchestration/coding_relay/config.py
+++ b/orchestration/coding_relay/config.py
@@ -1,0 +1,199 @@
+"""Per-repository relay configuration.
+
+One copy of the relay serves many repositories. Everything repo-specific
+lives here as data, not code: where plans live, the base ref, which path
+prefixes are DB or auth surfaces, which dependency dirs to junction into a
+worktree, and which test suites to infer from changed paths.
+
+The defaults reproduce THIS repo's behavior exactly. A repository that wants
+different behavior drops a `relay.config.json` at its root; `load_config`
+merges that partial JSON over the defaults. With no config file present the
+relay behaves as it always has.
+
+Stdlib only. No file at rest carries anything repo-specific except the JSON
+a downstream repo writes for itself.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field, fields
+from pathlib import Path
+
+CONFIG_FILENAME = "relay.config.json"
+
+# The interpreter placeholder in a suite command. run_suites substitutes the
+# resolved backend/PATH interpreter for it; an empty resolution leaves the
+# slot empty so the suite is SKIPPED honestly instead of failing with a 127.
+PY_PLACEHOLDER = "{py}"
+
+
+def _default_test_suites() -> list[dict]:
+    """The suite catalog that reproduces the old infer_suites if-ladder.
+
+    Each rule fires when any changed path starts with `when_touched`. The
+    repe-lint rule uses `when_touched_any` (an OR over several prefixes)
+    because it triggers on backend OR repo-b OR verification changes. Order
+    is preserved: suites append in this list's order, matching the old
+    ladder (backend, then repo-b, then rs_factory_seed, then repe-lint).
+    """
+    return [
+        {
+            "when_touched": "backend/",
+            "name": "backend-ruff",
+            "cwd": "backend",
+            "cmd": [PY_PLACEHOLDER, "-m", "ruff", "check", "app", "tests"],
+            "timeout": 600,
+            "runner": "python",
+        },
+        {
+            "when_touched": "backend/",
+            "name": "backend-pytest",
+            "cwd": "backend",
+            "cmd": [PY_PLACEHOLDER, "-m", "pytest", "tests", "-q"],
+            "timeout": 1800,
+            "runner": "python",
+        },
+        {
+            "when_touched": "repo-b/",
+            "name": "frontend-lint",
+            "cwd": "repo-b",
+            "cmd": ["npm", "run", "lint"],
+            "timeout": 900,
+            "runner": "npm",
+        },
+        {
+            "when_touched": "repo-b/",
+            "name": "frontend-typecheck",
+            "cwd": "repo-b",
+            "cmd": ["npm", "run", "typecheck"],
+            "timeout": 900,
+            "runner": "npm",
+        },
+        {
+            "when_touched": "repo-b/",
+            "name": "frontend-unit",
+            "cwd": "repo-b",
+            "cmd": ["npm", "run", "test:unit"],
+            "timeout": 900,
+            "runner": "npm",
+        },
+        {
+            "when_touched": "rs_factory_seed/",
+            "name": "rs-factory-pytest",
+            "cwd": "rs_factory_seed",
+            "cmd": [PY_PLACEHOLDER, "-m", "pytest", "tests", "-q"],
+            "timeout": 900,
+            "runner": "python",
+        },
+        {
+            "when_touched_any": ["backend/", "repo-b/", "verification/"],
+            "name": "repe-lint",
+            "cwd": ".",
+            "cmd": [PY_PLACEHOLDER, "-m", "verification.lint.no_legacy_repe_reads", "--json"],
+            "timeout": 300,
+            "runner": "python",
+        },
+    ]
+
+
+@dataclass
+class RelayConfig:
+    """Everything the relay needs to know about the repository it runs in.
+
+    Defaults reproduce this repo. `test_suites` entries are dicts with the
+    shape documented in `_default_test_suites`; a rule matches on either
+    `when_touched` (single prefix) or `when_touched_any` (list of prefixes).
+    """
+
+    plan_dir: str = "docs/plans/03-implementation-plans/active"
+    base_ref: str = "origin/main"
+    migration_prefixes: list[str] = field(
+        default_factory=lambda: ["supabase/", "repo-b/db/schema/", "migrations/"]
+    )
+    auth_prefixes: list[str] = field(
+        default_factory=lambda: ["backend/", "repo-b/"]
+    )
+    dep_links: list[str] = field(
+        default_factory=lambda: ["repo-b/node_modules", "backend/.venv"]
+    )
+    test_suites: list[dict] = field(default_factory=_default_test_suites)
+
+
+def default_config() -> RelayConfig:
+    return RelayConfig()
+
+
+def venv_rel_from(cfg: RelayConfig, default: str = "backend/.venv") -> str:
+    """The dep_links entry that names a virtualenv (ends in `.venv`), used to
+    resolve the backend interpreter. Falls back to `default` if none match."""
+    for rel in cfg.dep_links:
+        if str(rel).replace("\\", "/").rstrip("/").endswith(".venv"):
+            return rel
+    return default
+
+
+def config_to_dict(cfg: RelayConfig) -> dict:
+    """Serialize a config back to the JSON shape --init-config writes."""
+    return asdict(cfg)
+
+
+def _known_keys() -> set[str]:
+    return {f.name for f in fields(RelayConfig)}
+
+
+def merge_config(overrides: dict) -> RelayConfig:
+    """Build a config from defaults, replacing only the keys `overrides`
+    names. Any unknown key raises a clear error naming it, so a typo in a
+    repo's relay.config.json fails loudly instead of silently doing nothing.
+    """
+    if not isinstance(overrides, dict):
+        raise ValueError(
+            f"{CONFIG_FILENAME} must contain a JSON object, got {type(overrides).__name__}."
+        )
+    known = _known_keys()
+    unknown = sorted(k for k in overrides if k not in known)
+    if unknown:
+        raise ValueError(
+            f"{CONFIG_FILENAME} has unknown key(s): {', '.join(unknown)}. "
+            f"Allowed keys: {', '.join(sorted(known))}."
+        )
+    base = default_config()
+    for key, value in overrides.items():
+        setattr(base, key, value)
+    return base
+
+
+def load_config(repo_root: Path) -> RelayConfig:
+    """Return the repo's RelayConfig.
+
+    Reads `<repo_root>/relay.config.json` when present and merges it over the
+    defaults; otherwise returns the defaults unchanged. A malformed JSON file
+    raises ValueError with the path, rather than silently falling back to
+    defaults (a config that cannot be read must not be ignored).
+    """
+    path = repo_root / CONFIG_FILENAME
+    if not path.is_file():
+        return default_config()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not read {path}: {exc}") from exc
+    return merge_config(raw)
+
+
+def write_starter_config(repo_root: Path, force: bool = False) -> Path:
+    """Write the defaults to `<repo_root>/relay.config.json`, pretty-printed.
+
+    Refuses to overwrite an existing file unless `force` is set. Returns the
+    path written.
+    """
+    path = repo_root / CONFIG_FILENAME
+    if path.exists() and not force:
+        raise FileExistsError(
+            f"{path} already exists. Pass --force to overwrite it."
+        )
+    path.write_text(
+        json.dumps(config_to_dict(default_config()), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return path

--- a/orchestration/coding_relay/guided.py
+++ b/orchestration/coding_relay/guided.py
@@ -60,10 +60,10 @@ def safe_print(text: str = "") -> None:
 
 # ---------------------------------------------------------------- plan menu
 
-def plan_menu_entries(repo_root: Path) -> list:
+def plan_menu_entries(repo_root: Path, plan_dir: str | None = None) -> list:
     """(path, title, status) per active plan; robust to unparseable files."""
     entries = []
-    for path in intake_mod.list_active_plans(repo_root):
+    for path in intake_mod.list_active_plans(repo_root, plan_dir):
         title, status = "", ""
         try:
             for line in path.read_text(encoding="utf-8", errors="replace").splitlines()[:40]:

--- a/orchestration/coding_relay/intake.py
+++ b/orchestration/coding_relay/intake.py
@@ -161,20 +161,23 @@ class IntakeResult:
     criteria: AcceptanceCriteria = field(repr=False, default=None)  # type: ignore[assignment]
 
 
-def list_active_plans(repo_root: Path) -> list[Path]:
-    active = repo_root / ACTIVE_PLANS_REL
+def list_active_plans(repo_root: Path, plan_dir: str | Path | None = None) -> list[Path]:
+    active = repo_root / (plan_dir if plan_dir is not None else ACTIVE_PLANS_REL)
     if not active.is_dir():
         return []
     return sorted(p for p in active.glob("*.md") if p.is_file())
 
 
-def resolve_plan_path(repo_root: Path, plan_arg: str) -> Path:
-    """Resolve --plan as a path, or as a filename prefix in the active dir."""
+def resolve_plan_path(
+    repo_root: Path, plan_arg: str, plan_dir: str | Path | None = None
+) -> Path:
+    """Resolve --plan as a path, or as a filename prefix in the plans dir."""
+    rel = plan_dir if plan_dir is not None else ACTIVE_PLANS_REL
     direct = Path(plan_arg)
     for candidate in (direct, repo_root / plan_arg):
         if candidate.is_file():
             return candidate.resolve()
-    matches = [p for p in list_active_plans(repo_root) if p.name.startswith(plan_arg)]
+    matches = [p for p in list_active_plans(repo_root, rel) if p.name.startswith(plan_arg)]
     if len(matches) == 1:
         return matches[0]
     if len(matches) > 1:
@@ -182,7 +185,7 @@ def resolve_plan_path(repo_root: Path, plan_arg: str) -> Path:
         raise IntakeError(f"--plan {plan_arg!r} is ambiguous in the active plans dir: {names}")
     raise IntakeError(
         f"--plan {plan_arg!r} is neither a file nor a unique prefix in "
-        f"{ACTIVE_PLANS_REL}. Run with no arguments to list active plans."
+        f"{rel}. Run with no arguments to list active plans."
     )
 
 
@@ -308,6 +311,7 @@ def load_plan(
     repo_root: Path,
     plan_arg: str | None,
     paste_file: str | None,
+    plan_dir: str | Path | None = None,
 ) -> IntakeResult:
     """Load and validate the plan from --plan or --paste-file."""
     from orchestration.coding_relay.runs import safe_slug
@@ -322,7 +326,7 @@ def load_plan(
         plan_text = p.read_text(encoding="utf-8", errors="replace")
         fallback = p.stem
     elif plan_arg:
-        plan_path = resolve_plan_path(repo_root, plan_arg)
+        plan_path = resolve_plan_path(repo_root, plan_arg, plan_dir)
         plan_text = plan_path.read_text(encoding="utf-8", errors="replace")
         fallback = plan_path.stem
     else:

--- a/orchestration/coding_relay/loop.py
+++ b/orchestration/coding_relay/loop.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Callable, Optional
 
 from orchestration.coding_relay import prompts, safety, test_runner, verdict as verdict_mod
+from orchestration.coding_relay.config import RelayConfig, default_config, venv_rel_from
 from orchestration.coding_relay.intake import IntakeResult
 from orchestration.coding_relay.providers import AdapterResult
 from orchestration.coding_relay.runs import RunPaths
@@ -50,6 +51,7 @@ class LoopConfig:
     codex_max_effort: str = "medium"
     codex_repo_access: bool = False  # changes bundle wording only
     primary_root: Optional[Path] = None  # for venv resolution
+    relay_config: RelayConfig = field(default_factory=default_config)
 
 
 @dataclass
@@ -290,6 +292,8 @@ def run_loop(
             wt.path, snapshot, intake.plan_text,
             allow_migrations=cfg.allow_migrations,
             allow_relay_self_edit=cfg.allow_relay_self_edit,
+            migration_prefixes=cfg.relay_config.migration_prefixes,
+            auth_prefixes=cfg.relay_config.auth_prefixes,
         )
         if head_moved(wt.path, wt.base_sha):
             violations.append(
@@ -321,8 +325,10 @@ def run_loop(
         # ---- TEST
         test_results: list = []
         if cfg.run_tests and snapshot.changed_paths:
-            py, py_desc = test_runner.resolve_python(wt.path, cfg.primary_root)
-            suites = test_runner.infer_suites(snapshot.changed_paths, py)
+            py, py_desc = test_runner.resolve_python(
+                wt.path, cfg.primary_root, venv_rel_from(cfg.relay_config),
+            )
+            suites = test_runner.infer_suites(snapshot.changed_paths, py, cfg.relay_config)
             if suites:
                 log(f"[iteration {iteration}] TEST ({len(suites)} suites)")
             test_results = test_runner.run_suites(

--- a/orchestration/coding_relay/preflight.py
+++ b/orchestration/coding_relay/preflight.py
@@ -37,6 +37,10 @@ class PreflightConfig:
     fixture_mode: bool = False  # fixture runs skip the CLI checks
     fixture_dir: Path | None = None  # validated before any mutation
     read_only: bool = False  # strict --dry-run: no fetch, no write probes
+    # Relative path of the backend virtualenv to probe (from RelayConfig's
+    # dep_links). Defaults to this repo's backend venv. A repo without a
+    # Python backend can point this elsewhere or ignore the resulting warning.
+    venv_rel: str = "backend/.venv"
 
 
 @dataclass
@@ -178,12 +182,12 @@ def run_preflight(cfg: PreflightConfig) -> PreflightResult:
     for name in ("node", "npm"):
         r.add(f"{name}", OK if shutil.which(name) else WARN,
               shutil.which(name) or f"{name} not on PATH; frontend suites will be skipped honestly")
-    venv = root / "backend" / ".venv"
+    venv = root / cfg.venv_rel
     r.add(
         "backend-venv",
         OK if venv.is_dir() else WARN,
         str(venv) if venv.is_dir() else
-        "backend/.venv not found; backend suites use the PATH interpreter (recorded)",
+        f"{cfg.venv_rel} not found; backend suites use the PATH interpreter (recorded)",
     )
 
     # Plan path (when given as a file).

--- a/orchestration/coding_relay/safety.py
+++ b/orchestration/coding_relay/safety.py
@@ -67,7 +67,13 @@ def scan(
     plan_text: str,
     allow_migrations: bool = False,
     allow_relay_self_edit: bool = False,
+    migration_prefixes: tuple | list | None = None,
+    auth_prefixes: tuple | list | None = None,
 ) -> list:
+    # Fall back to this repo's constants when a caller passes no config, so
+    # existing call sites keep byte-identical behavior.
+    mig_prefixes = tuple(migration_prefixes) if migration_prefixes is not None else DB_MIGRATION_PREFIXES
+    surf_prefixes = tuple(auth_prefixes) if auth_prefixes is not None else AUTH_SURFACE_PREFIXES
     violations: list = []
     paths = [p.replace("\\", "/") for p in snapshot.changed_paths]
 
@@ -118,7 +124,7 @@ def scan(
         )
 
     # db_migration (stop unless --allow-migrations).
-    db_paths = [p for p in paths if p.startswith(DB_MIGRATION_PREFIXES) or "/migrations/" in p]
+    db_paths = [p for p in paths if p.startswith(mig_prefixes) or "/migrations/" in p]
     if db_paths and not allow_migrations:
         violations.append(
             Violation(
@@ -165,7 +171,7 @@ def scan(
     # auth_security (escalate).
     auth = [
         p for p in paths
-        if p.startswith(AUTH_SURFACE_PREFIXES) and AUTH_PATH_RE.search(p)
+        if p.startswith(surf_prefixes) and AUTH_PATH_RE.search(p)
     ]
     if auth:
         violations.append(

--- a/orchestration/coding_relay/test_runner.py
+++ b/orchestration/coding_relay/test_runner.py
@@ -60,14 +60,17 @@ class SuiteResult:
         }
 
 
-def resolve_python(worktree: Path, primary_root: Path | None) -> tuple[str | None, str]:
+def resolve_python(
+    worktree: Path, primary_root: Path | None, venv_rel: str = "backend/.venv"
+) -> tuple[str | None, str]:
     """Prefer a backend venv (worktree, then primary checkout), else PATH.
-    Returns (interpreter or None, description)."""
+    Returns (interpreter or None, description). `venv_rel` is the venv path
+    relative to a checkout root, from RelayConfig's dep_links."""
     candidates = []
     for root in (worktree, primary_root):
         if root is None:
             continue
-        venv = root / "backend" / ".venv"
+        venv = root / venv_rel
         candidates.append(venv / "Scripts" / "python.exe")
         candidates.append(venv / "bin" / "python")
     for c in candidates:
@@ -79,29 +82,51 @@ def resolve_python(worktree: Path, primary_root: Path | None) -> tuple[str | Non
     return None, "no python interpreter available"
 
 
-def infer_suites(changed_paths: list, python_exe: str | None) -> list:
-    """Changed paths -> suites, matching CI's canonical commands.
+def infer_suites(changed_paths: list, python_exe: str | None, config=None) -> list:
+    """Changed paths -> suites, driven by `config.test_suites`.
 
-    When no interpreter was resolved, python suites keep an empty command[0]
-    so run_suites SKIPS them honestly instead of failing with a bogus 127.
+    Each rule fires when any changed path starts with its `when_touched`
+    prefix (or any prefix in `when_touched_any`). The `{py}` placeholder in a
+    command is replaced with the resolved interpreter; when none was resolved
+    the slot is left empty so run_suites SKIPS python suites honestly instead
+    of failing with a bogus 127.
+
+    `config` defaults to the built-in RelayConfig, so callers that pass only
+    (changed_paths, python_exe) get this repo's canonical, CI-matching
+    suites unchanged.
     """
+    from orchestration.coding_relay.config import PY_PLACEHOLDER, default_config
+
+    if config is None:
+        config = default_config()
     paths = [p.replace("\\", "/") for p in changed_paths]
     py = python_exe or ""
-    suites: list = []
 
     def touched(prefix: str) -> bool:
         return any(p.startswith(prefix) for p in paths)
 
-    if touched("backend/"):
-        suites.append(Suite("backend-ruff", "backend", [py, "-m", "ruff", "check", "app", "tests"], 600, "python"))
-        suites.append(Suite("backend-pytest", "backend", [py, "-m", "pytest", "tests", "-q"], 1800, "python"))
-    if touched("repo-b/"):
-        for name, script in (("frontend-lint", "lint"), ("frontend-typecheck", "typecheck"), ("frontend-unit", "test:unit")):
-            suites.append(Suite(name, "repo-b", ["npm", "run", script], 900, "npm"))
-    if touched("rs_factory_seed/"):
-        suites.append(Suite("rs-factory-pytest", "rs_factory_seed", [py, "-m", "pytest", "tests", "-q"], 900, "python"))
-    if touched("backend/") or touched("repo-b/") or touched("verification/"):
-        suites.append(Suite("repe-lint", ".", [py, "-m", "verification.lint.no_legacy_repe_reads", "--json"], 300, "python"))
+    def rule_fires(rule: dict) -> bool:
+        prefixes = rule.get("when_touched_any")
+        if prefixes is not None:
+            return any(touched(prefix) for prefix in prefixes)
+        return touched(rule["when_touched"])
+
+    def resolve_cmd(cmd: list) -> list:
+        return [py if part == PY_PLACEHOLDER else part for part in cmd]
+
+    suites: list = []
+    for rule in config.test_suites:
+        if not rule_fires(rule):
+            continue
+        suites.append(
+            Suite(
+                rule["name"],
+                rule["cwd"],
+                resolve_cmd(rule["cmd"]),
+                rule["timeout"],
+                rule["runner"],
+            )
+        )
     return suites
 
 

--- a/orchestration/coding_relay/worktree.py
+++ b/orchestration/coding_relay/worktree.py
@@ -101,11 +101,18 @@ def link_junction(target: Path, link: Path) -> tuple[bool, str]:
         return False, f"{type(exc).__name__}: {exc}"
 
 
-def ensure_deps_links(repo_root: Path, wt: RelayWorktree) -> dict[str, str]:
+def ensure_deps_links(
+    repo_root: Path, wt: RelayWorktree, dep_links: tuple | list | None = None
+) -> dict[str, str]:
     """Junction heavyweight dependency dirs from the primary checkout into the
-    worktree so test suites can run there. Returns {name: detail}."""
+    worktree so test suites can run there. Returns {name: detail}.
+
+    `dep_links` defaults to this repo's dirs; a downstream repo passes its own
+    from RelayConfig.dep_links.
+    """
+    links = dep_links if dep_links is not None else ("repo-b/node_modules", "backend/.venv")
     results: dict[str, str] = {}
-    for rel in ("repo-b/node_modules", "backend/.venv"):
+    for rel in links:
         target = repo_root / rel
         link = wt.path / rel
         ok, detail = link_junction(target, link)


### PR DESCRIPTION
## Why
The relay was hardwired to this repo in six places, so it could not be used on another project without editing its source. This extracts those into a config the relay reads from the repo it is pointed at.

## What
New `orchestration/coding_relay/config.py` with `RelayConfig` + `load_config`, read from an optional `relay.config.json` at the repo root:

| Key | What it names |
|---|---|
| `plan_dir` | where active plans live (`--plan NNNN`, guided menu) |
| `base_ref` | branch the relay worktree is cut from |
| `test_suites` | changed-path -> test-command rules (`when_touched` / `when_touched_any`, `{py}` interpreter slot) |
| `migration_prefixes` | paths requiring `--allow-migrations` |
| `auth_prefixes` | paths whose edits escalate as an auth surface |
| `dep_links` | dirs junctioned into the worktree so suites can run |

`test_runner.py` now iterates `config.test_suites` instead of a hardcoded if-ladder. Config threaded through `intake`, `guided`, `__main__`, `preflight`, `safety`, `worktree`.

`--init-config` writes a starter file and refuses to overwrite without `--force`. An unknown key or malformed JSON **fails loudly by name** rather than silently falling back.

## Behavior here is unchanged
**No `relay.config.json` is added to this repo on purpose.** The defaults reproduce this repo exactly, and the old module constants remain as the no-config fallback — which is why every existing test passes untouched.

## Regression gate
- **215 passed** = 123 existing relay + 80 coordinator + 12 new config tests
- `ruff check app tests` and `ruff check orchestration/coding_relay` clean
- `--dry-run` with **no config file** still resolves `plan_dir`/`base_ref` from defaults, plans the worktree, and writes nothing

The new tests pin both halves: the defaults must not drift, and a foreign `relay.config.json` must actually drive its own suites (this repo's paths mean nothing to it).

## Using it elsewhere
Copy `orchestration/coding_relay/`, run `--init-config`, edit the six keys. Documented in `docs/reference/CODING_RELAY.md` -> "Using it in another repository". The `claude` and `codex` CLIs still need to be installed/authed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)