### PR TITLE
feat(sustainability): T7 standalone BOS sustainability environment

### DIFF
--- a/docs/plans/03-implementation-plans/active/0027-sustainability-t7-standalone-env-ui.md
+++ b/docs/plans/03-implementation-plans/active/0027-sustainability-t7-standalone-env-ui.md
@@ -1,0 +1,68 @@
+# 0027 - Sustainability T7: Standalone BOS Sustainability Environment (UI)
+
+- Status: Done (2026-07-13) - relay PASS, 12/12 criteria, 0 unmet, 0 unknown. All 4 suites green; self-corrected a unit-test failure on iteration 3.
+- Environment: Business OS / Sustainability
+- Risk: Medium (new frontend surface; no existing page modified)
+- Scope: Build the v1 sustainability surface as its own environment behind the login, reading only through the governed T5 endpoints. One ticket (T7 from plan 0018).
+- Master plan: `docs/plans/03-implementation-plans/active/0018-sustainability-tool-planning.md`
+- ADR: `docs/adr/sustainability/0001-brownfield-extension.md` (decisions 2 and 3).
+- Depends on: T5 routes (merged), T6 registry (merged, live).
+
+## Frozen decisions this ticket must honor (ADR 0001)
+
+- **Decision 2**: v1 ships as its **own standalone Business OS environment behind the login**, not as a section of the existing REPE workspace.
+- **Decision 3**: the UI **must not** be wrapped in shared workspace chrome. No `RepeWorkspaceShell`, no `DomainWorkspaceShell`, no shared app shell. It renders its own full-bleed layout. (This is a standing operator rule for environment UIs.)
+- **Decision 4**: the existing REPE-embedded `SustainabilityWorkspace.tsx` and its two pages are **kept as-is**. The new surface is net-new UI. It must not import from `SustainabilityWorkspace.tsx`.
+
+## Background (verified against the tree)
+
+- Existing standalone env pages are a plain `Suspense` + workspace component, with no shell wrapper (see `repo-b/src/app/lab/env/[envId]/re/sustainability/page.tsx`). That is the pattern to follow.
+- The API client is `repo-b/src/lib/bos-api.ts`, using `bosFetch(path, { params })` returning a typed promise (see `getReV2SustainabilityOverview`).
+- Reusable primitives confirmed present: `repo-b/src/components/ui/MetricCard.tsx`, `repo-b/src/components/ui/StateCard.tsx` (null/empty/error), `repo-b/src/components/telemetry/drawerPrimitives.tsx`.
+- The governed endpoints (T5) are `/api/re/v2/sustainability/authoritative/{overview,metric/{key},metric/{key}/evidence,context}` taking `business_id`, `env_id`, `entity_scope`, `period_key`, `metric_family`, optional `snapshot_version`.
+- The six governed metric keys (T6, live): `scope1_tco2e`, `scope2_location_tco2e`, `scope2_market_tco2e`, `scope3_tco2e`, `energy_intensity_kwh_per_sqft`, `water_intensity_gal_per_sqft`.
+
+## Scope
+
+In scope:
+
+1. **API client** additions in `repo-b/src/lib/bos-api.ts` (additive; do not modify existing exports): `getSusAuthoritativeOverview(params)` and `getSusAuthoritativeMetricEvidence(metricKey, params)`, both `bosFetch` against the T5 `/authoritative/*` paths, with exported response types mirroring the T5 Pydantic models (fields optional/nullable, since the reader is fail-closed).
+2. **Workspace component** `repo-b/src/components/sustainability/BosSustainabilityWorkspace.tsx` (new directory; NOT under `components/repe/`):
+   - Renders its **own full-bleed layout**. No shared shell import.
+   - A governed metric grid: one card per governed metric returned by `/authoritative/overview`, using `MetricCard`.
+   - **Fail-closed rendering is the point of this ticket**: when a metric's `value` is `null`, render its `null_reason` verbatim via `StateCard` (or an equivalent explicit state) instead of `0`, `-`, or a blank. When the whole snapshot is unavailable (`null_reason: "snapshot_unavailable"`), the page renders an explicit unavailable state naming the reason, not an empty grid.
+   - Surface the governance header from the reader payload: `snapshot_version`, `promotion_state`, `trust_status`, and `period_exact`. A snapshot that is not `released` or not `trusted` must be visibly marked, not silently shown as if it were.
+3. **Route** `repo-b/src/app/app/sustainability/page.tsx`: a client page that renders `BosSustainabilityWorkspace` inside `Suspense`, with **no shell wrapper**, mirroring the existing standalone env page pattern.
+
+Out of scope (explicit):
+- The evidence drawer (T8 owns it; T7 only needs the metric cards to be clickable-ready, but must not build the drawer).
+- Report center (T9), AI copilot panel (T10), any write/intake path.
+- Any change to `SustainabilityWorkspace.tsx`, the existing REPE sustainability pages, the T4 reader, T5 routes, or any backend file.
+- Seeding or releasing an authoritative snapshot. With no released snapshot in the demo env, the correct v1 behavior is the fail-closed `snapshot_unavailable` state, and this ticket must render that honestly.
+
+## Acceptance Criteria
+
+### Screen
+- A new route `/app/sustainability` exists at `repo-b/src/app/app/sustainability/page.tsx` and renders `BosSustainabilityWorkspace` inside `Suspense`.
+- The page and the workspace import **no** shared workspace shell: the strings `RepeWorkspaceShell`, `DomainWorkspaceShell`, and any import from `@/components/repe/sustainability/SustainabilityWorkspace` are absent from both new files.
+- The workspace renders a governed metric card per metric from `/authoritative/overview`, and renders `snapshot_version`, `promotion_state`, and `trust_status` from the reader payload.
+- When the reader returns `null_reason: "snapshot_unavailable"`, the page renders an explicit unavailable state that names that reason. It does not render an empty grid, a zero, or a dash.
+- When an individual metric's `value` is `null`, its card shows the metric's `null_reason` rather than `0` or a blank.
+
+### API
+- New additive exports in `repo-b/src/lib/bos-api.ts` call the T5 endpoints `/api/re/v2/sustainability/authoritative/overview` and `/api/re/v2/sustainability/authoritative/metric/{key}/evidence` via `bosFetch`. No existing export is modified.
+
+### DB/Data
+Not applicable (read-only UI over the governed endpoints; no direct table access).
+
+### AI behavior
+- The UI never computes a sustainability metric client-side and never substitutes a fallback number. Every displayed value comes from the governed reader payload, and every absent value renders its `null_reason`. A grep of the new files finds no arithmetic on metric values and no `?? 0` / `|| 0` fallback applied to a metric value.
+
+### Evals/tests
+- A new test `repo-b/src/components/sustainability/__tests__/BosSustainabilityWorkspace.test.tsx` renders the workspace with a mocked client and asserts: (1) a released snapshot renders a card per metric plus the `snapshot_version` / `trust_status`; (2) a `snapshot_unavailable` payload renders the explicit unavailable state naming the reason, and renders no `0`; (3) a metric whose `value` is `null` renders its `null_reason` and not `0`.
+- `cd repo-b && npm run lint`, `npm run typecheck`, and `npm run test:unit` pass.
+
+### Regression guard
+- Only these are added/changed: `repo-b/src/app/app/sustainability/page.tsx` (new), `repo-b/src/components/sustainability/BosSustainabilityWorkspace.tsx` (new), its new test, additive exports in `repo-b/src/lib/bos-api.ts`, and this plan.
+- `repo-b/src/components/repe/sustainability/SustainabilityWorkspace.tsx`, `repo-b/src/app/app/repe/sustainability/page.tsx`, and `repo-b/src/app/lab/env/[envId]/re/sustainability/page.tsx` are untouched.
+- No backend file, schema file, or existing `bos-api.ts` export is modified.

--- a/repo-b/src/app/app/sustainability/page.tsx
+++ b/repo-b/src/app/app/sustainability/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Suspense } from "react";
+import BosSustainabilityWorkspace from "@/components/sustainability/BosSustainabilityWorkspace";
+
+export default function BosSustainabilityPage() {
+  return (
+    <Suspense fallback={<div className="p-6 text-sm text-bm-muted2">Loading...</div>}>
+      <BosSustainabilityWorkspace />
+    </Suspense>
+  );
+}

--- a/repo-b/src/components/sustainability/BosSustainabilityWorkspace.tsx
+++ b/repo-b/src/components/sustainability/BosSustainabilityWorkspace.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  getSusAuthoritativeOverview,
+  type SusAuthoritativeStateResponse,
+  type SusAuthoritativeMetricItem,
+  type SusAuthoritativeQueryParams,
+} from "@/lib/bos-api";
+import { MetricCard } from "@/components/ui/MetricCard";
+import { StateCard } from "@/components/ui/StateCard";
+
+const METRIC_LABELS: Record<string, string> = {
+  scope1_tco2e: "Scope 1 (tCO2e)",
+  scope2_location_tco2e: "Scope 2 Location (tCO2e)",
+  scope2_market_tco2e: "Scope 2 Market (tCO2e)",
+  scope3_tco2e: "Scope 3 (tCO2e)",
+  energy_intensity_kwh_per_sqft: "Energy Intensity (kWh/sqft)",
+  water_intensity_gal_per_sqft: "Water Intensity (gal/sqft)",
+};
+
+const DEFAULT_QUERY: SusAuthoritativeQueryParams = {
+  business_id: "demo",
+  env_id: "sustainability-demo",
+  entity_scope: "portfolio",
+  period_key: "2026Q1",
+  metric_family: "ghg",
+};
+
+export type BosSustainabilityWorkspaceProps = {
+  query?: Partial<SusAuthoritativeQueryParams>;
+};
+
+function formatMetricValue(item: SusAuthoritativeMetricItem): string {
+  const { value, unit } = item;
+  if (value === null || value === undefined) {
+    return "";
+  }
+  const rendered = Number.isFinite(value) ? value.toLocaleString() : String(value);
+  return unit ? `${rendered} ${unit}` : rendered;
+}
+
+function GovernanceHeader({ state }: { state: SusAuthoritativeStateResponse }) {
+  const promotion = state.promotion_state ?? "unknown";
+  const trust = state.trust_status ?? "unknown";
+  const snapshot = state.snapshot_version ?? "—";
+  const notReleased = state.promotion_state !== "released";
+  const notTrusted = state.trust_status !== "trusted";
+  const warn = notReleased || notTrusted;
+  return (
+    <div
+      data-testid="bos-sus-governance-header"
+      className="flex flex-wrap items-center gap-3 rounded-xl border border-bm-border/50 bg-bm-surface/20 px-4 py-3 text-sm"
+    >
+      <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-bm-muted2">
+        Snapshot
+      </span>
+      <span data-testid="bos-sus-snapshot-version" className="font-mono text-bm-text">
+        {snapshot}
+      </span>
+      <span
+        data-testid="bos-sus-promotion-state"
+        className={
+          notReleased
+            ? "rounded-full border border-bm-warning/40 bg-bm-warning/15 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-bm-warning"
+            : "rounded-full border border-bm-border/40 bg-bm-surface2/60 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-bm-muted"
+        }
+      >
+        promotion: {promotion}
+      </span>
+      <span
+        data-testid="bos-sus-trust-status"
+        className={
+          notTrusted
+            ? "rounded-full border border-bm-warning/40 bg-bm-warning/15 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-bm-warning"
+            : "rounded-full border border-bm-success/40 bg-bm-success/15 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-bm-success"
+        }
+      >
+        trust: {trust}
+      </span>
+      {state.period_exact === false && (
+        <span
+          data-testid="bos-sus-period-inexact"
+          className="rounded-full border border-bm-warning/40 bg-bm-warning/15 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-bm-warning"
+        >
+          period: not exact
+        </span>
+      )}
+      {warn && (
+        <span className="text-xs text-bm-warning">
+          Snapshot is not released/trusted — displayed values are marked, not silently shown as authoritative.
+        </span>
+      )}
+    </div>
+  );
+}
+
+function MetricTile({ item }: { item: SusAuthoritativeMetricItem }) {
+  const label = METRIC_LABELS[item.metric_key] ?? item.metric_key;
+  if (item.value === null || item.value === undefined) {
+    const reason = item.null_reason ?? "unavailable";
+    return (
+      <div
+        data-testid={`bos-sus-metric-null-${item.metric_key}`}
+        className="rounded-xl border border-bm-warning/30 bg-bm-warning/8 p-4"
+      >
+        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-bm-muted2">
+          {label}
+        </p>
+        <p className="mt-2 font-mono text-xs text-bm-warning" data-testid={`bos-sus-metric-null-reason-${item.metric_key}`}>
+          null_reason: {reason}
+        </p>
+        {item.trust_status && (
+          <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.08em] text-bm-muted2">
+            trust: {item.trust_status}
+          </p>
+        )}
+      </div>
+    );
+  }
+  return (
+    <div
+      data-testid={`bos-sus-metric-${item.metric_key}`}
+      className="rounded-xl border border-bm-border/50 bg-bm-surface/20 p-4"
+    >
+      <MetricCard label={label} value={formatMetricValue(item)} />
+      {item.trust_status && (
+        <p className="mt-2 font-mono text-[10px] uppercase tracking-[0.08em] text-bm-muted2">
+          trust: {item.trust_status}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function BosSustainabilityWorkspace({
+  query,
+}: BosSustainabilityWorkspaceProps = {}) {
+  const [state, setState] = useState<SusAuthoritativeStateResponse | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const resolvedQuery: SusAuthoritativeQueryParams = { ...DEFAULT_QUERY, ...(query ?? {}) };
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getSusAuthoritativeOverview(resolvedQuery)
+      .then((res) => {
+        if (cancelled) return;
+        setState(res);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    resolvedQuery.business_id,
+    resolvedQuery.env_id,
+    resolvedQuery.entity_scope,
+    resolvedQuery.period_key,
+    resolvedQuery.metric_family,
+    resolvedQuery.snapshot_version,
+  ]);
+
+  return (
+    <div className="min-h-screen w-full bg-bm-bg text-bm-text">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-5 px-6 py-8">
+        <header className="flex flex-col gap-1">
+          <h1 className="font-display text-2xl font-semibold tracking-tight">
+            Sustainability
+          </h1>
+          <p className="text-sm text-bm-muted2">
+            Governed sustainability metrics. Every value comes from an authoritative snapshot; missing values render their null_reason.
+          </p>
+        </header>
+
+        {loading && <StateCard state="loading" />}
+
+        {!loading && error && (
+          <StateCard
+            state="error"
+            title="Could not load authoritative sustainability state"
+            message={error}
+          />
+        )}
+
+        {!loading && !error && state && (
+          <>
+            {state.null_reason === "snapshot_unavailable" ? (
+              <div
+                data-testid="bos-sus-snapshot-unavailable"
+                className="rounded-xl border border-bm-warning/40 bg-bm-warning/10 p-6"
+              >
+                <h2 className="text-base font-display font-semibold text-bm-text">
+                  Snapshot unavailable
+                </h2>
+                <p className="mt-1 text-sm text-bm-warning">
+                  null_reason: {state.null_reason}
+                </p>
+                <p className="mt-2 text-xs text-bm-muted2">
+                  No released, trusted authoritative snapshot exists for
+                  scope <span className="font-mono">{resolvedQuery.entity_scope}</span> at
+                  period <span className="font-mono">{resolvedQuery.period_key}</span> for
+                  metric family <span className="font-mono">{resolvedQuery.metric_family}</span>.
+                  The governed reader fails closed; nothing is substituted.
+                </p>
+              </div>
+            ) : (
+              <>
+                <GovernanceHeader state={state} />
+                {state.metrics.length === 0 ? (
+                  <div
+                    data-testid="bos-sus-no-metrics"
+                    className="rounded-xl border border-bm-border/50 bg-bm-surface/20 p-6 text-sm text-bm-muted2"
+                  >
+                    No governed metrics returned for this scope. null_reason:{" "}
+                    <span className="font-mono">{state.null_reason ?? "unspecified"}</span>
+                  </div>
+                ) : (
+                  <div
+                    data-testid="bos-sus-metric-grid"
+                    className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
+                  >
+                    {state.metrics.map((m) => (
+                      <MetricTile key={m.metric_key} item={m} />
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/repo-b/src/components/sustainability/__tests__/BosSustainabilityWorkspace.test.tsx
+++ b/repo-b/src/components/sustainability/__tests__/BosSustainabilityWorkspace.test.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import BosSustainabilityWorkspace from "@/components/sustainability/BosSustainabilityWorkspace";
+import type { SusAuthoritativeStateResponse } from "@/lib/bos-api";
+
+vi.mock("@/lib/bos-api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/bos-api")>("@/lib/bos-api");
+  return {
+    ...actual,
+    getSusAuthoritativeOverview: vi.fn(),
+  };
+});
+
+import { getSusAuthoritativeOverview } from "@/lib/bos-api";
+
+const mocked = getSusAuthoritativeOverview as unknown as ReturnType<typeof vi.fn>;
+
+const RELEASED_PAYLOAD: SusAuthoritativeStateResponse = {
+  entity_scope: "portfolio",
+  period_key: "2026Q1",
+  requested_period_key: "2026Q1",
+  period_exact: true,
+  state_origin: "authoritative_snapshot",
+  snapshot_version: "sv-abc-123",
+  promotion_state: "released",
+  trust_status: "trusted",
+  null_reason: null,
+  metrics: [
+    { metric_key: "scope1_tco2e", value: 1234.5, unit: "tCO2e", null_reason: null, trust_status: "trusted" },
+    { metric_key: "scope2_location_tco2e", value: 987.6, unit: "tCO2e", null_reason: null, trust_status: "trusted" },
+    { metric_key: "scope2_market_tco2e", value: 800.0, unit: "tCO2e", null_reason: null, trust_status: "trusted" },
+    { metric_key: "scope3_tco2e", value: 4200.0, unit: "tCO2e", null_reason: null, trust_status: "trusted" },
+    { metric_key: "energy_intensity_kwh_per_sqft", value: 18.4, unit: "kWh/sqft", null_reason: null, trust_status: "trusted" },
+    { metric_key: "water_intensity_gal_per_sqft", value: 12.1, unit: "gal/sqft", null_reason: null, trust_status: "trusted" },
+  ],
+  evidence: [],
+};
+
+const UNAVAILABLE_PAYLOAD: SusAuthoritativeStateResponse = {
+  entity_scope: "portfolio",
+  period_key: "2026Q1",
+  requested_period_key: "2026Q1",
+  period_exact: null,
+  state_origin: null,
+  snapshot_version: null,
+  promotion_state: null,
+  trust_status: null,
+  null_reason: "snapshot_unavailable",
+  metrics: [],
+  evidence: [],
+};
+
+const NULL_METRIC_PAYLOAD: SusAuthoritativeStateResponse = {
+  entity_scope: "portfolio",
+  period_key: "2026Q1",
+  requested_period_key: "2026Q1",
+  period_exact: true,
+  state_origin: "authoritative_snapshot",
+  snapshot_version: "sv-xyz-789",
+  promotion_state: "released",
+  trust_status: "trusted",
+  null_reason: null,
+  metrics: [
+    {
+      metric_key: "scope3_tco2e",
+      value: null,
+      unit: "tCO2e",
+      null_reason: "out_of_scope_requires_scope3_ingestion",
+      trust_status: "untrusted",
+    },
+  ],
+  evidence: [],
+};
+
+describe("BosSustainabilityWorkspace", () => {
+  beforeEach(() => {
+    mocked.mockReset();
+  });
+
+  it("renders a card per metric plus snapshot version and trust status for a released snapshot", async () => {
+    mocked.mockResolvedValueOnce(RELEASED_PAYLOAD);
+
+    render(<BosSustainabilityWorkspace />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bos-sus-metric-grid")).toBeInTheDocument();
+    });
+
+    for (const m of RELEASED_PAYLOAD.metrics) {
+      expect(screen.getByTestId(`bos-sus-metric-${m.metric_key}`)).toBeInTheDocument();
+    }
+    expect(screen.getByTestId("bos-sus-snapshot-version")).toHaveTextContent("sv-abc-123");
+    expect(screen.getByTestId("bos-sus-trust-status")).toHaveTextContent("trust: trusted");
+    expect(screen.getByTestId("bos-sus-promotion-state")).toHaveTextContent("promotion: released");
+    expect(screen.queryByTestId("bos-sus-snapshot-unavailable")).toBeNull();
+  });
+
+  it("renders an explicit unavailable state naming the reason and no zero when snapshot_unavailable", async () => {
+    mocked.mockResolvedValueOnce(UNAVAILABLE_PAYLOAD);
+
+    const { container } = render(<BosSustainabilityWorkspace />);
+    const banner = await screen.findByTestId("bos-sus-snapshot-unavailable");
+    expect(banner).toHaveTextContent("snapshot_unavailable");
+    expect(screen.queryByTestId("bos-sus-metric-grid")).toBeNull();
+    expect(screen.queryByTestId("bos-sus-governance-header")).toBeNull();
+    expect(screen.queryByTestId("bos-sus-snapshot-version")).toBeNull();
+    expect(screen.queryByTestId("bos-sus-trust-status")).toBeNull();
+    expect(screen.queryByTestId("bos-sus-promotion-state")).toBeNull();
+    expect(container.textContent).not.toContain("—");
+    expect(banner.textContent).not.toMatch(/(^|\s)0(\s|$)/);
+  });
+
+  it("renders a null metric's null_reason instead of 0 or a blank", async () => {
+    mocked.mockResolvedValueOnce(NULL_METRIC_PAYLOAD);
+
+    render(<BosSustainabilityWorkspace />);
+
+    const nullTile = await screen.findByTestId("bos-sus-metric-null-scope3_tco2e");
+    expect(nullTile).toHaveTextContent("out_of_scope_requires_scope3_ingestion");
+    expect(nullTile.textContent).not.toMatch(/(^|\s)0(\s|$)/);
+    expect(screen.queryByTestId("bos-sus-metric-scope3_tco2e")).toBeNull();
+  });
+});

--- a/repo-b/src/lib/bos-api.ts
+++ b/repo-b/src/lib/bos-api.ts
@@ -7176,6 +7176,67 @@ export function getReV2SustainabilityReport(
   return bosFetch(`/api/re/v2/sustainability/funds/${fundId}/reports/${reportKey}`, { params });
 }
 
+// Sustainability — governed authoritative reader (T5)
+export type SusAuthoritativeMetricItem = {
+  metric_key: string;
+  value: number | null;
+  unit: string | null;
+  null_reason: string | null;
+  trust_status: string | null;
+};
+
+export type SusAuthoritativeEvidenceItem = {
+  metric_key: string;
+  source_table: string | null;
+  source_row_ref: string | null;
+  emission_factor_set_id: string | null;
+  ingestion_run_id: string | null;
+  formula_id: string | null;
+};
+
+export type SusAuthoritativeStateResponse = {
+  entity_scope: string | null;
+  period_key: string | null;
+  requested_period_key: string | null;
+  period_exact: boolean | null;
+  state_origin: string | null;
+  snapshot_version: string | null;
+  promotion_state: string | null;
+  trust_status: string | null;
+  null_reason: string | null;
+  metrics: SusAuthoritativeMetricItem[];
+  evidence: SusAuthoritativeEvidenceItem[];
+};
+
+export type SusAuthoritativeEvidenceResponse = {
+  evidence: SusAuthoritativeEvidenceItem[];
+};
+
+export type SusAuthoritativeQueryParams = {
+  business_id: string;
+  env_id: string;
+  entity_scope: string;
+  period_key: string;
+  metric_family: string;
+  snapshot_version?: string;
+};
+
+export function getSusAuthoritativeOverview(
+  params: SusAuthoritativeQueryParams
+): Promise<SusAuthoritativeStateResponse> {
+  return bosFetch("/api/re/v2/sustainability/authoritative/overview", { params });
+}
+
+export function getSusAuthoritativeMetricEvidence(
+  metricKey: string,
+  params: SusAuthoritativeQueryParams
+): Promise<SusAuthoritativeEvidenceResponse> {
+  return bosFetch(
+    `/api/re/v2/sustainability/authoritative/metric/${metricKey}/evidence`,
+    { params }
+  );
+}
+
 // ── RE V2 Types ──────────────────────────────────────────────────────────────
 
 export type ReV2Investment = {


### PR DESCRIPTION
## Ticket
T7 from plan 0018 - the v1 sustainability surface, as **its own environment behind the login**.

## What
- **`/app/sustainability`** -> new `BosSustainabilityWorkspace`, rendered **full-bleed with no shared workspace chrome**. No `RepeWorkspaceShell`, no `DomainWorkspaceShell`, no import from the legacy `SustainabilityWorkspace` (ADR 0001, decisions 2-4). The existing REPE-embedded surface is **untouched**.
- Reads only through the governed T5 endpoints. **Additive** `bos-api` exports; no existing export changed.

## Fail-closed rendering is the substance here
- A metric whose value is `null` renders its **`null_reason` verbatim** - never `0`, never a blank.
- An unavailable snapshot renders an **explicit state naming the reason**, not an empty grid.
- `snapshot_version`, `promotion_state`, `trust_status` are surfaced, so a snapshot that is **not released or not trusted is visibly marked** rather than shown as if it were.
- Verified: no `?? 0` / `|| 0` fallback on any metric value.

## The relay passed this one clean
**12/12 criteria met, 0 unmet, 0 unknown.** lint + typecheck + unit + repe state-lock lint all green.

Notably, the builder **broke a unit test on iteration 2, and the relay caught it and fixed it on iteration 3** - the first real test failure it has caught, now that the `node_modules` junction is repaired and the frontend suites actually execute instead of silently reporting SKIPPED.

## Scope
4 files: the route, the workspace, its test, and additive `bos-api` exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)