### PR TITLE
fix(sustainability): the governed report must fail closed when the reader raises

### DIFF
--- a/backend/app/services/re_sustainability_report.py
+++ b/backend/app/services/re_sustainability_report.py
@@ -38,16 +38,34 @@ def build_governed_report(
     Every metric value comes from the T4 authoritative reader. The service
     does not read any ``sus_*`` table directly and does not compute totals.
     """
-    state = re_sustainability_authoritative.get_authoritative_state(
-        business_id=business_id,
-        env_id=env_id,
-        entity_scope=entity_scope,
-        period_key=period_key,
-        metric_family=metric_family,
-        snapshot_version=snapshot_version,
-    )
-
     generated_at = datetime.now(timezone.utc).isoformat()
+
+    try:
+        state = re_sustainability_authoritative.get_authoritative_state(
+            business_id=business_id,
+            env_id=env_id,
+            entity_scope=entity_scope,
+            period_key=period_key,
+            metric_family=metric_family,
+            snapshot_version=snapshot_version,
+        )
+    except Exception:
+        # Fail closed: never fabricate a value if the governed reader raises.
+        return {
+            "entity_scope": entity_scope,
+            "period_key": period_key,
+            "requested_period_key": period_key,
+            "period_exact": False,
+            "metric_family": metric_family,
+            "state_origin": "authoritative",
+            "snapshot_version": None,
+            "promotion_state": None,
+            "trust_status": "missing_source",
+            "null_reason": re_sustainability_authoritative.SNAPSHOT_UNAVAILABLE,
+            "metrics": [],
+            "evidence": [],
+            "generated_at": generated_at,
+        }
 
     if state.get("null_reason") == re_sustainability_authoritative.SNAPSHOT_UNAVAILABLE:
         return {

--- a/backend/tests/test_re_sustainability_report_fail_closed.py
+++ b/backend/tests/test_re_sustainability_report_fail_closed.py
@@ -1,0 +1,117 @@
+"""The governed report must fail closed when the authoritative reader raises.
+
+Found by the T12 acceptance evals: ``build_governed_report`` called
+``get_authoritative_state`` unguarded, so a reader that raised (database down,
+bad scope, driver error) propagated the exception out of the report service
+instead of degrading to an honest "no value" bundle.
+
+The rule the sustainability platform claims is that it never fabricates a
+number and never blows up in place of one: a value it cannot serve comes back
+as ``None`` with a reason. That has to hold on the error path too, not just
+when the reader politely reports ``snapshot_unavailable``.
+"""
+from __future__ import annotations
+
+
+from app.services import re_sustainability_report
+
+
+SCOPE = {
+    "business_id": "a1b2c3d4-0001-0001-0001-000000000001",
+    "env_id": "env-demo",
+    "entity_scope": "portfolio",
+    "period_key": "2026Q1",
+    "metric_family": "sustainability",
+}
+
+
+def test_reader_error_fails_closed_instead_of_raising(monkeypatch):
+    """A raising reader yields a bundle, not an exception."""
+
+    def boom(**_kwargs):
+        raise RuntimeError("database is unreachable")
+
+    monkeypatch.setattr(
+        re_sustainability_report.re_sustainability_authoritative,
+        "get_authoritative_state",
+        boom,
+    )
+
+    bundle = re_sustainability_report.build_governed_report(**SCOPE)
+
+    # It degraded rather than propagating.
+    assert isinstance(bundle, dict)
+    assert bundle["trust_status"] == "missing_source"
+    assert bundle["snapshot_version"] is None
+    assert bundle.get("null_reason")
+
+
+def test_reader_error_fabricates_no_number(monkeypatch):
+    """The degraded bundle carries no value for any metric, and no zero total.
+
+    Zero is the dangerous answer here: a report that quietly says 0 tCO2e when
+    the reader is down reads as "we emitted nothing," which is worse than
+    saying nothing at all.
+    """
+
+    def boom(**_kwargs):
+        raise RuntimeError("database is unreachable")
+
+    monkeypatch.setattr(
+        re_sustainability_report.re_sustainability_authoritative,
+        "get_authoritative_state",
+        boom,
+    )
+
+    bundle = re_sustainability_report.build_governed_report(**SCOPE)
+
+    assert bundle["metrics"] == []
+    assert bundle["evidence"] == []
+    for key, value in bundle.items():
+        if key in ("metrics", "evidence"):
+            continue
+        # Booleans are excluded on purpose: `period_exact` is a legitimate
+        # False flag, and in Python `False == 0`. What must never appear is a
+        # fabricated *numeric* value standing in for one we could not read.
+        if isinstance(value, bool):
+            continue
+        assert not isinstance(value, (int, float)) or value != 0, (
+            f"{key} fabricated a zero on the error path"
+        )
+
+
+def test_healthy_reader_is_unaffected(monkeypatch):
+    """The guard must not swallow or reshape a normal successful read."""
+    payload = {
+        "entity_scope": "portfolio",
+        "period_key": "2026Q1",
+        "requested_period_key": "2026Q1",
+        "period_exact": True,
+        "state_origin": "authoritative",
+        "snapshot_version": "sus-2026Q1-001",
+        "promotion_state": "released",
+        "trust_status": "trusted",
+        "null_reason": None,
+        "metrics": [
+            {
+                "metric_key": "scope1_tco2e",
+                "value": 42.5,
+                "unit": "tco2e",
+                "null_reason": None,
+                "trust_status": "trusted",
+            }
+        ],
+        "evidence": [],
+    }
+    monkeypatch.setattr(
+        re_sustainability_report.re_sustainability_authoritative,
+        "get_authoritative_state",
+        lambda **_kwargs: payload,
+    )
+
+    bundle = re_sustainability_report.build_governed_report(**SCOPE)
+
+    assert bundle["snapshot_version"] == "sus-2026Q1-001"
+    assert bundle["trust_status"] == "trusted"
+    assert bundle["metrics"][0]["metric_key"] == "scope1_tco2e"
+    assert bundle["metrics"][0]["value"] == 42.5


### PR DESCRIPTION
## The bug (found by the T12 acceptance evals, in code I shipped in T9)
`build_governed_report` called `get_authoritative_state` **unguarded**. A reader that **raised** - database unreachable, bad scope, driver error - propagated the exception straight out of the report service.

The platform's whole claim is that it **never fabricates a number and never blows up in place of one**: a value it cannot serve comes back as `None` with a reason. That has to hold on the **error path** too, not just when the reader politely reports `snapshot_unavailable`.

## The fix
A raising reader now degrades to an honest bundle: `trust_status: "missing_source"`, no `snapshot_version`, a `null_reason`, empty `metrics`/`evidence`, and **no fabricated totals**.

Zero is the dangerous answer here - a report that quietly says **0 tCO2e** when the reader is down reads as *"we emitted nothing,"* which is worse than saying nothing at all.

T9's core property is untouched: the report service still contains **zero SQL** and reads only through the governed reader, so report and dashboard remain incapable of diverging.

## Why this is a separate PR
The T12 ticket's regression guard says **tests-only**, precisely so that a discovered guarantee gap becomes a **visible follow-up** rather than a silent production edit smuggled into a test PR.

The relay's builder tried to patch production *inside* the T12 bundle to turn the failing test green. The reviewer **blocked it on that guard**, and it was right to. This is that follow-up, reviewed on its own merits.

## Verified in both directions
A regression test that passes on broken code is worthless, so I checked both:
- **2 of 3 cases FAIL** against `main`'s unfixed code (the bug is real and reproducible)
- **all 3 pass** with the fix
- T9's existing report tests still pass (7/7 total), ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)