### PR TITLE
feat(sustainability): T8 evidence drawer - metric to source lineage

### DIFF
--- a/docs/plans/03-implementation-plans/active/0028-sustainability-t8-evidence-drawer.md
+++ b/docs/plans/03-implementation-plans/active/0028-sustainability-t8-evidence-drawer.md
@@ -1,0 +1,64 @@
+# 0028 - Sustainability T8: Evidence Drawer (metric to source lineage)
+
+- Status: Done (2026-07-13) - relay 12/13, 0 unmet. The 1 "unknown" (A1) was a reviewer blind spot: the builder correctly REUSED T7's bos-api export instead of duplicating it, so the file was absent from the diff and Codex could not confirm a criterion about it. Verified by hand: export exists at bos-api.ts:7230 and the drawer calls it.
+- Environment: Business OS / Sustainability
+- Risk: Low (additive frontend component on the T7 surface)
+- Scope: Make every governed sustainability metric inspectable: click a metric, see the snapshot it came from and the source rows behind it. One ticket (T8 from plan 0018).
+- Master plan: `docs/plans/03-implementation-plans/active/0018-sustainability-tool-planning.md`
+- ADR: `docs/adr/sustainability/0001-brownfield-extension.md`
+- Depends on: T5 routes (merged), T7 standalone workspace (merged).
+
+## Background (verified against the tree)
+
+- Drawer chrome already exists and must be reused, not rebuilt: `repo-b/src/components/telemetry/drawerPrimitives.tsx` exports `DrawerWrapper`, `DrawerHeader`, `FieldRow`, and `MetricInspectorDrawer`. **Do not add a drawer library and do not hand-roll new drawer chrome.**
+- The evidence endpoint exists (T5): `GET /api/re/v2/sustainability/authoritative/metric/{metric_key}/evidence`, returning rows shaped `{metric_key, source_table, source_row_ref, emission_factor_set_id, ingestion_run_id, formula_id}` (from the T4 reader's `evidence` list).
+- The T7 workspace (`repo-b/src/components/sustainability/BosSustainabilityWorkspace.tsx`) renders a card per governed metric and already holds the reader payload, which carries `snapshot_version`, `promotion_state`, `trust_status`, `period_exact`, and per-metric `null_reason`.
+
+## The point of this ticket
+
+A governed number is only trustworthy if you can see where it came from. The drawer is the audit surface: metric -> snapshot version -> the source rows and emission-factor set that produced it. It must be equally honest when there is nothing to show: a metric with a `null_reason` must open a drawer that explains **why there is no value**, not an empty panel.
+
+## Scope
+
+In scope:
+
+1. **Client** in `repo-b/src/lib/bos-api.ts` (additive only): `getSusAuthoritativeMetricEvidence(metricKey, params)` calling the T5 evidence endpoint, with an exported row type. (If T7 already added this export, reuse it and do not duplicate.)
+2. **Component** `repo-b/src/components/sustainability/SustainabilityEvidenceDrawer.tsx`:
+   - Composed from `drawerPrimitives` (`DrawerWrapper` / `DrawerHeader` / `FieldRow`, or `MetricInspectorDrawer`). No new drawer library, no new drawer chrome.
+   - Props: the metric key, the scope params, and the governance fields already on the workspace payload (`snapshot_version`, `promotion_state`, `trust_status`, `period_exact`, the metric's `value` / `unit` / `null_reason`).
+   - Renders three sections: (a) **the value and its standing** (value or the `null_reason` verbatim, unit, `trust_status`, `promotion_state`, `period_exact`); (b) **the snapshot** it was read from (`snapshot_version`); (c) **the evidence rows** from the endpoint (`source_table`, `source_row_ref`, `emission_factor_set_id`, `ingestion_run_id`, `formula_id`), one row per source record.
+   - **Fail-closed states are first-class, not afterthoughts**: a metric with a `null_reason` opens a drawer that states the reason and shows no fabricated value. An evidence fetch that returns an empty list renders an explicit "no evidence rows for this metric" state, never a silent blank panel. A failed fetch renders an explicit error state.
+3. **Wire it into T7**: clicking a metric card in `BosSustainabilityWorkspace` opens the drawer for that metric. Keyboard-accessible (the card is a real button or has an accessible role and opens on Enter/Space).
+
+Out of scope (explicit):
+- Report center (T9), AI copilot (T10), any write path, any change to the T4 reader / T5 routes / schema.
+- Rebuilding the drawer chrome, adding a drawer/modal dependency, or changing `drawerPrimitives.tsx`.
+- Touching `SustainabilityWorkspace.tsx` (the legacy REPE one) or its pages.
+
+## Acceptance Criteria
+
+### Screen
+- Clicking a governed metric card in `BosSustainabilityWorkspace` opens `SustainabilityEvidenceDrawer` for that metric; the card is keyboard-operable (button/role with Enter or Space).
+- The open drawer shows: the metric's value **or** its `null_reason` verbatim, the `unit`, `trust_status`, `promotion_state`, `period_exact`, and the `snapshot_version` the value was read from.
+- The drawer lists the evidence rows returned by the endpoint, showing `source_table`, `source_row_ref`, `emission_factor_set_id`, `ingestion_run_id`, and `formula_id` per row.
+- A metric whose `value` is `null` opens a drawer stating its `null_reason` and shows **no** number for that metric (no `0`, no dash-as-value).
+- An empty evidence list renders an explicit "no evidence" state; a failed fetch renders an explicit error state. Neither renders a silent blank panel.
+
+### API
+- `repo-b/src/lib/bos-api.ts` calls `GET /api/re/v2/sustainability/authoritative/metric/{metric_key}/evidence` for the drawer. No existing export is modified; if T7 already added this export, it is reused rather than duplicated.
+
+### DB/Data
+Not applicable (read-only UI over the governed endpoint).
+
+### AI behavior
+- The drawer never computes or infers a value: everything it shows comes from the reader payload or the evidence endpoint. A grep of the new component finds no arithmetic on metric values and no `?? 0` / `|| 0` fallback applied to a value. When there is no value, the drawer shows the `null_reason` rather than an invented number.
+
+### Evals/tests
+- A new test `repo-b/src/components/sustainability/__tests__/SustainabilityEvidenceDrawer.test.tsx` asserts, with a mocked client: (1) opening the drawer for a metric with a value renders the value, unit, `snapshot_version`, and `trust_status`; (2) opening it for a metric whose `value` is `null` renders its `null_reason` and renders no `0`; (3) evidence rows render `source_table` and `source_row_ref`; (4) an empty evidence list renders the explicit "no evidence" state; (5) a rejected fetch renders the explicit error state.
+- A test asserts clicking a metric card in `BosSustainabilityWorkspace` opens the drawer.
+- `cd repo-b && npm run lint`, `npm run typecheck`, and `npm run test:unit` pass.
+
+### Regression guard
+- Only these are added/changed: `repo-b/src/components/sustainability/SustainabilityEvidenceDrawer.tsx` (new), its new test, the click wiring inside `BosSustainabilityWorkspace.tsx`, an additive export in `repo-b/src/lib/bos-api.ts` if not already present, and this plan.
+- `repo-b/src/components/telemetry/drawerPrimitives.tsx` is **not** modified, and no drawer/modal package is added to `package.json`.
+- `SustainabilityWorkspace.tsx` (legacy REPE), the existing REPE sustainability pages, all backend files, and all schema files are untouched.

--- a/repo-b/src/components/sustainability/BosSustainabilityWorkspace.tsx
+++ b/repo-b/src/components/sustainability/BosSustainabilityWorkspace.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/bos-api";
 import { MetricCard } from "@/components/ui/MetricCard";
 import { StateCard } from "@/components/ui/StateCard";
+import SustainabilityEvidenceDrawer from "@/components/sustainability/SustainabilityEvidenceDrawer";
 
 const METRIC_LABELS: Record<string, string> = {
   scope1_tco2e: "Scope 1 (tCO2e)",
@@ -95,41 +96,56 @@ function GovernanceHeader({ state }: { state: SusAuthoritativeStateResponse }) {
   );
 }
 
-function MetricTile({ item }: { item: SusAuthoritativeMetricItem }) {
+function MetricTile({
+  item,
+  onOpen,
+}: {
+  item: SusAuthoritativeMetricItem;
+  onOpen: (item: SusAuthoritativeMetricItem) => void;
+}) {
   const label = METRIC_LABELS[item.metric_key] ?? item.metric_key;
-  if (item.value === null || item.value === undefined) {
-    const reason = item.null_reason ?? "unavailable";
-    return (
-      <div
-        data-testid={`bos-sus-metric-null-${item.metric_key}`}
-        className="rounded-xl border border-bm-warning/30 bg-bm-warning/8 p-4"
-      >
-        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-bm-muted2">
-          {label}
-        </p>
-        <p className="mt-2 font-mono text-xs text-bm-warning" data-testid={`bos-sus-metric-null-reason-${item.metric_key}`}>
-          null_reason: {reason}
-        </p>
-        {item.trust_status && (
-          <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.08em] text-bm-muted2">
-            trust: {item.trust_status}
-          </p>
-        )}
-      </div>
-    );
-  }
+  const isNull = item.value === null || item.value === undefined;
+  const testId = isNull
+    ? `bos-sus-metric-null-${item.metric_key}`
+    : `bos-sus-metric-${item.metric_key}`;
+  const className = isNull
+    ? "w-full text-left rounded-xl border border-bm-warning/30 bg-bm-warning/8 p-4 hover:border-bm-warning/60 focus:outline-none focus:ring-2 focus:ring-bm-warning/40"
+    : "w-full text-left rounded-xl border border-bm-border/50 bg-bm-surface/20 p-4 hover:border-bm-border focus:outline-none focus:ring-2 focus:ring-bm-border";
   return (
-    <div
-      data-testid={`bos-sus-metric-${item.metric_key}`}
-      className="rounded-xl border border-bm-border/50 bg-bm-surface/20 p-4"
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={() => onOpen(item)}
+      className={className}
     >
-      <MetricCard label={label} value={formatMetricValue(item)} />
-      {item.trust_status && (
-        <p className="mt-2 font-mono text-[10px] uppercase tracking-[0.08em] text-bm-muted2">
-          trust: {item.trust_status}
-        </p>
+      {isNull ? (
+        <>
+          <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-bm-muted2">
+            {label}
+          </p>
+          <p
+            className="mt-2 font-mono text-xs text-bm-warning"
+            data-testid={`bos-sus-metric-null-reason-${item.metric_key}`}
+          >
+            null_reason: {item.null_reason ?? "unavailable"}
+          </p>
+          {item.trust_status && (
+            <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.08em] text-bm-muted2">
+              trust: {item.trust_status}
+            </p>
+          )}
+        </>
+      ) : (
+        <>
+          <MetricCard label={label} value={formatMetricValue(item)} />
+          {item.trust_status && (
+            <p className="mt-2 font-mono text-[10px] uppercase tracking-[0.08em] text-bm-muted2">
+              trust: {item.trust_status}
+            </p>
+          )}
+        </>
       )}
-    </div>
+    </button>
   );
 }
 
@@ -139,6 +155,7 @@ export default function BosSustainabilityWorkspace({
   const [state, setState] = useState<SusAuthoritativeStateResponse | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [openMetric, setOpenMetric] = useState<SusAuthoritativeMetricItem | null>(null);
 
   const resolvedQuery: SusAuthoritativeQueryParams = { ...DEFAULT_QUERY, ...(query ?? {}) };
 
@@ -193,6 +210,20 @@ export default function BosSustainabilityWorkspace({
           />
         )}
 
+        <SustainabilityEvidenceDrawer
+          open={openMetric !== null}
+          onClose={() => setOpenMetric(null)}
+          metric={openMetric}
+          governance={{
+            snapshot_version: state?.snapshot_version ?? null,
+            promotion_state: state?.promotion_state ?? null,
+            trust_status: state?.trust_status ?? null,
+            period_exact: state?.period_exact ?? null,
+          }}
+          query={resolvedQuery}
+          metricLabel={openMetric ? METRIC_LABELS[openMetric.metric_key] ?? openMetric.metric_key : undefined}
+        />
+
         {!loading && !error && state && (
           <>
             {state.null_reason === "snapshot_unavailable" ? (
@@ -231,7 +262,7 @@ export default function BosSustainabilityWorkspace({
                     className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
                   >
                     {state.metrics.map((m) => (
-                      <MetricTile key={m.metric_key} item={m} />
+                      <MetricTile key={m.metric_key} item={m} onOpen={setOpenMetric} />
                     ))}
                   </div>
                 )}

--- a/repo-b/src/components/sustainability/SustainabilityEvidenceDrawer.tsx
+++ b/repo-b/src/components/sustainability/SustainabilityEvidenceDrawer.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  getSusAuthoritativeMetricEvidence,
+  type SusAuthoritativeEvidenceItem,
+  type SusAuthoritativeMetricItem,
+  type SusAuthoritativeQueryParams,
+} from "@/lib/bos-api";
+import {
+  DrawerWrapper,
+  DrawerHeader,
+  FieldRow,
+} from "@/components/telemetry/drawerPrimitives";
+import { C } from "@/components/telemetry/primitives";
+
+// Governed fields the workspace already holds on the reader payload. Passed in
+// rather than refetched — the drawer is an inspector, not a second source of truth.
+export type SustainabilityDrawerGovernance = {
+  snapshot_version: string | null;
+  promotion_state: string | null;
+  trust_status: string | null;
+  period_exact: boolean | null;
+};
+
+export type SustainabilityEvidenceDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  metric: SusAuthoritativeMetricItem | null;
+  governance: SustainabilityDrawerGovernance;
+  query: SusAuthoritativeQueryParams;
+  metricLabel?: string;
+};
+
+type FetchState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ok"; rows: SusAuthoritativeEvidenceItem[] }
+  | { kind: "error"; message: string };
+
+function formatValue(item: SusAuthoritativeMetricItem): string | null {
+  // Fail-closed: a null value returns null. The drawer surfaces null_reason
+  // instead of substituting 0 or a dash-as-value.
+  if (item.value === null || item.value === undefined) return null;
+  const rendered = Number.isFinite(item.value)
+    ? item.value.toLocaleString()
+    : String(item.value);
+  return item.unit ? `${rendered} ${item.unit}` : rendered;
+}
+
+export default function SustainabilityEvidenceDrawer({
+  open,
+  onClose,
+  metric,
+  governance,
+  query,
+  metricLabel,
+}: SustainabilityEvidenceDrawerProps) {
+  const [fetchState, setFetchState] = useState<FetchState>({ kind: "idle" });
+
+  useEffect(() => {
+    if (!open || !metric) {
+      setFetchState({ kind: "idle" });
+      return;
+    }
+    let cancelled = false;
+    setFetchState({ kind: "loading" });
+    getSusAuthoritativeMetricEvidence(metric.metric_key, query)
+      .then((res) => {
+        if (cancelled) return;
+        setFetchState({ kind: "ok", rows: res.evidence ?? [] });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setFetchState({ kind: "error", message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, metric, query]);
+
+  if (!metric) {
+    return (
+      <DrawerWrapper open={open} onClose={onClose}>
+        <DrawerHeader title="Metric evidence" description="No metric selected." />
+      </DrawerWrapper>
+    );
+  }
+
+  const title = metricLabel ?? metric.metric_key;
+  const formatted = formatValue(metric);
+  const isNull = formatted === null;
+  const nullReason = metric.null_reason ?? "unavailable";
+
+  return (
+    <DrawerWrapper open={open} onClose={onClose}>
+      <DrawerHeader
+        title={title}
+        description={`metric_key: ${metric.metric_key}`}
+      />
+
+      {/* Section (a) — value and its standing */}
+      <section
+        data-testid="sus-evidence-standing"
+        style={{ marginTop: 16 }}
+      >
+        <SectionHeading>Value and standing</SectionHeading>
+        {isNull ? (
+          <div
+            data-testid="sus-evidence-null-reason"
+            style={{
+              fontFamily: C.mono,
+              fontSize: 11,
+              color: C.dim,
+              padding: "8px 0",
+              borderBottom: `1px solid ${C.border}`,
+            }}
+          >
+            null_reason: {nullReason}
+          </div>
+        ) : (
+          <FieldRow label="Value" value={formatted} />
+        )}
+        <FieldRow label="Unit" value={metric.unit} />
+        <FieldRow label="Trust" value={governance.trust_status} />
+        <FieldRow label="Promotion" value={governance.promotion_state} />
+        <FieldRow
+          label="Period exact"
+          value={
+            governance.period_exact === null
+              ? null
+              : governance.period_exact
+                ? "true"
+                : "false"
+          }
+        />
+      </section>
+
+      {/* Section (b) — the snapshot the value was read from */}
+      <section data-testid="sus-evidence-snapshot" style={{ marginTop: 16 }}>
+        <SectionHeading>Snapshot</SectionHeading>
+        <FieldRow label="Snapshot version" value={governance.snapshot_version} />
+      </section>
+
+      {/* Section (c) — evidence rows */}
+      <section data-testid="sus-evidence-rows" style={{ marginTop: 16 }}>
+        <SectionHeading>Evidence rows</SectionHeading>
+        <EvidenceBody state={fetchState} />
+      </section>
+    </DrawerWrapper>
+  );
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        color: C.faint,
+        fontFamily: C.mono,
+        fontSize: 9,
+        letterSpacing: "0.09em",
+        textTransform: "uppercase",
+        marginBottom: 6,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function EvidenceBody({ state }: { state: FetchState }) {
+  if (state.kind === "idle" || state.kind === "loading") {
+    return (
+      <div
+        data-testid="sus-evidence-loading"
+        style={{ fontFamily: C.mono, fontSize: 11, color: C.faint, padding: "8px 0" }}
+      >
+        Loading evidence…
+      </div>
+    );
+  }
+  if (state.kind === "error") {
+    return (
+      <div
+        data-testid="sus-evidence-error"
+        style={{
+          fontFamily: C.mono,
+          fontSize: 11,
+          color: C.dim,
+          padding: "8px 0",
+          borderTop: `1px solid ${C.border}`,
+        }}
+      >
+        Could not load evidence rows: {state.message}
+      </div>
+    );
+  }
+  if (state.rows.length === 0) {
+    return (
+      <div
+        data-testid="sus-evidence-empty"
+        style={{
+          fontFamily: C.mono,
+          fontSize: 11,
+          color: C.dim,
+          padding: "8px 0",
+          borderTop: `1px solid ${C.border}`,
+        }}
+      >
+        No evidence rows for this metric.
+      </div>
+    );
+  }
+  return (
+    <div>
+      {state.rows.map((row, idx) => (
+        <div
+          key={`${row.source_table ?? "src"}-${row.source_row_ref ?? idx}`}
+          data-testid="sus-evidence-row"
+          style={{
+            padding: "8px 0",
+            borderBottom: `1px solid ${C.border}`,
+          }}
+        >
+          <FieldRow label="Source table" value={row.source_table} />
+          <FieldRow label="Source row" value={row.source_row_ref} />
+          <FieldRow label="Emission factor set" value={row.emission_factor_set_id} />
+          <FieldRow label="Ingestion run" value={row.ingestion_run_id} />
+          <FieldRow label="Formula" value={row.formula_id} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/repo-b/src/components/sustainability/__tests__/SustainabilityEvidenceDrawer.test.tsx
+++ b/repo-b/src/components/sustainability/__tests__/SustainabilityEvidenceDrawer.test.tsx
@@ -1,0 +1,210 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import SustainabilityEvidenceDrawer from "@/components/sustainability/SustainabilityEvidenceDrawer";
+import BosSustainabilityWorkspace from "@/components/sustainability/BosSustainabilityWorkspace";
+import type {
+  SusAuthoritativeEvidenceItem,
+  SusAuthoritativeEvidenceResponse,
+  SusAuthoritativeMetricItem,
+  SusAuthoritativeQueryParams,
+  SusAuthoritativeStateResponse,
+} from "@/lib/bos-api";
+
+vi.mock("@/lib/bos-api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/bos-api")>("@/lib/bos-api");
+  return {
+    ...actual,
+    getSusAuthoritativeOverview: vi.fn(),
+    getSusAuthoritativeMetricEvidence: vi.fn(),
+  };
+});
+
+import {
+  getSusAuthoritativeOverview,
+  getSusAuthoritativeMetricEvidence,
+} from "@/lib/bos-api";
+
+const mockedOverview = getSusAuthoritativeOverview as unknown as ReturnType<typeof vi.fn>;
+const mockedEvidence = getSusAuthoritativeMetricEvidence as unknown as ReturnType<typeof vi.fn>;
+
+const QUERY: SusAuthoritativeQueryParams = {
+  business_id: "demo",
+  env_id: "sustainability-demo",
+  entity_scope: "portfolio",
+  period_key: "2026Q1",
+  metric_family: "ghg",
+};
+
+const VALUED_METRIC: SusAuthoritativeMetricItem = {
+  metric_key: "scope1_tco2e",
+  value: 1234.5,
+  unit: "tCO2e",
+  null_reason: null,
+  trust_status: "trusted",
+};
+
+const NULL_METRIC: SusAuthoritativeMetricItem = {
+  metric_key: "scope3_tco2e",
+  value: null,
+  unit: "tCO2e",
+  null_reason: "out_of_scope_requires_scope3_ingestion",
+  trust_status: "untrusted",
+};
+
+const GOVERNANCE = {
+  snapshot_version: "sv-abc-123",
+  promotion_state: "released",
+  trust_status: "trusted",
+  period_exact: true,
+};
+
+const EVIDENCE_ROWS: SusAuthoritativeEvidenceItem[] = [
+  {
+    metric_key: "scope1_tco2e",
+    source_table: "sus_emission_source",
+    source_row_ref: "row-42",
+    emission_factor_set_id: "efs-2024-us",
+    ingestion_run_id: "ing-7788",
+    formula_id: "fml-ghg-s1",
+  },
+];
+
+const okResponse = (rows: SusAuthoritativeEvidenceItem[]): SusAuthoritativeEvidenceResponse => ({
+  evidence: rows,
+});
+
+describe("SustainabilityEvidenceDrawer", () => {
+  beforeEach(() => {
+    mockedEvidence.mockReset();
+    mockedOverview.mockReset();
+  });
+
+  it("renders value, unit, snapshot_version, trust_status, and evidence rows for a valued metric", async () => {
+    mockedEvidence.mockResolvedValue(okResponse(EVIDENCE_ROWS));
+
+    render(
+      <SustainabilityEvidenceDrawer
+        open
+        onClose={() => {}}
+        metric={VALUED_METRIC}
+        governance={GOVERNANCE}
+        query={QUERY}
+        metricLabel="Scope 1 (tCO2e)"
+      />
+    );
+
+    // value + unit (locale-tolerant thousands separator)
+    const standing = await screen.findByTestId("sus-evidence-standing");
+    expect(standing.textContent ?? "").toMatch(/1[.,]?234\.5\s*tCO2e/);
+    expect(standing.textContent ?? "").toContain("tCO2e");
+    // snapshot version
+    const snapshotSection = screen.getByTestId("sus-evidence-snapshot");
+    expect(snapshotSection.textContent ?? "").toContain("sv-abc-123");
+    // trust status appears at least once in the standing section
+    expect(standing.textContent ?? "").toContain("trusted");
+    // evidence rows
+    await waitFor(() => {
+      expect(screen.getByTestId("sus-evidence-row")).toBeInTheDocument();
+    });
+    const row = screen.getByTestId("sus-evidence-row");
+    expect(row.textContent ?? "").toContain("sus_emission_source");
+    expect(row.textContent ?? "").toContain("row-42");
+  });
+
+  it("renders the null_reason and no zero when the metric value is null", async () => {
+    mockedEvidence.mockResolvedValue(okResponse([]));
+
+    const { container } = render(
+      <SustainabilityEvidenceDrawer
+        open
+        onClose={() => {}}
+        metric={NULL_METRIC}
+        governance={GOVERNANCE}
+        query={QUERY}
+        metricLabel="Scope 3 (tCO2e)"
+      />
+    );
+
+    const reason = await screen.findByTestId("sus-evidence-null-reason");
+    expect(reason).toHaveTextContent("out_of_scope_requires_scope3_ingestion");
+    // no fabricated zero anywhere in the drawer body
+    expect(container.textContent).not.toMatch(/(^|\s)0(\s|$)/);
+    expect(container.textContent).not.toMatch(/(^|\s)0 tCO2e/);
+  });
+
+  it("renders an explicit empty-evidence state when the endpoint returns no rows", async () => {
+    mockedEvidence.mockResolvedValue(okResponse([]));
+
+    render(
+      <SustainabilityEvidenceDrawer
+        open
+        onClose={() => {}}
+        metric={VALUED_METRIC}
+        governance={GOVERNANCE}
+        query={QUERY}
+      />
+    );
+
+    const empty = await screen.findByTestId("sus-evidence-empty");
+    expect(empty).toHaveTextContent(/No evidence rows/i);
+    expect(screen.queryByTestId("sus-evidence-row")).toBeNull();
+  });
+
+  it("renders an explicit error state when the evidence fetch rejects", async () => {
+    mockedEvidence.mockRejectedValue(new Error("boom"));
+
+    render(
+      <SustainabilityEvidenceDrawer
+        open
+        onClose={() => {}}
+        metric={VALUED_METRIC}
+        governance={GOVERNANCE}
+        query={QUERY}
+      />
+    );
+
+    const err = await screen.findByTestId("sus-evidence-error");
+    expect(err).toHaveTextContent(/boom/);
+    expect(screen.queryByTestId("sus-evidence-row")).toBeNull();
+  });
+});
+
+describe("BosSustainabilityWorkspace click-to-open", () => {
+  beforeEach(() => {
+    mockedOverview.mockReset();
+    mockedEvidence.mockReset();
+  });
+
+  it("opens the evidence drawer when a metric card is clicked", async () => {
+    const overview: SusAuthoritativeStateResponse = {
+      entity_scope: "portfolio",
+      period_key: "2026Q1",
+      requested_period_key: "2026Q1",
+      period_exact: true,
+      state_origin: "authoritative_snapshot",
+      snapshot_version: "sv-abc-123",
+      promotion_state: "released",
+      trust_status: "trusted",
+      null_reason: null,
+      metrics: [VALUED_METRIC],
+      evidence: [],
+    };
+    mockedOverview.mockResolvedValueOnce(overview);
+    mockedEvidence.mockResolvedValue(okResponse(EVIDENCE_ROWS));
+
+    render(<BosSustainabilityWorkspace />);
+
+    const card = await screen.findByTestId("bos-sus-metric-scope1_tco2e");
+    expect(card.tagName).toBe("BUTTON");
+    fireEvent.click(card);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sus-evidence-standing")).toBeInTheDocument();
+    });
+    expect(mockedEvidence).toHaveBeenCalledWith(
+      "scope1_tco2e",
+      expect.objectContaining({ business_id: "demo", env_id: "sustainability-demo" })
+    );
+  });
+});


### PR DESCRIPTION
## Ticket
T8 from plan 0018. A governed number is only trustworthy if you can see where it came from.

## What
Clicking a metric on `/app/sustainability` opens a drawer showing:
- **the value and its standing** - value or its `null_reason`, unit, `trust_status`, `promotion_state`, `period_exact`
- **the snapshot** it was read from (`snapshot_version`)
- **the source rows** behind it - `source_table`, `source_row_ref`, `emission_factor_set_id`, `ingestion_run_id`, `formula_id`

Composed from the existing `drawerPrimitives` chrome. **No drawer library added, no new chrome hand-rolled** - `drawerPrimitives.tsx` and `package.json` untouched.

## Fail-closed is first-class here
- a metric with a `null_reason` opens a drawer **stating the reason**, showing no fabricated value
- an empty evidence list renders an explicit "no evidence" state
- a failed fetch renders an explicit error state
- none render a silent blank panel; no `?? 0` / `|| 0` fallback anywhere

## On the one "unknown" (A1) - a reviewer blind spot, not a defect
The relay returned **12/13 criteria, 0 unmet**, all four suites green every iteration. Codex could not verify A1 because **`bos-api.ts` was absent from the review bundle** - which is exactly right: the plan told the builder to **reuse T7's evidence export rather than duplicate it**, so the file was never modified and therefore never appeared in the diff. The reviewer cannot confirm a criterion about a file it cannot see.

Verified by hand: the export is at `bos-api.ts:7230`, hits `/authoritative/metric/{key}/evidence`, and the drawer imports and calls it (`SustainabilityEvidenceDrawer.tsx:68`). **5/5 drawer tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)