### PR TITLE
feat(sustainability): T6 register governed metrics in the unified registry

### DIFF
--- a/backend/app/services/unified_metric_registry.py
+++ b/backend/app/services/unified_metric_registry.py
@@ -38,11 +38,21 @@ _SERVICE_MAP: dict[str, Any] | None = None
 def _get_service_map() -> dict[str, Any]:
     global _SERVICE_MAP
     if _SERVICE_MAP is None:
+        from app.services import re_sustainability_authoritative as _sus_auth
         from app.services.re_env_portfolio import get_portfolio_kpis
         from app.services.re_fund_metrics import get_fund_metrics
+
+        def _sustainability_authoritative(**kwargs: Any) -> dict[str, Any]:
+            # Route every governed sustainability metric through the T4
+            # authoritative-state reader. Attribute lookup on the module (not a
+            # captured reference) is deliberate so tests can monkeypatch
+            # ``re_sustainability_authoritative.get_metric`` and see the result.
+            return _sus_auth.get_metric(**kwargs)
+
         _SERVICE_MAP = {
             "portfolio_kpis": get_portfolio_kpis,
             "fund_metrics": get_fund_metrics,
+            "sustainability_authoritative": _sustainability_authoritative,
         }
     return _SERVICE_MAP
 

--- a/backend/tests/test_sustainability_metric_registry.py
+++ b/backend/tests/test_sustainability_metric_registry.py
@@ -1,0 +1,128 @@
+"""T6 (plan 0018): governed sustainability metrics in the unified registry.
+
+Note on API naming: plan 0018 refers to the registry's validation contract as
+``validate()``. The canonical method on ``UnifiedMetricRegistry`` is
+``validate_schema()`` (see ``backend/app/services/unified_metric_registry.py``);
+this test exercises that method — it is the single validation path the plan is
+naming. Renaming the method would be an unrelated refactor and is out of scope
+for T6.
+
+Verifies, without touching a real DB, that:
+
+1. The service dispatch map exposes ``sustainability_authoritative`` as a
+   callable — the registry's ``validate_schema()`` rejects any
+   ``service``-strategy metric whose ``service_function`` is missing from the
+   map.
+2. A ``MetricContract`` built for each of the six v1 sustainability metric keys
+   with ``query_strategy='service'`` +
+   ``service_function='sustainability_authoritative'`` passes the registry's
+   own ``validate_schema()`` with no issue naming those keys.
+3. The dispatch callable resolves through
+   ``re_sustainability_authoritative.get_metric`` and returns whatever
+   ``null_reason`` the reader produced, unchanged (no fabricated number).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.services import unified_metric_registry as umr
+from app.services.unified_metric_registry import (
+    MetricContract,
+    UnifiedMetricRegistry,
+)
+
+SUSTAINABILITY_METRIC_KEYS = (
+    "scope1_tco2e",
+    "scope2_location_tco2e",
+    "scope2_market_tco2e",
+    "scope3_tco2e",
+    "energy_intensity_kwh_per_sqft",
+    "water_intensity_gal_per_sqft",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_service_map():
+    # Force _get_service_map() to rebuild so monkeypatches on
+    # re_sustainability_authoritative land through the module attribute lookup.
+    umr._SERVICE_MAP = None
+    yield
+    umr._SERVICE_MAP = None
+
+
+def _make_sus_contract(metric_key: str) -> MetricContract:
+    return MetricContract(
+        metric_key=metric_key,
+        display_name=metric_key.replace("_", " ").title(),
+        description=None,
+        aliases=(metric_key.replace("_", " "),),
+        metric_family="sustainability",
+        query_strategy="service",
+        template_key=None,
+        service_function="sustainability_authoritative",
+        sql_template="-- served via sustainability_authoritative reader",
+        unit="tco2e",
+        aggregation="sum",
+        format_hint_fe="number",
+        polarity="down_good",
+        entity_key="asset",
+        allowed_breakouts=("fund", "asset", "quarter"),
+        time_behavior="additive_period",
+    )
+
+
+def test_service_map_registers_sustainability_authoritative():
+    svc_map = umr._get_service_map()
+    assert "sustainability_authoritative" in svc_map
+    assert callable(svc_map["sustainability_authoritative"])
+
+
+def test_all_six_sustainability_metrics_pass_validate():
+    contracts = [_make_sus_contract(k) for k in SUSTAINABILITY_METRIC_KEYS]
+    registry = UnifiedMetricRegistry(contracts)
+
+    issues = registry.validate_schema()
+
+    for key in SUSTAINABILITY_METRIC_KEYS:
+        offending = [i for i in issues if i.startswith(f"{key}:")]
+        assert offending == [], (
+            f"validate_schema() flagged {key}: {offending}"
+        )
+
+
+def test_dispatch_callable_returns_reader_null_reason_unchanged(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def _fake_get_metric(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {
+            "value": None,
+            "unit": None,
+            "null_reason": "snapshot_unavailable",
+            "trust_status": "missing_source",
+            "snapshot_version": None,
+            "state_origin": "authoritative",
+        }
+
+    from app.services import re_sustainability_authoritative as sus_auth
+
+    monkeypatch.setattr(sus_auth, "get_metric", _fake_get_metric)
+
+    dispatch = umr._get_service_map()["sustainability_authoritative"]
+    result = dispatch(
+        business_id="a1b2c3d4-0001-0001-0001-000000000001",
+        env_id="repe-demo",
+        entity_scope="portfolio",
+        period_key="2025Q4",
+        metric_family="sustainability",
+        metric_key="scope1_tco2e",
+    )
+
+    assert result["value"] is None
+    assert result["null_reason"] == "snapshot_unavailable"
+    assert result["trust_status"] == "missing_source"
+    assert captured["metric_key"] == "scope1_tco2e"
+    assert captured["metric_family"] == "sustainability"

--- a/docs/plans/03-implementation-plans/active/0026-sustainability-t6-metric-registry.md
+++ b/docs/plans/03-implementation-plans/active/0026-sustainability-t6-metric-registry.md
@@ -1,0 +1,60 @@
+# 0026 - Sustainability T6: Register Governed Metrics in the Unified Registry
+
+- Status: Done (2026-07-13) - relay-built with tests ON (backend-pytest-scoped PASS 51-71s, the suite that used to time out). MAX_ITER only on 2 CI-dependent criteria the artifact bundle cannot evidence (D4 schema-gate, targeted-pytest command string); 0 unmet, no defect. Verified by hand.
+- Environment: Business OS / Sustainability
+- Risk: Medium (additive seed migration + one dispatch entry)
+- Scope: Register the v1 sustainability metrics in the unified metric registry so the AI copilot can name, ground on, and fail closed for them. One ticket (T6 from plan 0018).
+- Master plan: `docs/plans/03-implementation-plans/active/0018-sustainability-tool-planning.md`
+- Depends on: T3 (schema, applied), T4 (reader), T5 (routes) - all merged.
+
+## Background (verified against the tree)
+
+The unified registry is **DB-driven**, not a Python constant list. `backend/app/services/unified_metric_registry.py::_load_from_db` reads `semantic_metric_def` (`WHERE business_id = %s AND is_active = true`). So "register the metrics" means seeding `semantic_metric_def` rows, not editing a list.
+
+- Table: `repo-b/db/schema/340_semantic_catalog.sql`. `sql_template` is `NOT NULL`. Routing columns (`query_strategy`, `service_function`, `metric_family`, `aliases`, `polarity`, `time_behavior`, `format_hint_fe`, `allowed_breakouts`) are seeded in the `448_metric_routing_seed.sql` pattern.
+- `query_strategy` values: `template | semantic | service | computed`. The registry's `validate()` requires a `service` metric's `service_function` to exist in `_get_service_map()`, which today only maps `portfolio_kpis` and `fund_metrics`.
+
+Sustainability metric values come from the **T4 authoritative reader**, not from raw SQL. Reading them via a `semantic` `sql_template` would bypass the single-fetch layer and violate the authoritative-state contract (ADR 0001, decision 5). So these metrics must use `query_strategy = 'service'` routed to the reader, which means T6 is two coupled pieces: the seed rows AND a dispatch-map entry.
+
+## Scope
+
+In scope:
+
+1. **Dispatch entry** in `backend/app/services/unified_metric_registry.py`: add one entry to `_get_service_map()` mapping `sustainability_authoritative` to a callable that resolves a governed sustainability metric through `re_sustainability_authoritative` (the T4 reader). Do not change any existing entry or the registry's contract/validation logic.
+2. **Seed migration** `repo-b/db/schema/619_sus_metric_registry_seed.sql` (next feature number; 618 is T3's) inserting `semantic_metric_def` rows for the v1 metric keys from plan 0018:
+   - `scope1_tco2e`, `scope2_location_tco2e`, `scope2_market_tco2e`, `scope3_tco2e`, `energy_intensity_kwh_per_sqft`, `water_intensity_gal_per_sqft`.
+   - Each row: `query_strategy = 'service'`, `service_function = 'sustainability_authoritative'`, `metric_family = 'sustainability'`, a real `unit` (`tco2e`, `kwh_per_sqft`, `gal_per_sqft`), `aggregation`, `polarity` (emissions and intensities are `down_good`), `time_behavior`, `aliases` (natural-language phrasings the copilot will hear), `allowed_breakouts`, and a non-null `sql_template` (the column is NOT NULL; use a comment-only placeholder such as `'-- served via sustainability_authoritative reader'` since routing is by service, not SQL).
+   - Idempotent: guard with `ON CONFLICT (business_id, metric_key, version) DO NOTHING` (the table's unique key) so re-running the migration is safe.
+   - Seed against the same demo `business_id` the existing seeds use (`a1b2c3d4-0001-0001-0001-000000000001`).
+
+Out of scope (explicit):
+- The AI copilot wiring itself (T10 consumes this registry; it is a separate ticket).
+- Any change to the T4 reader, T5 routes, or the T3 schema.
+- Any change to existing `semantic_metric_def` rows, existing dispatch entries, or the registry's validation logic.
+- Applying the migration to production (done separately after merge).
+
+## Acceptance Criteria
+
+### Screen
+Not applicable.
+
+### API
+Not applicable (no route change; T5 already exposes the reader).
+
+### DB/Data
+- A new `repo-b/db/schema/619_sus_metric_registry_seed.sql` exists (feature band, next after 618) and inserts `semantic_metric_def` rows for all six metric keys: `scope1_tco2e`, `scope2_location_tco2e`, `scope2_market_tco2e`, `scope3_tco2e`, `energy_intensity_kwh_per_sqft`, `water_intensity_gal_per_sqft`.
+- Every seeded row sets `query_strategy = 'service'`, `service_function = 'sustainability_authoritative'`, `metric_family = 'sustainability'`, a non-null `unit`, a non-null `sql_template`, and a non-empty `aliases` set.
+- The insert is idempotent (`ON CONFLICT ... DO NOTHING` on the table's unique key), and the migration is additive only: no `DROP`, no `UPDATE`/`DELETE` of existing rows.
+- The migration applies cleanly on the DB Schema Gate CI job.
+
+### AI behavior
+- Every seeded metric routes through the T4 authoritative reader rather than raw SQL, so a value the reader cannot serve surfaces its `null_reason` instead of a fabricated number. `polarity` is set so the copilot does not describe rising emissions as an improvement.
+- `_get_service_map()` gains exactly one new entry, `sustainability_authoritative`, so a `service`-strategy sustainability metric passes the registry's own `validate()` (which rejects a `service` metric whose `service_function` is not in the dispatch map).
+
+### Evals/tests
+- A new test `backend/tests/test_sustainability_metric_registry.py` asserts, without a real DB: (1) `_get_service_map()` contains `sustainability_authoritative` and its value is callable; (2) a `MetricContract` built for each of the six keys with `query_strategy='service'` and `service_function='sustainability_authoritative'` passes the registry's `validate()` with no issues naming those keys; (3) the dispatch callable resolves a metric through `re_sustainability_authoritative` (monkeypatched) and returns its `null_reason` unchanged when the reader reports one (no fabricated number).
+- `cd backend && python -m ruff check app tests` and `python -m pytest tests/test_sustainability_metric_registry.py -q` pass.
+
+### Regression guard
+- Only `backend/app/services/unified_metric_registry.py` (additive: one dispatch entry + its import), the new `repo-b/db/schema/619_sus_metric_registry_seed.sql`, the new test, and this plan are changed.
+- No existing dispatch entry, existing `semantic_metric_def` row, `MetricContract` field, or registry validation rule is modified. `re_sustainability_authoritative.py`, the T5 routes, and `618_sus_authoritative.sql` are untouched.

--- a/repo-b/db/schema/619_sus_metric_registry_seed.sql
+++ b/repo-b/db/schema/619_sus_metric_registry_seed.sql
@@ -1,0 +1,94 @@
+-- 619_sus_metric_registry_seed.sql
+--
+-- T6 of plan 0018 (Sustainability Tool). Registers the v1 governed
+-- sustainability metrics in the unified metric registry so the AI copilot can
+-- name them, ground on them, and fail closed on missing values.
+--
+-- The unified registry (``backend/app/services/unified_metric_registry.py``)
+-- is DB-driven: it reads active rows from ``semantic_metric_def`` at startup.
+-- Every seeded row here routes with ``query_strategy = 'service'`` +
+-- ``service_function = 'sustainability_authoritative'`` so values are served
+-- through the T4 authoritative reader
+-- (``backend/app/services/re_sustainability_authoritative.py``) rather than
+-- raw SQL. ``sql_template`` is NOT NULL on the table, so we store a comment
+-- placeholder that documents the routing.
+--
+-- Additive only. Uses ``ON CONFLICT (business_id, metric_key, version) DO
+-- NOTHING`` on the table's unique key so re-application is safe.
+--
+-- Depends on: 340_semantic_catalog.sql, 447_metric_routing_metadata.sql,
+-- 618_sus_authoritative.sql.
+
+INSERT INTO semantic_metric_def (
+  business_id, metric_key, display_name, description, sql_template,
+  unit, aggregation, entity_key,
+  query_strategy, service_function, metric_family, time_behavior,
+  polarity, format_hint_fe, aliases, allowed_breakouts
+) VALUES
+  (
+    'a1b2c3d4-0001-0001-0001-000000000001', 'scope1_tco2e',
+    'Scope 1 Emissions (tCO2e)',
+    'Direct greenhouse gas emissions from owned/controlled sources, in tonnes of CO2 equivalent.',
+    '-- served via sustainability_authoritative reader',
+    'tco2e', 'sum', 'asset',
+    'service', 'sustainability_authoritative', 'sustainability', 'additive_period',
+    'down_good', 'number',
+    '{"scope 1", "scope one", "scope 1 emissions", "direct emissions", "scope 1 tco2e", "scope1", "scope1 emissions"}',
+    '{fund, asset, market, property_type, quarter}'
+  ),
+  (
+    'a1b2c3d4-0001-0001-0001-000000000001', 'scope2_location_tco2e',
+    'Scope 2 Emissions, Location-Based (tCO2e)',
+    'Indirect emissions from purchased energy under the location-based method, in tonnes of CO2 equivalent.',
+    '-- served via sustainability_authoritative reader',
+    'tco2e', 'sum', 'asset',
+    'service', 'sustainability_authoritative', 'sustainability', 'additive_period',
+    'down_good', 'number',
+    '{"scope 2 location", "scope 2 location-based", "location-based emissions", "scope 2 location tco2e", "scope2 location"}',
+    '{fund, asset, market, property_type, quarter}'
+  ),
+  (
+    'a1b2c3d4-0001-0001-0001-000000000001', 'scope2_market_tco2e',
+    'Scope 2 Emissions, Market-Based (tCO2e)',
+    'Indirect emissions from purchased energy under the market-based method, in tonnes of CO2 equivalent.',
+    '-- served via sustainability_authoritative reader',
+    'tco2e', 'sum', 'asset',
+    'service', 'sustainability_authoritative', 'sustainability', 'additive_period',
+    'down_good', 'number',
+    '{"scope 2 market", "scope 2 market-based", "market-based emissions", "scope 2 market tco2e", "scope2 market"}',
+    '{fund, asset, market, property_type, quarter}'
+  ),
+  (
+    'a1b2c3d4-0001-0001-0001-000000000001', 'scope3_tco2e',
+    'Scope 3 Emissions (tCO2e)',
+    'Value-chain (indirect) emissions across upstream and downstream categories, in tonnes of CO2 equivalent.',
+    '-- served via sustainability_authoritative reader',
+    'tco2e', 'sum', 'asset',
+    'service', 'sustainability_authoritative', 'sustainability', 'additive_period',
+    'down_good', 'number',
+    '{"scope 3", "scope three", "scope 3 emissions", "value chain emissions", "scope 3 tco2e", "scope3"}',
+    '{fund, asset, market, property_type, quarter}'
+  ),
+  (
+    'a1b2c3d4-0001-0001-0001-000000000001', 'energy_intensity_kwh_per_sqft',
+    'Energy Intensity (kWh/sqft)',
+    'Energy use per rentable square foot, in kilowatt-hours per square foot.',
+    '-- served via sustainability_authoritative reader',
+    'kwh_per_sqft', 'avg', 'asset',
+    'service', 'sustainability_authoritative', 'sustainability', 'point_in_time',
+    'down_good', 'number',
+    '{"energy intensity", "eui", "energy use intensity", "kwh per sqft", "kwh/sqft"}',
+    '{fund, asset, market, property_type, quarter}'
+  ),
+  (
+    'a1b2c3d4-0001-0001-0001-000000000001', 'water_intensity_gal_per_sqft',
+    'Water Intensity (gal/sqft)',
+    'Water use per rentable square foot, in gallons per square foot.',
+    '-- served via sustainability_authoritative reader',
+    'gal_per_sqft', 'avg', 'asset',
+    'service', 'sustainability_authoritative', 'sustainability', 'point_in_time',
+    'down_good', 'number',
+    '{"water intensity", "wui", "water use intensity", "gallons per sqft", "gal/sqft"}',
+    '{fund, asset, market, property_type, quarter}'
+  )
+ON CONFLICT (business_id, metric_key, version) DO NOTHING;


### PR DESCRIPTION
## Ticket
T6 from plan 0018 - register the v1 sustainability metrics so the AI copilot can name them, ground on them, and fail closed.

## Why it is two pieces
The registry is **DB-driven** (`_load_from_db` reads `semantic_metric_def`), so "register the metrics" means **seeding rows**, not editing a Python list.

And sustainability values come from the **T4 authoritative reader**, not raw SQL. Routing them via a `semantic` `sql_template` would bypass the single-fetch layer and break the authoritative-state contract (ADR 0001, decision 5). So they must use `query_strategy='service'` — and the registry's own `validate()` **rejects** a `service` metric whose `service_function` is not in the dispatch map. Hence:

1. **`unified_metric_registry`** - one new `_get_service_map` entry, `sustainability_authoritative`: a thin pass-through to `re_sustainability_authoritative.get_metric`. Whatever the reader returns (**including `null_reason`**) surfaces unchanged; there is no code path that can fabricate a value.
2. **`619_sus_metric_registry_seed.sql`** - `semantic_metric_def` rows for the six keys, each `query_strategy='service'`, `metric_family='sustainability'`, real units, **`down_good` polarity** so rising emissions are never described as an improvement, plus aliases the copilot will actually hear. Idempotent (`ON CONFLICT DO NOTHING`), additive only.

## The relay ran clean this time
`backend-pytest-scoped: PASS` on **every iteration (51-71s)** — the exact suite that used to die at **exit 124 after 1800s** before the scoped config (#526). Real test evidence, no `--no-tests` crutch.

MAX_ITER was reached on **2 criteria the artifact bundle structurally cannot evidence** — the DB Schema Gate is a CI job that does not exist at review time, and the literal pytest command string. **0 unmet, no defect found.** That is my plan-authoring error (CI-dependent criteria in a relay plan), not a code problem.

## Verified by hand
3 files (in scope) - all six keys seeded - `ON CONFLICT` present - **0 destructive statements** - 3 registry tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)