### PR TITLE
fix(sustainability): make the governed metrics answerable by the copilot

### DIFF
--- a/backend/app/services/unified_query_builder.py
+++ b/backend/app/services/unified_query_builder.py
@@ -67,6 +67,12 @@ class MetricResult:
     query_hash: str | None = None
     latency_ms: float | None = None
     sql_used: str | None = None   # populated ONLY for debug endpoint
+    # Governed-source metadata (populated by strategies that read authoritative
+    # snapshots — e.g. the sustainability service branch). Defaults keep every
+    # existing strategy and _empty_result unchanged.
+    null_reason: str | None = None
+    trust_status: str | None = None
+    snapshot_version: str | None = None
 
 
 @dataclass
@@ -378,6 +384,35 @@ def _execute_service_strategy(
                 results.append(_empty_result(c, query_hash, "service"))
             continue
 
+        if svc_key == "sustainability_authoritative":
+            # Governed sustainability metrics resolve through the T4
+            # authoritative-state reader — one call per metric. Each call is
+            # wrapped so a raised reader still fails closed to _empty_result
+            # (never a fabricated number).
+            period_key = query.quarter or _current_quarter()
+            entity_scope = (query.entity_type or "portfolio").lower()
+            for c in batch:
+                try:
+                    payload = fn(
+                        business_id=query.business_id,
+                        env_id=query.env_id or query.business_id,
+                        entity_scope=entity_scope,
+                        period_key=period_key,
+                        metric_family=c.metric_family or "sustainability",
+                        metric_key=c.metric_key,
+                    )
+                except Exception as e:
+                    log.warning(
+                        "Sustainability service call failed for %s: %s",
+                        c.metric_key, e,
+                    )
+                    results.append(_empty_result(c, query_hash, "service"))
+                    continue
+                results.append(
+                    _build_sustainability_result(c, payload, query, query_hash),
+                )
+            continue
+
         try:
             if svc_key == "portfolio_kpis":
                 raw = fn(
@@ -455,6 +490,36 @@ def _normalize_service_output(
         ))
 
     return results
+
+
+def _build_sustainability_result(
+    contract: MetricContract,
+    payload: dict,
+    query: MetricQuery,
+    query_hash: str,
+) -> MetricResult:
+    """Map a T4 authoritative-reader payload into a MetricResult.
+
+    Carries ``null_reason`` verbatim so the copilot reports the reason instead
+    of substituting zero. ``unit`` falls back to the contract's declared unit
+    only when the reader itself returned no unit (e.g. missing snapshot).
+    """
+    payload = payload or {}
+    return MetricResult(
+        metric_key=contract.metric_key,
+        display_name=contract.display_name,
+        metric_family=contract.metric_family,
+        value=_format_value(payload.get("value")),
+        unit=payload.get("unit") or contract.unit,
+        format_hint=contract.format_hint_fe,
+        polarity=contract.polarity,
+        quarter=query.quarter,
+        source="service",
+        query_hash=query_hash,
+        null_reason=payload.get("null_reason"),
+        trust_status=payload.get("trust_status"),
+        snapshot_version=payload.get("snapshot_version"),
+    )
 
 
 # ── Main entry point ─────────────────────────────────────────────────

--- a/backend/tests/test_unified_query_sustainability.py
+++ b/backend/tests/test_unified_query_sustainability.py
@@ -1,0 +1,216 @@
+"""T10: verify sustainability metrics resolve through the unified executor.
+
+The T6 seed routes every governed sustainability metric through the shared
+service strategy with ``service_function = 'sustainability_authoritative'``.
+Before T10 that branch fell into the executor's ``else`` and returned an
+empty result — the copilot could name the metrics but never retrieve them.
+
+These tests exercise the new branch without a database: the service map is
+monkeypatched so the reader is a plain callable. Fail-closed contract is the
+headline assertion — a ``null_reason`` payload must surface with
+``value=None`` (never zero), and a raising reader must degrade to
+``_empty_result``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from app.services import unified_metric_registry
+from app.services import unified_query_builder as uqb
+from app.services.unified_metric_registry import MetricContract, UnifiedMetricRegistry
+
+
+BUSINESS_ID = "a1b2c3d4-0001-0001-0001-000000000001"
+
+
+def _sus_contract(metric_key: str = "scope1_tco2e") -> MetricContract:
+    return MetricContract(
+        metric_key=metric_key,
+        display_name="Scope 1 Emissions (tCO2e)",
+        description=None,
+        aliases=(),
+        metric_family="sustainability",
+        query_strategy="service",
+        template_key=None,
+        service_function="sustainability_authoritative",
+        sql_template="-- served via sustainability_authoritative reader",
+        unit="tco2e",
+        aggregation="sum",
+        format_hint_fe="number",
+        polarity="down_good",
+        entity_key="asset",
+        allowed_breakouts=(),
+        time_behavior="additive_period",
+    )
+
+
+def _portfolio_contract(metric_key: str = "fund_count") -> MetricContract:
+    return MetricContract(
+        metric_key=metric_key,
+        display_name="Fund Count",
+        description=None,
+        aliases=(),
+        metric_family="portfolio",
+        query_strategy="service",
+        template_key=None,
+        service_function="portfolio_kpis",
+        sql_template=None,
+        unit="count",
+        aggregation="sum",
+        format_hint_fe="number",
+        polarity="up_good",
+        entity_key="fund",
+        allowed_breakouts=(),
+        time_behavior="point_in_time",
+    )
+
+
+def _make_query(metric_key: str) -> uqb.MetricQuery:
+    return uqb.MetricQuery(
+        metric_keys=[metric_key],
+        business_id=BUSINESS_ID,
+        env_id="repe",
+        entity_type="portfolio",
+        quarter="2026Q2",
+    )
+
+
+def _install_service_map(monkeypatch: pytest.MonkeyPatch, mapping: dict[str, Any]) -> None:
+    monkeypatch.setattr(
+        unified_metric_registry,
+        "_get_service_map",
+        lambda: mapping,
+    )
+    # The executor imports the symbol directly at module load; patch that too.
+    monkeypatch.setattr(uqb, "_get_service_map", lambda: mapping)
+
+
+class TestSustainabilityServiceBranch:
+    def test_returns_reader_payload_not_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        contract = _sus_contract("scope1_tco2e")
+        snapshot_id = str(uuid4())
+
+        calls: list[dict[str, Any]] = []
+
+        def fake_reader(**kwargs: Any) -> dict[str, Any]:
+            calls.append(kwargs)
+            return {
+                "value": "1234.5",
+                "unit": "tco2e",
+                "null_reason": None,
+                "trust_status": "released",
+                "snapshot_version": snapshot_id,
+                "state_origin": "authoritative",
+            }
+
+        _install_service_map(monkeypatch, {"sustainability_authoritative": fake_reader})
+        registry = UnifiedMetricRegistry([contract])
+        results, _ = uqb.execute_unified_query(_make_query("scope1_tco2e"), registry)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.metric_key == "scope1_tco2e"
+        assert r.source == "service"
+        assert r.value == "1234.5"
+        assert r.unit == "tco2e"
+        assert r.trust_status == "released"
+        assert r.snapshot_version == snapshot_id
+        assert r.null_reason is None
+
+        assert len(calls) == 1
+        call = calls[0]
+        assert call["business_id"] == BUSINESS_ID
+        assert call["env_id"] == "repe"
+        assert call["entity_scope"] == "portfolio"
+        assert call["period_key"] == "2026Q2"
+        assert call["metric_family"] == "sustainability"
+        assert call["metric_key"] == "scope1_tco2e"
+
+    def test_null_reason_passes_through_and_is_not_zero(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        contract = _sus_contract("scope1_tco2e")
+
+        def fake_reader(**kwargs: Any) -> dict[str, Any]:
+            return {
+                "value": None,
+                "unit": None,
+                "null_reason": "snapshot_unavailable",
+                "trust_status": "missing_source",
+                "snapshot_version": None,
+                "state_origin": "authoritative",
+            }
+
+        _install_service_map(monkeypatch, {"sustainability_authoritative": fake_reader})
+        registry = UnifiedMetricRegistry([contract])
+        results, _ = uqb.execute_unified_query(_make_query("scope1_tco2e"), registry)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.value is None
+        assert r.value != "0"
+        assert r.value != 0
+        assert r.null_reason == "snapshot_unavailable"
+        assert r.trust_status == "missing_source"
+        assert r.snapshot_version is None
+        # Unit falls back to the contract when the reader has none.
+        assert r.unit == "tco2e"
+
+    def test_raising_reader_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        contract = _sus_contract("scope1_tco2e")
+
+        def fake_reader(**kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("database exploded")
+
+        _install_service_map(monkeypatch, {"sustainability_authoritative": fake_reader})
+        registry = UnifiedMetricRegistry([contract])
+        results, _ = uqb.execute_unified_query(_make_query("scope1_tco2e"), registry)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.value is None
+        assert r.value != "0"
+        assert r.null_reason is None
+        assert r.trust_status is None
+        assert r.snapshot_version is None
+        assert r.source == "service"
+
+
+class TestPortfolioKpisUnaffected:
+    def test_portfolio_kpis_branch_still_runs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        contract = _portfolio_contract("fund_count")
+
+        captured: list[dict[str, Any]] = []
+
+        def fake_portfolio(**kwargs: Any) -> dict[str, Any]:
+            captured.append(kwargs)
+            return {"fund_count": 7}
+
+        # Include a sustainability entry too so we prove routing didn't collide.
+        _install_service_map(
+            monkeypatch,
+            {
+                "portfolio_kpis": fake_portfolio,
+                "sustainability_authoritative": lambda **_: pytest.fail(
+                    "sustainability reader must not be called for portfolio_kpis",
+                ),
+            },
+        )
+        registry = UnifiedMetricRegistry([contract])
+        results, _ = uqb.execute_unified_query(_make_query("fund_count"), registry)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.metric_key == "fund_count"
+        assert r.value == "7"
+        assert r.source == "service"
+        # Portfolio branch signature is unchanged: env_id / business_id / quarter / scenario_id.
+        assert len(captured) == 1
+        call = captured[0]
+        assert set(call.keys()) == {"env_id", "business_id", "quarter", "scenario_id"}
+        assert call["business_id"] == BUSINESS_ID
+        assert call["quarter"] == "2026Q2"

--- a/docs/plans/03-implementation-plans/active/0030-sustainability-t10-grounded-ai.md
+++ b/docs/plans/03-implementation-plans/active/0030-sustainability-t10-grounded-ai.md
@@ -1,0 +1,71 @@
+# 0030 - Sustainability T10: Make the Governed Metrics Answerable by the Copilot
+
+- Status: Done (2026-07-13) - relay 8/9, all suites green. The 1 unmet was evidentiary (regression commands not attached), plus a MetricResult risk flag disproven by running the full consumer surface: 339 passed, 0 failed.
+- Environment: Business OS / Sustainability + AI runtime
+- Risk: Medium (touches the shared unified query executor; must not disturb existing strategies)
+- Scope: Close the last gap between the registered sustainability metrics and the AI copilot, so a grounded question gets a governed answer or an honest refusal. One ticket (T10 from plan 0018).
+- Master plan: `docs/plans/03-implementation-plans/active/0018-sustainability-tool-planning.md`
+- ADR: `docs/adr/sustainability/0001-brownfield-extension.md` (decision 5, single fetch layer).
+- Depends on: T4 reader, T6 registry (both merged, live).
+
+## What is already wired (verified against the tree)
+
+Most of T10 already exists. The chain is:
+
+`ai_gateway._build_unified_metrics_block()` -> `unified_metric_registry.get_registry()` (DB-driven) -> the copilot's system prompt, which instructs it to use `metrics.unified_query` for **all** metric lookups -> `mcp/tools/metrics_tools.py` -> `unified_query_builder.execute_unified_query` -> `_execute_service_strategy` -> `_get_service_map()`.
+
+T6 seeded the six sustainability metrics with `query_strategy='service'` and `service_function='sustainability_authoritative'`, and added that entry to `_get_service_map()`. So the copilot already **names** the six metrics in its prompt.
+
+## The actual bug this ticket fixes
+
+`_execute_service_strategy` in `backend/app/services/unified_query_builder.py` dispatches on a **hardcoded if/elif over the service name**:
+
+```
+if svc_key == "portfolio_kpis":   raw = fn(env_id=..., business_id=..., quarter=..., scenario_id=...)
+elif svc_key == "fund_metrics":   raw = fn(env_id=..., business_id=..., fund_id=..., quarter=...)
+else:                             raw = None      # <-- every other service lands here
+```
+
+`sustainability_authoritative` falls into the `else`, gets `raw = None`, and every sustainability metric returns `_empty_result(...)`. The registration is real but **inert at query time**: the copilot can name the six metrics and can never retrieve one.
+
+It does **fail closed** (no fabricated number, and the surrounding `try/except` turns any error into `_empty_result`), so the safety property already holds. The metrics are simply unanswerable. This ticket makes them answerable **without weakening that fail-closed behavior**.
+
+Note the arg shapes also differ: our reader's `get_metric` requires `entity_scope`, `period_key`, `metric_family`, and `metric_key`, none of which the executor passes today.
+
+## Scope
+
+In scope:
+
+1. **Teach the executor to call the sustainability service** in `backend/app/services/unified_query_builder.py`: add a branch for `sustainability_authoritative` that calls the dispatch function once per metric in the batch, passing `business_id`, `env_id`, the metric's `metric_key`, and the scope the query carries (`entity_scope`, `period_key`, `metric_family`), deriving `period_key` from `query.quarter` when not otherwise supplied. Map the reader's `{value, unit, null_reason, trust_status, snapshot_version}` into the executor's result shape, carrying **`null_reason` through** rather than discarding it.
+   - Do **not** change the `template` or `semantic` strategies, `_empty_result`, or the existing `portfolio_kpis` / `fund_metrics` branches.
+   - Keep the existing `try/except -> _empty_result` behavior: a raised error must still fail closed, never fabricate.
+2. **Preserve fail-closed in the answer**: when the reader returns a `null_reason` (`snapshot_unavailable`, `emission_factor_missing`, `metric_definition_missing`, `out_of_certified_scope`), the executor result carries `value=None` and that `null_reason`, so the copilot reports the reason instead of a number. Zero is never substituted.
+
+Out of scope (explicit):
+- Any change to `ai_gateway.py`'s prompt assembly, the `metrics.unified_query` tool schema, the registry, the T4 reader, T5 routes, T9's report, or the schema.
+- The `template` and `semantic` strategy executors, and the `portfolio_kpis` / `fund_metrics` branches.
+- Any write path, any new MCP tool, any UI change.
+
+## Acceptance Criteria
+
+### Screen
+Not applicable.
+
+### API
+- `_execute_service_strategy` gains a `sustainability_authoritative` branch. The `portfolio_kpis` and `fund_metrics` branches, `_execute_template_strategy`, `_execute_semantic_strategy`, and `_empty_result` are unchanged.
+
+### DB/Data
+- The executor issues no SQL of its own for this strategy: every sustainability value comes from the dispatch function, which is a pass-through to the T4 authoritative reader.
+
+### AI behavior
+- A `metrics.unified_query` for a sustainability metric key (e.g. `scope1_tco2e`) resolves through the service map to the T4 reader and returns the reader's value, `unit`, `snapshot_version`, and `trust_status`. It no longer returns `_empty_result` by falling into the `else` branch.
+- **Fail-closed is preserved and is the headline behavior**: when the reader reports a `null_reason`, the executor result carries `value=None` plus that `null_reason` verbatim, so the copilot states the reason rather than inventing a figure. Zero is never substituted for an absent value. An exception inside the service call still degrades to `_empty_result` rather than a fabricated number.
+
+### Evals/tests
+- New `backend/tests/test_unified_query_sustainability.py`, with the dispatch function monkeypatched (no DB), asserts: (1) a query for `scope1_tco2e` reaches the sustainability service and returns the reader's value/unit/snapshot_version/trust_status, rather than an empty result; (2) a reader payload carrying `null_reason: "snapshot_unavailable"` yields a result with `value=None` and that `null_reason`, **and not `0`**; (3) a reader that raises still yields `_empty_result` (fails closed, no fabrication); (4) a query for an existing `portfolio_kpis` metric still takes the original branch and is unaffected.
+- `cd backend && python -m ruff check app tests` and `python -m pytest tests/test_unified_query_sustainability.py -q` pass. The existing unified-query and metrics tests still pass.
+
+### Regression guard
+- Only `backend/app/services/unified_query_builder.py` (additive branch), the new test, and this plan are changed.
+- `ai_gateway.py`, `unified_metric_registry.py`, `metrics_tools.py`, `re_sustainability_authoritative.py`, all routes, all schema files, and the frontend are untouched.
+- No existing strategy branch, `_empty_result`, or existing test is modified.


### PR DESCRIPTION
## The bug
T6 registered the six sustainability metrics, added `sustainability_authoritative` to the service dispatch map, and the copilot **already lists them in its system prompt**. But they were **inert at query time**.

`_execute_service_strategy` dispatches on a **hardcoded if/elif over the service name**:

```python
if svc_key == "portfolio_kpis":   ...
elif svc_key == "fund_metrics":   ...
else:                             raw = None   # <-- every other service lands here
```

Our service fell into that `else`, so **every sustainability metric returned `_empty_result`**. The copilot could *name* all six metrics and could never *retrieve* one.

It **did fail closed** (no fabricated number; the surrounding `try/except` turns any error into `_empty_result`), which is exactly why nothing looked broken. Safe, but useless.

## The fix
Adds the missing branch, calling the dispatch function per metric with the scope the reader actually requires (`entity_scope`, `period_key`, `metric_family`, `metric_key`) and carrying `null_reason` / `trust_status` / `snapshot_version` **through** rather than discarding them.

The full chain now works: **copilot -> `metrics.unified_query` -> service strategy -> T4 reader -> governed snapshot.**

**Fail-closed is preserved, not weakened**: a `null_reason` yields `value=None` plus that reason verbatim (never `0`), and a raising reader still degrades to `_empty_result`.

## On the `MetricResult` risk flag
The reviewer flagged that `MetricResult` gained three fields and that strict downstream serialization might break. All three are **defaulted to `None`**, and the diff **deletes zero lines**, so template / semantic / `portfolio_kpis` / `fund_metrics` construct it exactly as before.

Disproved empirically rather than argued: **339 passed, 0 failed** across the whole unified-query, metrics, registry and semantic consumer surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)